### PR TITLE
ci(1.1): enable build workflow on release branches

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -25,6 +25,7 @@ on:
     branches:
       - 'ci-enable/**'
       - 'main'
+      - 'release/**'
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
### What changes were proposed in this PR?
Backport of #4595 to `release/v1.1.0-incubating`.

Adds `release/**` to the push-trigger list of the `Build` GitHub Actions workflow so direct pushes to release branches (such as `release/v1.1.0-incubating`) trigger CI.

### Any related issues, documentation, discussions?
Backports #4595 (closes #4594 on `main`).

### How was this PR tested?
- Cherry-picked the single-file change from #4595 (`90a92a3`) onto `release/v1.1.0-incubating`; conflict-free.
- Verified `.github/workflows/github-action-build.yml` now lists `release/**` under `on.push.branches` on this branch.
- CI itself will exercise the new trigger once this branch is pushed/merged.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7