### PR TITLE
chore: trim issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -40,13 +40,13 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: version
+    id: branch
     attributes:
-      label: Version
-      description: What version of Texera are you running?
+      label: Branch
+      description: Which branch did you hit this on?
       options:
-        - 1.1.0-incubating (Pre-release/Master)
-        - 1.0.0
+        - main
+        - 1.1.0-incubating
       default: 0
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature-template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-template.yaml
@@ -43,20 +43,6 @@ body:
       required: true
 
   - type: dropdown
-    id: impact
-    attributes:
-      label: Impact / Priority
-      description: How important is this feature?
-      options:
-        - (P0)Critical – blocks existing use cases
-        - (P1)High – significantly improves user experience
-        - (P2)Medium – useful enhancement
-        - (P3)Low – nice to have
-      default: 2
-    validations:
-      required: true
-
-  - type: dropdown
     id: affected-area
     attributes:
       label: Affected Area

--- a/.github/ISSUE_TEMPLATE/task-template.yaml
+++ b/.github/ISSUE_TEMPLATE/task-template.yaml
@@ -33,29 +33,18 @@ body:
     validations:
       required: true
 
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority
-      description: How urgent or important is this task?
-      options:
-        - P0 – Critical
-        - P1 – High
-        - P2 – Medium
-        - P3 – Low
-      default: 2
-
   - type: checkboxes
     id: checklist
     attributes:
       label: Task Type
       description: Select the type of work involved.
       options:
-        - label: Code Implementation
-        - label: Documentation
         - label: Refactor / Cleanup
+        - label: DevOps / Deployment / CI
         - label: Testing / QA
-        - label: DevOps / Deployment
+        - label: Documentation
+        - label: Performance
+        - label: Other
 
   - type: markdown
     attributes:


### PR DESCRIPTION
### What changes were proposed in this PR?

- Drop the **Priority** dropdown from `feature-template.yaml` and `task-template.yaml`. Priority is tracked on the issue itself via GitHub's native field, so the in-template dropdown is redundant. `bug-template.yaml` never had one.
- `bug-template.yaml`: replace the **Version** dropdown (`1.1.0-incubating (Pre-release/Master)` / `1.0.0`) with a **Branch** dropdown (`main` / `1.1.0-incubating`). Bugs are reported against branches more often than tagged releases.
- `task-template.yaml`: tighten **Task Type**. Drop "Code Implementation" (every task is code) and add Performance + Other. Final list: Refactor / Cleanup, DevOps / Deployment / CI, Testing / QA, Documentation, Performance, Other.

No other field changes.

### Any related issues, documentation, discussions?

Closes #4655

### How was this PR tested?

YAML parses locally for all three templates. Real-world test: open the "New issue" UI and confirm the dropdowns/labels render as expected once merged.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)