### PR TITLE
ci: protect release/* branches with CI

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -25,6 +25,7 @@ on:
     branches:
       - 'ci-enable/**'
       - 'main'
+      - 'release/**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR enables the existing `Build` GitHub Actions workflow to run on direct pushes to release branches by adding `release/**` to the workflow trigger list.

This is the minimal change needed so branches such as `release/v1.1.0-incubating` will receive CI runs on push.

### Any related issues, documentation, discussions?
Closes #4594 

### How was this PR tested?
- Verified the workflow trigger configuration now includes `release/**` in `.github/workflows/github-action-build.yml`.
- Ran `git diff --check` locally.
- Did not run the full CI suite locally; verification is expected from GitHub Actions after the PR updates.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Codex GPT-5
