### PR TITLE
fix(frontend): adjust dataset detail page's alignment and padding

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -319,9 +319,7 @@
               *ngIf="queuedCount > 0"
               [nzHeader]="'Pending: ' + queuedCount + ' file(s)'">
               <div class="upload-progress-wrapper-pending">
-                <div
-                  *ngFor="let fileName of queuedFileNames"
-                  class="upload-progress-container">
+                <div *ngFor="let fileName of queuedFileNames">
                   <span>{{ fileName }}</span>
                   <button
                     nz-button
@@ -347,9 +345,7 @@
               *ngIf="activeCount > 0"
               [nzHeader]="'Uploading: ' + activeCount + ' file(s)'">
               <div class="upload-progress-wrapper">
-                <div
-                  *ngFor="let task of uploadTasks; trackBy: trackByTask"
-                  class="upload-progress-container">
+                <div *ngFor="let task of uploadTasks; trackBy: trackByTask">
                   <div class="progress-header">
                     <span><b>{{ task.status }}</b>: {{ task.filePath }}</span>
                     <button

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
@@ -34,15 +34,13 @@
 }
 
 .version-storage {
-  padding-left: 20px;
-  width: 90%;
-  margin-left: auto;
-  margin-right: auto;
+  padding: 0 15px;
   margin-bottom: 25px;
 }
 
 .version-storage nz-select {
-  width: 100%; /* Make the select element take the full width of its parent */
+  width: 100%;
+  margin: 0;
 }
 
 nz-layout {
@@ -96,7 +94,7 @@ body {
 
 .select-and-button-container {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 10px;
 }
 
@@ -145,14 +143,9 @@ nz-select {
 
 .upload-progress-wrapper,
 .upload-progress-wrapper-pending {
-  margin-top: 5px;
   max-height: 25vh;
   overflow-y: auto;
   padding-right: 4px;
-}
-
-.upload-progress-container {
-  margin-left: 20px;
 }
 
 .upload-progress-wrapper-pending {
@@ -163,7 +156,7 @@ nz-select {
 
 .version-creator {
   margin-top: 20px;
-  padding: 40px;
+  padding: 20px;
 }
 
 .version-input-container label {
@@ -217,7 +210,7 @@ nz-select {
 }
 
 .status-tag {
-  padding: 3px 10px 3px 2px;
+  padding: 3px 10px 3px 3px;
   font-size: 13px;
   display: inline-flex;
   align-items: center;
@@ -228,8 +221,9 @@ nz-select {
   i {
     width: 22px;
     height: 22px;
-    line-height: 22px;
-    text-align: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     border-radius: 4px;
     background: #f0f0f0;
   }

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.scss
@@ -18,9 +18,8 @@
  */
 
 .file-display-area {
-  width: 90%;
+  width: 100%;
   height: 100%;
-  margin: auto;
 }
 
 /* CSS styles */


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR fixes some UI alignment issues on the dataset detail page:
- status tag icons not being centered within their colored background boxes.
- redundant margins on the file preview area.
- vertical misalignment between the version selector and the download button.
- unnecessary left padding on the version storage section.
- redundant margins on upload progress containers.

Current layout (extra padding on file preview):
<img width="3178" height="1624" alt="Screenshot 2026-04-30 at 10 02 32 AM" src="https://github.com/user-attachments/assets/ec59f311-628f-434e-8211-3c10a03360ac" />

New layout:

<img width="1809" height="859" alt="Screenshot 2026-04-30 at 12 37 18 PM" src="https://github.com/user-attachments/assets/faf7935e-c0a8-45a1-9222-ab826945f73f" />

New version section:
| current | updated |
|---|---|
| <img width="387" src="https://github.com/user-attachments/assets/8bc6f899-06e9-4f38-916d-9520af2a4233" /> | <img width="405" src="https://github.com/user-attachments/assets/6309cf95-1ca5-4550-ad29-5104c8e89ba4" /> |

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Resolves #4583

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
Manually tested

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.7