### PR TITLE
revert: "ci: protect future release branches via ASF rulesets"

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -59,35 +59,6 @@ github:
     squash_commit_message: PR_TITLE_AND_DESC
     merge:   false
     rebase:  false
-
-  rulesets:
-    - name: Release Branch Protection
-      type: branch
-      branches:
-        includes:
-          - release/*
-        excludes: []
-      restrict_deletion: true
-      restrict_force_push: true
-      required_linear_history: true
-      required_status_checks:
-        strict: true
-        contexts:
-          - frontend (ubuntu-latest, 18)
-          - frontend (windows-latest, 18)
-          - frontend (macos-latest, 18)
-          - scala (ubuntu-22.04, 11)
-          - python (ubuntu-latest, 3.10)
-          - python (ubuntu-latest, 3.11)
-          - python (ubuntu-latest, 3.12)
-          - python (ubuntu-latest, 3.13)
-          - Check License Headers
-          - Validate PR title
-      required_pull_request_reviews:
-        dismiss_stale_reviews: false
-        require_last_push_approval: false
-        require_code_owner_reviews: false
-        required_approving_review_count: 1
     
   protected_branches:
     main:


### PR DESCRIPTION
### What changes were proposed in this PR?

Reverts #4582 (commit `1045997b0e8f6bee850a27af53e65ae406d70481`), which added a `release/*` ruleset to `.asf.yaml`.

ASF infra's support for the `rulesets` directive is still incomplete (see also #4607 / apache/infrastructure-asfyaml#93). We'll protect release branches via a different mechanism in a follow-up; reverting for now to keep `.asf.yaml` clean and to unblock #4600.

### Any related issues, documentation, discussions?

Reopens #4579. Unblocks #4600.

### How was this PR tested?

Verified the ruleset never actually took effect — `GET /repos/apache/texera/rulesets` returns `[]` and `GET /repos/apache/texera/rules/branches/release/v1.1.0-incubating` returns `[]`. So this revert is effectively a no-op against live GitHub state and only cleans up `.asf.yaml`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)