### PR TITLE
fix(ci): treat skipped backport jobs as green in Direct Backport Push

### DIFF
--- a/.github/workflows/direct-backport-push.yml
+++ b/.github/workflows/direct-backport-push.yml
@@ -156,7 +156,14 @@ jobs:
               greenTargets = requestedTargets.filter((target) => {
                 const prefix = `backport (${target}) / `;
                 const targetJobs = allJobs.filter((job) => job.name.startsWith(prefix));
-                return targetJobs.length > 0 && targetJobs.every((job) => job.conclusion === "success");
+                // Treat skipped as green: precheck legitimately skips stacks
+                // based on PR labels, matching the Required Checks aggregator.
+                return (
+                  targetJobs.length > 0 &&
+                  targetJobs.every(
+                    (job) => job.conclusion === "success" || job.conclusion === "skipped"
+                  )
+                );
               });
             }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

After #4622 the `precheck` step legitimately skips build stacks based on PR labels (e.g., a PR without the `frontend` label skips the frontend stack). The backport caller propagates these toggles, so the corresponding `backport (target) / frontend (...)` job ends with `conclusion: "skipped"`.

`direct-backport-push.yml`'s discovery filter required **every** matching job to be `success`, so legitimately-skipped jobs caused the whole target to be classified as not-green and `push-backports` was silently skipped. Match the `Required Checks` aggregator's logic by accepting both `success` and `skipped`.

### Any related issues, documentation, discussions?

Closes #4628. Triggered by run [25237976528](https://github.com/apache/texera/actions/runs/25237976528) for the merge of #4622.

### How was this PR tested?

Single-line filter change; YAML parses locally. Will be exercised on the next merge of a PR with `release/*` labels and a partially-skipped build matrix.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)