### PR TITLE
feat: display datasets version creation timestamp

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -349,7 +349,7 @@ export class DatasetDetailComponent implements OnInit {
           this.currentDatasetVersionSize = data.size;
           if (typeof version.creationTime === "number") {
             const date = new Date(version.creationTime);
-            this.selectedVersionCreationTime = format(date, "MM/dd/yyyy");
+            this.selectedVersionCreationTime = format(date, "MM/dd/yyyy HH:mm:ss");
           }
           let currentNode = this.fileTreeNodeList[0];
           while (currentNode.type === "directory" && currentNode.children) {


### PR DESCRIPTION
### **Purpose**
This PR (in addition to #3706) enhances the dataset version display by adding the creation timestamp alongside version size, giving users clearer context for when each version was created and reducing reliance on manual descriptions.

### **Changes**
- Added creation timestamp display for dataset versions in `MM/dd/yyyy HH:mm:ss` format, using existing styling for consistent UI appearance.

### **Demonstration**
<img width="1424" height="785" alt="timestamp" src="https://github.com/user-attachments/assets/69809f85-9375-45fe-99f6-6d8503a06b93" />
