### PR TITLE
chore(ci): let new commits trigger PR linter CI

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -22,6 +22,7 @@ on:
       - opened
       - edited
       - reopened
+      - synchronize
 
 jobs:
   main:


### PR DESCRIPTION
This PR fixes the CI issue where the PR linter is not being triggered. Now we let each new commit trigger this CI execution as well.