### PR TITLE
fix: separate user activity window from jwt expiration

### DIFF
--- a/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
+++ b/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
@@ -54,6 +54,7 @@ class ConfigResource {
         "username" -> GuiConfig.guiLoginDefaultLocalUserUsername,
         "password" -> GuiConfig.guiLoginDefaultLocalUserPassword
       ),
+      "activeTimeInMinutes" -> GuiConfig.guiWorkflowWorkspaceActiveTimeInMinutes,
       // flags from the auth.conf if needed
       "expirationTimeInMinutes" -> AuthConfig.jwtExpirationMinutes
     )

--- a/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
+++ b/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
@@ -55,6 +55,8 @@ class ConfigResource {
         "password" -> GuiConfig.guiLoginDefaultLocalUserPassword
       ),
       "activeTimeInMinutes" -> GuiConfig.guiWorkflowWorkspaceActiveTimeInMinutes,
+      // flags from the auth.conf if needed
+      "expirationTimeInMinutes" -> AuthConfig.jwtExpirationMinutes
     )
 
   @GET

--- a/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
+++ b/core/config-service/src/main/scala/edu/uci/ics/texera/service/resource/ConfigResource.scala
@@ -55,8 +55,6 @@ class ConfigResource {
         "password" -> GuiConfig.guiLoginDefaultLocalUserPassword
       ),
       "activeTimeInMinutes" -> GuiConfig.guiWorkflowWorkspaceActiveTimeInMinutes,
-      // flags from the auth.conf if needed
-      "expirationTimeInMinutes" -> AuthConfig.jwtExpirationMinutes
     )
 
   @GET

--- a/core/config/src/main/resources/auth.conf
+++ b/core/config/src/main/resources/auth.conf
@@ -19,7 +19,7 @@
 # Configuration for JWT Authentication. Currently it is used by the FileService to parse the given JWT Token
 auth {
     jwt {
-        expiration-in-minutes = 15
+        expiration-in-minutes = 7200
         expiration-in-minutes = ${?AUTH_JWT_EXPIRATION_IN_MINUTES}
 
         256-bit-secret = "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"

--- a/core/config/src/main/resources/auth.conf
+++ b/core/config/src/main/resources/auth.conf
@@ -19,7 +19,7 @@
 # Configuration for JWT Authentication. Currently it is used by the FileService to parse the given JWT Token
 auth {
     jwt {
-        expiration-in-minutes = 7200
+        expiration-in-minutes = 2880
         expiration-in-minutes = ${?AUTH_JWT_EXPIRATION_IN_MINUTES}
 
         256-bit-secret = "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"

--- a/core/config/src/main/resources/gui.conf
+++ b/core/config/src/main/resources/gui.conf
@@ -101,7 +101,7 @@ gui {
     workflow-email-notification-enabled = false
     workflow-email-notification-enabled = ${?GUI_WORKFLOW_WORKSPACE_WORKFLOW_EMAIL_NOTIFICATION_ENABLED}
 
-    # amount of time to be elapsed before user is detected as inactive
+    # amount of time to be elapsed in minutes before user is detected as inactive
     active-time-in-minutes = 15
     active-time-in-minutes = ${?GUI_WORKFLOW_WORKSPACE_ACTIVE_TIME_IN_MINUTES}
   }

--- a/core/config/src/main/resources/gui.conf
+++ b/core/config/src/main/resources/gui.conf
@@ -100,5 +100,9 @@ gui {
     # whether to send email notification when workflow execution is completed/failed/paused/killed
     workflow-email-notification-enabled = false
     workflow-email-notification-enabled = ${?GUI_WORKFLOW_WORKSPACE_WORKFLOW_EMAIL_NOTIFICATION_ENABLED}
+
+    # amount of time to be elapsed before user is detected as inactive
+    active-time-in-minutes = 15
+    active-time-in-minutes = ${?GUI_WORKFLOW_WORKSPACE_ACTIVE_TIME_IN_MINUTES}
   }
 }

--- a/core/config/src/main/scala/edu/uci/ics/texera/config/GuiConfig.scala
+++ b/core/config/src/main/scala/edu/uci/ics/texera/config/GuiConfig.scala
@@ -65,4 +65,6 @@ object GuiConfig {
     conf.getInt("gui.workflow-workspace.operator-console-message-buffer-size")
   val guiWorkflowWorkspaceWorkflowEmailNotificationEnabled: Boolean =
     conf.getBoolean("gui.workflow-workspace.workflow-email-notification-enabled")
+  val guiWorkflowWorkspaceActiveTimeInMinutes: Int =
+    conf.getInt("gui.workflow-workspace.active-time-in-minutes")
 }

--- a/core/gui/src/app/common/service/gui-config.service.mock.ts
+++ b/core/gui/src/app/common/service/gui-config.service.mock.ts
@@ -47,7 +47,6 @@ export class MockGuiConfigService {
     sharingComputingUnitEnabled: false,
     operatorConsoleMessageBufferSize: 1000,
     defaultLocalUser: { username: "", password: "" },
-    expirationTimeInMinutes: 2880,
     activeTimeInMinutes: 15
   };
 

--- a/core/gui/src/app/common/service/gui-config.service.mock.ts
+++ b/core/gui/src/app/common/service/gui-config.service.mock.ts
@@ -48,7 +48,7 @@ export class MockGuiConfigService {
     operatorConsoleMessageBufferSize: 1000,
     defaultLocalUser: { username: "", password: "" },
     expirationTimeInMinutes: 2880,
-    activeTimeInMinutes: 15
+    activeTimeInMinutes: 15,
   };
 
   get env(): GuiConfig {

--- a/core/gui/src/app/common/service/gui-config.service.mock.ts
+++ b/core/gui/src/app/common/service/gui-config.service.mock.ts
@@ -47,7 +47,7 @@ export class MockGuiConfigService {
     sharingComputingUnitEnabled: false,
     operatorConsoleMessageBufferSize: 1000,
     defaultLocalUser: { username: "", password: "" },
-    expirationTimeInMinutes: 7200,
+    expirationTimeInMinutes: 2880,
     activeTimeInMinutes: 15
   };
 

--- a/core/gui/src/app/common/service/gui-config.service.mock.ts
+++ b/core/gui/src/app/common/service/gui-config.service.mock.ts
@@ -47,6 +47,7 @@ export class MockGuiConfigService {
     sharingComputingUnitEnabled: false,
     operatorConsoleMessageBufferSize: 1000,
     defaultLocalUser: { username: "", password: "" },
+    expirationTimeInMinutes: 2880,
     activeTimeInMinutes: 15
   };
 

--- a/core/gui/src/app/common/service/gui-config.service.mock.ts
+++ b/core/gui/src/app/common/service/gui-config.service.mock.ts
@@ -47,7 +47,8 @@ export class MockGuiConfigService {
     sharingComputingUnitEnabled: false,
     operatorConsoleMessageBufferSize: 1000,
     defaultLocalUser: { username: "", password: "" },
-    expirationTimeInMinutes: 15,
+    expirationTimeInMinutes: 7200,
+    activeTimeInMinutes: 15
   };
 
   get env(): GuiConfig {

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -170,8 +170,8 @@ export class AuthService {
 
   private registerAutoRefreshToken() {
     this.refreshTokenSubscription?.unsubscribe();
-    const TOKEN_REFRESH_INTERVAL_IN_MIN = this.config.env.expirationTimeInMinutes - 1;
-    // Token Refresh Interval set to Token Expiration Time - 1
+    const TOKEN_REFRESH_INTERVAL_IN_MIN = this.config.env.activeTimeInMinutes - 1;
+    // Token Refresh Interval set to Active Window Time - 1
     this.refreshTokenSubscription = interval(TOKEN_REFRESH_INTERVAL_IN_MIN * 60 * 1000)
       .pipe(startWith(0)) // to trigger immediately for the first time.
       .subscribe(() => {

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -170,8 +170,8 @@ export class AuthService {
 
   private registerAutoRefreshToken() {
     this.refreshTokenSubscription?.unsubscribe();
-    const TOKEN_REFRESH_INTERVAL_IN_MIN = this.config.env.activeTimeInMinutes - 1;
-    // Token Refresh Interval set to Active Window Time - 1
+    const TOKEN_REFRESH_INTERVAL_IN_MIN = this.config.env.expirationTimeInMinutes - 1;
+    // Token Refresh Interval set to Token Expiration Time - 1
     this.refreshTokenSubscription = interval(TOKEN_REFRESH_INTERVAL_IN_MIN * 60 * 1000)
       .pipe(startWith(0)) // to trigger immediately for the first time.
       .subscribe(() => {

--- a/core/gui/src/app/common/type/gui-config.ts
+++ b/core/gui/src/app/common/type/gui-config.ts
@@ -39,6 +39,7 @@ export interface GuiConfig {
   operatorConsoleMessageBufferSize: number;
   defaultLocalUser?: { username?: string; password?: string };
   expirationTimeInMinutes: number;
+  activeTimeInMinutes: number;
 }
 
 export interface SidebarTabs {

--- a/core/gui/src/app/common/type/gui-config.ts
+++ b/core/gui/src/app/common/type/gui-config.ts
@@ -38,6 +38,7 @@ export interface GuiConfig {
   sharingComputingUnitEnabled: boolean;
   operatorConsoleMessageBufferSize: number;
   defaultLocalUser?: { username?: string; password?: string };
+  expirationTimeInMinutes: number;
   activeTimeInMinutes: number;
 }
 

--- a/core/gui/src/app/common/type/gui-config.ts
+++ b/core/gui/src/app/common/type/gui-config.ts
@@ -38,7 +38,6 @@ export interface GuiConfig {
   sharingComputingUnitEnabled: boolean;
   operatorConsoleMessageBufferSize: number;
   defaultLocalUser?: { username?: string; password?: string };
-  expirationTimeInMinutes: number;
   activeTimeInMinutes: number;
 }
 

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -191,7 +191,7 @@ export class AdminUserComponent implements OnInit {
       return false;
     }
     // Active window set to expiration-in-minutes from auth.conf
-    const active_window = this.config.env.expirationTimeInMinutes * 60 * 1000;
+    const active_window = this.config.env.activeTimeInMinutes * 60 * 1000;
     const lastMs = user.lastLogin * 1000;
     return Date.now() - lastMs < active_window;
   }

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -190,7 +190,7 @@ export class AdminUserComponent implements OnInit {
     if (!user.lastLogin) {
       return false;
     }
-    // Active window set to expiration-in-minutes from auth.conf
+    // Active window set to active-time-in-minutes from auth.conf
     const active_window = this.config.env.activeTimeInMinutes * 60 * 1000;
     const lastMs = user.lastLogin * 1000;
     return Date.now() - lastMs < active_window;

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -190,7 +190,7 @@ export class AdminUserComponent implements OnInit {
     if (!user.lastLogin) {
       return false;
     }
-    // Active window set to active-time-in-minutes from auth.conf
+    // Active window set to active-time-in-minutes from gui.conf
     const active_window = this.config.env.activeTimeInMinutes * 60 * 1000;
     const lastMs = user.lastLogin * 1000;
     return Date.now() - lastMs < active_window;


### PR DESCRIPTION
**Description:**
--
This PR fixes the negative user experience created by #3625 where users would be logged out much more frequently. This was caused by the active-detection window being tied to the same variable as the jwt-expiration. 

**Problem**
--
In the previous implementation of `active_window` in `admin-user.component.ts` used the `expiration-in-minutes` environment variable from `auth.conf`.

**Solution**
--
Created a new environment variable `active-time-in-minutes` in `gui.conf`, `GuiConfig` scala file that replaces the `expiration-time-in-minutes` environment variable. This environment variable was preset to `15`, matching the desired 15 minute activity period. Additionally, the `expiration-in-minutes` variable was changed to `7200` matching the desired 2 day jwt expiry date.

Fixes #3730 