### PR TITLE
fixed delete button only clickable from outer ring

### DIFF
--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1374,7 +1374,6 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
         this.paper.translate(-targetCoord.x, -targetCoord.y);
       });
   }
-
   /**
    * Info button on link between operator shown when user hovers over links
    */
@@ -1422,13 +1421,23 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
   private static RemoveButton: new () => joint.linkTools.Button;
 
   private static getRemoveButton(): new () => joint.linkTools.Button {
-    // Check if the class has already been created.
     if (!WorkflowEditorComponent.RemoveButton) {
-      // If not, create it once and store it in the static property.
       WorkflowEditorComponent.RemoveButton = joint.linkTools.Button.extend({
         name: "remove-button",
         options: {
           markup: [
+            {
+              tagName: "circle",
+              selector: "hit-area",
+              attributes: {
+                r: 10,
+                fill: "#000",
+                "fill-opacity": 0.001,
+                stroke: "none",
+                "pointer-events": "visibleFill",
+                cursor: "pointer",
+              },
+            },
             {
               tagName: "circle",
               selector: "button",
@@ -1437,8 +1446,7 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
                 fill: "none",
                 stroke: "#D8656A",
                 "stroke-width": 2,
-                "pointer-events": "visibleStroke",
-                cursor: "pointer",
+                "pointer-events": "none",
               },
             },
             {
@@ -1465,7 +1473,6 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
       });
     }
 
-    // Return the cached class.
     return WorkflowEditorComponent.RemoveButton;
   }
 }


### PR DESCRIPTION
It’s only clickable on a tiny area because the button is drawn as a stroke-only ring with "pointer-events": "visibleStroke". That means clicks register only on the stroke pixels, not the whole circle area. To fix it, an invisible filled circle is placed underneath as a hit area, so the entire region inside the ring responds to clicks.