### PR TITLE
fix: visualization result panel iframe sizing after Angular upgrade

### DIFF
--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.html
@@ -103,7 +103,9 @@
       </div>
       <div *ngFor="let config of frameComponentConfigs | keyvalue">
         <nz-tab nzTitle="{{config.key}}">
-          <div #dynamicComponent>
+          <div
+            #dynamicComponent
+            class="result-frame">
             <ng-container
               *ngComponentOutlet="config.value.component;inputs: config.value.componentInputs"></ng-container>
           </div>

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.html
@@ -92,6 +92,7 @@
       Result Panel{{operatorTitle ? ': ' + operatorTitle : ''}}
     </h4>
     <nz-tabs
+      class="result-content"
       [nzSize]="'small'"
       [nzTabPosition]="'left'">
       <div *ngIf="frameComponentConfigs.size === 0">
@@ -105,7 +106,7 @@
         <nz-tab nzTitle="{{config.key}}">
           <div
             #dynamicComponent
-            class="result-frame">
+            class="result-content">
             <ng-container
               *ngComponentOutlet="config.value.component;inputs: config.value.componentInputs"></ng-container>
           </div>

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -73,6 +73,7 @@ $type-colors: (
   height: 100%;
 }
 
+
 #result-buttons {
   position: absolute;
   bottom: 0;

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -67,6 +67,13 @@ $type-colors: (
   height: inherit;
 }
 
+.result-content,
+:host ::ng-deep .result-content .ant-tabs-content-holder,
+:host ::ng-deep .result-content .ant-tabs-content,
+:host ::ng-deep .result-content .ant-tabs-tabpane {
+  height: 100%;
+}
+
 #result-buttons {
   position: absolute;
   bottom: 0;

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -68,7 +68,6 @@ $type-colors: (
 }
 
 .result-content,
-:host ::ng-deep .result-content .ant-tabs-content-holder,
 :host ::ng-deep .result-content .ant-tabs-content,
 :host ::ng-deep .result-content .ant-tabs-tabpane {
   height: 100%;

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -73,7 +73,6 @@ $type-colors: (
   height: 100%;
 }
 
-
 #result-buttons {
   position: absolute;
   bottom: 0;

--- a/frontend/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.scss
+++ b/frontend/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.scss
@@ -18,8 +18,8 @@
  */
 
 #html-content {
-  position: absolute;
-  width: calc(100% - 115px);
-  height: calc(100% - 40px);
+  display: block;
+  width: 100%;
+  height: 100%;
   border: none;
 }


### PR DESCRIPTION
### What changes were proposed in this PR?
- Fix visualization result rendering in the result panel after the Angular upgrade.
- Update result panel tab content styles so ng-zorro tab panes preserve full height.
- Remove absolute iframe sizing from visualization output and let the iframe fill its container.

### Any related issues, documentation, discussions?
Closes #4541


### How was this PR tested?
Tested manually.


### Was this PR authored or co-authored using generative AI tooling?
No.