### PR TITLE
Double clicks on the operator will open the property panel

### DIFF
--- a/core/gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -47,6 +47,7 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
     this.returnPosition = { x: -xOffset, y: -yOffset };
     this.registerHighlightEventsHandler();
     this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => this.closePanel());
+    this.panelService.openPanelStream.pipe(untilDestroyed(this)).subscribe(() => this.openPanel());
     this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => {
       this.resetPanelPosition();
       this.openPanel();

--- a/core/gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -47,7 +47,8 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
     this.returnPosition = { x: -xOffset, y: -yOffset };
     this.registerHighlightEventsHandler();
     this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => this.closePanel());
-    this.panelService.openPanelStream.pipe(untilDestroyed(this)).subscribe(() => this.openPanel());
+    this.panelService.openPropertyPanelStream.pipe(untilDestroyed(this)).subscribe(() => this.openPanel());
+    this.panelService.closePropertyPanelStream.pipe(untilDestroyed(this)).subscribe(() => this.closePanel());
     this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => {
       this.resetPanelPosition();
       this.openPanel();

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -445,7 +445,11 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
           this.wrapper.setMultiSelectMode(<boolean>event[1].shiftKey);
           const elementID = event[0].model.id.toString();
           if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
-            this.panelservice.openPanels();
+            if (this.panelservice.isPanelOpen) {
+              this.panelservice.closePropertyPanel();
+            } else {
+              this.panelservice.openPropertyPanel();
+            }
           }
         }
       });

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -19,6 +19,7 @@ import { WorkflowVersionService } from "../../../dashboard/service/user/workflow
 import { OperatorMenuService } from "../../service/operator-menu/operator-menu.service";
 import { NzContextMenuService } from "ng-zorro-antd/dropdown";
 import { ActivatedRoute, Router } from "@angular/router";
+import { PanelService } from "../../service/panel/panel.service";
 import * as _ from "lodash";
 import * as joint from "jointjs";
 
@@ -87,6 +88,7 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
     private operatorMenu: OperatorMenuService,
     private route: ActivatedRoute,
     private router: Router,
+    private panelservice: PanelService,
     public nzContextMenu: NzContextMenuService
   ) {
     this.wrapper = this.workflowActionService.getJointGraphWrapper();
@@ -426,15 +428,24 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
     fromJointPaperEvent(this.paper, "cell:pointerdblclick")
       .pipe(untilDestroyed(this))
       .subscribe(event => {
-        const clickedCommentBox = event[0].model;
+        const clickedBox = event[0].model;
         if (
-          clickedCommentBox.isElement() &&
-          this.workflowActionService.getTexeraGraph().hasCommentBox(clickedCommentBox.id.toString())
+          clickedBox.isElement() &&
+          this.workflowActionService.getTexeraGraph().hasCommentBox(clickedBox.id.toString())
         ) {
           this.wrapper.setMultiSelectMode(<boolean>event[1].shiftKey);
           const elementID = event[0].model.id.toString();
           if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.openCommentBox(elementID);
+          }
+        } else if (
+          clickedBox.isElement() &&
+          this.workflowActionService.getTexeraGraph().hasOperator(clickedBox.id.toString())
+        ) {
+          this.wrapper.setMultiSelectMode(<boolean>event[1].shiftKey);
+          const elementID = event[0].model.id.toString();
+          if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
+            this.panelservice.openPanels();
           }
         }
       });

--- a/core/gui/src/app/workspace/service/panel/panel.service.ts
+++ b/core/gui/src/app/workspace/service/panel/panel.service.ts
@@ -5,6 +5,7 @@ import { Injectable } from "@angular/core";
   providedIn: "root",
 })
 export class PanelService {
+  private openPanelSubject = new Subject<void>();
   private closePanelSubject = new Subject<void>();
   private resetPanelSubject = new Subject<void>();
 
@@ -22,5 +23,13 @@ export class PanelService {
 
   closePanels() {
     this.closePanelSubject.next();
+  }
+
+  get openPanelStream() {
+    return this.openPanelSubject.asObservable();
+  }
+
+  openPanels() {
+    this.openPanelSubject.next();
   }
 }

--- a/core/gui/src/app/workspace/service/panel/panel.service.ts
+++ b/core/gui/src/app/workspace/service/panel/panel.service.ts
@@ -5,31 +5,54 @@ import { Injectable } from "@angular/core";
   providedIn: "root",
 })
 export class PanelService {
-  private openPanelSubject = new Subject<void>();
   private closePanelSubject = new Subject<void>();
   private resetPanelSubject = new Subject<void>();
+  private openPropertyPanelSubject = new Subject<void>();
+  private closePropertyPanelSubject = new Subject<void>();
+
+  private _isPanelOpen = false;
+
+  get isPanelOpen(): boolean {
+    return this._isPanelOpen;
+  }
 
   get resetPanelStream() {
+    this._isPanelOpen = true;
     return this.resetPanelSubject.asObservable();
   }
 
   resetPanels() {
+    this._isPanelOpen = true;
     this.resetPanelSubject.next();
   }
 
   get closePanelStream() {
+    this._isPanelOpen = false;
     return this.closePanelSubject.asObservable();
   }
 
   closePanels() {
+    this._isPanelOpen = false;
     this.closePanelSubject.next();
   }
 
-  get openPanelStream() {
-    return this.openPanelSubject.asObservable();
+  get openPropertyPanelStream() {
+    this._isPanelOpen = true;
+    return this.openPropertyPanelSubject.asObservable();
   }
 
-  openPanels() {
-    this.openPanelSubject.next();
+  openPropertyPanel() {
+    this._isPanelOpen = true;
+    this.openPropertyPanelSubject.next();
+  }
+
+  get closePropertyPanelStream() {
+    this._isPanelOpen = false;
+    return this.closePropertyPanelSubject.asObservable();
+  }
+
+  closePropertyPanel() {
+    this._isPanelOpen = false;
+    this.closePropertyPanelSubject.next();
   }
 }


### PR DESCRIPTION
# Purpose
This pull request adds support for toggling the property panel by double-clicking on an operator in the workflow editor. The goal is to improve usability by allowing users to quickly open or close the property panel without relying on other UI elements. 

# Changes
- Subscribed to openPropertyPanelStream and closePropertyPanelStream in PropertyEditorComponent to handle panel visibility.
- Imported PanelService into WorkflowEditorComponent and injected it via the constructor.
- Added double-click logic in WorkflowEditorComponent to open or close the property panel based on isPanelOpen.
- Introduced openPropertyPanelSubject and closePropertyPanelSubject streams in PanelService along with their corresponding methods and accessors.

# Demo
![double-click](https://github.com/user-attachments/assets/ad8d0e3d-83be-4692-9184-5f7ed063f2f6)


