### PR TITLE
fix(ci): generate the coverage files Codecov uploads expect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,19 +21,22 @@ ThisBuild / scalaVersion := "2.13.18"
 
 // sbt-jacoco emits only HTML by default; add XML so Codecov can consume
 // per-module jacoco.xml at target/scala-2.13/jacoco/report/jacoco.xml.
-import com.github.sbt.jacoco.report.JacocoReportSettings
-import com.github.sbt.jacoco.report.formats.{ScalaHTMLReport, XMLReport}
-ThisBuild / jacocoReportSettings := JacocoReportSettings()
-  .withTitle("Apache Texera Coverage")
-  .withFormats(ScalaHTMLReport(), XMLReport(encoding = "utf-8"))
+// JacocoPlugin defines a project-scoped default that overrides ThisBuild,
+// so this Seq is bundled into asfLicensingSettings (applied to every module).
+import com.github.sbt.jacoco.report.{JacocoReportFormats, JacocoReportSettings}
+lazy val coverageReportSettings = Seq(
+  jacocoReportSettings := JacocoReportSettings()
+    .withTitle("Apache Texera Coverage")
+    .withFormats(JacocoReportFormats.ScalaHTML, JacocoReportFormats.XML)
+)
 
 // Per-module ASF licensing: each jar's META-INF/LICENSE describes only what is in that jar.
 // Modules without vendored code get Apache 2.0 only; workflow-operator includes mbknor attribution.
 // See project/AddMetaInfLicenseFiles.scala.
 // Dist-producing modules additionally override Universal / mappings in their own
 // build.sbt (not here) — see AddMetaInfLicenseFiles.distMappings.
-lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings
-lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings
+lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings ++ coverageReportSettings
+lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings ++ coverageReportSettings
 
 val jacksonVersion = "2.18.6"
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,14 @@ ThisBuild / organization := "org.apache.texera"
 ThisBuild / version      := "1.1.0-incubating"
 ThisBuild / scalaVersion := "2.13.18"
 
+// sbt-jacoco emits only HTML by default; add XML so Codecov can consume
+// per-module jacoco.xml at target/scala-2.13/jacoco/report/jacoco.xml.
+import com.github.sbt.jacoco.report.JacocoReportSettings
+import com.github.sbt.jacoco.report.formats.{ScalaHTMLReport, XMLReport}
+ThisBuild / jacocoReportSettings := JacocoReportSettings()
+  .withTitle("Apache Texera Coverage")
+  .withFormats(ScalaHTMLReport(), XMLReport(encoding = "utf-8"))
+
 // Per-module ASF licensing: each jar's META-INF/LICENSE describes only what is in that jar.
 // Modules without vendored code get Apache 2.0 only; workflow-operator includes mbknor attribution.
 // See project/AddMetaInfLicenseFiles.scala.

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -54,7 +54,12 @@ module.exports = function (config) {
         ],
       },
     },
-    reporters: ["dots"], // Use dots reporter
+    reporters: ["dots", "coverage"], // dots = test progress; coverage = lcov.info for Codecov when --code-coverage is passed
+    coverageReporter: {
+      dir: require("path").join(__dirname, "./coverage"),
+      subdir: ".",
+      reporters: [{ type: "lcovonly", file: "lcov.info" }, { type: "text-summary" }]
+    },
     port: 9876, // Karma's web server port
     colors: true, // Enable colors in the output (reporters and logs)
     logLevel: config.LOG_INFO, // Set log level


### PR DESCRIPTION
### What changes were proposed in this PR?

Follow-up to #4646. The upload steps wired in that PR for the scala and frontend stacks have been silently uploading nothing (`Found 0 coverage files to report` in the Codecov action logs); only `python` and `agent-service` flags reach Codecov today. Reason: the underlying tools were not configured to write the report files at the paths the upload globs expected.

`frontend/karma.conf.js`:
- Add `"coverage"` to the explicit `reporters` list. Without this, Angular's `--code-coverage` flag cannot inject the `karma-coverage` reporter because the user-supplied `reporters` array overrides Angular's defaults.
- Add an explicit `coverageReporter` block writing `lcovonly` to `frontend/coverage/lcov.info` — the path the Codecov upload step globs (`./frontend/coverage/**/lcov.info`).

`build.sbt`:
- Set `ThisBuild / jacocoReportSettings` to use both `ScalaHTMLReport()` and `XMLReport(encoding = "utf-8")`. By default `sbt-jacoco` emits only HTML; without XML there is nothing for Codecov to read at `<module>/target/scala-2.13/jacoco/report/jacoco.xml`.

### Any related issues, documentation, discussions?

Follow-up to #4646. Original tracking issue: #4645.

### How was this PR tested?

Will be exercised by this PR's own scala and frontend matrices on CI. Expected post-fix behaviour: both flags appear at https://app.codecov.io/gh/apache/texera (currently only `python` and `agent-service` are listed) and per-stack coverage shows up on PR commits.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7
