### PR TITLE
chore(amber): remove typing and dataclasses backport packages

### DIFF
--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -28,12 +28,10 @@ python-dateutil==2.8.2
 pytest-timeout==2.2.0
 protobuf==4.25.8
 betterproto==2.0.0b7
-typing==3.7.4.3
 pampy==0.3.0
 overrides==7.4.0
 typing_extensions==4.14.1
 pytest-reraise==2.1.2
-dataclasses==0.6
 Deprecated==1.2.14
 fs==2.4.16
 praw==7.6.1


### PR DESCRIPTION
### What changes were proposed in this PR?

Removes two PyPI backport packages from `amber/requirements.txt`:

- `typing==3.7.4.3` — backport of the `typing` stdlib module for Python <3.5. Has been part of the stdlib since 3.5.
- `dataclasses==0.6` — backport of the `dataclasses` stdlib module for Python <3.7. Has been part of the stdlib since 3.7.

This repo's CI matrix is Python 3.10–3.13, so both are obsolete. Installing them on supported versions is wasted CI time, and the PyPI `typing` package can shadow the stdlib version in subtle ways because its API is frozen at 3.7-era.

`typing_extensions==4.14.1` (line 34, kept) is a different, still-maintained package that backports *new* typing features to older Pythons; it's correctly retained.

### Any related issues, documentation, discussions?

Closes #4522. Surfaced during investigation in #4519/#4521.

### How was this PR tested?

CI

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)