### PR TITLE
chore: update default Iceberg catalog type to 'postgres'

### DIFF
--- a/core/config/src/main/resources/storage.conf
+++ b/core/config/src/main/resources/storage.conf
@@ -23,7 +23,7 @@ storage {
     # Configuration for Apache Iceberg, used for storing the workflow results & stats
     iceberg {
         catalog {
-            type = hadoop # either hadoop, rest, or postgres
+            type = postgres # either hadoop, rest, or postgres
             type = ${?STORAGE_ICEBERG_CATALOG_TYPE}
 
             rest-uri = ""


### PR DESCRIPTION
Changed the default catalog type from 'hadoop' to 'postgres' for Apache Iceberg configuration.

New developers previously had to manually set the catalog type to `postgres` in `core/config/src/main/resources/storage.conf` because the CI lacked a Postgres instance, and using it as the default would cause failures. However, since PR #3689 added a mock DB for CI, we can now safely set postgres as the default in the config file.

After this PR, we no longer need the following step in the wiki:

<img width="918" height="310" alt="Screenshot 2025-09-02 at 17 23 46" src="https://github.com/user-attachments/assets/f5558742-af5b-48e0-96e5-b4d34dd47eb6" />

https://github.com/apache/texera/wiki/Guide-for-Developers#clone-and-configure-texera
