### PR TITLE
feat: prevent export of results from non-downloadable datasets

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
@@ -28,10 +28,11 @@ import edu.uci.ics.amber.engine.architecture.logreplay.{ReplayDestination, Repla
 import edu.uci.ics.amber.engine.common.Utils.{maptoStatusCode, stringToAggregatedState}
 import edu.uci.ics.amber.engine.common.storage.SequentialRecordStorage
 import edu.uci.ics.amber.util.serde.GlobalPortIdentitySerde.SerdeOps
+import edu.uci.ics.amber.util.JSONUtils.objectMapper
 import edu.uci.ics.texera.dao.SqlServer
 import edu.uci.ics.texera.dao.jooq.generated.Tables._
 import edu.uci.ics.texera.dao.jooq.generated.tables.daos.WorkflowExecutionsDao
-import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.WorkflowExecutions
+import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{User => UserPojo, WorkflowExecutions}
 import edu.uci.ics.texera.auth.SessionUser
 import edu.uci.ics.texera.config.UserSystemConfig
 import edu.uci.ics.texera.dao.SqlServer.withTransaction
@@ -100,6 +101,140 @@ object WorkflowExecutionsResource {
     } else {
       Some(executions.max)
     }
+  }
+
+  private case class RestrictedDataset(ownerEmail: String, datasetName: String) {
+    def cacheKey: (String, String) = (ownerEmail.toLowerCase, datasetName.toLowerCase)
+    def label: String = s"$datasetName ($ownerEmail)"
+  }
+
+  private def parseDatasetPath(path: String): Option[RestrictedDataset] = {
+    if (path == null) {
+      return None
+    }
+    val trimmed = path.trim
+    if (!trimmed.startsWith("/")) {
+      return None
+    }
+    val segments = trimmed.split("/").filter(_.nonEmpty)
+    if (segments.length < 4) {
+      return None
+    }
+    val ownerEmail = segments(0)
+    val datasetName = segments(1)
+    Some(RestrictedDataset(ownerEmail, datasetName))
+  }
+
+  private def lookupDatasetDownloadable(
+      dataset: RestrictedDataset,
+      cache: mutable.Map[(String, String), Option[Boolean]]
+  ): Option[Boolean] = {
+    cache.getOrElseUpdate(
+      dataset.cacheKey, {
+        val record = context
+          .select(DATASET.IS_DOWNLOADABLE)
+          .from(DATASET)
+          .join(USER)
+          .on(DATASET.OWNER_UID.eq(USER.UID))
+          .where(
+            USER.EMAIL
+              .equalIgnoreCase(dataset.ownerEmail)
+              .and(DATASET.NAME.equalIgnoreCase(dataset.datasetName))
+          )
+          .fetchOne()
+        if (record == null) {
+          None
+        } else {
+          Option(record.value1())
+        }
+      }
+    )
+  }
+
+  private def computeDatasetRestrictionMap(
+      wid: Int,
+      currentUser: UserPojo
+  ): Map[String, Set[RestrictedDataset]] = {
+    val workflowRecord = context
+      .select(WORKFLOW.CONTENT)
+      .from(WORKFLOW)
+      .where(WORKFLOW.WID.eq(wid))
+      .fetchOne()
+
+    if (workflowRecord == null) {
+      return Map.empty
+    }
+
+    val content = workflowRecord.value1()
+    if (content == null || content.isEmpty) {
+      return Map.empty
+    }
+
+    val rootNode =
+      try {
+        objectMapper.readTree(content)
+      } catch {
+        case _: Exception => return Map.empty
+      }
+
+    val operatorsNode = rootNode.path("operators")
+    val linksNode = rootNode.path("links")
+
+    val datasetStatusCache = mutable.Map.empty[(String, String), Option[Boolean]]
+    val restrictedSourceMap = mutable.Map.empty[String, RestrictedDataset]
+    val adjacency = mutable.Map.empty[String, mutable.ListBuffer[String]]
+
+    operatorsNode.elements().asScala.foreach { operatorNode =>
+      val operatorId = operatorNode.path("operatorID").asText("")
+      if (operatorId.nonEmpty) {
+        val fileNameNode = operatorNode.path("operatorProperties").path("fileName")
+        if (fileNameNode.isTextual) {
+          parseDatasetPath(fileNameNode.asText()).foreach { dataset =>
+            val isOwner =
+              Option(currentUser.getEmail)
+                .exists(_.equalsIgnoreCase(dataset.ownerEmail))
+            if (!isOwner) {
+              lookupDatasetDownloadable(dataset, datasetStatusCache) match {
+                case Some(value) if !value =>
+                  restrictedSourceMap.update(operatorId, dataset)
+                case _ =>
+              }
+            }
+          }
+        }
+      }
+    }
+
+    linksNode.elements().asScala.foreach { linkNode =>
+      val sourceId = linkNode.path("source").path("operatorID").asText("")
+      val targetId = linkNode.path("target").path("operatorID").asText("")
+      if (sourceId.nonEmpty && targetId.nonEmpty) {
+        val targets = adjacency.getOrElseUpdate(sourceId, mutable.ListBuffer.empty[String])
+        targets += targetId
+      }
+    }
+
+    val restrictionMap = mutable.Map.empty[String, Set[RestrictedDataset]]
+    val queue = mutable.Queue.empty[(String, Set[RestrictedDataset])]
+
+    restrictedSourceMap.foreach {
+      case (operatorId, dataset) =>
+        queue.enqueue(operatorId -> Set(dataset))
+    }
+
+    while (queue.nonEmpty) {
+      val (currentOperatorId, datasetSet) = queue.dequeue()
+      val existing = restrictionMap.getOrElse(currentOperatorId, Set.empty)
+      val merged = existing ++ datasetSet
+      if (merged != existing) {
+        restrictionMap.update(currentOperatorId, merged)
+        adjacency
+          .get(currentOperatorId)
+          .foreach(_.foreach(nextOperator => queue.enqueue(nextOperator -> merged)))
+      }
+    }
+
+    restrictionMap.toMap
   }
 
   def insertOperatorPortResultUri(
@@ -695,12 +830,29 @@ class WorkflowExecutionsResource {
       @Auth user: SessionUser
   ): Response = {
 
-    if (request.operators.size <= 0)
-      Response
+    if (request.operators.isEmpty) {
+      return Response
         .status(Response.Status.BAD_REQUEST)
         .`type`(MediaType.APPLICATION_JSON)
         .entity(Map("error" -> "No operator selected").asJava)
         .build()
+    }
+    val datasetRestrictions = computeDatasetRestrictionMap(request.workflowId, user.user)
+    val restrictedOperators = request.operators.filter(op => datasetRestrictions.contains(op.id))
+    if (restrictedOperators.nonEmpty) {
+      val errorMessage = restrictedOperators
+        .map { op =>
+          val datasets = datasetRestrictions(op.id).map(_.label).toList.sorted
+          s"Operator ${op.id} cannot be exported because it depends on dataset(s): ${datasets.mkString(", ")}"
+        }
+        .mkString("; ")
+
+      return Response
+        .status(Response.Status.FORBIDDEN)
+        .`type`(MediaType.APPLICATION_JSON)
+        .entity(Map("error" -> errorMessage).asJava)
+        .build()
+    }
 
     try {
       request.destination match {

--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
@@ -18,126 +18,144 @@
 -->
 
 <div class="centered-container">
-  <div class="input-wrapper">
-    <form nz-form>
-      <nz-row *ngIf="exportType !== 'data'">
-        <nz-col [nzSpan]="24">
-          <nz-form-item>
-            <nz-form-label nzFor="exportTypeInput">Export Type</nz-form-label>
-            <nz-form-control>
-              <nz-select
-                id="exportTypeInput"
-                [(ngModel)]="exportType"
-                name="exportType"
-                nzPlaceHolder="Select export type">
-                <nz-option
-                  *ngIf="isTableOutput"
-                  nzValue="arrow"
-                  nzLabel="Binary Format (.arrow)"></nz-option>
-                <nz-option
-                  *ngIf="isTableOutput && !containsBinaryData"
-                  nzValue="csv"
-                  nzLabel="Comma Separated Values (.csv)"></nz-option>
-                <nz-option
-                  *ngIf="isVisualizationOutput"
-                  nzValue="html"
-                  nzLabel="Web Page (.html)"></nz-option>
-                <nz-option
-                  nzValue="parquet"
-                  nzLabel="Parquet (.parquet)"></nz-option>
-              </nz-select>
-            </nz-form-control>
-          </nz-form-item>
-        </nz-col>
-      </nz-row>
-      <nz-row *ngIf="exportType === 'data'">
-        <nz-col [nzSpan]="24">
-          <nz-form-item>
-            <nz-form-label nzFor="filenameInput">Filename</nz-form-label>
-            <nz-form-control>
-              <input
-                id="filenameInput"
-                [(ngModel)]="inputFileName"
-                name="filename"
-                type="text"
-                nz-input
-                placeholder="Enter filename for binary data" />
-            </nz-form-control>
-          </nz-form-item>
-        </nz-col>
-      </nz-row>
-      <nz-row>
-        <nz-col [nzSpan]="24">
-          <nz-form-item>
-            <nz-form-label nzFor="destinationInput">Destination</nz-form-label>
-            <nz-form-control>
-              <nz-select
-                id="destinationInput"
-                [(ngModel)]="destination"
-                name="destination"
-                nzPlaceHolder="Select destination">
-                <nz-option
-                  nzValue="dataset"
-                  nzLabel="Dataset"></nz-option>
-                <nz-option
-                  nzValue="local"
-                  nzLabel="Local"></nz-option>
-              </nz-select>
-            </nz-form-control>
-          </nz-form-item>
-        </nz-col>
-      </nz-row>
-    </form>
-  </div>
   <div
     class="input-wrapper"
-    *ngIf="destination === 'dataset'">
-    <input
-      [(ngModel)]="inputDatasetName"
-      (input)="onUserInputDatasetName($event)"
-      type="text"
-      nz-input
-      name="datasetName"
-      placeholder="Search for dataset by name..."
-      [nzAutocomplete]="auto" />
-    <nz-autocomplete #auto>
-      <nz-auto-option
-        *ngFor="let dataset of filteredUserAccessibleDatasets"
-        [nzLabel]="dataset.dataset.name">
-        <div class="auto-option-content">
-          <div class="dataset-id-container">{{dataset.dataset.did?.toString()}}</div>
+    *ngIf="hasPartialRestriction && blockingDatasetLabels.length > 0">
+    <nz-alert
+      nzType="warning"
+      nzMessage="Some operators will be skipped"
+      [nzDescription]="blockingDatasetSummary || null"></nz-alert>
+  </div>
+  <ng-container *ngIf="!isExportRestricted; else restrictedExport">
+    <div class="input-wrapper">
+      <form nz-form>
+        <nz-row *ngIf="exportType !== 'data'">
+          <nz-col [nzSpan]="24">
+            <nz-form-item>
+              <nz-form-label nzFor="exportTypeInput">Export Type</nz-form-label>
+              <nz-form-control>
+                <nz-select
+                  id="exportTypeInput"
+                  [(ngModel)]="exportType"
+                  name="exportType"
+                  nzPlaceHolder="Select export type">
+                  <nz-option
+                    *ngIf="isTableOutput"
+                    nzValue="arrow"
+                    nzLabel="Binary Format (.arrow)"></nz-option>
+                  <nz-option
+                    *ngIf="isTableOutput && !containsBinaryData"
+                    nzValue="csv"
+                    nzLabel="Comma Separated Values (.csv)"></nz-option>
+                  <nz-option
+                    *ngIf="isVisualizationOutput"
+                    nzValue="html"
+                    nzLabel="Web Page (.html)"></nz-option>
+                  <nz-option
+                    nzValue="parquet"
+                    nzLabel="Parquet (.parquet)"></nz-option>
+                </nz-select>
+              </nz-form-control>
+            </nz-form-item>
+          </nz-col>
+        </nz-row>
+        <nz-row *ngIf="exportType === 'data'">
+          <nz-col [nzSpan]="24">
+            <nz-form-item>
+              <nz-form-label nzFor="filenameInput">Filename</nz-form-label>
+              <nz-form-control>
+                <input
+                  id="filenameInput"
+                  [(ngModel)]="inputFileName"
+                  name="filename"
+                  type="text"
+                  nz-input
+                  placeholder="Enter filename for binary data" />
+              </nz-form-control>
+            </nz-form-item>
+          </nz-col>
+        </nz-row>
+        <nz-row>
+          <nz-col [nzSpan]="24">
+            <nz-form-item>
+              <nz-form-label nzFor="destinationInput">Destination</nz-form-label>
+              <nz-form-control>
+                <nz-select
+                  id="destinationInput"
+                  [(ngModel)]="destination"
+                  name="destination"
+                  nzPlaceHolder="Select destination">
+                  <nz-option
+                    nzValue="dataset"
+                    nzLabel="Dataset"></nz-option>
+                  <nz-option
+                    nzValue="local"
+                    nzLabel="Local"></nz-option>
+                </nz-select>
+              </nz-form-control>
+            </nz-form-item>
+          </nz-col>
+        </nz-row>
+      </form>
+    </div>
+    <div
+      class="input-wrapper"
+      *ngIf="destination === 'dataset'">
+      <input
+        [(ngModel)]="inputDatasetName"
+        (input)="onUserInputDatasetName($event)"
+        type="text"
+        nz-input
+        name="datasetName"
+        placeholder="Search for dataset by name..."
+        [nzAutocomplete]="auto" />
+      <nz-autocomplete #auto>
+        <nz-auto-option
+          *ngFor="let dataset of filteredUserAccessibleDatasets"
+          [nzLabel]="dataset.dataset.name">
+          <div class="auto-option-content">
+            <div class="dataset-id-container">{{dataset.dataset.did?.toString()}}</div>
 
-          <span class="dataset-name">{{ dataset.dataset.name }}</span>
+            <span class="dataset-name">{{ dataset.dataset.name }}</span>
 
-          <button
-            nz-button
-            nzType="primary"
-            class="dataset-option-link-btn"
-            (click)="onClickExportResult('dataset', dataset)">
-            Save
-          </button>
-        </div>
-      </nz-auto-option>
-    </nz-autocomplete>
-    <nz-divider
-      nzText="or"
-      nzOrientation="center"></nz-divider>
+            <button
+              nz-button
+              nzType="primary"
+              class="dataset-option-link-btn"
+              (click)="onClickExportResult('dataset', dataset)">
+              Save
+            </button>
+          </div>
+        </nz-auto-option>
+      </nz-autocomplete>
+      <nz-divider
+        nzText="or"
+        nzOrientation="center"></nz-divider>
+      <button
+        nz-button
+        nzType="dashed"
+        nzBlock
+        (click)="onClickCreateNewDataset()">
+        <span
+          nz-icon
+          nzType="plus-circle"></span>
+        Create New Dataset
+      </button>
+    </div>
     <button
       nz-button
-      nzType="dashed"
-      nzBlock
-      (click)="onClickCreateNewDataset()">
-      <span
-        nz-icon
-        nzType="plus-circle"></span>
-      Create New Dataset
+      nzType="default"
+      *ngIf="destination === 'local'"
+      (click)="onClickExportResult( 'local')">
+      Export
     </button>
-  </div>
-  <button
-    nz-button
-    nzType="default"
-    *ngIf="destination === 'local'"
-    (click)="onClickExportResult( 'local')">
-    Export
-  </button>
+  </ng-container>
+  <ng-template #restrictedExport>
+    <div class="input-wrapper">
+      <nz-alert
+        nzType="error"
+        nzMessage="Export unavailable"
+        [nzDescription]="blockingDatasetSummary || null"></nz-alert>
+    </div>
+  </ng-template>
 </div>

--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
@@ -52,6 +52,11 @@ export class ResultExportationComponent implements OnInit {
   containsBinaryData: boolean = false;
   inputDatasetName = "";
   selectedComputingUnit: DashboardWorkflowComputingUnit | null = null;
+  exportableOperatorIds: string[] = [];
+  blockedOperatorIds: string[] = [];
+  isExportRestricted: boolean = false;
+  hasPartialRestriction: boolean = false;
+  blockingDatasetLabels: string[] = [];
 
   userAccessibleDatasets: DashboardDataset[] = [];
   filteredUserAccessibleDatasets: DashboardDataset[] = [];
@@ -74,7 +79,11 @@ export class ResultExportationComponent implements OnInit {
         this.userAccessibleDatasets = datasets.filter(dataset => dataset.accessPrivilege === "WRITE");
         this.filteredUserAccessibleDatasets = [...this.userAccessibleDatasets];
       });
-    this.updateOutputType();
+
+    this.workflowResultExportService
+      .refreshDatasetMetadata()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.updateOutputType());
 
     this.computingUnitStatusService
       .getSelectedComputingUnit()
@@ -98,6 +107,12 @@ export class ResultExportationComponent implements OnInit {
       operatorIds = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
     }
 
+    this.exportableOperatorIds = this.workflowResultExportService.getExportableOperatorIds(operatorIds);
+    this.blockedOperatorIds = this.workflowResultExportService.getBlockedOperatorIds(operatorIds);
+    this.blockingDatasetLabels = this.workflowResultExportService.getBlockingDatasets(operatorIds);
+    this.isExportRestricted = this.exportableOperatorIds.length === 0 && operatorIds.length > 0;
+    this.hasPartialRestriction = this.exportableOperatorIds.length > 0 && this.blockedOperatorIds.length > 0;
+
     if (operatorIds.length === 0) {
       // No operators highlighted
       this.isTableOutput = false;
@@ -106,13 +121,22 @@ export class ResultExportationComponent implements OnInit {
       return;
     }
 
+    if (this.isExportRestricted) {
+      this.isTableOutput = false;
+      this.isVisualizationOutput = false;
+      this.containsBinaryData = false;
+      return;
+    }
+
+    const idsToEvaluate = this.exportableOperatorIds;
+
     // Assume they're all table or visualization
     // until we find an operator that isn't
     let allTable = true;
     let allVisualization = true;
     let anyBinaryData = false;
 
-    for (const operatorId of operatorIds) {
+    for (const operatorId of idsToEvaluate) {
       const outputTypes = this.workflowResultService.determineOutputTypes(operatorId);
       if (!outputTypes.hasAnyResult) {
         continue;
@@ -146,6 +170,9 @@ export class ResultExportationComponent implements OnInit {
   }
 
   onClickExportResult(destination: "dataset" | "local", dataset: DashboardDataset = {} as DashboardDataset) {
+    if (this.isExportRestricted) {
+      return;
+    }
     const datasetIds =
       destination === "dataset" ? [dataset.dataset.did].filter((id): id is number => id !== undefined) : [];
     this.workflowResultExportService.exportWorkflowExecutionResult(
@@ -180,5 +207,9 @@ export class ResultExportationComponent implements OnInit {
         this.inputDatasetName = result.dataset.name;
       }
     });
+  }
+
+  get blockingDatasetSummary(): string {
+    return this.blockingDatasetLabels.join(", ");
   }
 }

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -26,13 +26,15 @@ import { PaginatedResultEvent, ResultExportResponse } from "../../types/workflow
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
 import { ExecutionState, isNotInExecution } from "../../types/execute-workflow.interface";
-import { filter } from "rxjs/operators";
+import { catchError, filter, map, take, tap } from "rxjs/operators";
 import { OperatorResultService, WorkflowResultService } from "../workflow-result/workflow-result.service";
 import { DownloadService } from "../../../dashboard/service/user/download/download.service";
 import { HttpResponse } from "@angular/common/http";
 import { ExportWorkflowJsonResponse } from "../../../dashboard/service/user/download/download.service";
 import { DashboardWorkflowComputingUnit } from "../../types/workflow-computing-unit";
 import { GuiConfigService } from "../../../common/service/gui-config.service";
+import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.service";
+import { parseFilePathToDatasetFile } from "../../../common/type/dataset-file";
 
 @Injectable({
   providedIn: "root",
@@ -40,6 +42,10 @@ import { GuiConfigService } from "../../../common/service/gui-config.service";
 export class WorkflowResultExportService {
   hasResultToExportOnHighlightedOperators: boolean = false;
   hasResultToExportOnAllOperators = new BehaviorSubject<boolean>(false);
+  private datasetDownloadableMap = new Map<string, boolean>();
+  private datasetLabelMap = new Map<string, string>();
+  private restrictedOperatorMap = new Map<string, Set<string>>();
+  private datasetListLoaded = false;
   constructor(
     private workflowWebsocketService: WorkflowWebsocketService,
     private workflowActionService: WorkflowActionService,
@@ -47,9 +53,12 @@ export class WorkflowResultExportService {
     private executeWorkflowService: ExecuteWorkflowService,
     private workflowResultService: WorkflowResultService,
     private downloadService: DownloadService,
+    private datasetService: DatasetService,
     private config: GuiConfigService
   ) {
     this.registerResultToExportUpdateHandler();
+    this.registerRestrictionRecomputeTriggers();
+    this.refreshDatasetMetadata().subscribe();
   }
 
   registerResultToExportUpdateHandler() {
@@ -60,34 +69,217 @@ export class WorkflowResultExportService {
       this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
       this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream()
     ).subscribe(() => {
-      // check if there are any results to export on highlighted operators (either paginated or snapshot)
-      this.hasResultToExportOnHighlightedOperators =
-        isNotInExecution(this.executeWorkflowService.getExecutionState().state) &&
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedOperatorIDs()
-          .filter(
-            operatorId =>
-              this.workflowResultService.hasAnyResult(operatorId) ||
-              this.workflowResultService.getResultService(operatorId)?.getCurrentResultSnapshot() !== undefined
-          ).length > 0;
-
-      // check if there are any results to export on all operators (either paginated or snapshot)
-      let staticHasResultToExportOnAllOperators =
-        isNotInExecution(this.executeWorkflowService.getExecutionState().state) &&
-        this.workflowActionService
-          .getTexeraGraph()
-          .getAllOperators()
-          .map(operator => operator.operatorID)
-          .filter(
-            operatorId =>
-              this.workflowResultService.hasAnyResult(operatorId) ||
-              this.workflowResultService.getResultService(operatorId)?.getCurrentResultSnapshot() !== undefined
-          ).length > 0;
-
-      // Notify subscribers of changes
-      this.hasResultToExportOnAllOperators.next(staticHasResultToExportOnAllOperators);
+      this.updateExportAvailabilityFlags();
     });
+  }
+
+  private registerRestrictionRecomputeTriggers(): void {
+    const texeraGraph = this.workflowActionService.getTexeraGraph();
+    merge(
+      texeraGraph.getOperatorAddStream(),
+      texeraGraph.getOperatorDeleteStream(),
+      texeraGraph.getOperatorPropertyChangeStream(),
+      texeraGraph.getLinkAddStream(),
+      texeraGraph.getLinkDeleteStream(),
+      texeraGraph.getDisabledOperatorsChangedStream()
+    ).subscribe(() => {
+      this.runRestrictionAnalysis();
+    });
+  }
+
+  public refreshDatasetMetadata(): Observable<void> {
+    this.datasetListLoaded = false;
+    return this.datasetService.retrieveAccessibleDatasets().pipe(
+      take(1),
+      tap(datasets => {
+        this.datasetDownloadableMap.clear();
+        this.datasetLabelMap.clear();
+        datasets.forEach(dataset => {
+          const key = this.buildDatasetKey(dataset.ownerEmail, dataset.dataset.name);
+          const isDownloadable = dataset.dataset.isDownloadable || dataset.isOwner;
+          this.datasetDownloadableMap.set(key, isDownloadable);
+          this.datasetLabelMap.set(key, `${dataset.dataset.name} (${dataset.ownerEmail})`);
+        });
+        this.datasetListLoaded = true;
+        this.runRestrictionAnalysis();
+      }),
+      map(() => undefined),
+      catchError(() => {
+        this.datasetDownloadableMap.clear();
+        this.datasetLabelMap.clear();
+        this.datasetListLoaded = true;
+        this.runRestrictionAnalysis();
+        return of(undefined);
+      })
+    );
+  }
+
+  private buildDatasetKey(ownerEmail: string, datasetName: string): string {
+    return `${ownerEmail.toLowerCase()}::${datasetName.toLowerCase()}`;
+  }
+
+  private extractDatasetInfo(fileName: unknown): { key: string; label: string } | null {
+    if (typeof fileName !== "string") {
+      return null;
+    }
+    const trimmed = fileName.trim();
+    if (!trimmed.startsWith("/")) {
+      return null;
+    }
+    try {
+      const { ownerEmail, datasetName } = parseFilePathToDatasetFile(trimmed);
+      if (!ownerEmail || !datasetName) {
+        return null;
+      }
+      const key = this.buildDatasetKey(ownerEmail, datasetName);
+      if (!this.datasetDownloadableMap.has(key)) {
+        return null;
+      }
+      const label = this.datasetLabelMap.get(key) ?? `${datasetName} (${ownerEmail})`;
+      return { key, label };
+    } catch {
+      return null;
+    }
+  }
+
+  private runRestrictionAnalysis(): void {
+    if (!this.datasetListLoaded) {
+      this.restrictedOperatorMap.clear();
+      this.updateExportAvailabilityFlags();
+      return;
+    }
+
+    const texeraGraph = this.workflowActionService.getTexeraGraph();
+    const allOperators = texeraGraph.getAllOperators();
+    const operatorById = new Map(allOperators.map(op => [op.operatorID, op] as const));
+    const enabledOperators = allOperators.filter(operator => !operator.isDisabled);
+    const datasetSources: Array<{ operatorId: string; label: string }> = [];
+
+    enabledOperators.forEach(operator => {
+      const datasetInfo = this.extractDatasetInfo(operator.operatorProperties?.fileName);
+      if (!datasetInfo) {
+        return;
+      }
+      const isDownloadable = this.datasetDownloadableMap.get(datasetInfo.key);
+      if (isDownloadable === false) {
+        datasetSources.push({ operatorId: operator.operatorID, label: datasetInfo.label });
+      }
+    });
+
+    const restrictions = new Map<string, Set<string>>();
+
+    if (datasetSources.length === 0) {
+      this.restrictedOperatorMap = restrictions;
+      this.updateExportAvailabilityFlags();
+      return;
+    }
+
+    const adjacency = new Map<string, string[]>();
+    texeraGraph.getAllLinks().forEach(link => {
+      const sourceId = link.source.operatorID;
+      const targetId = link.target.operatorID;
+      const sourceOperator = operatorById.get(sourceId);
+      const targetOperator = operatorById.get(targetId);
+      if (!sourceOperator || !targetOperator) {
+        return;
+      }
+      if (sourceOperator.isDisabled || targetOperator.isDisabled) {
+        return;
+      }
+      const neighbors = adjacency.get(sourceId);
+      if (neighbors) {
+        neighbors.push(targetId);
+      } else {
+        adjacency.set(sourceId, [targetId]);
+      }
+    });
+
+    const queue: Array<{ operatorId: string; datasets: Set<string> }> = [];
+    datasetSources.forEach(source => {
+      queue.push({ operatorId: source.operatorId, datasets: new Set([source.label]) });
+    });
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const existing = restrictions.get(current.operatorId) ?? new Set<string>();
+      let updated = false;
+      current.datasets.forEach(label => {
+        if (!existing.has(label)) {
+          existing.add(label);
+          updated = true;
+        }
+      });
+      if (updated || !restrictions.has(current.operatorId)) {
+        restrictions.set(current.operatorId, existing);
+        const neighbors = adjacency.get(current.operatorId) ?? [];
+        neighbors.forEach(nextOperatorId => {
+          queue.push({ operatorId: nextOperatorId, datasets: new Set(existing) });
+        });
+      }
+    }
+
+    this.restrictedOperatorMap = restrictions;
+    this.updateExportAvailabilityFlags();
+  }
+
+  private updateExportAvailabilityFlags(): void {
+    const executionIdle = isNotInExecution(this.executeWorkflowService.getExecutionState().state);
+
+    const highlightedOperators = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
+
+    const highlightedHasResult = highlightedOperators.some(
+      operatorId =>
+        this.workflowResultService.hasAnyResult(operatorId) ||
+        this.workflowResultService.getResultService(operatorId)?.getCurrentResultSnapshot() !== undefined
+    );
+
+    this.hasResultToExportOnHighlightedOperators = executionIdle && highlightedHasResult;
+
+    const allOperatorIds = this.workflowActionService
+      .getTexeraGraph()
+      .getAllOperators()
+      .map(operator => operator.operatorID);
+
+    const hasAnyResult =
+      executionIdle &&
+      allOperatorIds.some(
+        operatorId =>
+          this.workflowResultService.hasAnyResult(operatorId) ||
+          this.workflowResultService.getResultService(operatorId)?.getCurrentResultSnapshot() !== undefined
+      );
+
+    this.hasResultToExportOnAllOperators.next(hasAnyResult);
+  }
+
+  private isOperatorEligibleForExport(operatorId: string): boolean {
+    if (this.restrictedOperatorMap.has(operatorId)) {
+      return false;
+    }
+    return (
+      this.workflowResultService.hasAnyResult(operatorId) ||
+      this.workflowResultService.getResultService(operatorId)?.getCurrentResultSnapshot() !== undefined
+    );
+  }
+
+  public getExportableOperatorIds(operatorIds: readonly string[]): string[] {
+    return operatorIds.filter(operatorId => !this.restrictedOperatorMap.has(operatorId));
+  }
+
+  public getBlockedOperatorIds(operatorIds: readonly string[]): string[] {
+    return operatorIds.filter(operatorId => this.restrictedOperatorMap.has(operatorId));
+  }
+
+  public hasBlockedOperators(operatorIds: readonly string[]): boolean {
+    return operatorIds.some(operatorId => this.restrictedOperatorMap.has(operatorId));
+  }
+
+  public getBlockingDatasets(operatorIds: readonly string[]): string[] {
+    const labels = new Set<string>();
+    operatorIds.forEach(operatorId => {
+      const datasets = this.restrictedOperatorMap.get(operatorId);
+      datasets?.forEach(label => labels.add(label));
+    });
+    return Array.from(labels);
   }
 
   /**
@@ -105,6 +297,34 @@ export class WorkflowResultExportService {
     // which means export button is selected from context-menu
     destination: "dataset" | "local" = "dataset", // default to dataset
     unit: DashboardWorkflowComputingUnit | null // computing unit for cluster setting
+  ): void {
+    this.refreshDatasetMetadata()
+      .pipe(take(1))
+      .subscribe(() =>
+        this.performExport(
+          exportType,
+          workflowName,
+          datasetIds,
+          rowIndex,
+          columnIndex,
+          filename,
+          exportAll,
+          destination,
+          unit
+        )
+      );
+  }
+
+  private performExport(
+    exportType: string,
+    workflowName: string,
+    datasetIds: number[],
+    rowIndex: number,
+    columnIndex: number,
+    filename: string,
+    exportAll: boolean,
+    destination: "dataset" | "local",
+    unit: DashboardWorkflowComputingUnit | null
   ): void {
     if (!this.config.env.exportExecutionResultEnabled) {
       return;
@@ -128,16 +348,33 @@ export class WorkflowResultExportService {
           .map(operator => operator.operatorID)
       : [...this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()];
 
-    const operatorArray = operatorIds.map(operatorId => {
-      return {
-        id: operatorId,
-        outputType: this.workflowResultService.determineOutputExtension(operatorId, exportType),
-      };
-    });
-
     if (operatorIds.length === 0) {
       return;
     }
+
+    const exportableOperatorIds = this.getExportableOperatorIds(operatorIds);
+
+    if (exportableOperatorIds.length === 0) {
+      const datasets = this.getBlockingDatasets(operatorIds);
+      const suffix = datasets.length > 0 ? `: ${datasets.join(", ")}` : "";
+      this.notificationService.error(
+        `Cannot export result: selection depends on dataset(s) that are not downloadable${suffix}`
+      );
+      return;
+    }
+
+    if (exportableOperatorIds.length < operatorIds.length) {
+      const datasets = this.getBlockingDatasets(operatorIds);
+      const suffix = datasets.length > 0 ? ` (${datasets.join(", ")})` : "";
+      this.notificationService.warning(
+        `Some operators were skipped because their results depend on dataset(s) that are not downloadable${suffix}`
+      );
+    }
+
+    const operatorArray = exportableOperatorIds.map(operatorId => ({
+      id: operatorId,
+      outputType: this.workflowResultService.determineOutputExtension(operatorId, exportType),
+    }));
 
     // show loading
     this.notificationService.loading("Exporting...");


### PR DESCRIPTION
### Description:
Implemented restriction on `export result` to prevent users from exporting workflow results that depend on non-downloadable datasets they don't own. This ensures dataset download cannot be circumvented through workflow execution and result export.

Closes #3766 

### Changes:
**Backend**
- Added server-side validation to analyze workflow dependencies and block export of operators that depend on non-downloadable datasets
- Implemented algorithm to propagate restrictions to downstream operators

**Frontend**
- Updated export dialog component to show restriction warnings, filter exportable operators, and display blocking dataset
  information

### Video:
The video demonstrates how `export result` behaves on:
- workflows with downloadable datasets
- workflows with non-downloadable datasets
- workflows with both downloadable and non-downloadable datasets

https://github.com/user-attachments/assets/56b78aeb-dbcc-40fc-89b4-9c4238f8bc56