### PR TITLE
fix: remove erisu/apache-rat-action@v1

### DIFF
--- a/.github/workflows/check-header.yml
+++ b/.github/workflows/check-header.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: erisu/apache-rat-action@v1
+#      - uses: erisu/apache-rat-action@v1


### PR DESCRIPTION
Remove the GitHub action erisu/apache-rat-action@v1 since it's not approved by the Apache organization.