### PR TITLE
feat: enable configurable multipart upload settings

### DIFF
--- a/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
+++ b/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
@@ -47,7 +47,7 @@ class ConfigResource {
       "productionSharedEditingServer" -> GuiConfig.guiWorkflowWorkspaceProductionSharedEditingServer,
       "singleFileUploadMaximumSizeMB" -> GuiConfig.guiDatasetSingleFileUploadMaximumSizeMB,
       "maxNumberOfConcurrentUploadingFileChunks" -> GuiConfig.guiDatasetMaxNumberOfConcurrentUploadingFileChunks,
-      "multipartUploadChunkSizeByte" -> GuiConfig.guiDatasetMultipartUploadChunkSizeByte,
+      "multipartUploadChunkSizeMB" -> GuiConfig.guiDatasetMultipartUploadChunkSizeMB,
       "defaultDataTransferBatchSize" -> GuiConfig.guiWorkflowWorkspaceDefaultDataTransferBatchSize,
       "workflowEmailNotificationEnabled" -> GuiConfig.guiWorkflowWorkspaceWorkflowEmailNotificationEnabled,
       "sharingComputingUnitEnabled" -> ComputingUnitConfig.sharingComputingUnitEnabled,

--- a/core/config/src/main/resources/gui.conf
+++ b/core/config/src/main/resources/gui.conf
@@ -113,7 +113,7 @@ gui {
     max-number-of-concurrent-uploading-file-chunks = ${?GUI_DATASET_MAX_NUMBER_OF_CONCURRENT_UPLOADING_FILE_CHUNKS}
 
     # the size of each chunk during the multipart upload of file
-    multipart-upload-chunk-size-byte = 52428800 # 50 MB
-    multipart-upload-chunk-size-byte = ${?GUI_DATASET_MULTIPART_UPLOAD_CHUNK_SIZE_BYTE}
+    multipart-upload-chunk-size-mb = 50 # 50 MB
+    multipart-upload-chunk-size-mb = ${?GUI_DATASET_MULTIPART_UPLOAD_CHUNK_SIZE_BYTE}
   }
 }

--- a/core/config/src/main/scala/edu/uci/ics/texera/config/GuiConfig.scala
+++ b/core/config/src/main/scala/edu/uci/ics/texera/config/GuiConfig.scala
@@ -71,6 +71,6 @@ object GuiConfig {
     conf.getInt("gui.dataset.single-file-upload-maximum-size-mb")
   val guiDatasetMaxNumberOfConcurrentUploadingFileChunks: Int =
     conf.getInt("gui.dataset.max-number-of-concurrent-uploading-file-chunks")
-  val guiDatasetMultipartUploadChunkSizeByte: Long =
-    conf.getLong("gui.dataset.multipart-upload-chunk-size-byte")
+  val guiDatasetMultipartUploadChunkSizeMB: Long =
+    conf.getLong("gui.dataset.multipart-upload-chunk-size-mb")
 }

--- a/core/gui/src/app/app.module.ts
+++ b/core/gui/src/app/app.module.ts
@@ -171,6 +171,7 @@ import { NzSliderModule } from "ng-zorro-antd/slider";
 import { AdminSettingsComponent } from "./dashboard/component/admin/settings/admin-settings.component";
 import { catchError, of } from "rxjs";
 import { FormlyRepeatDndComponent } from "./common/formly/repeat-dnd/repeat-dnd.component";
+import { NzInputNumberModule } from "ng-zorro-antd/input-number";
 
 registerLocaleData(en);
 
@@ -328,6 +329,7 @@ registerLocaleData(en);
     NzEmptyModule,
     NzDividerModule,
     NzProgressModule,
+    NzInputNumberModule,
   ],
   providers: [
     provideNzI18n(en_US),

--- a/core/gui/src/app/common/service/gui-config.service.mock.ts
+++ b/core/gui/src/app/common/service/gui-config.service.mock.ts
@@ -44,7 +44,7 @@ export class MockGuiConfigService {
     pythonLanguageServerPort: "3000",
     singleFileUploadMaximumSizeMB: 100,
     maxNumberOfConcurrentUploadingFileChunks: 5,
-    multipartUploadChunkSizeByte: 1048576, // 1MB
+    multipartUploadChunkSizeMB: 1, // 1MB
     defaultDataTransferBatchSize: 100,
     workflowEmailNotificationEnabled: false,
     sharingComputingUnitEnabled: false,

--- a/core/gui/src/app/common/type/gui-config.ts
+++ b/core/gui/src/app/common/type/gui-config.ts
@@ -35,7 +35,7 @@ export interface GuiConfig {
   pythonLanguageServerPort: string;
   singleFileUploadMaximumSizeMB: number;
   maxNumberOfConcurrentUploadingFileChunks: number;
-  multipartUploadChunkSizeByte: number;
+  multipartUploadChunkSizeMB: number;
   defaultDataTransferBatchSize: number;
   workflowEmailNotificationEnabled: boolean;
   sharingComputingUnitEnabled: boolean;

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -241,6 +241,53 @@
           nzActive="true"
           nzHeader="Create New Version">
           <texera-user-files-uploader (uploadedFiles)="onNewUploadFilesChanged($event)"> </texera-user-files-uploader>
+
+          <nz-collapse
+            nzGhost
+            class="advanced-setting">
+            <nz-collapse-panel nzHeader="Advanced Settings">
+              <div class="settings-row">
+                <nz-form-item>
+                  <nz-form-label>
+                    Part Size (MB)
+                    <i
+                      nz-icon
+                      nzType="question-circle"
+                      nz-tooltip
+                      nzTooltipTitle="Size of each upload chunk, higher values use more memory."
+                      class="tooltip"></i>
+                  </nz-form-label>
+                  <nz-form-control>
+                    <nz-input-number
+                      [(ngModel)]="uploadChunkSizeMB"
+                      [nzMin]="10"
+                      [nzStep]="10">
+                    </nz-input-number>
+                  </nz-form-control>
+                </nz-form-item>
+
+                <nz-form-item>
+                  <nz-form-label>
+                    Concurrent Parts
+                    <i
+                      nz-icon
+                      nzType="question-circle"
+                      nz-tooltip
+                      nzTooltipTitle="Number of parallel uploads, higher values use more memory."
+                      class="tooltip"></i>
+                  </nz-form-label>
+                  <nz-form-control>
+                    <nz-input-number
+                      [(ngModel)]="uploadConcurrentChunks"
+                      [nzMin]="1"
+                      [nzStep]="1">
+                    </nz-input-number>
+                  </nz-form-control>
+                </nz-form-item>
+              </div>
+            </nz-collapse-panel>
+          </nz-collapse>
+
           <div class="upload-progress-wrapper">
             <div
               *ngFor="let task of uploadTasks; trackBy: trackByTask"

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
@@ -174,3 +174,21 @@ nz-select {
 .upload-progress-container {
   margin-left: 20px;
 }
+
+.advanced-setting {
+  margin-left: 20px;
+}
+
+.settings-row {
+  margin-left: 12px;
+  transform: scale(0.95);
+}
+
+.settings-row nz-form-item {
+  margin-bottom: 10px;
+}
+
+.tooltip {
+  margin-left: 6px;
+  color: #1890ff;
+}

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -137,10 +137,14 @@ export class DatasetService {
    * Handles multipart upload for large files using RxJS,
    * with a concurrency limit on how many parts we process in parallel.
    */
-  public multipartUpload(datasetName: string, filePath: string, file: File): Observable<MultipartUploadProgress> {
-    const partSize = this.config.env.multipartUploadChunkSizeByte;
+  public multipartUpload(
+    datasetName: string,
+    filePath: string,
+    file: File,
+    partSize: number,
+    concurrencyLimit: number
+  ): Observable<MultipartUploadProgress> {
     const partCount = Math.ceil(file.size / partSize);
-    const concurrencyLimit = this.config.env.maxNumberOfConcurrentUploadingFileChunks;
 
     // track progress bar
     let totalBytesUploaded = 0;


### PR DESCRIPTION
### **Purpose**
This PR addresses issue #3610 by enabling users to configure multipart upload parameters dynamically. Previously, all file uploads used fixed settings that might not be optimal for different network conditions and file sizes. Users can now adjust chunk size and concurrent upload count to optimize upload and balance upload speed vs. memory usage based on their specific requirements.

### **Changes**
- dataset-detailed.component.ts/scss/html: 
  - Introduced an advanced settings panel under the file uploader, values will be revert if page refreshed. 
  - Added two number inputs with minimum values of 1 MB (chunk size) and 1 part (concurrency). 
  - Included tooltips explain the memory ↔ speed trade-off for each control.
- datasetservice.ts: Extended multipartUpload() signature to accept partSize and concurrencyLimit.
- gui-config.service.mock.ts/gui-config.ts: Switched default chunk‐size from bytes to MB/count.
- gui.conf/GuiConfig.scala/ConfigResource.scala: Switched default chunk‐size from bytes to MB/count.
- app.module.ts: Imported the NzInputNumberModule to support the new controls.

### **Demonstration**
Advanced Settings panel under the file upload section (Default):
| Expanded | Collapsed |
|-------------|-------------|
| ![default](https://github.com/user-attachments/assets/4836c940-9c58-49af-809c-fccdd4ba7072) | ![default1](https://github.com/user-attachments/assets/bd405676-b563-4053-832e-cc11ea2fbbe5) |

| Chunk size | Concurrent chunk |
|-------------|-------------|
| ![tooltip](https://github.com/user-attachments/assets/7d1b4bc0-378b-43ec-85f1-373f1a377c4d) | ![tooltip1](https://github.com/user-attachments/assets/8dfcf6d0-57f0-4f83-b31f-22f99de291df) |

**After adjustment:** 
<img width="400" height="519" alt="changed" src="https://github.com/user-attachments/assets/58b2bc66-6d8c-4ef0-977f-6b119e831f00" />

**Performance Comparison:**
<img width="554" height="362" alt="sample" src="https://github.com/user-attachments/assets/d77be5ce-7b32-4d84-b621-1bc8fb8470d0" />



