### PR TITLE
fix(ci): label root scala build files and .asf.yaml so the right stacks run

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -67,9 +67,7 @@ docs:
 ci:
   - changed-files:
       - any-glob-to-any-file:
-          - '.github/workflows/**'
-          - '.github/scripts/**'
-          - '.github/labeler.yml'
+          - '.github/**'
           - '.asf.yaml'
 
 dev:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,6 +68,7 @@ ci:
   - changed-files:
       - any-glob-to-any-file:
           - '.github/workflows/**'
+          - '.asf.yaml'
 
 dev:
   - changed-files:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,6 +68,8 @@ ci:
   - changed-files:
       - any-glob-to-any-file:
           - '.github/workflows/**'
+          - '.github/scripts/**'
+          - '.github/labeler.yml'
           - '.asf.yaml'
 
 dev:

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -33,6 +33,12 @@ service:
           - 'file-service/**'
           - 'pyright-language-service/**'
           - 'workflow-compiling-service/**'
+          # Root-level scala build / lint config: a change to any of these
+          # affects the scala stack, but no component label catches them.
+          - 'build.sbt'
+          - 'project/**'
+          - '.scalafix.conf'
+          - '.scalafmt.conf'
 
 agent-service:
   - changed-files:


### PR DESCRIPTION
### What changes were proposed in this PR?

Close `.github/labeler.yml` gaps where root-level / workflow-adjacent config files matched no rule that maps to a CI stack:

**Scala build / lint config → `service` label** (so the scala stack runs):

- `build.sbt` (root)
- `project/**` (sbt build sources, `plugins.sbt`)
- `.scalafix.conf` (moved to root by #3888)
- `.scalafmt.conf`

Today these match either `**/build.sbt` (label `dependencies`, which `LABEL_STACKS` from #4640 maps to no-op) or no rule at all. A PR that only edits one of them skipped the scala stack — concrete example: PR #4649, labels `dependencies, fix, frontend, release/v1.1.0-incubating`, union `{frontend}`, no scala. `service` already maps to scala in `LABEL_STACKS`, so the union picks up scala automatically.

**Workflow-adjacent / repo-wide config → `ci` label** (so the full matrix runs):

- `.github/scripts/**` (CI helper scripts)
- `.github/labeler.yml` (the labeler config itself)
- `.asf.yaml` (branch protection rulesets, mailing list, GitHub features)

These currently match no rule. `ci` already maps to all four stacks, which is the right gate for changes that can affect every stack.

### Any related issues, documentation, discussions?

Closes #4653.

### How was this PR tested?

This PR's own labeler run picks up `ci` (it edits `.github/labeler.yml`), so all stacks gate the change. After merge, future PRs that only edit a root scala build file pick up `service`, and PRs editing `.github/scripts/**`, `.github/labeler.yml`, or `.asf.yaml` pick up `ci`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7