### PR TITLE
chore(ci): remove JOOQ Generation from CI

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -112,8 +112,6 @@ jobs:
         run: psql -h localhost -U postgres -f deployment/k8s/texera-helmchart/files/texera_ddl.sql
         env:
           PGPASSWORD: postgres
-      - name: Jooq Code Generator
-        run: cd core && sbt "DAO/runMain edu.uci.ics.texera.dao.JooqCodeGenerator"
       - name: Compile with sbt
         run: cd core && sbt clean package
       - name: Run backend tests


### PR DESCRIPTION
Since the JOOQ code generator was merged into the sbt compiler in PR #3746, there’s no longer a need for a separate step for JOOQ code generator in CI.