### PR TITLE
fix(ci): wire CODECOV_TOKEN to coverage uploads (Phase 2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && always()
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./frontend/coverage/**/lcov.info
           flags: frontend
           fail_ci_if_error: false
@@ -247,6 +248,7 @@ jobs:
         if: always()
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./**/target/scala-2.13/jacoco/report/jacoco.xml
           flags: scala
           fail_ci_if_error: false
@@ -316,6 +318,7 @@ jobs:
         if: matrix.python-version == '3.12' && always()
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./amber/src/main/python/coverage.xml
           flags: python
           fail_ci_if_error: false
@@ -368,6 +371,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && always()
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./agent-service/coverage/lcov.info
           flags: agent-service
           fail_ci_if_error: false


### PR DESCRIPTION
### What changes were proposed in this PR?

Phase 2 of #4645. Pass `token: ${{ secrets.CODECOV_TOKEN }}` to all four `codecov/codecov-action` invocations in `.github/workflows/build.yml` (frontend, scala, python, agent-service).

```diff
       - name: Upload <stack> coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ...
           flags: <stack>
           fail_ci_if_error: false
```

The token has been added as a repo secret. Phase 1 deferred this on the assumption that the tokenless flow was sufficient; in practice Codecov rejects tokenless uploads on protected default branches (`{"message":"Token required because branch is protected"}`), which has been silent because `fail_ci_if_error: false`.

### Any related issues, documentation, discussions?

Closes #4665. Follow-up to #4645.

### How was this PR tested?

Will be verified post-merge: a new commit on `main` should appear at https://app.codecov.io/gh/apache/texera/branch/main with a coverage report (currently 404 — no main commit has ever produced a report).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7, 1M context)