### PR TITLE
fix(ci): add explicit jdbc driver loading in relevant e2e tests

### DIFF
--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -121,7 +121,7 @@ class DataProcessingSpec
         }
       })
     Await.result(client.controllerInterface.startWorkflow(EmptyRequest(), ()))
-    Await.result(completion, Duration.fromMinutes(1))
+    Await.result(completion, Duration.fromMinutes(5))
     results
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -59,6 +59,7 @@ class DataProcessingSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
+    Class.forName("org.postgresql.Driver")
   }
 
   override def afterAll(): Unit = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -52,7 +52,7 @@ class DataProcessingSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach {
 
-  implicit val timeout: Timeout = Timeout(5.seconds)
+  implicit val timeout: Timeout = Timeout(1.seconds)
 
   var inMemoryMySQLInstance: Option[DB] = None
   val workflowContext: WorkflowContext = new WorkflowContext()

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -59,6 +59,8 @@ class DataProcessingSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
+    // These test cases access postgres in CI, but occasionally the jdbc driver cannot be found during CI run.
+    // Explicitly load the JDBC driver to avoid flaky CI failures.
     Class.forName("org.postgresql.Driver")
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -52,7 +52,7 @@ class DataProcessingSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach {
 
-  implicit val timeout: Timeout = Timeout(1.seconds)
+  implicit val timeout: Timeout = Timeout(5.seconds)
 
   var inMemoryMySQLInstance: Option[DB] = None
   val workflowContext: WorkflowContext = new WorkflowContext()
@@ -122,7 +122,7 @@ class DataProcessingSpec
         }
       })
     Await.result(client.controllerInterface.startWorkflow(EmptyRequest(), ()))
-    Await.result(completion, Duration.fromMinutes(5))
+    Await.result(completion, Duration.fromMinutes(1))
     results
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
@@ -50,6 +50,7 @@ class PauseSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
+    Class.forName("org.postgresql.Driver")
   }
 
   override def afterAll(): Unit = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
@@ -50,6 +50,8 @@ class PauseSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
+    // These test cases access postgres in CI, but occasionally the jdbc driver cannot be found during CI run.
+    // Explicitly load the JDBC driver to avoid flaky CI failures.
     Class.forName("org.postgresql.Driver")
   }
 


### PR DESCRIPTION
## Purpose

This PR adds a fix for recent random CI failures caused by `No suitable driver found for jdbc:[postgresql](postgresql://localhost:5432/texera_iceberg_catalog)`.

- Closes #3570 

## Content

- Add an explicit step to load JDBC driver in e2e test cases that need to access postgres catalog.
- Affected test cases are `DataProcessingSpec` and `PauseSpec`.