### PR TITLE
chore(asf): require conversation resolution before merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,6 +77,7 @@ github:
         require_code_owner_reviews: false
         required_approving_review_count: 1
       required_linear_history: true
+      required_conversation_resolution: true
 
 notifications:
   commits:              commits@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `required_conversation_resolution: true` to the `main` branch protection block in `.asf.yaml`.

```diff
       required_linear_history: true
+      required_conversation_resolution: true
```

This is a passthrough to GitHub's branch-protection API and will be synced by ASF INFRA's `.asf.yaml` bot.

**Effect** — PR review threads must be marked Resolved before merging. The approval flow is unchanged (1 approving review still required, no stale dismissal). Comment-style reviews remain non-blocking by themselves, but any inline conversation they create is gated.

**Why** — Today only "Approve" / "Request changes" gate merging; inline comments and Copilot review feedback do not. This change makes reviewer feedback explicitly addressable before merge, matching the practice of 40 other Apache repositories (airflow, pulsar, log4j2, cloudberry, fineract, ignite-3, nuttx, etc.).

### Any related issues, documentation, discussions?

Closes #4659.

ASF INFRA `.asf.yaml` features: https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features

### How was this PR tested?

This is a configuration change — no automated tests apply. Verification plan:

1. After merge, ASF INFRA bot syncs `.asf.yaml` to GitHub branch protection on `main`.
2. Open a follow-up PR with an unresolved inline comment and confirm the merge button is blocked until the thread is resolved.
3. Approve flow regression — confirm a PR with 1 approval and all conversations resolved still merges.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7, 1M context)