### PR TITLE
fix(gui): reopen workflow websocket when switching workflows

### DIFF
--- a/core/gui/src/app/workspace/service/computing-unit-status/computing-unit-status.service.ts
+++ b/core/gui/src/app/workspace/service/computing-unit-status/computing-unit-status.service.ts
@@ -51,6 +51,7 @@ export class ComputingUnitStatusService implements OnDestroy {
   private readonly REFRESH_INTERVAL_MS = 2000;
   private refreshSubscription: Subscription | null = null;
   private currentConnectedCuid?: number;
+  private currentConnectedWid?: number;
   private selectedUnitPoll?: Subscription;
 
   constructor(
@@ -116,6 +117,8 @@ export class ComputingUnitStatusService implements OnDestroy {
       // The selected unit is no longer in the list
       this.selectedUnitSubject.next(null);
       this.stopPollingSelectedUnit();
+      this.currentConnectedCuid = undefined;
+      this.currentConnectedWid = undefined;
     }
   }
 
@@ -153,17 +156,25 @@ export class ComputingUnitStatusService implements OnDestroy {
    */
   public selectComputingUnit(wid: number | undefined, cuid: number): void {
     const trySelect = (unit: DashboardWorkflowComputingUnit) => {
-      // open websocket if needed
-      if (isDefined(wid) && this.currentConnectedCuid !== cuid) {
+      if (!isDefined(wid)) {
+        return;
+      }
+
+      const shouldReconnect = this.currentConnectedCuid !== cuid || this.currentConnectedWid !== wid;
+
+      if (shouldReconnect) {
         if (this.workflowWebsocketService.isConnected) {
           this.workflowWebsocketService.closeWebsocket();
           this.workflowStatusService.clearStatus();
         }
+
         this.workflowWebsocketService.openWebsocket(wid, this.userService.getCurrentUser()?.uid, cuid);
         this.currentConnectedCuid = cuid;
-        this.selectedUnitSubject.next(unit);
+        this.currentConnectedWid = wid;
         this.startPollingSelectedUnit(cuid);
       }
+
+      this.selectedUnitSubject.next(unit);
     };
 
     // try immediate lookup in the current cache
@@ -248,9 +259,13 @@ export class ComputingUnitStatusService implements OnDestroy {
   public terminateComputingUnit(cuid: number): Observable<boolean> {
     const isSelected = this.selectedUnitSubject.value?.computingUnit.cuid === cuid;
 
-    if (isSelected && this.workflowWebsocketService.isConnected) {
-      this.workflowWebsocketService.closeWebsocket();
-      this.workflowStatusService.clearStatus();
+    if (isSelected) {
+      if (this.workflowWebsocketService.isConnected) {
+        this.workflowWebsocketService.closeWebsocket();
+        this.workflowStatusService.clearStatus();
+      }
+      this.currentConnectedCuid = undefined;
+      this.currentConnectedWid = undefined;
     }
 
     return this.computingUnitService.terminateComputingUnit(cuid).pipe(


### PR DESCRIPTION
### Description:
Ensure workflow executions are always attributed to the correct workflow even when reusing a computing unit across multiple workflows.

Closes #3759 

### Problem:
When users switch workflows without changing the computing unit, the frontend keeps the existing websocket session so the backend continues to use the previous wid and execution history is midfiled.

### Solution:
Have the Angular computing-unit status service track the `wid` and `cuid`, forcing the websocket to reconnect whenever either of them change and clear the cached identifiers when the selection disappears or is terminated.