### PR TITLE
ci: fix labeler configuration for file glob patterns

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -23,7 +23,7 @@ backend:
   - changed-files:
       - any-glob-to-any-file:
           - 'core/**'
-      - all-glob-to-any-file:
+      - all-globs-to-all-files:
           - '!core/gui/**'
           - '!core/log/**'
           - '!core/scripts/**'


### PR DESCRIPTION
Fix negation rule for `backend`. 