### PR TITLE
fix(amber): emit ExecutionStateUpdate after resume

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
@@ -22,6 +22,7 @@ package org.apache.texera.amber.engine.architecture.controller.promisehandlers
 import com.twitter.util.Future
 import org.apache.texera.amber.engine.architecture.controller.{
   ControllerAsyncRPCHandlerInitializer,
+  ExecutionStateUpdate,
   ExecutionStatsUpdate,
   RuntimeStatisticsPersist
 }
@@ -62,6 +63,7 @@ trait ResumeHandler {
         val stats = cp.workflowExecution.getAllRegionExecutionsStats
         sendToClient(ExecutionStatsUpdate(stats))
         sendToClient(RuntimeStatisticsPersist(stats))
+        sendToClient(ExecutionStateUpdate(cp.workflowExecution.getState))
         cp.controllerTimerService
           .enableStatusUpdate() //re-enabled it since it is disabled in pause
         cp.controllerTimerService


### PR DESCRIPTION
### What changes were proposed in this PR?

`ResumeHandler.resumeWorkflow` (`ResumeHandler.scala`) finished by sending `ExecutionStatsUpdate` and `RuntimeStatisticsPersist` to the client but never sent `ExecutionStateUpdate`. `PauseHandler.scala:88-90` emits the corresponding state event at the end of pause, so the asymmetry meant clients (and tests) had no event-driven signal for the resume → RUNNING transition.

The aggregated state is already correct on the server side after the per-worker resume futures resolve (each `workerInterface.resumeWorker(...)` returns a `WorkerStateResponse` and `ResumeHandler` updates the internal `WorkerExecution` state with that result, so `cp.workflowExecution.getState` returns `RUNNING`). The fix is to broadcast it:

```diff
 sendToClient(ExecutionStatsUpdate(stats))
 sendToClient(RuntimeStatisticsPersist(stats))
+sendToClient(ExecutionStateUpdate(cp.workflowExecution.getState))
```

### Any related issues, documentation, discussions?

Closes #4514

### How was this PR tested?

`sbt WorkflowExecutionService/compile` succeeds; `scalafmtCheckAll` clean. The two existing consumers of `ExecutionStateUpdate` (`ExecutionStatsService.scala:209` and `ExecutionConsoleService.scala:204`) already handle `WorkflowAggregatedState.Recognized`, so an additional `RUNNING` emit at resume time is a strictly additive event. No existing test asserts the absence of this event. Relying on CI for the full backend test run.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)