### PR TITLE
chore: Redirect jobs notifications to commits@t.a.o

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -76,4 +76,4 @@ notifications:
   issues:               dev@texera.apache.org
   pullrequests:         dev@texera.apache.org
   discussions:          dev@texera.apache.org
-  jobs:                 dev@texera.apache.org
+  jobs:                 commits@texera.apache.org


### PR DESCRIPTION
As we use GitHub Action to run CI, we prefer to keep those notifications in the commits mail list.