### PR TITLE
ci: opt in to .asf.yaml rulesets staged rollout

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,6 +17,12 @@
 
 # https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
 
+meta:
+  # Opt in to the staged rollout of the asfyaml `rulesets:` directive.
+  # See apache/infrastructure-asfyaml asfyaml/feature/github/rulesets.py — the
+  # directive is gated on the `github_rulesets` environment flag.
+  environment: github_rulesets
+
 github:
   description: "Collaborative Machine-Learning-Centric Data Analytics Using Workflows"
   homepage: https://texera.io/


### PR DESCRIPTION
### What changes were proposed in this PR?
Add a `meta:` block to `.asf.yaml` that opts the repository in to the staged rollout of the asfyaml `rulesets:` directive:

```yaml
meta:
  environment: github_rulesets
```

Without this, the `Release Branch Protection` ruleset added in #4582 is silently skipped: the strictyaml schema accepts `rulesets:`, but `asfyaml/feature/github/rulesets.py` early-returns unless `github_rulesets` is in `environments_enabled`.

### Any related issues, documentation, discussions?
- Closes #4603
- Follow-up to #4579 / #4582 (the ruleset config is already in `.asf.yaml`; this PR makes it actually run)
- Verified the gap via the GitHub API:
  - `GET /repos/apache/texera/rulesets` → `[]`
  - `GET /repos/apache/texera/rules/branches/release/v1.1.0-incubating` → `[]`
- Verified the gating in `apache/infrastructure-asfyaml` source:
  - Schema accepts `rulesets:` (`asfyaml/feature/github/__init__.py`)
  - Directive gated on `github_rulesets` env flag (`asfyaml/feature/github/rulesets.py`, commit `8d2ca2c2` — \"Gate rulesets directive behind github_rulesets environment for staged rollout\")
  - `meta.environment` is added to `environments_enabled` (`asfyaml/asfyaml.py`)

### How was this PR tested?
- Diff is a 6-line addition to `.asf.yaml`; no code paths are exercised locally.
- After merge, the expected outcome is that ASF Infra reconciles the existing `Release Branch Protection` ruleset into the repo. Verification plan post-merge:
  - `gh api repos/apache/texera/rulesets` should return one entry named `Release Branch Protection`
  - `gh api repos/apache/texera/rules/branches/release/v1.1.0-incubating` should list the required status checks and PR-review rule

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7