### PR TITLE
fix(hub-frontend): display public datasets/workflows on hub page

### DIFF
--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.html
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.html
@@ -28,7 +28,7 @@
   <div class="search-result">
     <texera-search-results
       [showResourceTypes]="true"
-      [searchKeywords]="this.filters.getSearchKeywords()"
+      [searchKeywords]="searchKeywords"
       [currentUid]="this.currentUid">
     </texera-search-results>
   </div>

--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -38,26 +38,21 @@ import { map } from "rxjs/operators";
 })
 export class HubSearchResultComponent implements OnInit, AfterViewInit {
   public searchType: "dataset" | "workflow" = "workflow";
+  public searchKeywords: string[] = [];
   currentUid = this.userService.getCurrentUser()?.uid;
 
   private isLogin = false;
   private includePublic = true;
   private _searchResultsComponent?: SearchResultsComponent;
-  @ViewChild(SearchResultsComponent) get searchResultsComponent(): SearchResultsComponent {
-    if (this._searchResultsComponent) {
-      return this._searchResultsComponent;
-    }
-    throw new Error("Property cannot be accessed before it is initialized.");
+  @ViewChild(SearchResultsComponent) get searchResultsComponent(): SearchResultsComponent | undefined {
+    return this._searchResultsComponent;
   }
   set searchResultsComponent(value: SearchResultsComponent) {
     this._searchResultsComponent = value;
   }
   private _filters?: FiltersComponent;
-  @ViewChild(FiltersComponent) get filters(): FiltersComponent {
-    if (this._filters) {
-      return this._filters;
-    }
-    throw new Error("Property cannot be accessed before it is initialized.");
+  @ViewChild(FiltersComponent) get filters(): FiltersComponent | undefined {
+    return this._filters;
   }
   set filters(value: FiltersComponent) {
     value.masterFilterListChange.pipe(untilDestroyed(this)).subscribe({ next: () => this.search() });
@@ -106,6 +101,9 @@ export class HubSearchResultComponent implements OnInit, AfterViewInit {
    * todo: Integrate the search functions from different interfaces into a single method.
    */
   async search(forced: boolean = false): Promise<void> {
+    if (!this.filters || !this.searchResultsComponent) {
+      return;
+    }
     const sameList =
       this.masterFilterList !== null &&
       this.filters.masterFilterList.length === this.masterFilterList.length &&
@@ -116,6 +114,7 @@ export class HubSearchResultComponent implements OnInit, AfterViewInit {
     }
     this.lastSortMethod = this.sortMethod;
     this.masterFilterList = this.filters.masterFilterList;
+    this.searchKeywords = this.filters.getSearchKeywords();
     let filterParams = this.filters.getSearchFilterParameters();
     if (isDefined(this.pid)) {
       // force the project id in the search query to be the current pid.


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR fixes an issue where public datasets/workflows fail to display on the hub search result page on first render. After the Angular upgrade, `@ViewChild` is `undefined` during the first render, and the previous getters for `filters` and `searchResultsComponent` threw an error in that case.

Changes:
- Change the `filters` and `searchResultsComponent` getters to return `undefined` when the child view is not yet initialized.
- Add a guard at the start of `search()` to skip until both are ready.
- Move `searchKeywords` into a component property so the template no longer dereferences `filters` while it's `undefined`.

<img width="1361" height="648" alt="Screenshot 2026-04-30 at 3 14 29 PM" src="https://github.com/user-attachments/assets/937852d7-f992-4572-b3ff-402dc78d539c" />

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Resolves #4578 

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
Manually tested

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.7