### PR TITLE
fix(ci): bump sbt/setup-sbt to v1.1.22 in generate-jooq job

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -126,7 +126,7 @@ jobs:
           java-version: 11
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd # v1.1.14
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
 
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:


### PR DESCRIPTION
### What changes were proposed in this PR?

Bumps `sbt/setup-sbt` in the `generate-jooq` job of `.github/workflows/build-and-push-images.yml` from the v1.1.14 SHA (`3e125ece…`) to the v1.1.22 SHA (`508b753e…`), matching the SHA already used by the `build-amd64` and `build-arm64` jobs.

The v1.1.14 SHA is no longer on ASF Infra's allowlist, so the workflow currently fails immediately with:

> The action `sbt/setup-sbt@3e125ece5c3e5248e18da9ed8d2cce3d335ec8dd` is not allowed in apache/texera because all actions must be from a repository owned by your enterprise

Since `generate-jooq` is a `needs:` of both build jobs, this single mismatch blocks the entire workflow.

### Any related issues, documentation, discussions?

Closes #4643

### How was this PR tested?

Will be verified by triggering the `Build and push images` workflow on `workflow_dispatch` once merged. The change is a one-line action SHA bump aligning with SHAs already validated by the parallel build jobs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)