### PR TITLE
Add publish section with whoami to .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -78,3 +78,6 @@ notifications:
   pullrequests:         dev@texera.apache.org
   discussions:          dev@texera.apache.org
   jobs:                 commits@texera.apache.org
+
+publish:
+  whoami: asf-site


### PR DESCRIPTION
See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features and section called 'Web site deployment service for Git repositories'.