### PR TITLE
feat(ci): split agent-service out of the service label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -27,7 +27,17 @@ common:
 service:
   - changed-files:
       - any-glob-to-any-file:
-          - '*-service/**'
+          - 'access-control-service/**'
+          - 'computing-unit-managing-service/**'
+          - 'config-service/**'
+          - 'file-service/**'
+          - 'pyright-language-service/**'
+          - 'workflow-compiling-service/**'
+
+agent-service:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'agent-service/**'
 
 engine:
   - changed-files:

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -118,7 +118,8 @@ jobs:
             //   frontend             |    x     |       |        |
             //   python               |          |   x   |   x    |
             //   engine               |          |   x   |   x    |
-            //   service              |          |   x   |        |     x
+            //   service              |          |   x   |        |
+            //   agent-service        |          |       |        |     x
             //   common               |          |   x   |        |
             //   ddl-change           |          |   x   |        |
             //   ci                   |    x     |   x   |   x    |     x
@@ -126,9 +127,10 @@ jobs:
             //   release/* / branch   |          |       |        |
             const LABEL_STACKS = {
               frontend: ["frontend"],
-              python: ["scala", "python"],   // pyamber drives scala integration tests too
-              engine: ["scala", "python"],   // amber/** spans both
-              service: ["scala", "agent-service"],
+              python: ["scala", "python"],     // pyamber drives scala integration tests too
+              engine: ["scala", "python"],     // amber/** spans both
+              service: ["scala"],              // scala-side services; agent-service is its own label
+              "agent-service": ["agent-service"],
               common: ["scala"],
               "ddl-change": ["scala"],
               ci: ["frontend", "scala", "python", "agent-service"],


### PR DESCRIPTION
### What changes were proposed in this PR?

Split `agent-service` out of the broad `service` label so an agent-service-only PR runs only the agent-service stack, not scala.

`.github/labeler.yml`:
- `service` no longer matches `*-service/**`. It enumerates the scala-side service directories instead, because `actions/labeler@v6`'s `any-glob-to-any-file` does not exclude with negation patterns and the `all-globs-to-all-files: ['!agent-service/**']` workaround mishandles PRs that touch both agent-service and another service.
- New `agent-service` label matches `agent-service/**`.

`.github/workflows/required-checks.yml`:

```js
service:        ["scala"],            // was ["scala", "agent-service"]
"agent-service": ["agent-service"],   // new
```

Updated decision table (bolded rows are this PR's diff vs #4640):

| label | frontend | scala | python | agent-service |
|---|---|---|---|---|
| `frontend` | ✓ |  |  |  |
| `python` |  | ✓ | ✓ |  |
| `engine` |  | ✓ | ✓ |  |
| **`service`** |  | **✓** |  | ~~✓~~ |
| **`agent-service`** (new) |  |  |  | **✓** |
| `common` |  | ✓ |  |  |
| `ddl-change` |  | ✓ |  |  |
| `ci` | ✓ | ✓ | ✓ | ✓ |
| `docs` / `dev` / `dependencies` / `release/*` / branch-name |  |  |  |  |

PRs touching both directories keep both labels and run both stacks via the union.

### Any related issues, documentation, discussions?

Closes #4642.

### How was this PR tested?

This PR's own run will exercise it: it touches `.github/workflows/**` and `.github/labeler.yml`, so the labeler will add `ci`, which fans out to every stack. After merge, an agent-service-only change should land only the `agent-service` label and run only the agent-service stack.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
