### PR TITLE
fix(op): add ML training operators for linear and logistic regression

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
@@ -76,7 +76,10 @@ import edu.uci.ics.amber.operator.sklearn.training.{
   SklearnTrainingGaussianNaiveBayesOpDesc,
   SklearnTrainingGradientBoostingOpDesc,
   SklearnTrainingKNNOpDesc,
+  SklearnTrainingLinearRegressionOpDesc,
   SklearnTrainingLinearSVMOpDesc,
+  SklearnTrainingLogisticRegressionCVOpDesc,
+  SklearnTrainingLogisticRegressionOpDesc,
   SklearnTrainingMultiLayerPerceptronOpDesc,
   SklearnTrainingMultinomialNaiveBayesOpDesc,
   SklearnTrainingNearestCentroidOpDesc,
@@ -334,6 +337,18 @@ trait StateTransferFunc
     new Type(
       value = classOf[SklearnTrainingDummyClassifierOpDesc],
       name = "SklearnTrainingDummyClassifier"
+    ),
+    new Type(
+      value = classOf[SklearnTrainingLinearRegressionOpDesc],
+      name = "SklearnTrainingLinearRegression"
+    ),
+    new Type(
+      value = classOf[SklearnTrainingLogisticRegressionOpDesc],
+      name = "SklearnTrainingLogisticRegression"
+    ),
+    new Type(
+      value = classOf[SklearnTrainingLogisticRegressionCVOpDesc],
+      name = "SklearnTrainingLogisticRegressionCV"
     ),
     new Type(value = classOf[SklearnLogisticRegressionOpDesc], name = "SklearnLogisticRegression"),
     new Type(

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/training/SklearnTrainingLinearRegressionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/training/SklearnTrainingLinearRegressionOpDesc.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.uci.ics.amber.operator.sklearn.training
+
+class SklearnTrainingLinearRegressionOpDesc extends SklearnTrainingOpDesc {
+  override def getImportStatements = "from sklearn.linear_model import LinearRegression"
+  override def getUserFriendlyModelName = "Training: Linear Regression"
+}


### PR DESCRIPTION
Fix #3581 

This PR introduces ML training operators for common regression tasks:

-  `SklearnTrainingLinearRegressionOpDesc` for linear regression  
-  `SklearnTrainingLogisticRegressionOpDesc` for logistic regression  
-  `SklearnTrainingLogisticRegressionCVOpDesc` for cross-validated logistic regression

These additions extend the training operator suite to support basic supervised learning using scikit-learn.

![Screen Recording 2025-09-28 at 5 05 31 PM](https://github.com/user-attachments/assets/06ea2fa7-7e51-4e40-b521-5eb54498ac54)
