### PR TITLE
feat: enforce S3 multipart-upload limits in configuration

### DIFF
--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.html
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.html
@@ -245,32 +245,38 @@
     <nz-input-number
       [(ngModel)]="maxFileSizeMB"
       [nzMin]="1"
+      [nzMax]="MAX_FILE_SIZE_MB"
       [nzStep]="10">
     </nz-input-number>
   </div>
-  <div class="help-text-number">Maximum size allowed for individual file uploads (MB).</div>
+  <div class="help-text-number">
+    Maximum size allowed for individual file uploads (MB). (Range: 1 MB - {{ MAX_FILE_SIZE_MB }} MB (5 TiB))
+  </div>
 
   <div class="settings-row">
     <span>Concurrent Parts:</span>
     <nz-input-number
       [(ngModel)]="maxConcurrentChunks"
       [nzMin]="1"
+      [nzMax]="MAX_TOTAL_PARTS"
       [nzStep]="1">
     </nz-input-number>
   </div>
-  <div class="help-text-number">
-    Number of file chunks that can be uploaded simultaneously. Higher values use more memory.
-  </div>
+  <div class="help-text-number">Number of file chunks that can be uploaded simultaneously. (Range: 1 - 10000)</div>
 
   <div class="settings-row">
     <span>Part Size:</span>
     <nz-input-number
       [(ngModel)]="chunkSizeMB"
-      [nzMin]="1"
+      [nzMin]="MIN_PART_SIZE_MB"
+      [nzMax]="MAX_PART_SIZE_MB"
       [nzStep]="10">
     </nz-input-number>
   </div>
-  <div class="help-text-number">Size of each chunk during multipart upload in MB. Larger chunks use more memory.</div>
+  <div class="help-text-number">
+    Size of each chunk during multipart upload in MB. (Range: {{ MIN_PART_SIZE_MB }} MB - {{ MAX_PART_SIZE_MB }} MB (5
+    GiB))
+  </div>
 
   <div class="button-row">
     <button

--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.ts
@@ -52,6 +52,12 @@ export class AdminSettingsComponent implements OnInit {
   maxConcurrentChunks: number = 10;
   chunkSizeMB: number = 50;
 
+  // S3 Multipart Upload Constraints
+  readonly MIN_PART_SIZE_MB = 5; // 5 MiB minimum for parts (except last part)
+  readonly MAX_PART_SIZE_MB = 5120; // 5 GiB maximum per part (5 * 1024 MiB)
+  readonly MAX_FILE_SIZE_MB = 5242880; // 5 TiB maximum object size (5 * 1024 * 1024 MiB)
+  readonly MAX_TOTAL_PARTS = 10000; // S3 maximum parts per upload
+
   constructor(
     private adminSettingsService: AdminSettingsService,
     private message: NzMessageService
@@ -204,8 +210,28 @@ export class AdminSettingsComponent implements OnInit {
   }
 
   saveDatasetSettings(): void {
-    if (this.maxFileSizeMB < 1 || this.maxConcurrentChunks < 1 || this.chunkSizeMB < 1) {
-      this.message.info("Value must be at least 1.");
+    if (this.maxFileSizeMB < 1 || this.maxFileSizeMB > this.MAX_FILE_SIZE_MB) {
+      this.message.error("File size must be between 1 MB and 5,242,880 MB (5 TiB).");
+      return;
+    }
+
+    if (this.chunkSizeMB < this.MIN_PART_SIZE_MB || this.chunkSizeMB > this.MAX_PART_SIZE_MB) {
+      this.message.error("Part size must be between 5 MB and 5,120 MB (5 GiB).");
+      return;
+    }
+
+    if (this.maxConcurrentChunks < 1) {
+      this.message.error("Concurrent Parts must be at least 1.");
+      return;
+    }
+
+    const partsAtMax = Math.ceil(this.maxFileSizeMB / this.chunkSizeMB);
+    if (partsAtMax > this.MAX_TOTAL_PARTS) {
+      const requiredMin = Math.max(this.MIN_PART_SIZE_MB, Math.ceil(this.maxFileSizeMB / this.MAX_TOTAL_PARTS));
+      this.message.error(
+        `This setting would create ${partsAtMax.toLocaleString()} parts (>10,000). ` +
+          `Increase "Part Size" to at least ${requiredMin} MB or reduce "File Size".`
+      );
       return;
     }
 


### PR DESCRIPTION
### **Purpose**
This PR adds validation to Admin → Dataset settings to ensure all multipart-upload configurations comply with AWS S3 limits, preventing uploads from aborting or being rejected.

### **Changes**
- admin-settings.component.ts/html: enforce maximum object size, per-part size, and total parts-per-upload as defined in the attached limits; block saving invalid configurations and display error messages.

<img width="972" height="361" alt="limitation" src="https://github.com/user-attachments/assets/bb2a9efa-a9d8-4b22-8639-838eecb6bd00" />

### **Demonstration**
New interface:
<img width="791" height="346" alt="new-ui" src="https://github.com/user-attachments/assets/d752a393-6795-4f0d-b1ac-da6e89f0b522" />
