### PR TITLE
ci: protect future release branches via ASF rulesets

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -103,6 +103,7 @@ github:
           - python (ubuntu-latest, 3.10)
           - python (ubuntu-latest, 3.11)
           - python (ubuntu-latest, 3.12)
+          - python (ubuntu-latest, 3.13)
           - Check License Headers
           - Validate PR title
       required_pull_request_reviews:
@@ -115,5 +116,5 @@ notifications:
   commits:              commits@texera.apache.org
   issues:               notifications@texera.apache.org
   pullrequests:         notifications@texera.apache.org
-  discussions:          notifications@texera.apache.org
+  discussions:          dev@texera.apache.org
   jobs:                 commits@texera.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -70,6 +70,19 @@ github:
       restrict_deletion: true
       restrict_force_push: true
       required_linear_history: true
+      required_status_checks:
+        strict: true
+        contexts:
+          - frontend (ubuntu-latest, 18)
+          - frontend (windows-latest, 18)
+          - frontend (macos-latest, 18)
+          - scala (ubuntu-22.04, 11)
+          - python (ubuntu-latest, 3.10)
+          - python (ubuntu-latest, 3.11)
+          - python (ubuntu-latest, 3.12)
+          - python (ubuntu-latest, 3.13)
+          - Check License Headers
+          - Validate PR title
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_last_push_approval: false
@@ -90,7 +103,6 @@ github:
           - python (ubuntu-latest, 3.10)
           - python (ubuntu-latest, 3.11)
           - python (ubuntu-latest, 3.12)
-          - python (ubuntu-latest, 3.13)
           - Check License Headers
           - Validate PR title
       required_pull_request_reviews:
@@ -103,5 +115,5 @@ notifications:
   commits:              commits@texera.apache.org
   issues:               notifications@texera.apache.org
   pullrequests:         notifications@texera.apache.org
-  discussions:          dev@texera.apache.org
+  discussions:          notifications@texera.apache.org
   jobs:                 commits@texera.apache.org

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -59,6 +59,22 @@ github:
     squash_commit_message: PR_TITLE_AND_DESC
     merge:   false
     rebase:  false
+
+  rulesets:
+    - name: Release Branch Protection
+      type: branch
+      branches:
+        includes:
+          - release/*
+        excludes: []
+      restrict_deletion: true
+      restrict_force_push: true
+      required_linear_history: true
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_last_push_approval: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
     
   protected_branches:
     main:


### PR DESCRIPTION
### What changes were proposed in this PR?
Add an ASF `.asf.yaml` ruleset to protect future `release/*` branches.

We use `github.rulesets` here because `protected_branches` in ASF `.asf.yaml` requires explicit branch names, while `rulesets` can cover future release branches with `release/*`.

This ruleset is intended to mirror `main` by requiring:
- pull requests
- linear history
- 1 approving review
- the same required CI checks as `main`
- no force-push
- no branch deletion

### Any related issues, documentation, discussions?
Closes #4579

### How was this PR tested?
- Validated `.asf.yaml` parses as YAML locally.
- Created an equivalent native GitHub ruleset in my fork: [ruleset #15794451](https://github.com/Yicong-Huang/texera/rules/15794451)
- Verified the ruleset applies to `release/*`: [branch rule evaluation](https://github.com/Yicong-Huang/texera/rules?ref=refs%2Fheads%2Frelease%2Fruleset-test)
- Verified a direct push to a protected `release/*` branch was rejected.
- Verified branch deletion on a protected `release/*` branch was rejected.
- Re-ran the test with the exact required CI list from latest `origin/main`. When pushing a full-tree `release/*` branch, GitHub rejected it with `10 of 10 required status checks are expected`, which confirms the required-check set is being enforced.
- Test PR in fork: [Yicong-Huang/texera#3](https://github.com/Yicong-Huang/texera/pull/3)

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex GPT-5
