### PR TITLE
fix(ci): use uv for python deps, keep pip on 3.12 license-check leg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,10 +228,13 @@ jobs:
       - name: Install dependencies
         # Only the backend test step needs the python deps; install just
         # before tests so a lint or dist failure does not pay for them.
+        # Use uv for speed — the scala job's binary license check is
+        # jar-only, so any pip-vs-uv resolver differences in the Python
+        # tree don't affect amber/LICENSE-binary-python here.
         run: |
-          python -m pip install --upgrade pip
-          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
-          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
+          python -m pip install uv
+          if [ -f amber/requirements.txt ]; then uv pip install --system -r amber/requirements.txt; fi
+          if [ -f amber/operator-requirements.txt ]; then uv pip install --system -r amber/operator-requirements.txt; fi
       - name: Create texera_db_for_test_cases
         run: psql -h localhost -U postgres -v DB_NAME=texera_db_for_test_cases -f sql/texera_ddl.sql
         env:
@@ -287,11 +290,22 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
+        # 3.12 is the only leg that drives the binary-license check via
+        # pip-licenses. Keep stock pip there so the resolved versions
+        # match amber/LICENSE-binary-python (also generated with pip,
+        # tracking what the production image installs). Other legs use
+        # uv purely for install-speed.
         run: |
-          python -m pip install --upgrade pip
-          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
-          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
-          if [ "${{ matrix.python-version }}" = "3.12" ]; then pip install pip-licenses; fi
+          if [ "${{ matrix.python-version }}" = "3.12" ]; then
+            python -m pip install --upgrade pip
+            if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
+            if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
+            pip install pip-licenses
+          else
+            python -m pip install uv
+            if [ -f amber/requirements.txt ]; then uv pip install --system -r amber/requirements.txt; fi
+            if [ -f amber/operator-requirements.txt ]; then uv pip install --system -r amber/operator-requirements.txt; fi
+          fi
       - name: Generate pip-licenses manifest
         if: matrix.python-version == '3.12'
         run: pip-licenses --format=csv --ignore-packages pip-licenses prettytable wcwidth > /tmp/pip-licenses.csv
@@ -308,9 +322,11 @@ jobs:
       - name: Install dev dependencies
         # Test-only deps live in amber/dev-requirements.txt and are
         # installed after the LICENSE-binary snapshot above so they never
-        # appear in pip-licenses output. Packaging skips this file.
+        # appear in pip-licenses output. Packaging skips this file. uv
+        # is safe here regardless of leg because it runs post-snapshot.
         run: |
-          if [ -f amber/dev-requirements.txt ]; then pip install -r amber/dev-requirements.txt; fi
+          python -m pip install uv
+          if [ -f amber/dev-requirements.txt ]; then uv pip install --system -r amber/dev-requirements.txt; fi
       - name: Test with pytest
         run: |
           cd amber/src/main/python && pytest --cov=. --cov-report=xml -sv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,15 +297,14 @@ jobs:
         # uv purely for install-speed.
         run: |
           if [ "${{ matrix.python-version }}" = "3.12" ]; then
-            python -m pip install --upgrade pip
-            if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
-            if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
-            pip install pip-licenses
+            python -m pip install --upgrade pip pip-licenses
+            install="pip install"
           else
             python -m pip install uv
-            if [ -f amber/requirements.txt ]; then uv pip install --system -r amber/requirements.txt; fi
-            if [ -f amber/operator-requirements.txt ]; then uv pip install --system -r amber/operator-requirements.txt; fi
+            install="uv pip install --system"
           fi
+          if [ -f amber/requirements.txt ]; then $install -r amber/requirements.txt; fi
+          if [ -f amber/operator-requirements.txt ]; then $install -r amber/operator-requirements.txt; fi
       - name: Generate pip-licenses manifest
         if: matrix.python-version == '3.12'
         run: pip-licenses --format=csv --ignore-packages pip-licenses prettytable wcwidth > /tmp/pip-licenses.csv


### PR DESCRIPTION
## What changes were proposed in this PR?

#4521 had the python dep install in the scala and python matrix jobs on `uv pip install --system` for install-speed. #4597 unintentionally rewrote those lines back to stock `pip install` while inlining the binary license checks, and the regression has been carried forward by every subsequent rebase. Restore uv — but with a targeted carve-out for the leg that drives the binary license check.

### Why the carve-out

The python job's `3.12` matrix entry is the only leg that runs `pip-licenses` and feeds the result into `bin/licensing/check_binary_deps.py python`. That tool compares the installed Python tree against `amber/LICENSE-binary-python`, which is generated **with pip** and tracks what the production image installs. uv and pip resolvers can land on different versions of unpinned transitives — if the 3.12 leg installs with uv, `check_binary_deps.py` would false-positive on resolver drift, forcing us to chase those drifts in `LICENSE-binary-python` (and diverge from production).

So: stock `pip install` on the 3.12 leg only; uv everywhere else.

### Per-step shape

- **scala job → Install dependencies**: `uv pip install --system`. Its license check is jar-only, so Python resolver differences don't matter here.
- **python job → Install dependencies**: branches on `matrix.python-version`. `3.12` keeps `pip install`; `3.10`, `3.11`, `3.13` use `uv pip install --system`.
- **python job → Install dev dependencies**: `uv pip install --system`. Runs post-snapshot, so uv is safe on all legs.

No behaviour change for the license check itself. Other legs gain install speed.

## Any related issues, documentation, discussions?

Closes #4635. Restores #4521. Regression introduced by #4597.

## How was this PR tested?

Will be exercised by this PR's own scala and python matrices. The expected signal:

- [x] scala job: install step uses uv, tests still run.
- [x] python 3.10 / 3.11 / 3.13 legs: install step uses uv.
- [x] python 3.12 leg: install step uses pip; pip-licenses manifest unchanged; `check_binary_deps.py python` passes.

## Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (Claude Code)