### PR TITLE
feat: enable file upload speed and time display

### DIFF
--- a/core/gui/src/app/common/util/format.util.ts
+++ b/core/gui/src/app/common/util/format.util.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+const BYTES_PER_UNIT = 1024;
+
+/**
+ * Format upload speed
+ */
+export const formatSpeed = (bytesPerSecond = 0) => {
+  if (bytesPerSecond <= 0) return "0.0 MB/s";
+
+  const mbps = bytesPerSecond / (BYTES_PER_UNIT * BYTES_PER_UNIT);
+  return `${mbps.toFixed(1)} MB/s`;
+};
+
+/**
+ * Format time duration
+ */
+export const formatTime = (seconds?: number): string => {
+  if (!seconds || seconds <= 0) return "1s";
+  const s = Math.max(1, Math.round(seconds));
+
+  // Under 1 minute: show seconds only
+  if (s < 60) {
+    return `${s}s`;
+  }
+
+  // Under 1 hour: show minutes (and seconds if not zero)
+  if (s < 3600) {
+    const m = Math.floor(s / 60);
+    const sec = s % 60;
+    return sec === 0 ? `${m}m` : `${m}m${sec.toString().padStart(2, "0")}s`;
+  }
+
+  // 1 hour+: show hours (and minutes if not zero)
+  const h = Math.floor(s / 3600);
+  const min = Math.floor((s % 3600) / 60);
+
+  return min === 0 ? `${h}h` : `${h}h${min}m`;
+};

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -263,12 +263,29 @@
                     nzTheme="outline"></i>
                 </button>
               </div>
+              <div
+                class="upload-stats"
+                *ngIf="task.status !== 'initializing'">
+                <nz-tag
+                  *ngIf="task.status === 'uploading'"
+                  [nzColor]="'blue'">
+                  <span class="fixed-width-speed">{{ formatSpeed(task.uploadSpeed) }}</span> • Elapsed:
+                  <span class="fixed-width-time">{{ formatTime(task.totalTime ?? 0) }}</span> • Remaining:
+                  <span class="fixed-width-time">{{ formatTime(task.estimatedTimeRemaining ?? 0) }}</span>
+                </nz-tag>
+
+                <nz-tag *ngIf="(task.status === 'finished' || task.status === 'aborted')">
+                  Total time: {{ formatTime(task.totalTime ?? 0) }}
+                </nz-tag>
+              </div>
               <nz-progress
                 [nzPercent]="task.percentage"
                 [nzStatus]="getUploadStatus(task.status)"></nz-progress>
             </div>
           </div>
+
           <texera-dataset-staged-objects-list
+            [uploadTimeMap]="uploadTimeMap"
             [did]="did"
             [userMakeChangesEvent]="userMakeChanges"
             (stagedObjectsChanged)="onStagedObjectsUpdated($event)"></texera-dataset-staged-objects-list>

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
@@ -193,3 +193,23 @@ nz-select {
 .version-input {
   padding: 6px;
 }
+
+.upload-stats {
+  font-size: 13px;
+}
+
+::ng-deep .ant-tag {
+  border: none !important;
+}
+
+.fixed-width-speed {
+  display: inline-block;
+  min-width: 5ch;
+  text-align: right;
+}
+
+.fixed-width-time {
+  display: inline-block;
+  min-width: 4ch;
+  text-align: right;
+}

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -42,6 +42,7 @@ import { UserDatasetVersionCreatorComponent } from "./user-dataset-version-creat
 import { AdminSettingsService } from "../../../../service/admin/settings/admin-settings.service";
 import { HttpErrorResponse } from "@angular/common/http";
 import { Subscription } from "rxjs";
+import { formatSpeed, formatTime } from "src/app/common/util/format.util";
 
 export const THROTTLE_TIME_MS = 1000;
 
@@ -83,6 +84,7 @@ export class DatasetDetailComponent implements OnInit {
   chunkSizeMB: number = 50;
   maxConcurrentChunks: number = 10;
   private uploadSubscriptions = new Map<string, Subscription>();
+  uploadTimeMap = new Map<string, number>();
 
   versionName: string = "";
   isCreatingVersion: boolean = false;
@@ -367,7 +369,9 @@ export class DatasetDetailComponent implements OnInit {
                 };
 
                 // Auto‑hide when upload is truly finished
-                if (progress.status === "finished") {
+                if (progress.status === "finished" && progress.totalTime) {
+                  const filename = file.name.split("/").pop() || file.name;
+                  this.uploadTimeMap.set(filename, progress.totalTime);
                   this.userMakeChanges.emit();
                   this.scheduleHide(taskIndex);
                 }
@@ -473,6 +477,8 @@ export class DatasetDetailComponent implements OnInit {
     }
     return count.toString();
   }
+  formatTime = formatTime;
+  formatSpeed = formatSpeed;
 
   toggleLike(): void {
     const userId = this.currentUid;

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.html
@@ -28,12 +28,14 @@
       </span>
       <span
         class="truncate-file-path"
-        [attr.data-fullpath]="obj.path"
         nz-tooltip
-        [nzTooltipTitle]="obj.path">
+        [nzTooltipTitle]="fileTooltipTpl">
         {{ obj.path }}
       </span>
-
+      <ng-template #fileTooltipTpl>
+        <div>{{ obj.path }}</div>
+        <div *ngIf="getFileUploadTime(obj.path) as uploadTime">Upload time: {{ formatTime(uploadTime) }}</div>
+      </ng-template>
       <!-- Small delete button with tooltip -->
       <button
         nz-button

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.ts
@@ -22,6 +22,7 @@ import { DatasetStagedObject } from "../../../../../../common/type/dataset-stage
 import { DatasetService } from "../../../../../service/user/dataset/dataset.service";
 import { NotificationService } from "../../../../../../common/service/notification/notification.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { formatTime } from "src/app/common/util/format.util";
 
 @UntilDestroy()
 @Component({
@@ -38,10 +39,12 @@ export class UserDatasetStagedObjectsListComponent implements OnInit {
       });
     }
   }
+  @Input() uploadTimeMap?: Map<string, number>;
 
   @Output() stagedObjectsChanged = new EventEmitter<DatasetStagedObject[]>(); // Emits staged objects list
 
   datasetStagedObjects: DatasetStagedObject[] = [];
+  formatTime = formatTime;
 
   constructor(
     private datasetService: DatasetService,
@@ -80,5 +83,12 @@ export class UserDatasetStagedObjectsListComponent implements OnInit {
           },
         });
     }
+  }
+
+  getFileUploadTime(filePath: string): number | null {
+    if (!this.uploadTimeMap) return null;
+
+    const filename = filePath.split("/").pop() || filePath;
+    return this.uploadTimeMap.get(filename) || null;
   }
 }

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -52,6 +52,9 @@ export interface MultipartUploadProgress {
   status: "initializing" | "uploading" | "finished" | "aborted";
   uploadId: string;
   physicalAddress: string;
+  uploadSpeed?: number; // bytes per second
+  estimatedTimeRemaining?: number; // seconds
+  totalTime?: number; // total seconds taken
 }
 
 @Injectable({
@@ -173,6 +176,58 @@ export class DatasetService {
       // Track upload progress for each part independently
       const partProgress = new Map<number, number>();
 
+      // Track upload speed & time
+      const startTime = Date.now();
+      let lastUpdateTime = startTime;
+      let lastUploadedBytes = 0;
+
+      // Simple smoothing
+      let smoothedSpeed = 0;
+      let smoothedTimeRemaining = 0;
+
+      const calculateStats = (totalUploaded: number) => {
+        const currentTime = Date.now();
+        const timeDelta = (currentTime - lastUpdateTime) / 1000;
+        const elapsedTime = (currentTime - startTime) / 1000;
+
+        // Calculate current speed (only update every 500ms to reduce jumpiness)
+        let currentSpeed = smoothedSpeed;
+        if (timeDelta > 1.0) {
+          const bytesDelta = totalUploaded - lastUploadedBytes;
+          const instantSpeed = bytesDelta / timeDelta;
+
+          // smoothing for speed
+          if (smoothedSpeed === 0) {
+            smoothedSpeed = instantSpeed;
+          } else {
+            smoothedSpeed = 0.3 * instantSpeed + 0.7 * smoothedSpeed;
+          }
+          currentSpeed = smoothedSpeed;
+
+          lastUpdateTime = currentTime;
+          lastUploadedBytes = totalUploaded;
+        }
+
+        // Calculate time remaining with smoothing
+        const remainingBytes = file.size - totalUploaded;
+        if (currentSpeed > 0 && remainingBytes > 0) {
+          const instantTimeRemaining = Math.min(remainingBytes / currentSpeed, 24 * 3600); // max: 24h
+
+          // Simple smoothing for time remaining
+          if (smoothedTimeRemaining === 0) {
+            smoothedTimeRemaining = instantTimeRemaining;
+          } else {
+            smoothedTimeRemaining = 0.2 * instantTimeRemaining + 0.8 * smoothedTimeRemaining;
+          }
+        }
+
+        return {
+          uploadSpeed: currentSpeed,
+          estimatedTimeRemaining: Math.max(0, smoothedTimeRemaining),
+          totalTime: elapsedTime,
+        };
+      };
+
       const subscription = this.initiateMultipartUpload(datasetName, filePath, partCount)
         .pipe(
           switchMap(initiateResponse => {
@@ -187,6 +242,9 @@ export class DatasetService {
               status: "initializing",
               uploadId: uploadId,
               physicalAddress: physicalAddress,
+              uploadSpeed: 0,
+              estimatedTimeRemaining: 0,
+              totalTime: 0,
             });
 
             // Keep track of all uploaded parts
@@ -214,6 +272,7 @@ export class DatasetService {
                       let totalUploaded = 0;
                       partProgress.forEach(bytes => (totalUploaded += bytes));
                       const percentage = Math.round((totalUploaded / file.size) * 100);
+                      const stats = calculateStats(totalUploaded);
 
                       observer.next({
                         filePath,
@@ -221,6 +280,9 @@ export class DatasetService {
                         status: "uploading",
                         uploadId,
                         physicalAddress,
+                        uploadSpeed: stats.uploadSpeed,
+                        estimatedTimeRemaining: stats.estimatedTimeRemaining,
+                        totalTime: stats.totalTime,
                       });
                     }
                   });
@@ -241,6 +303,7 @@ export class DatasetService {
                       let totalUploaded = 0;
                       partProgress.forEach(bytes => (totalUploaded += bytes));
                       const percentage = Math.round((totalUploaded / file.size) * 100);
+                      const stats = calculateStats(totalUploaded);
 
                       observer.next({
                         filePath,
@@ -248,6 +311,9 @@ export class DatasetService {
                         status: "uploading",
                         uploadId,
                         physicalAddress,
+                        uploadSpeed: stats.uploadSpeed,
+                        estimatedTimeRemaining: stats.estimatedTimeRemaining,
+                        totalTime: stats.totalTime,
                       });
                       partObserver.complete();
                     } else {
@@ -273,23 +339,31 @@ export class DatasetService {
                 this.finalizeMultipartUpload(datasetName, filePath, uploadId, uploadedParts, physicalAddress, false)
               ),
               tap(() => {
+                const finalTotalTime = (Date.now() - startTime) / 1000;
                 observer.next({
                   filePath,
                   percentage: 100,
                   status: "finished",
                   uploadId: uploadId,
                   physicalAddress: physicalAddress,
+                  uploadSpeed: 0,
+                  estimatedTimeRemaining: 0,
+                  totalTime: finalTotalTime,
                 });
                 observer.complete();
               }),
               catchError((error: unknown) => {
                 // If an error occurred, abort the upload
+                const currentTotalTime = (Date.now() - startTime) / 1000;
                 observer.next({
                   filePath,
                   percentage: Math.round((uploadedParts.length / partCount) * 100),
                   status: "aborted",
                   uploadId: uploadId,
                   physicalAddress: physicalAddress,
+                  uploadSpeed: 0,
+                  estimatedTimeRemaining: 0,
+                  totalTime: currentTotalTime,
                 });
 
                 return this.finalizeMultipartUpload(


### PR DESCRIPTION
### **Purpose**
This PR enhances the upload experience by displaying real-time speed, elapsed time, and estimated time remaining (ETA) in a compact tag, so users can understand progress at a glance and reference the final upload duratione via tooltip after completion.

### **Changes**
dataset.service.ts: add uploadSpeed, totalTime, estimatedTimeRemaining to MultipartUploadProgress; apply smoothing for speed/ETA; cap ETA at 24h; add basic bounds checks
dataset-detail.component.ts/html/scss: render compact status tag \<speed> • Elapsed <time> • Remaining <time>; apply fixed/min width to time/speed to reduce jitter.
user-dataset-staged-objects-list.component.ts/html: show post-upload duration in the file tooltip (full path + upload time)
gui/src/app/common/util/format.util.ts: add formatting utilities for time and speed.

### **Demonstration**
**Single File:**

https://github.com/user-attachments/assets/72291b68-1b50-40a3-a81c-b46bde9a7f9a

**Speed-limited (throttled):**

https://github.com/user-attachments/assets/7748d9f1-d197-44b7-bb02-9444c03cec49


**Multiple Files:**

https://github.com/user-attachments/assets/6bca7ec8-c019-40ff-b1da-34dabad88aad

