### PR TITLE
perf(build): remove global Tags.limit(Tags.Test, 1) restriction (experiment)

### DIFF
--- a/access-control-service/build.sbt
+++ b/access-control-service/build.sbt
@@ -29,9 +29,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/access-control-service/src/test/scala/org/apache/texera/AccessControlResourceSpec.scala
+++ b/access-control-service/src/test/scala/org/apache/texera/AccessControlResourceSpec.scala
@@ -20,7 +20,7 @@ package org.apache.texera
 import jakarta.ws.rs.core.{HttpHeaders, MultivaluedHashMap, Response, UriInfo}
 import org.apache.texera.auth.JwtAuth
 import org.apache.texera.auth.util.HeaderField
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.enums.{
   PrivilegeEnum,
   UserRoleEnum,
@@ -50,7 +50,8 @@ class AccessControlResourceSpec
     with Matchers
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with MockTexeraDB {
+    with MockTexeraDB
+    with SerializedSuite {
 
   private val testURI: String = "http://localhost:8080/"
   private val testPath: String = "/api/executions/1/stats/1"

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -36,9 +36,6 @@ scalacOptions += "-Ywarn-unused:imports"
 
 conflictManager := ConflictManager.latestRevision
 
-// ensuring no parallel execution of multiple tasks
-concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
-
 // add python as an additional source
 Compile / unmanagedSourceDirectories += baseDirectory.value / "src" / "main" / "python"
 

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/scheduling/DefaultCostEstimatorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/scheduling/DefaultCostEstimatorSpec.scala
@@ -35,7 +35,7 @@ import org.apache.texera.amber.operator.TestOperators
 import org.apache.texera.amber.operator.aggregate.{AggregateOpDesc, AggregationFunction}
 import org.apache.texera.amber.operator.keywordSearch.KeywordSearchOpDesc
 import org.apache.texera.amber.operator.source.scan.csv.CSVScanSourceOpDesc
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
 import org.apache.texera.dao.jooq.generated.tables.daos._
 import org.apache.texera.dao.jooq.generated.tables.pojos._
@@ -51,7 +51,8 @@ class DefaultCostEstimatorSpec
     extends AnyFlatSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with MockTexeraDB {
+    with MockTexeraDB
+    with SerializedSuite {
 
   private val headerlessCsvOpDesc: CSVScanSourceOpDesc =
     TestOperators.headerlessSmallCsvScanOpDesc()

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/DataProcessingSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/DataProcessingSpec.scala
@@ -47,6 +47,7 @@ import org.apache.texera.amber.engine.e2e.TestUtils.{
 }
 import org.apache.texera.amber.operator.TestOperators
 import org.apache.texera.amber.operator.aggregate.AggregationFunction
+import org.apache.texera.dao.SerializedSuite
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource.getResultUriByLogicalPortId
 import org.apache.texera.workflow.LogicalLink
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -60,7 +61,8 @@ class DataProcessingSpec
     with AnyFlatSpecLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with Retries {
+    with Retries
+    with SerializedSuite {
 
   /**
     * This block retries each test once if it fails.

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/PauseSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/PauseSpec.scala
@@ -40,6 +40,7 @@ import org.apache.texera.amber.engine.e2e.TestUtils.{
   setUpWorkflowExecutionData
 }
 import org.apache.texera.amber.operator.{LogicalOp, TestOperators}
+import org.apache.texera.dao.SerializedSuite
 import org.apache.texera.workflow.LogicalLink
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Outcome, Retries}
@@ -52,7 +53,8 @@ class PauseSpec
     with AnyFlatSpecLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with Retries {
+    with Retries
+    with SerializedSuite {
 
   /**
     * This block retries each test once if it fails.

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/ReconfigurationSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/ReconfigurationSpec.scala
@@ -49,6 +49,7 @@ import org.apache.texera.amber.engine.e2e.TestUtils.{
   setUpWorkflowExecutionData
 }
 import org.apache.texera.amber.operator.{LogicalOp, TestOperators}
+import org.apache.texera.dao.SerializedSuite
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource.getResultUriByLogicalPortId
 import org.apache.texera.workflow.LogicalLink
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Outcome, Retries}
@@ -62,7 +63,8 @@ class ReconfigurationSpec
     with AnyFlatSpecLike
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with Retries {
+    with Retries
+    with SerializedSuite {
 
   /**
     * This block retries each test once if it fails.

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -66,6 +66,21 @@ object TestUtils {
       StorageConfig.jdbcUsername,
       StorageConfig.jdbcPassword
     )
+    // The CI Postgres service is shared across e2e specs, so rows from a
+    // previous spec would otherwise leak into this one. Truncate every table
+    // in the texera_db schema before each spec runs.
+    SqlServer
+      .getInstance()
+      .context
+      .execute(
+        """DO $$ DECLARE r RECORD;
+          |BEGIN
+          |  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname='texera_db' LOOP
+          |    EXECUTE 'TRUNCATE TABLE texera_db.' || quote_ident(r.tablename) ||
+          |            ' RESTART IDENTITY CASCADE';
+          |  END LOOP;
+          |END $$;""".stripMargin
+      )
   }
 
   val testUser: User = {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.web.resource.dashboard.file
 
 import org.apache.texera.auth.SessionUser
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.Tables.{USER, WORKFLOW, WORKFLOW_OF_PROJECT}
 import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
 import org.apache.texera.dao.jooq.generated.tables.daos.UserDao
@@ -49,7 +49,8 @@ class WorkflowResourceSpec
     extends AnyFlatSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with MockTexeraDB {
+    with MockTexeraDB
+    with SerializedSuite {
 
   // An example creation time to test Account Creation Time attribute
   private val exampleCreationTime: OffsetDateTime =

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowAccessResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowAccessResourceSpec.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.web.resource.dashboard.user.workflow
 
 import org.apache.texera.auth.SessionUser
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.Tables._
 import org.apache.texera.dao.jooq.generated.enums.PrivilegeEnum
 import org.apache.texera.dao.jooq.generated.tables.daos.{
@@ -45,7 +45,8 @@ class WorkflowAccessResourceSpec
     extends AnyFlatSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with MockTexeraDB {
+    with MockTexeraDB
+    with SerializedSuite {
 
   private val ownerUid = 1000 + scala.util.Random.nextInt(1000)
   private val userWithWriteUid = 2000 + scala.util.Random.nextInt(1000)

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
@@ -19,7 +19,7 @@
 
 package org.apache.texera.web.resource.dashboard.user.workflow
 
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.Tables._
 import org.apache.texera.dao.jooq.generated.tables.daos.{
   UserDao,
@@ -46,6 +46,7 @@ class WorkflowExecutionsResourceSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
     with MockTexeraDB
+    with SerializedSuite
     with PrivateMethodTester {
 
   private val testWorkflowWid = 3000 + scala.util.Random.nextInt(1000)

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -22,6 +22,7 @@ package org.apache.texera.web.resource.dashboard.user.workflow
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.apache.texera.dao.MockTexeraDB
 import org.apache.texera.dao.jooq.generated.Tables
+import org.apache.texera.dao.SerializedSuite
 import org.apache.texera.dao.jooq.generated.tables.daos.{WorkflowDao, WorkflowVersionDao}
 import org.apache.texera.dao.jooq.generated.tables.pojos.{Workflow, WorkflowVersion}
 import org.jooq.impl.DSL
@@ -37,7 +38,8 @@ class WorkflowVersionResourceSpec
     extends AnyFlatSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with MockTexeraDB {
+    with MockTexeraDB
+    with SerializedSuite {
 
   private val testWorkflowWid = 2000 + scala.util.Random.nextInt(1000)
 

--- a/build.sbt
+++ b/build.sbt
@@ -26,6 +26,9 @@ ThisBuild / scalaVersion := "2.13.18"
 // than one per JVM, so cross-module specs no longer share their lock or their
 // EmbeddedPostgres binary lock and collide on a shared /tmp resource.
 ThisBuild / Test / fork := true
+// Forked JVMs default to the subproject's base directory; pin them to the
+// repo root so relative paths like `sql/texera_ddl.sql` keep resolving.
+ThisBuild / Test / baseDirectory := (ThisBuild / baseDirectory).value
 
 // Per-module ASF licensing: each jar's META-INF/LICENSE describes only what is in that jar.
 // Modules without vendored code get Apache 2.0 only; workflow-operator includes mbknor attribution.

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,14 @@ ThisBuild / organization := "org.apache.texera"
 ThisBuild / version      := "1.1.0-incubating"
 ThisBuild / scalaVersion := "2.13.18"
 
+// Each subproject's test task runs in its own JVM. Without forking, sbt loads
+// every subproject's test classes through separate classloaders inside the
+// same JVM. Test utilities like MockTexeraDB and SerializedSuite that rely on
+// a Scala object as a singleton then get one instance per classloader rather
+// than one per JVM, so cross-module specs no longer share their lock or their
+// EmbeddedPostgres binary lock and collide on a shared /tmp resource.
+ThisBuild / Test / fork := true
+
 // Per-module ASF licensing: each jar's META-INF/LICENSE describes only what is in that jar.
 // Modules without vendored code get Apache 2.0 only; workflow-operator includes mbknor attribution.
 // See project/AddMetaInfLicenseFiles.scala.

--- a/common/auth/build.sbt
+++ b/common/auth/build.sbt
@@ -31,10 +31,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/common/config/build.sbt
+++ b/common/config/build.sbt
@@ -29,9 +29,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/common/dao/build.sbt
+++ b/common/dao/build.sbt
@@ -30,9 +30,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
 /////////////////////////////////////////////////////////////////////////////
 // JOOQ Code Generation
 /////////////////////////////////////////////////////////////////////////////

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -27,139 +27,141 @@ import java.nio.file.Paths
 import java.sql.{Connection, DriverManager}
 import scala.io.Source
 
-trait MockTexeraDB {
+/**
+  * Provides a JVM-singleton EmbeddedPostgres for tests. Multiple specs that mix
+  * in this trait share one Postgres instance for the lifetime of the JVM, which
+  * avoids the OverlappingFileLockException that occurs when each spec tries to
+  * extract the embedded Postgres binaries into the same directory in parallel.
+  */
+object MockTexeraDB {
 
-  private var dbInstance: Option[EmbeddedPostgres] = None
-  private var dslContext: Option[DSLContext] = None
   private val database: String = "texera_db"
   private val username: String = "postgres"
   private val password: String = ""
 
+  private var dbInstance: Option[EmbeddedPostgres] = None
+  private var dslContext: Option[DSLContext] = None
+
+  def ensureInitialized(): Unit =
+    synchronized {
+      if (dbInstance.isDefined) return
+
+      val driver = new org.postgresql.Driver()
+      DriverManager.registerDriver(driver)
+
+      val embedded = EmbeddedPostgres.builder().start()
+      dbInstance = Some(embedded)
+
+      val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
+      val source = Source.fromFile(ddlPath.toString)
+      val content =
+        try source.mkString
+        finally source.close()
+      val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
+      def removeCCommands(sql: String): String =
+        sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
+      val createDBStatement =
+        """DROP DATABASE IF EXISTS texera_db;
+          |CREATE DATABASE texera_db;""".stripMargin
+      executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
+      val texeraDB = embedded.getDatabase(username, database)
+      var tablesAndIndexCreation = removeCCommands(parts(1))
+
+      // remove indexes creation for pgroonga because we cannot install the plugin
+      val blockPattern =
+        """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
+      val replacementText =
+        """CREATE INDEX idx_workflow_name_description_content
+          |    ON workflow
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '') || ' ' ||
+          |    COALESCE(content, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_user_name
+          |    ON "user"
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_user_project_name_description
+          |    ON project
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_dataset_name_description
+          |    ON dataset
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_dataset_version_name
+          |    ON dataset_version
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '')
+          |    )
+          |    );""".stripMargin
+
+      tablesAndIndexCreation =
+        blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
+      executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
+      SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
+      val sqlServerInstance = SqlServer.getInstance()
+      val ctx = DSL.using(texeraDB, SQLDialect.POSTGRES)
+      dslContext = Some(ctx)
+      sqlServerInstance.replaceDSLContext(ctx)
+    }
+
+  def getDSLContext: DSLContext =
+    dslContext.getOrElse(
+      throw new RuntimeException(
+        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
+      )
+    )
+
+  def getDBInstance: EmbeddedPostgres =
+    dbInstance.getOrElse(
+      throw new RuntimeException(
+        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
+      )
+    )
+
+  private def executeScriptInJDBC(conn: Connection, script: String): Unit = {
+    conn.prepareStatement(script).execute()
+    conn.close()
+  }
+}
+
+trait MockTexeraDB {
+
   def executeScriptInJDBC(conn: Connection, script: String): Unit = {
-    assert(dbInstance.nonEmpty)
     conn.prepareStatement(script).execute()
     conn.close()
   }
 
-  def getDSLContext: DSLContext = {
-    dslContext match {
-      case Some(value) => value
-      case None =>
-        throw new RuntimeException(
-          "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-        )
-    }
-  }
+  def getDSLContext: DSLContext = MockTexeraDB.getDSLContext
 
-  def getDBInstance: EmbeddedPostgres = {
-    dbInstance match {
-      case Some(value) => value
-      case None =>
-        throw new RuntimeException(
-          "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-        )
-    }
-  }
+  def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def shutdownDB(): Unit = {
-    dbInstance match {
-      case Some(value) =>
-        value.close()
-        dbInstance = None
-        dslContext = None
-        SqlServer.clearInstance()
-      case None =>
-      // do nothing
-    }
-  }
+  def initializeDBAndReplaceDSLContext(): Unit = MockTexeraDB.ensureInitialized()
 
-  def initializeDBAndReplaceDSLContext(): Unit = {
-    assert(dbInstance.isEmpty && dslContext.isEmpty)
-
-    val driver = new org.postgresql.Driver()
-    DriverManager.registerDriver(driver)
-
-    val embedded = EmbeddedPostgres.builder().start()
-
-    dbInstance = Some(embedded)
-
-    val ddlPath = {
-      Paths.get("sql/texera_ddl.sql").toRealPath()
-    }
-    val source = Source.fromFile(ddlPath.toString)
-    val content =
-      try {
-        source.mkString
-      } finally {
-        source.close()
-      }
-    val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
-    def removeCCommands(sql: String): String =
-      sql.linesIterator
-        .filterNot(_.trim.startsWith("\\c"))
-        .mkString("\n")
-    val createDBStatement =
-      """DROP DATABASE IF EXISTS texera_db;
-        |CREATE DATABASE texera_db;""".stripMargin
-    executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
-    val texeraDB = embedded.getDatabase(username, database)
-    var tablesAndIndexCreation = removeCCommands(parts(1))
-
-    // remove indexes creation for pgroonga because we cannot install the plugin
-    val blockPattern =
-      """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
-    // replace with native fulltext indexes
-    val replacementText =
-      """CREATE INDEX idx_workflow_name_description_content
-        |    ON workflow
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '') || ' ' ||
-        |    COALESCE(content, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_user_name
-        |    ON "user"
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_user_project_name_description
-        |    ON project
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_dataset_name_description
-        |    ON dataset
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_dataset_version_name
-        |    ON dataset_version
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '')
-        |    )
-        |    );""".stripMargin
-
-    tablesAndIndexCreation = blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
-    executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
-    SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
-    val sqlServerInstance = SqlServer.getInstance()
-    dslContext = Some(DSL.using(texeraDB, SQLDialect.POSTGRES))
-
-    sqlServerInstance.replaceDSLContext(dslContext.get)
-  }
+  /**
+    * No-op. The singleton EmbeddedPostgres lives for the lifetime of the JVM,
+    * so individual specs should not shut it down. Kept for API compatibility
+    * with existing afterAll hooks.
+    */
+  def shutdownDB(): Unit = ()
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -139,6 +139,25 @@ object MockTexeraDB {
       )
     )
 
+  /**
+    * Truncate every user-owned table in the singleton EmbeddedPostgres so the
+    * caller starts from a clean state. Specs sharing this singleton must call
+    * this in their setup (or rely on the helper trait that does it for them)
+    * to avoid colliding with rows left behind by previous specs.
+    */
+  def truncateAllTables(): Unit =
+    synchronized {
+      getDSLContext.execute(
+        """DO $$ DECLARE r RECORD;
+          |BEGIN
+          |  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname='texera_db' LOOP
+          |    EXECUTE 'TRUNCATE TABLE texera_db.' || quote_ident(r.tablename) ||
+          |            ' RESTART IDENTITY CASCADE';
+          |  END LOOP;
+          |END $$;""".stripMargin
+      )
+    }
+
   private def executeScriptInJDBC(conn: Connection, script: String): Unit = {
     conn.prepareStatement(script).execute()
     conn.close()
@@ -156,7 +175,12 @@ trait MockTexeraDB {
 
   def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def initializeDBAndReplaceDSLContext(): Unit = MockTexeraDB.ensureInitialized()
+  def initializeDBAndReplaceDSLContext(): Unit = {
+    MockTexeraDB.ensureInitialized()
+    // The singleton lives for the JVM, so rows from a previous spec would
+    // otherwise leak into this one. Truncate every table on each spec setup.
+    MockTexeraDB.truncateAllTables()
+  }
 
   /**
     * No-op. The singleton EmbeddedPostgres lives for the lifetime of the JVM,

--- a/common/dao/src/test/scala/org/apache/texera/dao/SerializedSuite.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/SerializedSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.dao
+
+import org.scalatest.{BeforeAndAfterAll, Suite}
+
+import java.util.concurrent.Semaphore
+
+/**
+  * Mix into any test suite that touches a shared database (the singleton
+  * EmbeddedPostgres in `MockTexeraDB`, the CI's `texera_db_for_test_cases`
+  * service, or the shared Iceberg JDBC catalog). The trait acquires a
+  * JVM-wide semaphore in `beforeAll` and releases it in `afterAll`, so all
+  * suites mixing it in run one at a time relative to each other while
+  * non-DB suites in the build are free to run in parallel.
+  *
+  * This is the alternative to setting `Global / concurrentRestrictions +=
+  * Tags.limit(Tags.Test, 1)`, which serialised every test in the build.
+  */
+trait SerializedSuite extends BeforeAndAfterAll { this: Suite =>
+
+  override protected def beforeAll(): Unit = {
+    SerializedSuite.lock.acquire()
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    try super.afterAll()
+    finally SerializedSuite.lock.release()
+  }
+}
+
+object SerializedSuite {
+  private val lock = new Semaphore(1, true)
+}

--- a/common/dao/src/test/scala/org/apache/texera/dao/SerializedSuite.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/SerializedSuite.scala
@@ -19,31 +19,33 @@
 
 package org.apache.texera.dao
 
-import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.scalatest.{Args, Status, Suite}
 
 import java.util.concurrent.Semaphore
 
 /**
-  * Mix into any test suite that touches a shared database (the singleton
+  * Mix into any test suite that touches a shared resource (the singleton
   * EmbeddedPostgres in `MockTexeraDB`, the CI's `texera_db_for_test_cases`
-  * service, or the shared Iceberg JDBC catalog). The trait acquires a
-  * JVM-wide semaphore in `beforeAll` and releases it in `afterAll`, so all
-  * suites mixing it in run one at a time relative to each other while
-  * non-DB suites in the build are free to run in parallel.
+  * service, or the shared Iceberg JDBC catalog). Suites mixing this in run
+  * one at a time relative to each other; suites that do not mix it in are
+  * free to run in parallel.
   *
-  * This is the alternative to setting `Global / concurrentRestrictions +=
-  * Tags.limit(Tags.Test, 1)`, which serialised every test in the build.
+  * The lock is held around the entire `Suite.run` invocation, so it works
+  * even for specs whose `beforeAll` overrides do not call `super.beforeAll`.
   */
-trait SerializedSuite extends BeforeAndAfterAll { this: Suite =>
+trait SerializedSuite extends Suite {
 
-  override protected def beforeAll(): Unit = {
+  abstract override def run(testName: Option[String], args: Args): Status = {
     SerializedSuite.lock.acquire()
-    super.beforeAll()
-  }
-
-  override protected def afterAll(): Unit = {
-    try super.afterAll()
-    finally SerializedSuite.lock.release()
+    val status =
+      try super.run(testName, args)
+      catch {
+        case t: Throwable =>
+          SerializedSuite.lock.release()
+          throw t
+      }
+    status.whenCompleted(_ => SerializedSuite.lock.release())
+    status
   }
 }
 

--- a/common/pybuilder/build.sbt
+++ b/common/pybuilder/build.sbt
@@ -32,10 +32,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -31,10 +31,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/FileResolverSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/FileResolverSpec.scala
@@ -21,7 +21,7 @@ package org.apache.texera.amber.storage
 
 import org.apache.texera.amber.core.storage.FileResolver
 import org.apache.commons.vfs2.FileNotFoundException
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
 import org.apache.texera.dao.jooq.generated.tables.daos.{DatasetDao, DatasetVersionDao, UserDao}
 import org.apache.texera.dao.jooq.generated.tables.pojos.{Dataset, DatasetVersion, User}
@@ -34,7 +34,8 @@ class FileResolverSpec
     extends AnyFlatSpec
     with BeforeAndAfterAll
     with BeforeAndAfterEach
-    with MockTexeraDB {
+    with MockTexeraDB
+    with SerializedSuite {
 
   private val testUser: User = {
     val user = new User

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/result/iceberg/IcebergDocumentConsoleMessagesSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/result/iceberg/IcebergDocumentConsoleMessagesSpec.scala
@@ -23,6 +23,7 @@ import org.apache.texera.amber.core.storage.model._
 import org.apache.texera.amber.core.storage.result.ResultSchema
 import org.apache.texera.amber.core.storage.{DocumentFactory, VFSURIFactory}
 import org.apache.texera.amber.core.tuple.{Schema, Tuple}
+import org.apache.texera.dao.SerializedSuite
 import org.apache.texera.amber.core.virtualidentity._
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
@@ -36,7 +37,8 @@ class IcebergDocumentConsoleMessagesSpec
     extends AnyFlatSpec
     with Matchers
     with VirtualDocumentSpec[Tuple]
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with SerializedSuite {
 
   private val amberSchema: Schema = ResultSchema.consoleMessagesSchema
   var uri: URI = _

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/result/iceberg/IcebergDocumentSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/result/iceberg/IcebergDocumentSpec.scala
@@ -32,6 +32,7 @@ import org.apache.texera.amber.core.virtualidentity.{
 }
 import org.apache.texera.amber.core.workflow.{GlobalPortIdentity, PortIdentity}
 import org.apache.texera.amber.util.IcebergUtil
+import org.apache.texera.dao.SerializedSuite
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.data.Record
 import org.apache.iceberg.{Schema => IcebergSchema}
@@ -43,7 +44,10 @@ import java.sql.Timestamp
 import java.util.UUID
 import java.util.concurrent.atomic.AtomicInteger
 
-class IcebergDocumentSpec extends VirtualDocumentSpec[Tuple] with BeforeAndAfterAll {
+class IcebergDocumentSpec
+    extends VirtualDocumentSpec[Tuple]
+    with BeforeAndAfterAll
+    with SerializedSuite {
 
   var amberSchema: Schema = _
   var icebergSchema: IcebergSchema = _

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/result/iceberg/IcebergTableStatsSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/result/iceberg/IcebergTableStatsSpec.scala
@@ -29,6 +29,7 @@ import org.apache.texera.amber.core.virtualidentity.{
   WorkflowIdentity
 }
 import org.apache.texera.amber.core.workflow.{GlobalPortIdentity, PortIdentity}
+import org.apache.texera.dao.SerializedSuite
 import org.apache.texera.amber.util.IcebergUtil
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.data.Record
@@ -42,7 +43,11 @@ import java.time.format.DateTimeFormatter
 import java.time.{LocalDate, ZoneId}
 import java.util.UUID
 
-class IcebergTableStatsSpec extends AnyFlatSpec with BeforeAndAfterAll with Suite {
+class IcebergTableStatsSpec
+    extends AnyFlatSpec
+    with BeforeAndAfterAll
+    with Suite
+    with SerializedSuite {
 
   var amberSchema: Schema = _
   var icebergSchema: IcebergSchema = _

--- a/common/workflow-operator/build.sbt
+++ b/common/workflow-operator/build.sbt
@@ -32,10 +32,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/config-service/build.sbt
+++ b/config-service/build.sbt
@@ -29,9 +29,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/file-service/build.sbt
+++ b/file-service/build.sbt
@@ -29,9 +29,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
@@ -25,7 +25,7 @@ import jakarta.ws.rs._
 import jakarta.ws.rs.core._
 import org.apache.texera.amber.core.storage.util.LakeFSStorageClient
 import org.apache.texera.auth.SessionUser
-import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.{MockTexeraDB, SerializedSuite}
 import org.apache.texera.dao.jooq.generated.enums.{PrivilegeEnum, UserRoleEnum}
 import org.apache.texera.dao.jooq.generated.tables.DatasetUploadSession.DATASET_UPLOAD_SESSION
 import org.apache.texera.dao.jooq.generated.tables.DatasetUploadSessionPart.DATASET_UPLOAD_SESSION_PART
@@ -61,7 +61,8 @@ class DatasetResourceSpec
     with MockTexeraDB
     with MockLakeFS
     with BeforeAndAfterAll
-    with BeforeAndAfterEach {
+    with BeforeAndAfterEach
+    with SerializedSuite {
 
   // ---------- Response entity helpers ----------
   private def entityAsScalaMap(resp: Response): Map[String, Any] = {

--- a/workflow-compiling-service/build.sbt
+++ b/workflow-compiling-service/build.sbt
@@ -31,9 +31,6 @@ ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 // Manage dependency conflicts by always using the latest revision
 ThisBuild / conflictManager := ConflictManager.latestRevision
 
-// Restrict parallel execution of tests to avoid conflicts
-Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
-
 /////////////////////////////////////////////////////////////////////////////
 // Compiler Options
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
> [!IMPORTANT]
> Draft / experiment. Goal is to use CI to find out whether the test suite is still stable under sbt's default parallelization. If CI is green across multiple runs, this becomes a real PR. If something flakes, we identify the specific shared state instead of carrying the global workaround.

### What changes were proposed in this PR?

Removed the line

```sbt
Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
```

from all 11 module `build.sbt` files where it was copy-pasted (`amber`, `common/auth`, `common/config`, `common/dao`, `common/pybuilder`, `common/workflow-core`, `common/workflow-operator`, `access-control-service`, `file-service`, `config-service`, `workflow-compiling-service`).

This restriction forces every test in every module to run sequentially in a single JVM, and is one of the biggest single contributors to backend test runtime in CI.

### History

`git log -S "concurrentRestrictions in Global"` traces the line to commit `6a79a655ca` (2020-12-28), part of PR #938 (*Extending the runtime error raising framework to all actors*). That PR mainly reworked exception handling across `Controller`, `Principal`, and `WorkerBase`. The restriction was added in the same PR with the only comment being "ensuring no parallel execution of multiple tasks" — no specific reason given. Most likely the actor-error refactor introduced shared mutable state that couldn't tolerate parallel test JVMs and the global `Tags.limit` was applied as a quick fix, then copy-pasted into every new module.

### Any related issues, documentation, discussions?

Refs #4525.

### How was this PR tested?

Local full-suite run is impractical (JDK 17 + Arrow incompatibility blocks several e2e specs). Relying on this PR's CI on JDK 11 to validate. Expected to need 2–3 reruns to confirm stability, since flakiness from shared state may be intermittent.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)