### PR TITLE
chore: fix token refresh interval to prevent frequent logout

### DIFF
--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -170,8 +170,8 @@ export class AuthService {
 
   private registerAutoRefreshToken() {
     this.refreshTokenSubscription?.unsubscribe();
-    const TOKEN_REFRESH_INTERVAL_IN_MIN = this.config.env.expirationTimeInMinutes + 1;
-    // Token Refresh Interval set to Token Expiration Time + 1
+    const TOKEN_REFRESH_INTERVAL_IN_MIN = this.config.env.expirationTimeInMinutes - 1;
+    // Token Refresh Interval set to Token Expiration Time - 1
     this.refreshTokenSubscription = interval(TOKEN_REFRESH_INTERVAL_IN_MIN * 60 * 1000)
       .pipe(startWith(0)) // to trigger immediately for the first time.
       .subscribe(() => {


### PR DESCRIPTION
### Summary
After the change in #3625, many users reported that they are now more frequently logged out after some inactivity. We investigated and found that token refresh interval is falsely set to a value larger than token expiration time, which led to this behavior. This PR fixes this issue.

Changed token refresh interval to be equal to token expiration time - 1.

In order to keep active users logged in, the refresh interval should be less than the expiration time so that the token gets refreshed correctly.

Fixes Issue #3624