### PR TITLE
perf(amber): exit TrivialControlSpec receiveWhile early

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/control/TrivialControlSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/control/TrivialControlSpec.scala
@@ -64,29 +64,30 @@ class TrivialControlSpec
     val (events, expectedValues) = eventPairs.unzip
     val (probe, idMap) = setUp(numActors, events: _*)
     var flag = 0
-    probe.receiveWhile(5.minutes, 10.seconds) {
-      case GetActorRef(id, replyTo) =>
-        replyTo.foreach { actor =>
-          actor ! RegisterActorRef(id, idMap(id))
-        }
-      case NetworkMessage(
+    while (flag < expectedValues.length) {
+      probe.receiveOne(10.seconds) match {
+        case null =>
+          throw new AssertionError(
+            s"timeout: received $flag of ${expectedValues.length} expected returns"
+          )
+        case GetActorRef(id, replyTo) =>
+          replyTo.foreach { actor =>
+            actor ! RegisterActorRef(id, idMap(id))
+          }
+        case NetworkMessage(
+              msgID,
+              workflowMsg @ WorkflowFIFOMessage(_, _, ReturnInvocation(id, returnValue))
+            ) =>
+          probe.sender() ! NetworkAck(
             msgID,
-            workflowMsg @ WorkflowFIFOMessage(_, _, ReturnInvocation(id, returnValue))
-          ) =>
-        probe.sender() ! NetworkAck(
-          msgID,
-          getInMemSize(workflowMsg),
-          0L // no queued credit
-        )
-        returnValue match {
-          case _ => assert(returnValue.asInstanceOf[T] == expectedValues(id.toInt))
-        }
-        flag += 1
-      case other =>
-      //skip
-    }
-    if (flag != expectedValues.length) {
-      throw new AssertionError()
+            getInMemSize(workflowMsg),
+            0L // no queued credit
+          )
+          assert(returnValue.asInstanceOf[T] == expectedValues(id.toInt))
+          flag += 1
+        case _ =>
+        //skip
+      }
     }
     idMap.foreach { x =>
       x._2 ! PoisonPill


### PR DESCRIPTION
### What changes were proposed in this PR?

`TrivialControlSpec.testControl` used `probe.receiveWhile(5.minutes, 10.seconds)` with a catch-all `case other => skip`. Because the partial function always matched, `receiveWhile` could only exit via the 10s idle timeout — so every test sat idle for ~10s after collecting all expected returns. With 8 tests, that was ~80s of pure waiting.

Replace `receiveWhile` with a manual loop that exits as soon as `flag == expectedValues.length`. Behavior preserved: same per-message handling, same per-call 10s timeout (now via `receiveOne`), still throws `AssertionError` on timeout or wrong return values.

### Any related issues, documentation, discussions?

Closes #4505

### How was this PR tested?

Existing 8 tests in `TrivialControlSpec` all pass locally. Measured locally on the same worktree with a fresh sbt session:

| | `Run completed in` |
|---|---|
| before | 1 minute, 11 seconds |
| after  | 1 second, 16 milliseconds |

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)