### PR TITLE
ci: consolidate PR-open automation into Pull Request Labeler

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -17,32 +17,15 @@
 name: Auto-assign
 on:
   pull_request_target:
-    types: [opened, closed]
+    types: [closed]
 
 permissions:
   issues: write
   pull-requests: write
 
 jobs:
-  assign-pr-author:
-    if: >-
-      github.event.action == 'opened'
-      && github.event.pull_request.user.type != 'Bot'
-      && github.event.pull_request.assignees[0] == null
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const pr = context.payload.pull_request;
-            await github.rest.issues.addAssignees({
-              ...context.repo,
-              issue_number: pr.number,
-              assignees: [pr.user.login],
-            });
-
   credit-issue-on-pr-merge:
-    if: github.event.action == 'closed' && github.event.pull_request.merged
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -23,9 +23,25 @@ jobs:
   labeler:
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v6
         with:
           sync-labels: true
+
+      - name: Assign PR author
+        if: >-
+          github.event.action == 'opened'
+          && github.event.pull_request.user.type != 'Bot'
+          && github.event.pull_request.assignees[0] == null
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            await github.rest.issues.addAssignees({
+              ...context.repo,
+              issue_number: pr.number,
+              assignees: [pr.user.login],
+            });


### PR DESCRIPTION
### What changes were proposed in this PR?

Consolidate the two PR-open automation jobs into a single check:

- Move `Auto-assign / assign-pr-author` into the `Pull Request Labeler / labeler` job as an additional step, gated on `action == 'opened'` with the same bot/assignee guards.
- Reduce `auto-assign.yml` to just `credit-issue-on-pr-merge`. It now triggers on `pull_request_target: [closed]` and is gated on `pull_request.merged == true`, instead of running on both `opened` and `closed`.

Net effect: PR-open events produce a single check (`Pull Request Labeler / labeler`), and the merge-time issue credit logic remains isolated under `Auto-assign / credit-issue-on-pr-merge`.

### Any related issues, documentation, discussions?
Closes #4605

### How was this PR tested?
Workflow-only change; will be exercised by CI on this PR.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7