### PR TITLE
perf(amber): reuse spec ActorSystem in CheckpointSpec

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/common/AmberRuntime.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/common/AmberRuntime.scala
@@ -51,6 +51,11 @@ object AmberRuntime {
     _actorSystem
   }
 
+  def actorSystem_=(system: ActorSystem): Unit = {
+    _actorSystem = system
+    _serde = SerializationExtension(system)
+  }
+
   def scheduleCallThroughActorSystem(delay: FiniteDuration)(call: => Unit): Cancellable = {
     _actorSystem.scheduler.scheduleOnce(delay)(call)
   }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/faulttolerance/CheckpointSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/faulttolerance/CheckpointSpec.scala
@@ -60,7 +60,12 @@ class CheckpointSpec extends AnyFlatSpecLike with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     system = ActorSystem("CheckpointSpec", AmberRuntime.akkaConfig)
+    AmberRuntime.actorSystem = system
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
   }
 
   "Default controller state" should "be serializable" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

`CheckpointSpec` was the slowest spec in CI (~70s for 2 trivial assertions) because it booted **two** Pekko `ActorSystem`s:
- one in `beforeAll` (`CheckpointSpec.scala:62`)
- a second one created lazily inside `AmberRuntime.serde` when `chkpt.save(...)` was first called

The two systems never interacted — the second only existed so `SerializationExtension` had a system to attach to.

This PR adds an `actorSystem_=` setter on `AmberRuntime` and uses it in `CheckpointSpec.beforeAll` to hand the spec's own system to the runtime, so the lazy fallback never fires.

### Any related issues, documentation, discussions?

Closes #4501

### How was this PR tested?

Existing `CheckpointSpec` tests cover the two assertions. Verified locally that the spec still completes the same two assertions; relying on CI to confirm full timing improvement.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)