### PR TITLE
fix(ci): preserve PR author on backport commits

### DIFF
--- a/.github/workflows/direct-backport-push.yml
+++ b/.github/workflows/direct-backport-push.yml
@@ -153,6 +153,7 @@ jobs:
 
           pr_title=$(gh pr view "${PR_NUMBER}" --json title --jq .title)
           pr_body=$(gh pr view "${PR_NUMBER}" --json body --jq .body)
+          original_author=$(git log -1 --format='%an <%ae>' "${MERGE_SHA}")
 
           git fetch --no-tags origin "${TARGET_BRANCH}"
           git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
@@ -164,6 +165,6 @@ jobs:
               printf '%s\n\n' "${pr_body}"
             fi
             printf '(cherry picked from commit %s)\n' "${MERGE_SHA}"
-          } | git commit -F -
+          } | git commit -F - --author="${original_author}"
 
           git push origin "HEAD:${TARGET_BRANCH}"

--- a/.github/workflows/direct-backport-push.yml
+++ b/.github/workflows/direct-backport-push.yml
@@ -137,8 +137,6 @@ jobs:
         env:
           MERGE_SHA: ${{ github.sha }}
           TARGET_BRANCH: ${{ matrix.target }}
-          PR_NUMBER: ${{ needs.discover.outputs.pr_number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -151,20 +149,19 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          pr_title=$(gh pr view "${PR_NUMBER}" --json title --jq .title)
-          pr_body=$(gh pr view "${PR_NUMBER}" --json body --jq .body)
+          # Reuse the squash commit's full message so the PR title, description,
+          # and any Co-Authored-By trailers GitHub injected stay attached to
+          # the backport commit. The author is the squash commit's author
+          # (the original PR author for squash merges).
           original_author=$(git log -1 --format='%an <%ae>' "${MERGE_SHA}")
+          merge_message=$(git log -1 --format=%B "${MERGE_SHA}")
 
           git fetch --no-tags origin "${TARGET_BRANCH}"
           git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
           git cherry-pick --no-commit "${MERGE_SHA}"
 
           {
-            printf '%s (#%s)\n\n' "${pr_title}" "${PR_NUMBER}"
-            if [[ -n "${pr_body}" ]]; then
-              printf '%s\n\n' "${pr_body}"
-            fi
-            printf '(cherry picked from commit %s)\n' "${MERGE_SHA}"
+            printf '%s\n\n(cherry picked from commit %s)\n' "${merge_message}" "${MERGE_SHA}"
           } | git commit -F - --author="${original_author}"
 
           git push origin "HEAD:${TARGET_BRANCH}"

--- a/.github/workflows/direct-backport-push.yml
+++ b/.github/workflows/direct-backport-push.yml
@@ -161,7 +161,7 @@ jobs:
           git cherry-pick --no-commit "${MERGE_SHA}"
 
           {
-            printf '%s\n\n(cherry picked from commit %s)\n' "${merge_message}" "${MERGE_SHA}"
+            printf '%s\n\n(backported from commit %s)\n' "${merge_message}" "${MERGE_SHA}"
           } | git commit -F - --author="${original_author}"
 
           git push origin "HEAD:${TARGET_BRANCH}"


### PR DESCRIPTION
### What changes were proposed in this PR?

The `Direct Backport Push` workflow added in #4598 commits the cherry-pick onto the release branch with `github-actions[bot]` as both author and committer, and rebuilds the commit message from the PR title and description fetched via `gh pr view`. Two issues:

- The committer takeover happens because `git config user.name/email` runs before `git commit -F -` and `git cherry-pick --no-commit` does not retain the original commit's authorship in the index.
- Reconstructing the message from `gh pr view --json body` drops the `Co-Authored-By` trailers that GitHub injects into the squash commit when a PR has commits from multiple contributors, so co-authors are lost on the release branch.

This PR captures the squash commit's author with `git log -1 --format='%an <%ae>'` and passes it to `git commit --author=`, and reuses the squash commit's full message via `git log -1 --format=%B` instead of reconstructing it. A `(backported from commit <sha>)` trailer is appended at the end.

After this fix the backport commit on the release branch carries the original PR author, all `Co-Authored-By` trailers from the squash commit, and `github-actions[bot]` only as the committer (preserving the audit trail for the automated push).

### Any related issues, documentation, discussions?

Follow-up to #4598.

### How was this PR tested?

Local verification of the commit construction: cherry-picking the squash commit with `--no-commit` and committing with `--author=<original>` produces a commit whose `Author` line matches the squash author, whose `Committer` line is `github-actions[bot]`, and whose body contains the squash commit's full body (including any `Co-Authored-By` trailers) plus a `(backported from commit ...)` footer.

The next `Direct Backport Push` invocation against a `release/*` labelled PR will surface the new author and trailers on the cherry-picked commit on the release branch; existing backport commits already on release branches are unaffected.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
