### PR TITLE
fix(amber): fix output port writer thread closed by finalizing an input port

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -178,7 +178,9 @@ class DataProcessor(
           asyncRPCClient.mkContext(CONTROLLER)
         )
       case FinalizePort(portId, input) =>
-        outputManager.closeOutputStorageWriterIfNeeded(portId)
+        if (!input) {
+          outputManager.closeOutputStorageWriterIfNeeded(portId)
+        }
         asyncRPCClient.controllerInterface.portCompleted(
           PortCompletedRequest(portId, input),
           asyncRPCClient.mkContext(CONTROLLER)


### PR DESCRIPTION
The current logic that determines when an output port result writer thread should be terminated is not correct as it can be called upon the completion of either an input port or an output port. This causes a port result writer to be closed earlier than it should.

The fix is to enforce that only an output port's `FinalizePort` should call the `closeOutputStorageWriterIfNeeded` method.