### PR TITLE
fix(ci): include litellm-config.yaml in RC docker-compose bundle

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -155,6 +155,7 @@ jobs:
           # Copy deployment files
           cp "$TEMP_DIR/_raw/bin/single-node/docker-compose.yml" "$BUNDLE_DIR/"
           cp "$TEMP_DIR/_raw/bin/single-node/nginx.conf" "$BUNDLE_DIR/"
+          cp "$TEMP_DIR/_raw/bin/single-node/litellm-config.yaml" "$BUNDLE_DIR/"
           cp -r "$TEMP_DIR/_raw/sql" "$BUNDLE_DIR/"
 
           # Patch the SQL mount path for the self-contained bundle layout


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds the missing `cp` of `bin/single-node/litellm-config.yaml` into the bundle directory in the `Create Docker Compose deployment bundle` step of `.github/workflows/create-release-candidate.yml`.

`bin/single-node/docker-compose.yml` bind-mounts the file:

```yaml
volumes:
  - ./litellm-config.yaml:/app/config.yaml:ro
```

Without this copy, the RC tarball ships without `litellm-config.yaml`. When users extract it and run `docker compose up`, Docker creates an empty directory at the bind source, and litellm crashes with `IsADirectoryError: '/app/config.yaml'`.

### Any related issues, documentation, discussions?

Closes #4651

### How was this PR tested?

To be verified by re-running the `Create and upload release candidate artifacts` workflow against the next RC tag and confirming `litellm-config.yaml` is present in the docker-compose tarball and that `docker compose up` starts the litellm container cleanly.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)