### PR TITLE
chore(amber): remove unused SchedulerTimeSlotExpiredPause

### DIFF
--- a/amber/src/main/python/core/architecture/managers/pause_manager.py
+++ b/amber/src/main/python/core/architecture/managers/pause_manager.py
@@ -29,10 +29,9 @@ from ...models import InternalQueue
 class PauseType(Enum):
     NO_PAUSE = 0
     USER_PAUSE = 1
-    SCHEDULER_TIME_SLOT_EXPIRED_PAUSE = 2
-    DEBUG_PAUSE = 3
-    EXCEPTION_PAUSE = 4
-    ECM_PAUSE = 5
+    DEBUG_PAUSE = 2
+    EXCEPTION_PAUSE = 3
+    ECM_PAUSE = 4
 
 
 class PauseManager:

--- a/amber/src/main/python/core/runnables/main_loop.py
+++ b/amber/src/main/python/core/runnables/main_loop.py
@@ -422,19 +422,6 @@ class MainLoop(StoppableQueueBlockingRunnable):
             except Exception as err:
                 logger.exception(err)
 
-    def _scheduler_time_slot_event(self, time_slot_expired: bool) -> None:
-        """
-        The time slot for scheduling this worker has expired.
-        """
-        if time_slot_expired:
-            self.context.pause_manager.pause(
-                PauseType.SCHEDULER_TIME_SLOT_EXPIRED_PAUSE
-            )
-        else:
-            self.context.pause_manager.resume(
-                PauseType.SCHEDULER_TIME_SLOT_EXPIRED_PAUSE
-            )
-
     def _send_console_message(self, console_message: ConsoleMessage):
         self._async_rpc_client.controller_stub().console_message_triggered(
             ConsoleMessageTriggeredRequest(console_message=console_message)

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/PauseType.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/PauseType.scala
@@ -29,6 +29,4 @@ object BackpressurePause extends PauseType
 
 object OperatorLogicPause extends PauseType
 
-object SchedulerTimeSlotExpiredPause extends PauseType
-
 case class ECMPause(id: EmbeddedControlMessageIdentity) extends PauseType


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove the unused `SchedulerTimeSlotExpiredPause` pause type and the dead Python handler that referenced it. None of the following symbols are referenced anywhere in the codebase:

- `SchedulerTimeSlotExpiredPause` (Scala) in `amber/src/main/scala/.../worker/PauseType.scala`
- `PauseType.SCHEDULER_TIME_SLOT_EXPIRED_PAUSE` (Python) in `amber/src/main/python/core/architecture/managers/pause_manager.py`
- `MainLoop._scheduler_time_slot_event` (Python) in `amber/src/main/python/core/runnables/main_loop.py` — never called

The Python enum is renumbered to keep values consecutive; the int values are not serialized externally.

### Any related issues, documentation, discussions?

Closes #4532

### How was this PR tested?

Pure dead-code removal — no behavior change. Verified via repo-wide grep that no references to the removed symbols remain. Existing `sbt test` and Python tests cover the surrounding pause/main-loop code paths.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)