### PR TITLE
fix(frontend): version history timestamp display

### DIFF
--- a/frontend/src/app/workspace/component/left-panel/versions-list/versions-list.component.html
+++ b/frontend/src/app/workspace/component/left-panel/versions-list/versions-list.component.html
@@ -53,7 +53,7 @@
             nzType="link"
             (click)="getVersion(row.vId, getDisplayedVersionId(i, l), i)"
             class="version-link">
-            {{row.creationTime | date:'MM/dd/YY HH:mm:ss'}}
+            {{row.creationTime | date:'MM/dd/yy HH:mm:ss'}}
           </button>
         </td>
       </tr>


### PR DESCRIPTION
### What changes were proposed in this PR?
- update the version history timestamp format from `YY` to `yy`
- use Angular’s calendar-year token so timestamps render correctly in the frontend
- `yy` is Angular’s calendar-year token for a 2-digit year, while `YY` is the ISO week-numbering year token.

### Any related issues, documentation, discussions?
Closes #4538

### How was this PR tested?
Tested with test case.

### Was this PR authored or co-authored using generative AI tooling?
No.