### PR TITLE
perf(ci): use postgres service container for python job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,6 +234,18 @@ jobs:
         os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - name: Checkout Texera
         uses: actions/checkout@v5
@@ -259,13 +271,10 @@ jobs:
       - name: Check installed Python packages against LICENSE-binary
         if: matrix.python-version == '3.12'
         run: ./bin/licensing/check_binary_deps.py python /tmp/pip-licenses.csv
-      - name: Install PostgreSQL
-        run: sudo apt-get update && sudo apt-get install -y postgresql
-      - name: Start PostgreSQL Service
-        run: sudo systemctl start postgresql
-      - name: Create Database and User
-        run: |
-          cd sql && sudo -u postgres psql -f iceberg_postgres_catalog.sql
+      - name: Create iceberg catalog database
+        run: psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
+        env:
+          PGPASSWORD: postgres
       - name: Lint with Ruff
         run: |
           cd amber/src/main/python && ruff check . && ruff format --check .


### PR DESCRIPTION
### What changes were proposed in this PR?

Switch the python job in `build.yml` from `apt-get install postgresql` + `systemctl start` to a `services: postgres` container, mirroring what the scala job already does:

- Add `services.postgres` (image `postgres`, `POSTGRES_PASSWORD=postgres`, port 5432, `pg_isready` healthcheck).
- Drop `Install PostgreSQL`, `Start PostgreSQL Service`, and the `sudo -u postgres psql -f` seed step.
- Single `Create iceberg catalog database` step that runs `psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql` (same pattern as the scala job).

### Any related issues, documentation, discussions?

Closes #4634.

Driven by repeated python-job failures on `apt-get update` against `azure.archive.ubuntu.com`, which has been unreliable; runs sit ignoring the InRelease responses for tens of seconds and either fail or surface stale package metadata. The docker registry path used by `services` is independent of that mirror.

Side benefit: postgres container starts in seconds, vs. ~30 s of `apt-get update` even on a healthy day. Removes the only place in `build.yml` that still needed the apt mirror.

### How was this PR tested?

Will be exercised by this PR's own python matrix once the CI runs. The seed SQL is the same one the scala job already runs successfully against the same container image.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
