### PR TITLE
chore(ci): Add Mock DB and JOOQ Generation to CI

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -89,7 +89,7 @@ jobs:
           - 5432:5432
         # Add a health check so steps wait until Postgres is ready
         options: >-
-          --health-cmd="pg_isready -U test -d texera_db"
+          --health-cmd="pg_isready -U postgres"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -71,42 +71,55 @@ jobs:
         run: yarn --cwd core/gui run build:ci
 
   core:
-    strategy:
-      matrix:
-        os: [ ubuntu-22.04 ]
-        java-version: [ 11 ]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        # Add a health check so steps wait until Postgres is ready
+        options: >-
+          --health-cmd="pg_isready -U test -d texera_db"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
-      - name: Prepare ENV
-        run: sudo apt-get install libncurses5
-      - name: Checkout Texera
-        uses: actions/checkout@v2
-      - name: Setup Java
-        uses: actions/setup-java@v2
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: ${{ matrix.java-version }}
+          java-version: 11
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@v1
       - uses: coursier/cache-action@v6
         with:
           extraSbtFiles: '["core/*.sbt", "core/project/**.{scala,sbt}", "core/project/build.properties" ]'
       - name: Lint with scalafmt
         run: cd core && sbt scalafmtCheckAll
+      - name: Create Database
+        run: psql -h localhost -U postgres -f deployment/k8s/texera-helmchart/files/texera_ddl.sql
+        env:
+          PGPASSWORD: postgres
+      - name: Jooq Code Generator
+        run: cd core && sbt "DAO/runMain edu.uci.ics.texera.dao.JooqCodeGenerator"
       - name: Compile with sbt
         run: cd core && sbt clean package
       - name: Run backend tests
         run: cd core && sbt test
 
   python_udf:
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Texera
         uses: actions/checkout@v2

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -71,14 +71,14 @@ jobs:
         run: yarn --cwd core/gui run build:ci
 
   core:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     services:
       postgres:
-        image: postgres:16
+        image: postgres
         env:
           POSTGRES_PASSWORD: postgres
         ports:

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -71,7 +71,11 @@ jobs:
         run: yarn --cwd core/gui run build:ci
 
   core:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04 ]
+        java-version: [ 11 ]
+    runs-on: ${{ matrix.os }}
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
@@ -118,8 +122,9 @@ jobs:
   python_udf:
     strategy:
       matrix:
+        os: [ ubuntu-latest ]
         python-version: [ '3.9', '3.10', '3.11', '3.12' ]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Texera
         uses: actions/checkout@v2

--- a/core/config/src/main/resources/storage.conf
+++ b/core/config/src/main/resources/storage.conf
@@ -128,7 +128,7 @@ storage {
         username = "postgres"
         username = ${?STORAGE_JDBC_USERNAME}
 
-        password = ""
+        password = "postgres"
         password = ${?STORAGE_JDBC_PASSWORD}
     }
 }


### PR DESCRIPTION
This PR introduces the following changes:

1. Adds a mock database for use in the CI environment.
2. Configures CI to generate JOOQ files before running tests.

We are planning to remove the JOOQ-generated files from the codebase. However, the CI/CD pipeline currently relies on these files, and JOOQ cannot regenerate them without a live database, which is not available during CI/CD runs. This change addresses that limitation.

Additionally, the default configuration is updated to use the password `postgres` instead of an empty string. This change is necessary because the CI database does not permit empty passwords. It has no impact on development or production environments, as developers and deployment will override this default with their own credentials.

Closes issue #3688.