### PR TITLE
ci: add Required Checks aggregator job

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -73,14 +73,7 @@ github:
       required_status_checks:
         strict: true
         contexts:
-          - frontend (ubuntu-latest, 18)
-          - frontend (windows-latest, 18)
-          - frontend (macos-latest, 18)
-          - scala (ubuntu-22.04, 11)
-          - python (ubuntu-latest, 3.10)
-          - python (ubuntu-latest, 3.11)
-          - python (ubuntu-latest, 3.12)
-          - python (ubuntu-latest, 3.13)
+          - Required Checks
           - Check License Headers
           - Validate PR title
       required_pull_request_reviews:
@@ -96,14 +89,7 @@ github:
         strict: true
         # contexts are the names of checks that must pass
         contexts:
-          - frontend (ubuntu-latest, 18)
-          - frontend (windows-latest, 18)
-          - frontend (macos-latest, 18)
-          - scala (ubuntu-22.04, 11)
-          - python (ubuntu-latest, 3.10)
-          - python (ubuntu-latest, 3.11)
-          - python (ubuntu-latest, 3.12)
-          - python (ubuntu-latest, 3.13)
+          - Required Checks
           - Check License Headers
           - Validate PR title
       required_pull_request_reviews:

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -378,3 +378,34 @@ jobs:
       run_python: true
       run_agent_service: true
     secrets: inherit
+
+  required-checks:
+    # Do not rename this job — its display name is referenced in .asf.yaml.
+    name: Required Checks
+    needs: [precheck, frontend, scala, python, agent-service, backport]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all required checks succeeded or were skipped
+        run: |
+          declare -A results=(
+            [precheck]="${{ needs.precheck.result }}"
+            [frontend]="${{ needs.frontend.result }}"
+            [scala]="${{ needs.scala.result }}"
+            [python]="${{ needs.python.result }}"
+            [agent-service]="${{ needs.agent-service.result }}"
+            [backport]="${{ needs.backport.result }}"
+          )
+          failed=0
+          for job in "${!results[@]}"; do
+            r="${results[$job]}"
+            echo "${job}: ${r}"
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              failed=1
+            fi
+          done
+          if (( failed )); then
+            echo "::error::One or more required checks did not succeed."
+            exit 1
+          fi
+          echo "All required checks succeeded or were skipped."


### PR DESCRIPTION
### What changes were proposed in this PR?

- Add a `required-checks` job (display name `Required Checks`, following the apache/polaris and apache/skywalking convention) that `needs:` every top-level Build job and reports a single pass/fail. `if: always()` plus "skipped counts as success" lets `precheck`-gated or label-gated jobs skip without blocking unrelated PRs.
- Replace the eight matrix-expanded contexts in `.asf.yaml` (both `main` protection and the `release/*` ruleset) with `Required Checks`.

**Note:** this implicitly promotes `agent-service` and `backport` to required checks. Neither was previously required individually; through `Required Checks` they now block merge if they fail. `backport` is skipped (and therefore treated as success) when the PR has no `release/*` labels.

The action workflow looks like this:
<img width="808" height="650" alt="Screenshot 2026-05-01 at 2 04 10 PM" src="https://github.com/user-attachments/assets/ce6a661e-0bf5-4b72-bd76-1c11f4264926" />


### Any related issues, documentation, discussions?

Closes #4599

### How was this PR tested?

Verified both YAML files parse and that `needs`/`if` semantics match GitHub Actions docs. The job is exercised on this PR itself.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)