### PR TITLE
revert: "ci: opt in to .asf.yaml rulesets staged rollout"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -17,12 +17,6 @@
 
 # https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
 
-meta:
-  # Opt in to the staged rollout of the asfyaml `rulesets:` directive.
-  # See apache/infrastructure-asfyaml asfyaml/feature/github/rulesets.py — the
-  # directive is gated on the `github_rulesets` environment flag.
-  environment: github_rulesets
-
 github:
   description: "Collaborative Machine-Learning-Centric Data Analytics Using Workflows"
   homepage: https://texera.io/


### PR DESCRIPTION
### What changes were proposed in this PR?
Reverts #4604 (commit `875616561f3cbcc77e7b86d6a02b5ac1c5f706f5`).

The opt-in had no observable effect 18+ minutes after merge:

- `GET /repos/apache/texera/rulesets` → `[]`
- `GET /repos/apache/texera/rules/branches/release/v1.1.0-incubating` → `[]`

Root cause traced into `apache/infrastructure-asfyaml`:

1. The dispatcher (`infrastructure-p6/.../05-asfyaml.py`) routes to next-gen by default and our `meta.environment: github_rulesets` opt-in is honored — the `rulesets` directive does run.
2. But `_build_ref_name_condition` in `asfyaml/feature/github/rulesets.py` doesn't prefix bare convenience patterns with `refs/heads/`. `release/*` is sent as-is to the GitHub Rulesets API, which requires `refs/heads/release/*` (or `~DEFAULT_BRANCH` / `~ALL`).
3. The reconciler's REST calls don't check HTTP status, so the resulting 422 is silently swallowed — no email, no log, `/rulesets` stays empty.

Both issues are being fixed in apache/infrastructure-asfyaml#93 ("Follow-up fixes for the GitHub rulesets feature"), which is still **open**. `apache/logging-parent` — the only other ASF project using this opt-in — has the same empty-`/rulesets` symptom.

Reverting to keep `main` clean. Will revisit once apache/infrastructure-asfyaml#93 lands upstream, or pursue an INFRA Jira ticket (Kafka-style, INFRA-26603 precedent).

### Any related issues, documentation, discussions?
Reopens #4603.

### How was this PR tested?
- `git revert` of the squash-merge commit applies cleanly (single-parent commit; `.asf.yaml` returns to its pre-#4604 state — verified `head -25 .asf.yaml`).
- Diff is `-6 +0` on `.asf.yaml` only.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.7