### PR TITLE
fix: conditionally show upload panels based on upload activity

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -281,12 +281,9 @@
             nzGhost
             class="upload-status-panels">
             <nz-collapse-panel
-              [nzHeader]="queuedCount > 0
-                  ? ('Pending: ' + queuedCount + ' file(s)')
-                  : 'Pending'">
-              <div
-                *ngIf="queuedCount > 0"
-                class="upload-progress-wrapper-pending">
+              *ngIf="queuedCount > 0"
+              [nzHeader]="'Pending: ' + queuedCount + ' file(s)'">
+              <div class="upload-progress-wrapper-pending">
                 <div
                   *ngFor="let fileName of queuedFileNames"
                   class="upload-progress-container">
@@ -294,15 +291,15 @@
                 </div>
               </div>
             </nz-collapse-panel>
-            <nz-divider class="section-divider"></nz-divider>
+
+            <nz-divider
+              class="section-divider"
+              *ngIf="queuedCount > 0"></nz-divider>
 
             <nz-collapse-panel
-              [nzHeader]="activeCount > 0
-                  ? ('Uploading: ' + activeCount + ' file(s)')
-                  : 'Uploading'">
-              <div
-                *ngIf="activeCount > 0"
-                class="upload-progress-wrapper">
+              *ngIf="activeCount > 0"
+              [nzHeader]="'Uploading: ' + activeCount + ' file(s)'">
+              <div class="upload-progress-wrapper">
                 <div
                   *ngFor="let task of uploadTasks; trackBy: trackByTask"
                   class="upload-progress-container">
@@ -346,20 +343,31 @@
                 </div>
               </div>
             </nz-collapse-panel>
-            <nz-divider class="section-divider"></nz-divider>
+
+            <nz-divider
+              class="section-divider"
+              *ngIf="activeCount > 0"></nz-divider>
 
             <nz-collapse-panel
-              [nzHeader]="pendingChangesCount > 0
-              ? ('Finished: ' + pendingChangesCount + ' file(s)')
-              : 'Finished'"
-              [nzActive]="false">
+              *ngIf="hasAnyActivity"
+              [nzHeader]="'Finished: ' + pendingChangesCount + ' file(s)'">
               <texera-dataset-staged-objects-list
                 [uploadTimeMap]="uploadTimeMap"
                 [did]="did"
                 [userMakeChangesEvent]="userMakeChanges"
-                (stagedObjectsChanged)="onStagedObjectsUpdated($event)"></texera-dataset-staged-objects-list>
+                (stagedObjectsChanged)="onStagedObjectsUpdated($event)">
+              </texera-dataset-staged-objects-list>
             </nz-collapse-panel>
           </nz-collapse>
+
+          <texera-dataset-staged-objects-list
+            *ngIf="!hasAnyActivity"
+            [uploadTimeMap]="uploadTimeMap"
+            [did]="did"
+            [userMakeChangesEvent]="userMakeChanges"
+            (stagedObjectsChanged)="onStagedObjectsUpdated($event)">
+          </texera-dataset-staged-objects-list>
+
           <div
             *ngIf="userHasWriteAccess() && userHasPendingChanges"
             class="version-creator">

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -533,6 +533,10 @@ export class DatasetDetailComponent implements OnInit {
     return this.activeUploads;
   }
 
+  get hasAnyActivity(): boolean {
+    return this.pendingChangesCount > 0 || this.activeCount > 0 || this.queuedCount > 0;
+  }
+
   // Hide a task row after 5s
   private scheduleHide(idx: number) {
     if (idx === -1) {

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.html
@@ -20,7 +20,8 @@
 <div class="staged-object-list-container">
   <nz-list
     nzSize="small"
-    *ngIf="datasetStagedObjects.length > 0">
+    *ngIf="datasetStagedObjects.length > 0"
+    class="custom-border-list">
     <nz-list-item *ngFor="let obj of datasetStagedObjects">
       <span>
         <nz-tag [nzColor]="obj.diffType === 'added' ? 'green' : 'red'"> {{ obj.diffType }} </nz-tag>

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-staged-objects-list/user-dataset-staged-objects-list.component.scss
@@ -24,6 +24,10 @@
   overflow-x: auto; /* Prevents horizontal scrolling */
 }
 
+.custom-border-list {
+  border-bottom: 1px solid #f0f0f0;
+}
+
 .truncate-file-path {
   display: inline-block;
   max-width: 250px; /* Adjust width as needed */


### PR DESCRIPTION
### **Purpose**
This PR fixes #3804 that the upload status panel behaved unexpectedly: when there were no queued/active uploads, the UI still rendered empty panels, which was confusing. This PR hides empty panels and restores the clear empty state.

### **Changes**
- Introduce a flag ` hasAnyActivity = queuedCount > 0 || activeCount > 0 || pendingChangesCount > 0 `
- Conditionally render status panels:
  - Pending only when queuedCount > 0
  - Uploading only when activeCount > 0
  - Finished only when hasAnyActivity
- Restore the empty state: when no activity, render `<texera-dataset-staged-objects-list>` outside the collapse so “No pending changes” is visible
- Add a bottom divider beneath the staged list to improve visual separation (the previous `[nzBorder]` was removed to avoid overlapping with the vertical divider)

### **Demonstration**
**Datasets page:**
<img width="1315" height="870" alt="main" src="https://github.com/user-attachments/assets/9112999c-24bc-4076-b139-eb3b405c2288" />

**Finished panel:** 
| Collapsed | Expanded (delete) | Expanded (adds) |
|---|---|---|
| <img width="260" src="https://github.com/user-attachments/assets/58fe8ba4-2b13-45a6-b049-318b288ec37e" alt="collapsed" /> | <img width="260" src="https://github.com/user-attachments/assets/21dada5c-0e39-4a9f-b1ee-ab0ede345aca" alt="delete" /> | <img width="260" src="https://github.com/user-attachments/assets/d3a25bea-bee3-4bb7-8023-b407741b01fe" alt="expand" /> |


**Uploading files:**

https://github.com/user-attachments/assets/413f9480-330e-456a-8a0a-7f87511fbf13

**Remove files:** 

https://github.com/user-attachments/assets/04fc0dc0-4f59-4e18-bb1d-72b0132ac943


