### PR TITLE
test(amber): ignore failing source-propagation reconfiguration case

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/ReconfigurationSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/ReconfigurationSpec.scala
@@ -256,7 +256,11 @@ class ReconfigurationSpec
     )
   }
 
-  "Engine" should "propagate reconfiguration through a source operator in workflow" in {
+  // Disabled: the workflow hangs after the UDF processes the EndChannel ECM in this
+  // multi-worker (Python source -> Python UDF) propagation case, causing a 1-minute
+  // Await timeout. The single-op reconfigure path and the CSV-source variants pass.
+  // Re-enable once the source-propagation completion path is fixed.
+  "Engine" should "propagate reconfiguration through a source operator in workflow" ignore {
     val sourceOpDesc = TestOperators.pythonSourceOpDesc(10000)
     val udfOpDesc = TestOperators.pythonOpDesc()
     val code = """


### PR DESCRIPTION
### What changes were proposed in this PR?

Marks `ReconfigurationSpec`'s `"Engine should propagate reconfiguration through a source operator in workflow"` case as `ignore` to unblock CI. The test consistently hangs at the 1-minute `Await` because the UDF stops making progress after processing the `EndChannel` ECM in the multi-worker (Python source -> Python UDF) propagation path.

The other four cases in the spec (single-op python UDF reconfigure, java operator reconfigure, source-as-target rejection, two-UDF chain) still run and pass.

A code comment is left at the test pointing at the symptom and the condition for re-enabling.

### Any related issues, documentation, discussions?

Put out the fire in #4545. Investigation is in parallel.

Follow-up to #4220 (which added the test) and #4531 (which restored the web-service entrypoint but did not fix this hang).

### How was this PR tested?

`sbt "WorkflowExecutionService/testOnly *ReconfigurationSpec"` locally — 4 cases pass, the 5th is now skipped (was previously timing out at 1 min).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)