### PR TITLE
feat(backend): Support flow control (backpressure) visualization in backend

### DIFF
--- a/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/rpc/controlreturns.proto
+++ b/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/rpc/controlreturns.proto
@@ -43,6 +43,7 @@ message ControlReturn {
     WorkerStateResponse workerStateResponse = 50;
     WorkerMetricsResponse workerMetricsResponse = 51;
     FinalizeCheckpointResponse finalizeCheckpointResponse = 52;
+    FlowControlUsageResponse flowControlUsageResponse = 53;
 
     // common responses
     ControlError controlError = 101;
@@ -138,4 +139,8 @@ message WorkerStateResponse {
 
 message WorkerMetricsResponse {
   worker.WorkerMetrics metrics = 1  [(scalapb.field).no_box = true];
+}
+
+message FlowControlUsageResponse {
+  map<string, int64> channel_usage_bytes = 1;
 }

--- a/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/rpc/workerservice.proto
+++ b/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/rpc/workerservice.proto
@@ -39,6 +39,7 @@ service WorkerService {
   rpc OpenExecutor(EmptyRequest) returns (EmptyReturn);
   rpc PauseWorker(EmptyRequest) returns (WorkerStateResponse);
   rpc PrepareCheckpoint(PrepareCheckpointRequest) returns (EmptyReturn);
+  rpc QueryFlowControlUsage(EmptyRequest) returns (FlowControlUsageResponse);
   rpc QueryStatistics(EmptyRequest) returns (WorkerMetricsResponse);
   rpc ResumeWorker(EmptyRequest) returns (WorkerStateResponse);
   rpc RetrieveState(EmptyRequest) returns (EmptyReturn);

--- a/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/worker/statistics.proto
+++ b/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/worker/statistics.proto
@@ -55,6 +55,7 @@ message WorkerStatistics {
   int64 data_processing_time = 3;
   int64 control_processing_time = 4;
   int64 idle_time = 5;
+  map<string, int64> channel_usage_bytes = 6;
 }
 
 message WorkerMetrics {

--- a/amber/src/main/protobuf/org/apache/texera/amber/engine/common/executionruntimestate.proto
+++ b/amber/src/main/protobuf/org/apache/texera/amber/engine/common/executionruntimestate.proto
@@ -84,11 +84,20 @@ message OperatorMetrics{
   OperatorStatistics operator_statistics = 2 [(scalapb.field).no_box = true];
 }
 
+message EdgeStatistics{
+  string from_op_id = 1;
+  int32 from_port_id = 2;
+  string to_op_id = 3;
+  int32 to_port_id = 4;
+  int64 usage_bytes = 5;
+}
+
 message ExecutionStatsStore {
   int64 startTimeStamp = 1;
   int64 endTimeStamp = 2;
   map<string, OperatorMetrics> operator_info = 3;
   repeated OperatorWorkerMapping operator_worker_mapping = 4;
+  repeated EdgeStatistics edge_info = 5;
 }
 
 

--- a/amber/src/main/python/core/architecture/managers/statistics_manager.py
+++ b/amber/src/main/python/core/architecture/managers/statistics_manager.py
@@ -16,7 +16,7 @@
 # under the License.
 
 from collections import defaultdict
-from typing import DefaultDict
+from typing import DefaultDict, Optional
 
 from proto.org.apache.texera.amber.core import PortIdentity
 from proto.org.apache.texera.amber.engine.architecture.worker import (
@@ -40,7 +40,11 @@ class StatisticsManager:
         self._total_execution_time: int = 0
         self._worker_start_time: int = 0
 
-    def get_statistics(self) -> WorkerStatistics:
+    def get_statistics(
+        self, channel_usage_bytes: Optional[dict[str, int]] = None
+    ) -> WorkerStatistics:
+        if channel_usage_bytes is None:
+            channel_usage_bytes = {}
         # Compile and return worker statistics
         return WorkerStatistics(
             [
@@ -56,6 +60,7 @@ class StatisticsManager:
             self._total_execution_time
             - self._data_processing_time
             - self._control_processing_time,
+            channel_usage_bytes,
         )
 
     def increase_input_statistics(self, port_id: PortIdentity, size: int) -> None:

--- a/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
+++ b/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
@@ -29,13 +29,34 @@ K = TypeVar("K")
 T = TypeVar("T")
 
 
+def _estimate_in_mem_size(item: T) -> int:
+    """
+    Estimate in-memory bytes for queue accounting.
+    Prefer payload/frame byte size when available; otherwise fall back to object size.
+    """
+    if item is None:
+        return 0
+
+    payload = getattr(item, "payload", None)
+    frame = getattr(payload, "frame", None) if payload is not None else None
+    if frame is not None:
+        if hasattr(frame, "nbytes"):
+            return int(frame.nbytes)
+        if hasattr(frame, "to_table"):
+            table = frame.to_table()
+            if hasattr(table, "nbytes"):
+                return int(table.nbytes)
+
+    return sys.getsizeof(item)
+
+
 class LinkedBlockingMultiQueue(IKeyedQueue):
     @inner
     class Node(Generic[T]):
         def __init__(self, item: T):
             self.item = item
             self.next: Optional[LinkedBlockingMultiQueue.Node[T]] = None
-            self.in_mem_size = sys.getsizeof(item)
+            self.in_mem_size = _estimate_in_mem_size(item)
 
     @inner
     class SubQueue(Generic[T]):

--- a/amber/src/main/python/proto/org/apache/texera/amber/engine/architecture/rpc/__init__.py
+++ b/amber/src/main/python/proto/org/apache/texera/amber/engine/architecture/rpc/__init__.py
@@ -419,6 +419,9 @@ class ControlReturn(betterproto.Message):
     finalize_checkpoint_response: "FinalizeCheckpointResponse" = (
         betterproto.message_field(52, group="sealed_value")
     )
+    flow_control_usage_response: "FlowControlUsageResponse" = betterproto.message_field(
+        53, group="sealed_value"
+    )
     control_error: "ControlError" = betterproto.message_field(101, group="sealed_value")
     """common responses"""
 
@@ -515,6 +518,13 @@ class WorkerStateResponse(betterproto.Message):
 @dataclass(eq=False, repr=False)
 class WorkerMetricsResponse(betterproto.Message):
     metrics: "_worker__.WorkerMetrics" = betterproto.message_field(1)
+
+
+@dataclass(eq=False, repr=False)
+class FlowControlUsageResponse(betterproto.Message):
+    channel_usage_bytes: Dict[str, int] = betterproto.map_field(
+        1, betterproto.TYPE_STRING, betterproto.TYPE_INT64
+    )
 
 
 class RpcTesterStub(betterproto.ServiceStub):
@@ -833,11 +843,28 @@ class WorkerServiceStub(betterproto.ServiceStub):
         timeout: Optional[float] = None,
         deadline: Optional["Deadline"] = None,
         metadata: Optional["MetadataLike"] = None
-    ) -> "EmptyReturn":
+        ) -> "EmptyReturn":
         return await self._unary_unary(
             "/org.apache.texera.amber.engine.architecture.rpc.WorkerService/PrepareCheckpoint",
             prepare_checkpoint_request,
             EmptyReturn,
+            timeout=timeout,
+            deadline=deadline,
+            metadata=metadata,
+        )
+
+    async def query_flow_control_usage(
+        self,
+        empty_request: "EmptyRequest",
+        *,
+        timeout: Optional[float] = None,
+        deadline: Optional["Deadline"] = None,
+        metadata: Optional["MetadataLike"] = None
+    ) -> "FlowControlUsageResponse":
+        return await self._unary_unary(
+            "/org.apache.amber.engine.architecture.rpc.WorkerService/QueryFlowControlUsage",
+            empty_request,
+            FlowControlUsageResponse,
             timeout=timeout,
             deadline=deadline,
             metadata=metadata,

--- a/amber/src/main/python/proto/org/apache/texera/amber/engine/architecture/worker/__init__.py
+++ b/amber/src/main/python/proto/org/apache/texera/amber/engine/architecture/worker/__init__.py
@@ -4,7 +4,7 @@
 # This file has been @generated
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
 
 import betterproto
 
@@ -39,6 +39,9 @@ class WorkerStatistics(betterproto.Message):
     data_processing_time: int = betterproto.int64_field(3)
     control_processing_time: int = betterproto.int64_field(4)
     idle_time: int = betterproto.int64_field(5)
+    channel_usage_bytes: Dict[str, int] = betterproto.map_field(
+        6, betterproto.TYPE_STRING, betterproto.TYPE_INT64
+    )
 
 
 @dataclass(eq=False, repr=False)

--- a/amber/src/main/python/proto/org/apache/texera/amber/engine/common/__init__.py
+++ b/amber/src/main/python/proto/org/apache/texera/amber/engine/common/__init__.py
@@ -116,6 +116,15 @@ class OperatorMetrics(betterproto.Message):
 
 
 @dataclass(eq=False, repr=False)
+class EdgeStatistics(betterproto.Message):
+    from_op_id: str = betterproto.string_field(1)
+    from_port_id: int = betterproto.int32_field(2)
+    to_op_id: str = betterproto.string_field(3)
+    to_port_id: int = betterproto.int32_field(4)
+    usage_bytes: int = betterproto.int64_field(5)
+
+
+@dataclass(eq=False, repr=False)
 class ExecutionStatsStore(betterproto.Message):
     start_time_stamp: int = betterproto.int64_field(1)
     end_time_stamp: int = betterproto.int64_field(2)
@@ -125,6 +134,7 @@ class ExecutionStatsStore(betterproto.Message):
     operator_worker_mapping: List["OperatorWorkerMapping"] = betterproto.message_field(
         4
     )
+    edge_info: List["EdgeStatistics"] = betterproto.message_field(5)
 
 
 @dataclass(eq=False, repr=False)

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/common/AkkaMessageTransferService.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/common/AkkaMessageTransferService.scala
@@ -70,7 +70,7 @@ class AkkaMessageTransferService(
   private def checkCreditPolling(): Unit = {
     channelToFC.foreach {
       case (channel, fc) =>
-        if (fc.isOverloaded) {
+        if (fc.isOverloaded || fc.getQueuedBytes > 0) {
           refService.askForCredit(channel)
         }
     }
@@ -162,6 +162,14 @@ class AkkaMessageTransferService(
     logger.debug(s"current backpressure status = $backpressured channel credits = ${channelToFC
       .map(c => c._1 -> c._2.getCredit)}")
     handleBackpressure(backpressured)
+  }
+
+  def getChannelUsageBytes: Map[String, Long] = {
+    channelToFC.map {
+      case (channelId, flowControl) =>
+      val key = java.util.Base64.getEncoder.encodeToString(channelId.toByteArray)
+      key -> flowControl.getUsedBytes
+    }.toMap
   }
 
   private def checkResend(): Unit = {

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/ClientEvent.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/ClientEvent.scala
@@ -23,13 +23,16 @@ import org.apache.texera.amber.core.tuple.Tuple
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import org.apache.texera.amber.engine.common.ambermessage.WorkflowFIFOMessagePayload
-import org.apache.texera.amber.engine.common.executionruntimestate.OperatorMetrics
+import org.apache.texera.amber.engine.common.executionruntimestate.{EdgeStatistics, OperatorMetrics}
 
 trait ClientEvent extends WorkflowFIFOMessagePayload
 
 case class ExecutionStateUpdate(state: WorkflowAggregatedState) extends ClientEvent
 
-case class ExecutionStatsUpdate(operatorMetrics: Map[String, OperatorMetrics]) extends ClientEvent
+case class ExecutionStatsUpdate(
+    operatorMetrics: Map[String, OperatorMetrics],
+    edgeStatistics: Seq[EdgeStatistics] = Seq.empty
+) extends ClientEvent
 
 case class RuntimeStatisticsPersist(operatorMetrics: Map[String, OperatorMetrics])
     extends ClientEvent

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/Controller.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/Controller.scala
@@ -244,7 +244,8 @@ class Controller(
     outputMessages.foreach(transferService.send)
     cp.asyncRPCClient.sendToClient(
       ExecutionStatsUpdate(
-        cp.workflowExecution.getAllRegionExecutionsStats
+        cp.workflowExecution.getAllRegionExecutionsStats,
+        cp.workflowExecution.getAllRegionEdgeStatistics
       )
     )
     globalReplayManager.markRecoveryStatus(CONTROLLER, isRecovering = false)

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/WorkflowExecution.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/WorkflowExecution.scala
@@ -19,12 +19,13 @@
 
 package org.apache.texera.amber.engine.architecture.controller.execution
 
-import org.apache.texera.amber.core.virtualidentity.PhysicalOpIdentity
+import org.apache.texera.amber.core.virtualidentity.{ChannelIdentity, PhysicalOpIdentity}
 import org.apache.texera.amber.engine.architecture.controller.execution.ExecutionUtils.aggregateMetrics
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState._
 import org.apache.texera.amber.engine.architecture.scheduling.{Region, RegionIdentity}
-import org.apache.texera.amber.engine.common.executionruntimestate.OperatorMetrics
+import org.apache.texera.amber.engine.common.executionruntimestate.{EdgeStatistics, OperatorMetrics}
+import org.apache.texera.amber.util.VirtualIdentityUtils
 
 import scala.collection.mutable
 
@@ -104,6 +105,68 @@ case class WorkflowExecution() {
     * @return An `Iterable` of all `RegionExecution` objects in the order they were added.
     */
   def getAllRegionExecutions: Iterable[RegionExecution] = regionExecutions.values
+
+  def getAllRegionEdgeStatistics: Seq[EdgeStatistics] = {
+    val channelUsage: mutable.HashMap[ChannelIdentity, Long] = mutable.HashMap()
+
+    getAllRegionExecutions.foreach { regionExecution =>
+      regionExecution.getAllOperatorExecutions.foreach {
+        case (_, operatorExecution) =>
+          operatorExecution.getWorkerIds.foreach { workerId =>
+            val stats = operatorExecution.getWorkerExecution(workerId).getStats
+            stats.channelUsageBytes.foreach {
+              case (encodedChannelId, usageBytes) =>
+                val bytes =
+                  java.util.Base64.getDecoder.decode(encodedChannelId)
+                val channelId = ChannelIdentity.parseFrom(bytes)
+                val value = Math.max(0L, usageBytes)
+                // Keep latest sampled usage for this channel.
+                channelUsage.update(channelId, value)
+            }
+          }
+      }
+    }
+
+    val logicalEdgeUsage =
+      mutable.HashMap[(String, String), mutable.ArrayBuffer[Long]]()
+
+    channelUsage.foreach {
+      case (channelId, usageBytes) =>
+        val fromLogical = VirtualIdentityUtils.getPhysicalOpId(channelId.fromWorkerId).logicalOpId.id
+        val toLogical = VirtualIdentityUtils.getPhysicalOpId(channelId.toWorkerId).logicalOpId.id
+        logicalEdgeUsage
+          .getOrElseUpdate((fromLogical, toLogical), mutable.ArrayBuffer())
+          .append(usageBytes)
+    }
+
+    val edgeUsage =
+      mutable.HashMap[(String, Int, String, Int), mutable.ArrayBuffer[Long]]()
+    val edgeChannelCounts = mutable.HashMap[(String, Int, String, Int), Int]()
+
+    getAllRegionExecutions.foreach { regionExecution =>
+      regionExecution.region.resourceConfig.foreach { resourceConfig =>
+        resourceConfig.linkConfigs.foreach {
+          case (link, linkConfig) =>
+            val fromOpId = link.fromOpId.logicalOpId.id
+            val toOpId = link.toOpId.logicalOpId.id
+            val fromPortId = link.fromPortId.id
+            val toPortId = link.toPortId.id
+            val key = (fromOpId, fromPortId, toOpId, toPortId)
+            edgeUsage.getOrElseUpdate(key, mutable.ArrayBuffer())
+            edgeChannelCounts.update(key, linkConfig.channelConfigs.size)
+            logicalEdgeUsage.get((fromOpId, toOpId)).foreach { usages =>
+              edgeUsage.getOrElseUpdate(key, mutable.ArrayBuffer()).appendAll(usages)
+            }
+        }
+      }
+    }
+
+    edgeUsage.map {
+      case ((fromOpId, fromPortId, toOpId, toPortId), usages) =>
+        val avgUsage = if (usages.nonEmpty) usages.sum / usages.size else 0L
+        EdgeStatistics(fromOpId, fromPortId, toOpId, toPortId, avgUsage)
+    }.toSeq
+  }
 
   /**
     * Retrieves the latest `OperatorExecution` associated with the specified physical operatorId.

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
@@ -85,10 +85,11 @@ trait PauseHandler {
       .map { _ =>
         // update frontend workflow status and persist statistics
         val stats = cp.workflowExecution.getAllRegionExecutionsStats
-        sendToClient(ExecutionStatsUpdate(stats))
+        val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
+        sendToClient(ExecutionStatsUpdate(stats, edgeStats))
         sendToClient(RuntimeStatisticsPersist(stats))
         sendToClient(ExecutionStateUpdate(cp.workflowExecution.getState))
-        logger.info(s"workflow paused")
+        logger.info("workflow paused")
       }
     EmptyReturn()
   }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
@@ -21,6 +21,7 @@ package org.apache.texera.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
 import org.apache.texera.amber.config.ApplicationConfig
+import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
 import org.apache.texera.amber.core.virtualidentity.PhysicalOpIdentity
 import org.apache.texera.amber.engine.architecture.controller.{
   ControllerAsyncRPCHandlerInitializer,
@@ -65,16 +66,39 @@ trait QueryWorkerStatisticsHandler {
   // Reads the current cached stats and forwards them to the appropriate client sink(s).
   private def forwardStats(updateTarget: StatisticsUpdateTarget): Unit = {
     val stats = cp.workflowExecution.getAllRegionExecutionsStats
+    val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
     updateTarget match {
       case StatisticsUpdateTarget.UI_ONLY =>
-        sendToClient(ExecutionStatsUpdate(stats))
+        sendToClient(ExecutionStatsUpdate(stats, edgeStats))
       case StatisticsUpdateTarget.PERSISTENCE_ONLY =>
         sendToClient(RuntimeStatisticsPersist(stats))
       case StatisticsUpdateTarget.BOTH_UI_AND_PERSISTENCE |
           StatisticsUpdateTarget.Unrecognized(_) =>
-        sendToClient(ExecutionStatsUpdate(stats))
+        sendToClient(ExecutionStatsUpdate(stats, edgeStats))
         sendToClient(RuntimeStatisticsPersist(stats))
     }
+  }
+
+  private def withChannelUsage(
+      statsResp: WorkerMetricsResponse,
+      usage: Map[String, Long]
+  ): WorkerMetricsResponse = {
+    val mergedWorkerStats =
+      statsResp.metrics.workerStatistics.copy(channelUsageBytes = usage)
+    statsResp.copy(metrics = statsResp.metrics.copy(workerStatistics = mergedWorkerStats))
+  }
+
+  private def queryStatisticsWithFlow(
+      wid: ActorVirtualIdentity
+  ): Future[WorkerMetricsResponse] = {
+    Future
+      .join(
+        workerInterface.queryStatistics(EmptyRequest(), wid),
+        workerInterface.queryFlowControlUsage(EmptyRequest(), wid)
+      )
+      .map { case (statsResp, flowResp) =>
+        withChannelUsage(statsResp, flowResp.channelUsageBytes)
+      }
   }
 
   override def controllerInitiateQueryStatistics(
@@ -156,9 +180,13 @@ trait QueryWorkerStatisticsHandler {
 
                     // Send queryStatistics to each worker and update internal state on reply
                     workerIds.map { wid =>
-                      workerInterface.queryStatistics(EmptyRequest(), wid).map { resp =>
+                      queryStatisticsWithFlow(wid).map { mergedResp =>
                         collectedResults.addOne(
-                          (exec.getWorkerExecution(wid), resp, System.nanoTime())
+                          (
+                            exec.getWorkerExecution(wid),
+                            mergedResp,
+                            System.nanoTime()
+                          )
                         )
                       }
                     }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
@@ -60,12 +60,11 @@ trait ResumeHandler {
       .map { _ =>
         // update frontend status and persist statistics
         val stats = cp.workflowExecution.getAllRegionExecutionsStats
-        sendToClient(ExecutionStatsUpdate(stats))
+        val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
+        sendToClient(ExecutionStatsUpdate(stats, edgeStats))
         sendToClient(RuntimeStatisticsPersist(stats))
-        cp.controllerTimerService
-          .enableStatusUpdate() //re-enabled it since it is disabled in pause
-        cp.controllerTimerService
-          .enableRuntimeStatisticsCollection() //re-enabled it since it is disabled in pause
+        cp.controllerTimerService.enableStatusUpdate()
+        cp.controllerTimerService.enableRuntimeStatisticsCollection()
         EmptyReturn()
       }
   }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
@@ -27,10 +27,13 @@ import org.apache.texera.amber.engine.architecture.controller.{
 }
 import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
   AsyncRPCContext,
-  EmptyRequest
+  EmptyRequest,
+  QueryStatisticsRequest,
+  StatisticsUpdateTarget
 }
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.EmptyReturn
 import org.apache.texera.amber.util.VirtualIdentityUtils
+import org.apache.texera.amber.engine.common.virtualidentity.util.SELF
 
 /** resume the entire workflow
   *
@@ -40,13 +43,17 @@ trait ResumeHandler {
   this: ControllerAsyncRPCHandlerInitializer =>
 
   override def resumeWorkflow(msg: EmptyRequest, ctx: AsyncRPCContext): Future[EmptyReturn] = {
+    val resumedWorkerIds =
+      cp.workflowExecution.getRunningRegionExecutions
+        .flatMap(_.getAllOperatorExecutions.map(_._2))
+        .flatMap(_.getWorkerIds)
+        .toSeq
+
     // send all workers resume
     // resume message has no effect on non-paused workers
     Future
       .collect(
-        cp.workflowExecution.getRunningRegionExecutions
-          .flatMap(_.getAllOperatorExecutions.map(_._2))
-          .flatMap(_.getWorkerIds)
+        resumedWorkerIds
           .map { workerId =>
             workerInterface.resumeWorker(EmptyRequest(), mkContext(workerId)).map { resp =>
               cp.workflowExecution
@@ -55,19 +62,33 @@ trait ResumeHandler {
                 .update(System.nanoTime(), resp.state)
             }
           }
-          .toSeq
       )
-      .map { _ =>
-        // update frontend status and persist statistics
-        val stats = cp.workflowExecution.getAllRegionExecutionsStats
-        val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
-        sendToClient(ExecutionStatsUpdate(stats, edgeStats))
-        sendToClient(RuntimeStatisticsPersist(stats))
-        cp.controllerTimerService
-          .enableStatusUpdate() //re-enabled it since it is disabled in pause
-        cp.controllerTimerService
-          .enableRuntimeStatisticsCollection() //re-enabled it since it is disabled in pause
-        EmptyReturn()
+      .flatMap { _ =>
+        val statsRefresh =
+          if (resumedWorkerIds.nonEmpty) {
+            controllerInterface.controllerInitiateQueryStatistics(
+              QueryStatisticsRequest(
+                resumedWorkerIds,
+                StatisticsUpdateTarget.BOTH_UI_AND_PERSISTENCE
+              ),
+              mkContext(SELF)
+            )
+          } else {
+            // Keep the old behavior for degenerate cases where no worker needs to be resumed.
+            val stats = cp.workflowExecution.getAllRegionExecutionsStats
+            val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
+            sendToClient(ExecutionStatsUpdate(stats, edgeStats))
+            sendToClient(RuntimeStatisticsPersist(stats))
+            Future.value(EmptyReturn())
+          }
+
+        statsRefresh.map { _ =>
+          cp.controllerTimerService
+            .enableStatusUpdate() //re-enabled it since it is disabled in pause
+          cp.controllerTimerService
+            .enableRuntimeStatisticsCollection() //re-enabled it since it is disabled in pause
+          EmptyReturn()
+        }
       }
   }
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
@@ -63,8 +63,10 @@ trait ResumeHandler {
         val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
         sendToClient(ExecutionStatsUpdate(stats, edgeStats))
         sendToClient(RuntimeStatisticsPersist(stats))
-        cp.controllerTimerService.enableStatusUpdate()
-        cp.controllerTimerService.enableRuntimeStatisticsCollection()
+        cp.controllerTimerService
+          .enableStatusUpdate() //re-enabled it since it is disabled in pause
+        cp.controllerTimerService
+          .enableRuntimeStatisticsCollection() //re-enabled it since it is disabled in pause
         EmptyReturn()
       }
   }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/WorkerStateUpdatedHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/WorkerStateUpdatedHandler.scala
@@ -52,7 +52,8 @@ trait WorkerStateUpdatedHandler {
         operatorExecution.getWorkerExecution(ctx.sender).update(System.nanoTime(), msg.state)
       )
     val stats = cp.workflowExecution.getAllRegionExecutionsStats
-    sendToClient(ExecutionStatsUpdate(stats))
+    val edgeStats = cp.workflowExecution.getAllRegionEdgeStatistics
+    sendToClient(ExecutionStatsUpdate(stats, edgeStats))
     sendToClient(RuntimeStatisticsPersist(stats))
     EmptyReturn()
   }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/deploysemantics/layer/WorkerExecution.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/deploysemantics/layer/WorkerExecution.scala
@@ -35,7 +35,7 @@ case class WorkerExecution() extends Serializable {
 
   private var state: WorkerState = UNINITIALIZED
   private var stats: WorkerStatistics = {
-    WorkerStatistics(Seq.empty, Seq.empty, 0, 0, 0)
+    WorkerStatistics(Seq.empty, Seq.empty, 0, 0, 0, Map.empty)
   }
   private var lastUpdateTimeStamp = 0L
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/FlowControl.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/FlowControl.scala
@@ -123,4 +123,8 @@ class FlowControl {
   def getUsedBytes: Long = {
     inflightCredit + queuedCredit
   }
+
+  def getQueuedBytes: Long = {
+    queuedCredit
+  }
 }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/FlowControl.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/FlowControl.scala
@@ -119,4 +119,8 @@ class FlowControl {
   def getCredit: Long = {
     maxByteAllowed - inflightCredit - queuedCredit
   }
+
+  def getUsedBytes: Long = {
+    inflightCredit + queuedCredit
+  }
 }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -219,8 +219,11 @@ class PythonProxyClient(portNumberPromise: Promise[Int], val actorId: ActorVirtu
     val schemaRoot = VectorSchemaRoot.create(ArrowUtils.fromTexeraSchema(schema), allocator)
     val writer = flightClient.startPut(descriptor, schemaRoot, flightListener)
     schemaRoot.allocateNew()
+    var tupleInMemBytes: Long = 0L
     while (tuples.nonEmpty) {
-      ArrowUtils.appendTexeraTuple(tuples.dequeue(), schemaRoot)
+      val tuple = tuples.dequeue()
+      tupleInMemBytes += tuple.inMemSize
+      ArrowUtils.appendTexeraTuple(tuple, schemaRoot)
     }
     writer.putNext()
     schemaRoot.clear()

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyServer.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyServer.scala
@@ -50,6 +50,12 @@ private class AmberProducer(
     outputPort: NetworkOutputGateway,
     promise: Promise[Int]
 ) extends NoOpFlightProducer {
+  @volatile private var queuedCreditOf: ChannelIdentity => Long = _ => 0L
+
+  def setQueuedCreditOf(provider: ChannelIdentity => Long): Unit = {
+    queuedCreditOf = provider
+  }
+
   var _portNumber: AtomicInteger = new AtomicInteger(0)
 
   def portNumber: AtomicInteger = _portNumber
@@ -78,8 +84,8 @@ private class AmberProducer(
             throw new RuntimeException(s"not supported payload $payload")
         }
 
-        // get little-endian representation of credits
-        var creditVal: Long = 30L // TODO : replace with actual credit value
+        // Return current queued credit (bytes).
+        val creditVal: Long = queuedCreditOf(pythonControlMessage.tag)
         val creditByteArr: Array[Byte] =
           ByteBuffer.allocate(Longs.BYTES).order(ByteOrder.LITTLE_ENDIAN).putLong(creditVal).array
 
@@ -112,9 +118,7 @@ private class AmberProducer(
     val bufferAllocator = new RootAllocator(8 * 1024)
     try {
       val arrowBuf: ArrowBuf = bufferAllocator.buffer(Longs.BYTES + 4)
-      arrowBuf.writeLong(
-        31L
-      ) // TODO : replace with actual credit value
+      arrowBuf.writeLong(queuedCreditOf(to))
       ackStream.onNext(PutResult.metadata(arrowBuf))
       arrowBuf.close()
     } finally if (bufferAllocator != null) bufferAllocator.close()
@@ -153,6 +157,16 @@ class PythonProxyServer(
 ) extends Runnable
     with AutoCloseable
     with AmberLogging {
+  @volatile private var queuedCreditProvider: ChannelIdentity => Long = _ => 0L
+
+  def setQueuedCreditProvider(provider: ChannelIdentity => Long): Unit = {
+    queuedCreditProvider = provider
+  }
+
+  private def queuedCreditOf(channelId: ChannelIdentity): Long = {
+    queuedCreditProvider(channelId)
+  }
+
   private lazy val portNumber: AtomicInteger = new AtomicInteger(getFreeLocalPort)
 
   def getPortNumber: AtomicInteger = portNumber
@@ -160,7 +174,9 @@ class PythonProxyServer(
   val allocator: BufferAllocator =
     new RootAllocator().newChildAllocator("flight-server", 0, Long.MaxValue)
 
-  val producer: FlightProducer = new AmberProducer(actorId, outputPort, promise)
+  private val producerImpl = new AmberProducer(actorId, outputPort, promise)
+  producerImpl.setQueuedCreditOf(queuedCreditOf)
+  val producer: FlightProducer = producerImpl
 
   val location: Location = (() => {
     Location.forGrpcInsecure("localhost", portNumber.intValue())

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessor.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessor.scala
@@ -91,11 +91,19 @@ class DataProcessor(
     inputGateway.getChannel(channelId).getQueuedCredit
   }
 
+  @volatile private var channelUsageBytesProvider: () => Map[String, Long] = () => Map.empty
+
+  def setChannelUsageBytesProvider(provider: () => Map[String, Long]): Unit = {
+    channelUsageBytesProvider = provider
+  }
+
+  def collectFlowControlUsage(): Map[String, Long] = channelUsageBytesProvider()
+
   /**
     * provide API for actor to get stats of this operator
     */
   def collectStatistics(): WorkerStatistics =
-    statisticsManager.getStatistics(executor)
+    statisticsManager.getStatistics(executor, Map.empty)
 
   /**
     * process currentInputTuple through executor logic.

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorRPCHandlerInitializer.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorRPCHandlerInitializer.scala
@@ -41,6 +41,7 @@ class DataProcessorRPCHandlerInitializer(val dp: DataProcessor)
     with OpenExecutorHandler
     with PauseHandler
     with AddPartitioningHandler
+    with QueryFlowControlUsageHandler
     with QueryStatisticsHandler
     with ResumeHandler
     with StartHandler

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -95,6 +95,7 @@ class WorkflowWorker(
 
   override def initState(): Unit = {
     dp.initTimerService(timerService)
+    dp.setChannelUsageBytesProvider(() => transferService.getChannelUsageBytes)
     if (replayInitialization.restoreConfOpt.isDefined) {
       context.parent ! ReplayStatusUpdate(actorId, status = true)
       setupReplay(

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -172,6 +172,7 @@ class WorkflowWorker(
     logger.info("output messages restored.")
     dp = dpState // overwrite dp state
     dp.outputHandler = logManager.sendCommitted
+    dp.setChannelUsageBytesProvider(() => transferService.getChannelUsageBytes)
     dp.initTimerService(timerService)
     logger.info("start re-initialize executor from checkpoint.")
     val (executor, iter) = dp.serializationManager.restoreExecutorState(chkpt)

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/managers/StatisticsManager.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/managers/StatisticsManager.scala
@@ -47,7 +47,10 @@ class StatisticsManager {
     * @param operator the operator executor
     * @return a WorkerStatistics object containing the statistics
     */
-  def getStatistics(operator: OperatorExecutor): WorkerStatistics = {
+  def getStatistics(
+      operator: OperatorExecutor,
+      channelUsageBytes: Map[String, Long]
+  ): WorkerStatistics = {
     WorkerStatistics(
       inputStatistics.map {
         case (portId, (tupleCount, tupleSize)) =>
@@ -59,7 +62,8 @@ class StatisticsManager {
       }.toSeq,
       dataProcessingTime,
       controlProcessingTime,
-      totalExecutionTime - dataProcessingTime - controlProcessingTime
+      totalExecutionTime - dataProcessingTime - controlProcessingTime,
+      channelUsageBytes
     )
   }
 

--- a/amber/src/main/scala/org/apache/texera/web/model/websocket/event/TexeraWebSocketEvent.scala
+++ b/amber/src/main/scala/org/apache/texera/web/model/websocket/event/TexeraWebSocketEvent.scala
@@ -32,6 +32,7 @@ import org.apache.texera.web.model.websocket.response.{HeartBeatResponse, Modify
     new Type(value = classOf[WorkflowErrorEvent]),
     new Type(value = classOf[WorkflowStateEvent]),
     new Type(value = classOf[OperatorStatisticsUpdateEvent]),
+    new Type(value = classOf[EdgeStatisticsUpdateEvent]),
     new Type(value = classOf[WebResultUpdateEvent]),
     new Type(value = classOf[ConsoleUpdateEvent]),
     new Type(value = classOf[CacheStatusUpdateEvent]),

--- a/amber/src/main/scala/org/apache/texera/web/service/ExecutionStatsService.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/ExecutionStatsService.scala
@@ -21,6 +21,7 @@ package org.apache.texera.web.service
 
 import com.google.protobuf.timestamp.Timestamp
 import com.typesafe.scalalogging.LazyLogging
+import org.apache.texera.amber.config.ApplicationConfig
 import org.apache.texera.amber.core.storage.model.BufferedItemWriter
 import org.apache.texera.amber.core.storage.result.ResultSchema
 import org.apache.texera.amber.core.storage.{DocumentFactory, VFSURIFactory}
@@ -28,39 +29,16 @@ import org.apache.texera.amber.core.tuple.Tuple
 import org.apache.texera.amber.core.workflow.WorkflowContext
 import org.apache.texera.amber.core.workflowruntimestate.FatalErrorType.EXECUTION_FAILURE
 import org.apache.texera.amber.core.workflowruntimestate.WorkflowFatalError
-import org.apache.texera.amber.engine.architecture.controller.{
-  ExecutionStateUpdate,
-  ExecutionStatsUpdate,
-  FatalError,
-  RuntimeStatisticsPersist,
-  WorkerAssignmentUpdate,
-  WorkflowRecoveryStatus
-}
+import org.apache.texera.amber.engine.architecture.controller.{ExecutionStateUpdate, ExecutionStatsUpdate, FatalError, RuntimeStatisticsPersist, WorkerAssignmentUpdate, WorkflowRecoveryStatus}
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
-import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
-  COMPLETED,
-  FAILED,
-  KILLED
-}
+import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{COMPLETED, FAILED, KILLED}
 import org.apache.texera.amber.engine.common.Utils
 import org.apache.texera.amber.engine.common.Utils.maptoStatusCode
 import org.apache.texera.amber.engine.common.client.AmberClient
-import org.apache.texera.amber.engine.common.executionruntimestate.{
-  OperatorMetrics,
-  OperatorStatistics,
-  OperatorWorkerMapping
-}
-import org.apache.texera.amber.error.ErrorUtils.{
-  getOperatorFromActorIdOpt,
-  getStackTraceWithAllCauses
-}
+import org.apache.texera.amber.engine.common.executionruntimestate.{OperatorMetrics, OperatorStatistics, OperatorWorkerMapping}
+import org.apache.texera.amber.error.ErrorUtils.{getOperatorFromActorIdOpt, getStackTraceWithAllCauses}
 import org.apache.texera.web.SubscriptionManager
-import org.apache.texera.web.model.websocket.event.{
-  ExecutionDurationUpdateEvent,
-  OperatorAggregatedMetrics,
-  OperatorStatisticsUpdateEvent,
-  WorkerAssignmentUpdateEvent
-}
+import org.apache.texera.web.model.websocket.event.{EdgeStatistics, EdgeStatisticsUpdateEvent, ExecutionDurationUpdateEvent, OperatorAggregatedMetrics, OperatorStatisticsUpdateEvent, WorkerAssignmentUpdateEvent}
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource
 import org.apache.texera.web.storage.ExecutionStateStore
 import org.apache.texera.web.storage.ExecutionStateStore.updateWorkflowState
@@ -137,6 +115,29 @@ class ExecutionStatsService(
 
   addSubscription(
     stateStore.statsStore.registerDiffHandler((oldState, newState) => {
+      if (newState.edgeInfo != oldState.edgeInfo) {
+        Iterable(
+          EdgeStatisticsUpdateEvent(
+            newState.edgeInfo.map { edge =>
+              EdgeStatistics(
+                edge.fromOpId,
+                edge.fromPortId,
+                edge.toOpId,
+                edge.toPortId,
+                edge.usageBytes
+              )
+            },
+            ApplicationConfig.maxCreditAllowedInBytesPerChannel
+          )
+        )
+      } else {
+        Iterable.empty
+      }
+    })
+  )
+
+  addSubscription(
+    stateStore.statsStore.registerDiffHandler((oldState, newState) => {
       // update operators' workers.
       if (newState.operatorWorkerMapping != oldState.operatorWorkerMapping) {
         newState.operatorWorkerMapping
@@ -187,7 +188,7 @@ class ExecutionStatsService(
       client
         .registerCallback[ExecutionStatsUpdate]((evt: ExecutionStatsUpdate) => {
           stateStore.statsStore.updateState { statsStore =>
-            statsStore.withOperatorInfo(evt.operatorMetrics)
+            statsStore.withOperatorInfo(evt.operatorMetrics).withEdgeInfo(evt.edgeStatistics)
           }
         })
     )
@@ -207,7 +208,7 @@ class ExecutionStatsService(
   addSubscription(
     client.registerCallback[ExecutionStateUpdate] {
       case ExecutionStateUpdate(state: WorkflowAggregatedState.Recognized)
-          if Set(COMPLETED, FAILED, KILLED).contains(state) =>
+        if Set(COMPLETED, FAILED, KILLED).contains(state) =>
         logger.info("Workflow execution terminated. Commit runtime statistics.")
         try {
           runtimeStatsWriter.close()

--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -188,6 +188,14 @@
                   >Status</label
                 >
               </li>
+              <li nz-menu-item>
+                <label
+                  nz-checkbox
+                  [(ngModel)]="showEdgeStats"
+                  (ngModelChange)="toggleEdgeStats()"
+                  >Edge Stats</label
+                >
+              </li>
             </ul>
           </nz-dropdown-menu>
           <button

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -93,6 +93,7 @@ export class MenuComponent implements OnInit, OnDestroy {
   public showGrid: boolean = false;
   public showNumWorkers: boolean = false;
   public showStatus: boolean = false;
+  public showEdgeStats: boolean = false;
   protected readonly DASHBOARD_USER_WORKFLOW = DASHBOARD_USER_WORKFLOW;
 
   @Input() public writeAccess: boolean = false;
@@ -270,6 +271,12 @@ export class MenuComponent implements OnInit, OnDestroy {
       .getJointGraphWrapper()
       .mainPaper.el.classList.toggle("hide-operator-status", !this.showStatus);
     this.applyOperatorStatusPosition();
+  }
+
+  toggleEdgeStats() {
+    const mainPaper = this.workflowActionService.getJointGraphWrapper().mainPaper;
+    mainPaper.el.classList.toggle("hide-edge-stats", !this.showEdgeStats);
+    mainPaper.trigger("edge-stats-visibility-changed");
   }
 
   private applyOperatorStatusPosition(): void {

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.scss
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.scss
@@ -32,3 +32,25 @@
 ::ng-deep .hide-operator-status .operator-status {
   display: none;
 }
+
+::ng-deep .edge-stats-label {
+  fill: #4d4d4d;
+  font-size: 11px;
+  font-weight: 500;
+  pointer-events: none;
+}
+
+::ng-deep .edge-stats-bg {
+  fill: #ffffff;
+  stroke: #d9d9d9;
+  stroke-width: 1px;
+  opacity: 0.9;
+  rx: 3px;
+  ry: 3px;
+  pointer-events: none;
+}
+
+::ng-deep .hide-edge-stats .edge-stats-label,
+::ng-deep .hide-edge-stats .edge-stats-bg {
+  display: none;
+}

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -30,6 +30,7 @@ import { WorkflowActionService } from "../../service/workflow-graph/model/workfl
 import { WorkflowStatusService } from "../../service/workflow-status/workflow-status.service";
 import { ExecutionState, OperatorState } from "../../types/execute-workflow.interface";
 import { LogicalPort, OperatorLink } from "../../types/workflow-common.interface";
+import { EdgeStatistics } from "../../types/workflow-websocket.interface";
 import { auditTime, filter, map, takeUntil } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { UndoRedoService } from "../../service/undo-redo/undo-redo.service";
@@ -94,6 +95,8 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
   private currentOpenedOperatorID: string | null = null;
   private removeButton!: new () => joint.linkTools.Button;
   private breakpointButton!: new () => joint.linkTools.Button;
+  private latestEdgeStatistics: ReadonlyArray<EdgeStatistics> = [];
+  private latestMaxCreditAllowedInBytesPerChannel = 0;
 
   constructor(
     private workflowActionService: WorkflowActionService,
@@ -163,6 +166,8 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     this.handlePortHighlightEvent();
     this.registerPortDisplayNameChangeHandler();
     this.handleOperatorStatisticsUpdate();
+    this.handleEdgeStatisticsUpdate();
+    this.handleEdgeStatsVisibilityEvents();
     this.handleRegionEvents();
     this.handleOperatorSuggestionHighlightEvent();
     this.handleElementDelete();
@@ -249,6 +254,143 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     });
     this.editor.classList.add("hide-worker-count");
     this.editor.classList.add("hide-operator-status");
+    this.editor.classList.add("hide-edge-stats");
+  }
+
+  private handleEdgeStatisticsUpdate(): void {
+    this.executeWorkflowService
+      .getEdgeStatisticsUpdateStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(event => {
+        this.latestEdgeStatistics = event.edgeStatistics;
+        this.latestMaxCreditAllowedInBytesPerChannel = event.maxCreditAllowedInBytesPerChannel;
+        this.updateEdgeStatisticsLabels();
+      });
+  }
+
+  private updateEdgeStatisticsLabels(): void {
+    const edgeStatsVisible = !this.editor.classList.contains("hide-edge-stats");
+
+    this.paper.model.getLinks().forEach(link => {
+      link.labels([]);
+      this.applyEdgeStyle(link, linkPathStrokeColor, 2);
+    });
+    if (!edgeStatsVisible) {
+      return;
+    }
+
+    const keyToLink = new Map<string, joint.dia.Link>();
+    this.paper.model.getLinks().forEach(link => {
+      const source = link.get("source");
+      const target = link.get("target");
+      if (!source?.id || !target?.id || source.port === undefined || target.port === undefined) {
+        return;
+      }
+      const fromPort = this.toPortNumber(source.port);
+      const toPort = this.toPortNumber(target.port);
+      if (fromPort === undefined || toPort === undefined) {
+        return;
+      }
+      keyToLink.set(this.makeEdgeKey(String(source.id), fromPort, String(target.id), toPort), link);
+    });
+
+    this.latestEdgeStatistics.forEach(edgeStat => {
+      const link = keyToLink.get(
+        this.makeEdgeKey(edgeStat.fromOpId, edgeStat.fromPortId, edgeStat.toOpId, edgeStat.toPortId)
+      );
+      if (!link) {
+        return;
+      }
+      link.labels([
+        {
+          position: 0.5,
+          attrs: {
+            rect: {
+              class: "edge-stats-bg",
+            },
+            text: {
+              class: "edge-stats-label",
+              text: this.formatEdgeUsage(edgeStat.usageBytes, this.latestMaxCreditAllowedInBytesPerChannel),
+            },
+          },
+        },
+      ]);
+      this.applyEdgeStyle(
+        link,
+        this.getEdgeUsageColor(edgeStat.usageBytes, this.latestMaxCreditAllowedInBytesPerChannel),
+        this.getEdgeUsageStrokeWidth(edgeStat.usageBytes, this.latestMaxCreditAllowedInBytesPerChannel)
+      );
+    });
+  }
+
+  private makeEdgeKey(fromOpId: string, fromPortId: number, toOpId: string, toPortId: number): string {
+    return `${fromOpId}:${fromPortId}->${toOpId}:${toPortId}`;
+  }
+
+  private toPortNumber(port: unknown): number | undefined {
+    if (typeof port === "number" && Number.isFinite(port)) {
+      return port;
+    }
+    if (typeof port !== "string") {
+      return undefined;
+    }
+    const direct = Number(port);
+    if (!Number.isNaN(direct)) {
+      return direct;
+    }
+    const match = port.match(/(\d+)$/);
+    if (!match) {
+      return undefined;
+    }
+    const parsed = Number(match[1]);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  }
+
+  private formatEdgeUsage(usageBytes: number, maxCreditAllowedInBytesPerChannel: number): string {
+    const usage = Math.max(0, usageBytes);
+    const maxCredit = Math.max(1, maxCreditAllowedInBytesPerChannel);
+    const percentage = (usage / maxCredit) * 100;
+    return `${this.formatBytes(usage)} (${percentage.toFixed(1)}%)`;
+  }
+
+  private formatBytes(bytes: number): string {
+    if (bytes < 1024) {
+      return `${bytes} B`;
+    }
+    if (bytes < 1024 * 1024) {
+      return `${(bytes / 1024).toFixed(1)} KB`;
+    }
+    if (bytes < 1024 * 1024 * 1024) {
+      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    }
+    return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  }
+
+  private getEdgeUsageColor(usageBytes: number, maxCreditAllowedInBytesPerChannel: number): string {
+    const usage = Math.max(0, usageBytes);
+    const maxCredit = Math.max(1, maxCreditAllowedInBytesPerChannel);
+    const ratio = usage / maxCredit;
+    if (ratio >= 0.6) {
+      return "#ff4d4f";
+    }
+    if (ratio >= 0.3) {
+      return "#fa8c16";
+    }
+    return "#52c41a";
+  }
+
+  private getEdgeUsageStrokeWidth(usageBytes: number, maxCreditAllowedInBytesPerChannel: number): number {
+    const usage = Math.max(0, usageBytes);
+    const maxCredit = Math.max(1, maxCreditAllowedInBytesPerChannel);
+    const ratio = Math.min(usage / maxCredit, 1);
+    return 2 + ratio * 4;
+  }
+
+  private applyEdgeStyle(link: joint.dia.Link, color: string, strokeWidth: number): void {
+    link.attr(".connection/stroke", color);
+    link.attr(".connection/stroke-width", strokeWidth);
+    link.attr(".marker-source/fill", color);
+    link.attr(".marker-target/fill", color);
   }
 
   private handleDisableJointPaperInteractiveness(): void {
@@ -265,6 +407,12 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
         }
         this.changeDetectorRef.detectChanges();
       });
+  }
+
+  private handleEdgeStatsVisibilityEvents(): void {
+    this.paper.on("edge-stats-visibility-changed", () => {
+      this.updateEdgeStatisticsLabels();
+    });
   }
 
   /**

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -30,6 +30,7 @@ import {
 } from "../../types/execute-workflow.interface";
 import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
 import {
+  EdgeStatisticsUpdateEvent,
   OperatorCurrentTuples,
   RegionStateEvent,
   RegionUpdateEvent,
@@ -89,6 +90,7 @@ export class ExecuteWorkflowService {
 
   private regionUpdateStream = new Subject<RegionUpdateEvent>();
   private regionStateStream = new Subject<RegionStateEvent>();
+  private edgeStatisticsUpdateStream = new Subject<EdgeStatisticsUpdateEvent>();
 
   // TODO: move this to another service, or redesign how this
   //   information is stored on the frontend.
@@ -109,6 +111,9 @@ export class ExecuteWorkflowService {
           break;
         case "RegionStateEvent":
           this.regionStateStream.next(event);
+          break;
+        case "EdgeStatisticsUpdateEvent":
+          this.edgeStatisticsUpdateStream.next(event);
           break;
         case "WorkerAssignmentUpdateEvent":
           this.assignedWorkerIds.set(event.operatorId, event.workerIds);
@@ -346,6 +351,10 @@ export class ExecuteWorkflowService {
 
   public getRegionStateStream(): Observable<RegionStateEvent> {
     return this.regionStateStream.asObservable();
+  }
+
+  public getEdgeStatisticsUpdateStream(): Observable<EdgeStatisticsUpdateEvent> {
+    return this.edgeStatisticsUpdateStream.asObservable();
   }
 
   public resetExecutionState(): void {

--- a/frontend/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/frontend/src/app/workspace/types/workflow-websocket.interface.ts
@@ -185,6 +185,19 @@ export type RegionStateEvent = Readonly<{
   state: string;
 }>;
 
+export type EdgeStatistics = Readonly<{
+  fromOpId: string;
+  fromPortId: number;
+  toOpId: string;
+  toPortId: number;
+  usageBytes: number;
+}>;
+
+export type EdgeStatisticsUpdateEvent = Readonly<{
+  edgeStatistics: ReadonlyArray<EdgeStatistics>;
+  maxCreditAllowedInBytesPerChannel: number;
+}>;
+
 export type ModifyLogicResponse = Readonly<{
   opId: string;
   isValid: boolean;
@@ -243,6 +256,7 @@ export type TexeraWebsocketEventTypeMap = {
   ClusterStatusUpdateEvent: ClusterStatusUpdateEvent;
   RegionUpdateEvent: RegionUpdateEvent;
   RegionStateEvent: RegionStateEvent;
+  EdgeStatisticsUpdateEvent: EdgeStatisticsUpdateEvent;
 };
 
 // helper type definitions to generate the request and event types


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR introduces backend support for flow control (backpressure) visualization in workflow execution.

During workflow execution, operators may experience backpressure when they receive data faster than they can process. In such cases, the operator signals its upstream operators to temporarily slow down or pause data transmission. This mechanism helps prevent buffer overflow and maintains stable execution.

This PR exposes the backpressure status of operators and edges from the backend so that the frontend can visualize the flow control behavior of the workflow.

The main changes include:

- Adding backend support to collect and propagate flow control / backpressure status
- Extending execution monitoring data structures to include flow control information
- Merge per-worker physical channel usage into logical workflow-edge statistics so the frontend can render pressure on graph edges.
- Keep the feature visualization-only: this PR does not change the existing flow-control algorithm, thresholds, scheduling behavior, or acknowledgement semantics. It only exposes and aggregates the runtime values already used by the backpressure mechanism.

In short, this PR makes the backend capable of reporting where backpressure is happening and how much queued data is currently contributing to flow control, so the frontend can visualize execution bottlenecks directly on workflow edges.

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
This PR fixes Issue #4321.

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
This PR was tested manually in a local development environment.

The following scenarios were verified:

- Confirmed the backend successfully collects flow-control usage from workers during workflow execution.
- Confirmed execution statistics events include edge-level usage data and the configured flow-control credit limit.
- Verified the both Scala and Python worker reports more realistic queue usage values.
- Ran workflows with intentionally slowed downstream operators to create backpressure and verified that the reported edge statistics increase under congestion and decrease as queued data is drained.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
