### PR TITLE
ci: fix labeler.yml glob pattern syntax

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,7 +23,7 @@ backend:
   - changed-files:
       - any-glob-to-any-file:
           - 'core/**'
-      - all-globs-to-any-files:
+      - all-globs-to-all-files:
           - '!core/gui/**'
           - '!core/log/**'
           - '!core/scripts/**'


### PR DESCRIPTION
The `all-globs-to-any-files` dose not exist. Fixing typo `glob`.