### PR TITLE
docs(scala): fully-qualify ScalaDoc @throws and link references

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/OperatorExecution.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/OperatorExecution.scala
@@ -48,7 +48,7 @@ case class OperatorExecution() {
     *
     * @param workerId The `ActorVirtualIdentity` representing the unique identity of the worker.
     * @return The `WorkerExecution` instance associated with the specified workerId.
-    * @throws AssertionError if a `WorkerExecution` already exists for the given workerId.
+    * @throws java.lang.AssertionError if a `WorkerExecution` already exists for the given workerId.
     */
   def initWorkerExecution(workerId: ActorVirtualIdentity): WorkerExecution = {
     assert(

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/RegionExecution.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/RegionExecution.scala
@@ -53,7 +53,7 @@ case class RegionExecution(region: Region) {
     * @param physicalOpId             The physical operatorId for which to initialize or retrieve the execution.
     * @param inheritOperatorExecution An optional `OperatorExecution` to make a copy.
     * @return The `OperatorExecution` associated with the given physical operatorId.
-    * @throws AssertionError if the `OperatorExecution` has already been initialized.
+    * @throws java.lang.AssertionError if the `OperatorExecution` has already been initialized.
     */
   def initOperatorExecution(
       physicalOpId: PhysicalOpIdentity,
@@ -98,7 +98,7 @@ case class RegionExecution(region: Region) {
     *
     * @param link The `PhysicalLink` for which to initialize the `LinkExecution`.
     * @return The newly initialized `LinkExecution`.
-    * @throws AssertionError if the `LinkExecution` has already been initialized for the link.
+    * @throws java.lang.AssertionError if the `LinkExecution` has already been initialized for the link.
     */
   def initLinkExecution(link: PhysicalLink): LinkExecution = {
     assert(!linkExecutions.contains(link))

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/WorkflowExecution.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/execution/WorkflowExecution.scala
@@ -41,7 +41,7 @@ case class WorkflowExecution() {
     *
     * @param region The `Region` for which to initialize or retrieve the `RegionExecution`.
     * @return The `RegionExecution` associated with the given `Region`.
-    * @throws AssertionError if the `RegionExecution` has already been initialized.
+    * @throws java.lang.AssertionError if the `RegionExecution` has already been initialized.
     */
   def initRegionExecution(region: Region): RegionExecution = {
     // ensure the region execution hasn't been initialized already.
@@ -130,7 +130,7 @@ case class WorkflowExecution() {
     * @param physicalOpId The unique identifier of the physical operator for which the latest execution is
     *                     to be retrieved.
     * @return The latest `OperatorExecution` instance associated with the given physical operatorId.
-    * @throws NoSuchElementException if no `OperatorExecution` is found for the specified operatorId.
+    * @throws java.util.NoSuchElementException if no `OperatorExecution` is found for the specified operatorId.
     */
   def getLatestOperatorExecution(physicalOpId: PhysicalOpIdentity): OperatorExecution = {
     getLatestOperatorExecutionOption(physicalOpId).get

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
@@ -523,7 +523,7 @@ class HubResource {
     *                      Supported values: View, Like, Clone, Unlike. If empty or null, all actions are returned.
     * @return              A list of CountResponse objects, one per (entityType, entityId) pair,
     *                      each containing the counts for the requested actions.
-    * @throws BadRequestException if entityTypes or entityIds are missing, empty, mismatched in length,
+    * @throws javax.ws.rs.BadRequestException if entityTypes or entityIds are missing, empty, mismatched in length,
     *         or if actionTypes contains an unsupported value.
     */
   @GET

--- a/common/pybuilder/src/main/scala/org/apache/texera/amber/pybuilder/EncodableInspector.scala
+++ b/common/pybuilder/src/main/scala/org/apache/texera/amber/pybuilder/EncodableInspector.scala
@@ -70,7 +70,7 @@ final class EncodableInspector[C <: blackbox.Context](val c: C) {
   }
 
   /**
-   * True if a [[Type]] carries @EncodableStringAnnotation as a TYPE_USE annotation (via [[AnnotatedType]]).
+   * True if a [[Type]] carries @EncodableStringAnnotation as a TYPE_USE annotation (via [[java.lang.reflect.AnnotatedType]]).
    *
    * Walks common wrappers (existentials, refinements, type refs) to find nested annotations.
    */
@@ -103,7 +103,7 @@ final class EncodableInspector[C <: blackbox.Context](val c: C) {
   /**
    * Checks @EncodableStringAnnotation on either:
    *   - accessed symbol (field/param), or
-   *   - type (TYPE_USE), via [[AnnotatedType]].
+   *   - type (TYPE_USE), via [[java.lang.reflect.AnnotatedType]].
    */
   def treeHasEncodableString(tree: Tree): Boolean = {
     val rawSym = tree.symbol

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/FileResolver.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/FileResolver.scala
@@ -44,7 +44,7 @@ object FileResolver {
     * Resolves a given fileName to either a file on the local file system or a dataset file.
     *
     * @param fileName the name of the file to resolve.
-    * @throws FileNotFoundException if the file cannot be resolved.
+    * @throws java.io.FileNotFoundException if the file cannot be resolved.
     * @return A URI pointing to the resolved file.
     */
   def resolve(fileName: String): URI = {
@@ -64,7 +64,7 @@ object FileResolver {
 
   /**
     * Attempts to resolve a local file path.
-    * @throws FileNotFoundException if the local file does not exist
+    * @throws java.io.FileNotFoundException if the local file does not exist
     * @param fileName the name of the file to check
     */
   private def localResolveFunc(fileName: String): URI = {
@@ -110,7 +110,7 @@ object FileResolver {
     *
     * @param fileName the name of the file to attempt resolving as a DatasetFileDocument
     * @return Either[String, DatasetFileDocument] - Right(document) if creation succeeds
-    * @throws FileNotFoundException if the dataset file does not exist or cannot be created
+    * @throws java.io.FileNotFoundException if the dataset file does not exist or cannot be created
     */
   private def datasetResolveFunc(fileName: String): URI = {
     val (ownerEmail, datasetName, versionName, fileRelativePathSegments) =

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/VFSURIFactory.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/VFSURIFactory.scala
@@ -44,7 +44,7 @@ object VFSURIFactory {
     *
     * @param uri The VFS URI to parse.
     * @return A `VFSUriComponents` object with the extracted data.
-    * @throws IllegalArgumentException if the URI is malformed.
+    * @throws java.lang.IllegalArgumentException if the URI is malformed.
     */
   def decodeURI(uri: URI): (
       WorkflowIdentity,
@@ -135,7 +135,7 @@ object VFSURIFactory {
     * @param executionId    Execution identifier.
     * @param operatorId     Operator identifier.
     * @return A VFS URI
-    * @throws IllegalArgumentException if `resourceType` is `RESULT`, if `operatorId` is provided for
+    * @throws java.lang.IllegalArgumentException if `resourceType` is `RESULT`, if `operatorId` is provided for
     *                                  `RUNTIME_STATISTICS`, or if `operatorId` is not provided for `CONSOLE_MESSAGES`.
     */
   private def createNonResultVFSURI(

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/util/LakeFSStorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/util/LakeFSStorageClient.scala
@@ -400,7 +400,7 @@ object LakeFSStorageClient {
     *
     * @param address URI string in the form "<scheme>://<bucket>/<key...>"
     * @return (bucket, key) where key does not start with "/"
-    * @throws IllegalArgumentException
+    * @throws java.lang.IllegalArgumentException
     *   if the address is empty, not a valid URI, missing bucket/host, or missing key/path
     */
   def parsePhysicalAddress(address: String): (String, String) = {

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/tuple/Tuple.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/tuple/Tuple.scala
@@ -40,7 +40,7 @@ class TupleBuildingException(errorMessage: String) extends RuntimeException(erro
   * @param fieldVals A list of values corresponding to the fields defined in the schema. Each value in this list
   *                  is mapped to a field in the schema, in the same order as the fields are defined.
   *
-  * @throws IllegalArgumentException if either schema or fieldVals is null, ensuring that every Tuple has a well-defined structure.
+  * @throws java.lang.IllegalArgumentException if either schema or fieldVals is null, ensuring that every Tuple has a well-defined structure.
   */
 case class Tuple @JsonCreator() (
     @JsonProperty(value = "schema", required = true) schema: Schema,

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/util/ArrowUtils.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/util/ArrowUtils.scala
@@ -115,7 +115,7 @@ object ArrowUtils extends LazyLogging {
     * Converts an ArrowType into an AttributeType.
     *
     * @param srcType the ArrowType to be converted.
-    * @throws AttributeTypeException if the type cannot be converted.
+    * @throws org.apache.texera.amber.core.tuple.AttributeTypeUtils.AttributeTypeException if the type cannot be converted.
     * @return An AttributeType.
     */
   @throws[AttributeTypeException]
@@ -259,7 +259,7 @@ object ArrowUtils extends LazyLogging {
     * Converts an AttributeType into an ArrowType (PrimitiveType).
     *
     * @param srcType The AttributeType to be converted.
-    * @throws AttributeTypeException if the type cannot be converted.
+    * @throws org.apache.texera.amber.core.tuple.AttributeTypeUtils.AttributeTypeException if the type cannot be converted.
     * @return A PrimitiveType, a type of ArrowType, does not handle complex data.
     */
   @throws[AttributeTypeException]

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/LargeBinaryManager.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/LargeBinaryManager.scala
@@ -48,7 +48,7 @@ object LargeBinaryManager extends LazyLogging {
   /**
     * Deletes all large binaries from the bucket.
     *
-    * @throws Exception if the deletion fails
+    * @throws java.lang.Exception if the deletion fails
     * @return Unit
     */
   def deleteAllObjects(): Unit = {

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
@@ -266,8 +266,8 @@ object S3StorageClient {
     * Uploads a single part for an in-progress S3 multipart upload.
     *
     * This method wraps the AWS SDK v2 {@code UploadPart} API:
-    * it builds an {@link software.amazon.awssdk.services.s3.model.UploadPartRequest}
-    * and streams the part payload via a {@link software.amazon.awssdk.core.sync.RequestBody}.
+    * it builds an [[software.amazon.awssdk.services.s3.model.UploadPartRequest]]
+    * and streams the part payload via a [[software.amazon.awssdk.core.sync.RequestBody]].
     *
     * Payload handling:
     *   - If {@code contentLength} is provided, the payload is streamed directly from {@code inputStream}
@@ -287,7 +287,7 @@ object S3StorageClient {
     * @param partNumber    1-based part number for this upload.
     * @param inputStream   Stream containing the bytes for this part.
     * @param contentLength Optional size (in bytes) of this part; provide it to avoid buffering in memory.
-    * @return              The {@link software.amazon.awssdk.services.s3.model.UploadPartResponse},
+    * @return              The [[software.amazon.awssdk.services.s3.model.UploadPartResponse]],
     *                      including the part ETag used for completing the multipart upload.
     */
   def uploadPartWithRequest(

--- a/common/workflow-operator/src/main/scala/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaInject.java
+++ b/common/workflow-operator/src/main/scala/com/kjetland/jackson/jsonSchema/annotations/JsonSchemaInject.java
@@ -30,7 +30,7 @@ public @interface JsonSchemaInject {
     String json() default "{}";
 
     /**
-     * @return a class for supplier of a raw json. The json gets applied after {@link #json()}.
+     * @return a class for supplier of a raw json. The json gets applied after {@link JsonSchemaInject#json()}.
      */
     Class<? extends Supplier<JsonNode>> jsonSupplier() default None.class;
 
@@ -40,7 +40,7 @@ public @interface JsonSchemaInject {
     String jsonSupplierViaLookup() default "";
 
     /**
-     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link #jsonSupplier()}
+     * @return a collection of key/value pairs to merge on top of the generated jsonSchema and applied after {@link JsonSchemaInject#jsonSupplier()}
      */
     JsonSchemaString[] strings() default {};
 

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/SQLSourceOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/SQLSourceOpExec.scala
@@ -68,7 +68,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
         * - If resultSet is exhausted, send the next query until no more queries are available.
         * - If no more queries, return null.
         *
-        * @throws SQLException all possible exceptions from JDBC
+        * @throws java.sql.SQLException all possible exceptions from JDBC
         * @return Tuple
         */
       @throws[SQLException]
@@ -143,7 +143,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * - tableNames, to check if the input tableName exists on the database server, to prevent SQL injection.
     * - batchColumnBoundaries, to be used to split mini queries, if progressive mode is enabled.
     *
-    * @throws SQLException all possible exceptions from JDBC
+    * @throws java.sql.SQLException all possible exceptions from JDBC
     */
   @throws[SQLException]
   override def open(): Unit = {
@@ -164,7 +164,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
   /**
     * close resultSet, preparedStatement and connection
     *
-    * @throws SQLException all possible exceptions from JDBC
+    * @throws java.sql.SQLException all possible exceptions from JDBC
     */
   @throws[SQLException]
   override def close(): Unit = {
@@ -180,7 +180,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * Build a Tuple from a row of curResultSet
     *
     * @return the new Tuple
-    * @throws SQLException all possible exceptions from JDBC
+    * @throws java.sql.SQLException all possible exceptions from JDBC
     */
   @throws[SQLException]
   protected def buildTupleFromRow: Tuple = {
@@ -214,7 +214,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * - If it is not progressive mode, this method will return false when
     * invoked the second time. Which means there is only one query.
     *
-    * @throws IllegalArgumentException if the given batchByAttribute's type is
+    * @throws java.lang.IllegalArgumentException if the given batchByAttribute's type is
     *                                  not supported to be incremental.
     * @return A boolean value whether there exists the next query or not.
     */
@@ -266,7 +266,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * be [lower, nextLower)
     *
     * @param queryBuilder the target query builder
-    * @throws IllegalArgumentException if the given batchByAttribute's type is
+    * @throws java.lang.IllegalArgumentException if the given batchByAttribute's type is
     *                                  not supported to be incremental.
     */
   @throws[IllegalArgumentException]
@@ -305,7 +305,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * Convert the Number value to a String to be concatenate to SQL.
     *
     * @param value a Number, contains the value to be converted.
-    * @throws IllegalArgumentException when the batchByAttribute is missing or the type is unexpected
+    * @throws java.lang.IllegalArgumentException when the batchByAttribute is missing or the type is unexpected
     * @return a String of that value
     */
   @throws[IllegalArgumentException]
@@ -332,7 +332,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * Fetch for a numeric value of the boundary of the batchByColumn.
     *
     * @param side either "MAX" or "MIN" for boundary
-    * @throws IllegalArgumentException if the batchByAttribute type is unexpected
+    * @throws java.lang.IllegalArgumentException if the batchByAttribute type is unexpected
     * @return a numeric value, could be Int, Long or Double
     */
   @throws[IllegalArgumentException]
@@ -368,7 +368,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
   /**
     * Establishes the connection to database.
     *
-    * @throws SQLException all possible exceptions from JDBC
+    * @throws java.sql.SQLException all possible exceptions from JDBC
     * @return a SQL connection over JDBC
     */
   @throws[SQLException]
@@ -378,7 +378,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * Fetch all table names from the given database. This is used to
     * check the input table name to prevent from SQL injection.
     *
-    * @throws SQLException all possible exceptions from JDBC
+    * @throws java.sql.SQLException all possible exceptions from JDBC
     */
   @throws[SQLException]
   protected def loadTableNames(): Unit
@@ -397,7 +397,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     *
     * Or a fixed offset [OFFSET ?] to be added if not progressive.
     *
-    * @throws IllegalArgumentException if the given batchByAttribute's type is
+    * @throws java.lang.IllegalArgumentException if the given batchByAttribute's type is
     *                                  not supported to be incremental.
     * @return string of sql query
     */
@@ -443,7 +443,7 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * - If progressive mode is not enabled, this method will be invoked
     * only once, returning the one giant query.
     *
-    * @throws SQLException all possible exceptions from JDBC
+    * @throws java.sql.SQLException all possible exceptions from JDBC
     * @return a PreparedStatement to be filled with values.
     */
   @throws[SQLException]
@@ -492,8 +492,8 @@ abstract class SQLSourceOpExec(descString: String) extends SourceOperatorExecuto
     * Load the lower bound and upper bound of the batchByColumn. Those
     * bounds will be used in progressive mode to determine mini-queries.
     *
-    * @throws SQLException             all possible exceptions from JDBC
-    * @throws IllegalArgumentException if the batchByAttribute is missing or the type is unexpected
+    * @throws java.sql.SQLException             all possible exceptions from JDBC
+    * @throws java.lang.IllegalArgumentException if the batchByAttribute is missing or the type is unexpected
     */
   @throws[SQLException]
   @throws[IllegalArgumentException]

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/asterixdb/AsterixDBSourceOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/asterixdb/AsterixDBSourceOpExec.scala
@@ -198,7 +198,7 @@ class AsterixDBSourceOpExec private[asterixdb] (
     * ['hello', 'world'], {'mode':'all'}
     *
     * @param queryBuilder queryBuilder for concatenation
-    * @throws IllegalArgumentException if attribute does not support string based search
+    * @throws java.lang.IllegalArgumentException if attribute does not support string based search
     */
   @throws[IllegalArgumentException]
   def addFilterConditions(queryBuilder: StringBuilder): Unit = {

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sort/StableMergeSortOpExecSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sort/StableMergeSortOpExecSpec.scala
@@ -62,7 +62,7 @@ class StableMergeSortOpExecSpec extends AnyFlatSpec {
     * Construct a Tuple for the provided schema.
     *
     * @param values map-like varargs: "colName" -> value. Must provide every column.
-    * @throws NoSuchElementException if a provided key is not in the schema.
+    * @throws java.util.NoSuchElementException if a provided key is not in the schema.
     */
   private def tupleOf(schema: Schema, values: (String, Any)*): Tuple = {
     val valueMap = values.toMap

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -585,7 +585,7 @@ class ComputingUnitManagingResource {
   }
 
   /**
-    * Return a fully populated [[DashboardWorkflowComputingUnit]] for the
+    * Return a fully populated [[org.apache.texera.service.resource.ComputingUnitManagingResource.DashboardWorkflowComputingUnit]] for the
     * specified `cuid`, identical to one row produced by /list.
     *
     * @param cuid the ID of the computing-unit to fetch

--- a/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
+++ b/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
@@ -1359,7 +1359,7 @@ class DatasetResource {
     * - Cannot start with a hyphen.
     *
     * @param name The dataset name to validate.
-    * @throws IllegalArgumentException if the name is invalid.
+    * @throws java.lang.IllegalArgumentException if the name is invalid.
     */
   private def validateDatasetName(name: String): Unit = {
     val datasetNamePattern = "^[A-Za-z0-9_-]+$".r


### PR DESCRIPTION
### What changes were proposed in this PR?

Resolve the ScalaDoc broken-link warnings tracked in #4670 by replacing bare class names with fully-qualified names in `@throws` tags and `[[X]]` inline links.

- JDK exception references → `java.lang.AssertionError`, `java.util.NoSuchElementException`, `java.lang.IllegalArgumentException`, `java.io.FileNotFoundException`, `java.lang.Exception`, `java.sql.SQLException`, `java.lang.reflect.AnnotatedType`.
- JAX-RS exception → `javax.ws.rs.BadRequestException`.
- Project-internal references resolved against their companion objects: `org.apache.texera.amber.core.tuple.AttributeTypeUtils.AttributeTypeException`, `org.apache.texera.service.resource.ComputingUnitManagingResource.DashboardWorkflowComputingUnit`.
- `S3StorageClient.scala` — Javadoc `{@link software.amazon.awssdk...}` references converted to ScalaDoc `[[software.amazon.awssdk...]]` form (the AWS SDK references are already on the classpath; ScalaDoc was rejecting the Javadoc syntax).
- Vendored `JsonSchemaInject.java` — same-class method links `{@link #json()}` rewritten with explicit class context as `{@link JsonSchemaInject#json()}`.

`@throws[X]` annotations in code (Scala-level annotations, not docstring tags) are intentionally untouched — only the ScalaDoc `* @throws X` lines and `[[X]]` references in comments change.

Two extra docstring sites were swept up while at it (`StableMergeSortOpExecSpec.scala`, `DatasetResource.scala`) so the build does not start emitting new warnings the next time their modules' scaladoc runs.

### Any related issues, documentation, discussions?

Closes #4670.

### How was this PR tested?

Pure ScalaDoc / comment changes — no behavioral effect, no test changes. Verified by:

1. \`grep -r '@throws AssertionError' --include='*.scala'\` and the same for the other 8 bare class names returns zero hits across the repo.
2. CI's scala job runs scaladoc as part of \`sbt jacoco\` / compile and will report any remaining unresolved references.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7, 1M context)