### PR TITLE
chore: improve naming convention of admin user resource 

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -36,7 +36,7 @@ import javax.annotation.security.RolesAllowed
 import javax.ws.rs._
 import javax.ws.rs.core.{MediaType, Response}
 
-case class UserWithLastLogin(
+case class UserInfo(
     uid: Int,
     name: String,
     email: String,
@@ -58,14 +58,14 @@ object AdminUserResource {
 @RolesAllowed(Array("ADMIN"))
 class AdminUserResource {
   /**
-    * This method returns the list of users with lastLogin time
+    * This method returns the list of users
     *
-    * @return a list of UserWithLastLogin
+    * @return a list of UserInfo
     */
   @GET
   @Path("/list")
   @Produces(Array(MediaType.APPLICATION_JSON))
-  def listUserWithActivity(): util.List[UserWithLastLogin] = {
+  def listUserWithActivity(): util.List[UserInfo] = {
     AdminUserResource.context
       .select(
         USER.UID,
@@ -80,7 +80,7 @@ class AdminUserResource {
       .from(USER)
       .leftJoin(TIME_LOG)
       .on(USER.UID.eq(TIME_LOG.UID))
-      .fetchInto(classOf[UserWithLastLogin])
+      .fetchInto(classOf[UserInfo])
   }
 
   @PUT

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -57,26 +57,13 @@ object AdminUserResource {
 @Path("/admin/user")
 @RolesAllowed(Array("ADMIN"))
 class AdminUserResource {
-
-  /**
-    * This method returns the list of users
-    *
-    * @return a list of users
-    */
-  @GET
-  @Path("/list")
-  @Produces(Array(MediaType.APPLICATION_JSON))
-  def listUser(): util.List[User] = {
-    userDao.fetchRangeOfUid(Integer.MIN_VALUE, Integer.MAX_VALUE)
-  }
-
   /**
     * This method returns the list of users with lastLogin time
     *
     * @return a list of UserWithLastLogin
     */
   @GET
-  @Path("/listWithActivity")
+  @Path("/list")
   @Produces(Array(MediaType.APPLICATION_JSON))
   def listUserWithActivity(): util.List[UserWithLastLogin] = {
     AdminUserResource.context

--- a/core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts
+++ b/core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts
@@ -25,7 +25,7 @@ import { Role, User, File, Workflow, ExecutionQuota } from "../../../../common/t
 import { DatasetQuota } from "src/app/dashboard/type/quota-statistic.interface";
 
 export const USER_BASE_URL = `${AppSettings.getApiEndpoint()}/admin/user`;
-export const USER_LIST_URL = `${USER_BASE_URL}/listWithActivity`;
+export const USER_LIST_URL = `${USER_BASE_URL}/list`;
 export const USER_UPDATE_URL = `${USER_BASE_URL}/update`;
 export const USER_ADD_URL = `${USER_BASE_URL}/add`;
 export const USER_CREATED_FILES = `${USER_BASE_URL}/uploaded_files`;


### PR DESCRIPTION
## Summary

In effort to improve the naming convention of variables and api endpoints of previous PR #3625, this PR is raised to change the names and signatures of two files: 
1. core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
2. core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts

The original obsolete `/list` is no longer used, therefore it has been replaced with the code inside the api endpoint `/listWithActivity`.  
The class name `UserWithLastLogin` is changed to `UserInfo` to make the name more intuitive.

Fixes Issue #3624.
