### PR TITLE
fix(debugger): do not truncate debug messages

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionConsoleService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionConsoleService.scala
@@ -24,15 +24,27 @@ import com.twitter.util.{Await, Duration}
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.config.ApplicationConfig
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.ConsoleMessageType.COMMAND
-import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{ConsoleMessage, ConsoleMessageType, EvaluatePythonExpressionRequest, DebugCommandRequest => AmberDebugCommandRequest}
+import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{
+  ConsoleMessage,
+  ConsoleMessageType,
+  EvaluatePythonExpressionRequest,
+  DebugCommandRequest => AmberDebugCommandRequest
+}
 import edu.uci.ics.amber.engine.common.client.AmberClient
-import edu.uci.ics.amber.engine.common.executionruntimestate.{EvaluatedValueList, ExecutionConsoleStore, OperatorConsole}
+import edu.uci.ics.amber.engine.common.executionruntimestate.{
+  EvaluatedValueList,
+  ExecutionConsoleStore,
+  OperatorConsole
+}
 import edu.uci.ics.amber.util.VirtualIdentityUtils
 import edu.uci.ics.amber.core.virtualidentity.{ActorVirtualIdentity, OperatorIdentity}
 import edu.uci.ics.texera.web.model.websocket.event.TexeraWebSocketEvent
 import edu.uci.ics.texera.web.model.websocket.event.python.ConsoleUpdateEvent
 import edu.uci.ics.texera.web.model.websocket.request.RetryRequest
-import edu.uci.ics.texera.web.model.websocket.request.python.{DebugCommandRequest, PythonExpressionEvaluateRequest}
+import edu.uci.ics.texera.web.model.websocket.request.python.{
+  DebugCommandRequest,
+  PythonExpressionEvaluateRequest
+}
 import edu.uci.ics.texera.web.model.websocket.response.python.PythonExpressionEvaluateResponse
 import edu.uci.ics.texera.web.storage.ExecutionStateStore
 import edu.uci.ics.texera.web.{SubscriptionManager, WebsocketInput}
@@ -43,7 +55,11 @@ import edu.uci.ics.amber.core.tuple.Tuple
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller.ExecutionStateUpdate
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
-import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{COMPLETED, FAILED, KILLED}
+import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
+  COMPLETED,
+  FAILED,
+  KILLED
+}
 import edu.uci.ics.texera.config.UserSystemConfig
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionConsoleService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionConsoleService.scala
@@ -24,26 +24,15 @@ import com.twitter.util.{Await, Duration}
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.config.ApplicationConfig
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.ConsoleMessageType.COMMAND
-import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{
-  ConsoleMessage,
-  EvaluatePythonExpressionRequest,
-  DebugCommandRequest => AmberDebugCommandRequest
-}
+import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{ConsoleMessage, ConsoleMessageType, EvaluatePythonExpressionRequest, DebugCommandRequest => AmberDebugCommandRequest}
 import edu.uci.ics.amber.engine.common.client.AmberClient
-import edu.uci.ics.amber.engine.common.executionruntimestate.{
-  EvaluatedValueList,
-  ExecutionConsoleStore,
-  OperatorConsole
-}
+import edu.uci.ics.amber.engine.common.executionruntimestate.{EvaluatedValueList, ExecutionConsoleStore, OperatorConsole}
 import edu.uci.ics.amber.util.VirtualIdentityUtils
 import edu.uci.ics.amber.core.virtualidentity.{ActorVirtualIdentity, OperatorIdentity}
 import edu.uci.ics.texera.web.model.websocket.event.TexeraWebSocketEvent
 import edu.uci.ics.texera.web.model.websocket.event.python.ConsoleUpdateEvent
 import edu.uci.ics.texera.web.model.websocket.request.RetryRequest
-import edu.uci.ics.texera.web.model.websocket.request.python.{
-  DebugCommandRequest,
-  PythonExpressionEvaluateRequest
-}
+import edu.uci.ics.texera.web.model.websocket.request.python.{DebugCommandRequest, PythonExpressionEvaluateRequest}
 import edu.uci.ics.texera.web.model.websocket.response.python.PythonExpressionEvaluateResponse
 import edu.uci.ics.texera.web.storage.ExecutionStateStore
 import edu.uci.ics.texera.web.{SubscriptionManager, WebsocketInput}
@@ -54,11 +43,7 @@ import edu.uci.ics.amber.core.tuple.Tuple
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller.ExecutionStateUpdate
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
-import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
-  COMPLETED,
-  FAILED,
-  KILLED
-}
+import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{COMPLETED, FAILED, KILLED}
 import edu.uci.ics.texera.config.UserSystemConfig
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource
 
@@ -225,6 +210,10 @@ class ExecutionConsoleService(
     * @return The truncated console message
     */
   def processConsoleMessage(consoleMessage: ConsoleMessage): ConsoleMessage = {
+    // Do not truncate debugger messages
+    if (consoleMessage.msgType== ConsoleMessageType.DEBUGGER){
+      return consoleMessage
+    }
     ConsoleMessageProcessor.processConsoleMessage(consoleMessage, consoleMessageDisplayLength)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionConsoleService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionConsoleService.scala
@@ -211,7 +211,7 @@ class ExecutionConsoleService(
     */
   def processConsoleMessage(consoleMessage: ConsoleMessage): ConsoleMessage = {
     // Do not truncate debugger messages
-    if (consoleMessage.msgType== ConsoleMessageType.DEBUGGER){
+    if (consoleMessage.msgType == ConsoleMessageType.DEBUGGER) {
       return consoleMessage
     }
     ConsoleMessageProcessor.processConsoleMessage(consoleMessage, consoleMessageDisplayLength)


### PR DESCRIPTION
This PR fixes an issue where a breakpoint cannot be removed. The root cause is that debugger rely on ConsoleMessages that contains events emitted from debugger to update the debugger UI, however the message got truncated, and lost information. 

For instance:
```
Deleted breakpoint 1 at /var/folders/vx/n8rz0dfx0lq3rmb976tsg1840000gn/T/tmprook3p18fsTempFS/udf-v1.py:9
```
has been truncated to:
```
Deleted breakpoint 1 at /var/folders/vx/n8rz0dfx0lq3rmb976tsg1840000gn/T/tmprook3p18fsTem...
```

This causes the line number lost from the message, and UI cannot remove breakpoint from the correct line.

This PR fixes the issue by temporarily disable truncating for ConsoleMessages emitted by the debugger. A long term solution should not truncate the ground truth message, but to alter display only.