### PR TITLE
Improve Bug Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -46,9 +46,18 @@ body:
       description: What version of Texera are you running?
       options:
         - 1.0.0 (Default)
+        - 1.1.0-incubating (Pre-release/Master)
       default: 0
     validations:
       required: true
+  - type: input
+    id: commit-hash
+    attributes:
+      label: Commit Hash (Optional)
+      description: If you know the specific commit that has the issue, please provide the commit hash here.
+      placeholder: e.g., a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0
+    validations:
+      required: false
   - type: dropdown
     id: browsers
     attributes:


### PR DESCRIPTION
This PR improves the template for creating GitHub issues of type "Bug", based on the feedback provided in [this comment](https://github.com/apache/texera/pull/3812#issuecomment-3369000235)

1. Added a Pre-release Version option to the version selection field.
2. Added an optional Commit Hash field for developers to specify the exact commit associated with the issue.