### PR TITLE
chore(test): instrument DataProcessingSpec with per-test timing log

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/DataProcessingSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/DataProcessingSpec.scala
@@ -62,13 +62,28 @@ class DataProcessingSpec
     with BeforeAndAfterEach
     with Retries {
 
+  // Diagnostic: per-test elapsed time, dumped sorted at the end of the suite.
+  // Used to identify the slowest e2e workflow tests so we can target them
+  // for consolidation / rewrite.
+  private val testTimingsMs =
+    scala.collection.mutable.ListBuffer[(String, Long)]()
+
   /**
     * This block retries each test once if it fails.
     * In the CI environment, there is a chance that executeWorkflow does not receive "COMPLETED" status.
     * Until we find the root cause of this issue, we use a retry mechanism here to stablize CI runs.
     */
-  override def withFixture(test: NoArgTest): Outcome =
-    withRetry { super.withFixture(test) }
+  override def withFixture(test: NoArgTest): Outcome = {
+    val startNs = System.nanoTime()
+    try {
+      withRetry { super.withFixture(test) }
+    } finally {
+      val elapsedMs = (System.nanoTime() - startNs) / 1000000L
+      testTimingsMs.synchronized {
+        testTimingsMs += ((test.name, elapsedMs))
+      }
+    }
+  }
 
   implicit val timeout: Timeout = Timeout(5.seconds)
 
@@ -98,6 +113,15 @@ class DataProcessingSpec
   }
 
   override def afterAll(): Unit = {
+    val rows = testTimingsMs.synchronized(testTimingsMs.toList)
+    val sorted = rows.sortBy(-_._2)
+    val totalMs = sorted.iterator.map(_._2).sum
+    val header =
+      f"DataProcessingSpec per-test timings (sorted desc, total ${totalMs}%dms across ${sorted.size}%d tests):"
+    info(header)
+    sorted.foreach {
+      case (name, ms) => info(f"  ${ms}%6dms  ${name}")
+    }
     TestKit.shutdownActorSystem(system)
   }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

**Draft / diagnostic** — wrap \`DataProcessingSpec.withFixture\` with a nano-timer and dump a sorted per-test elapsed-time table in \`afterAll\`.

\`DataProcessingSpec\` is the dominant contributor to scala test wall time on a typical main-push run (its 16 e2e workflow tests run for the full ~6 minute test phase, with each test bounded by a 1-minute \`Await\`). Without per-test numbers there is no way to decide which workflows to consolidate or delete.

This change is intended to land long enough to gather one CI run's worth of timings; once the slow tests are identified (#4670 follow-up), this instrumentation is expected to be removed or rewritten as a stricter timeout per test.

\`\`\`
[info] DataProcessingSpec per-test timings (sorted desc, total NNNNms across 16 tests):
[info]    XXXXXms  Engine should execute csv->keyword->averageAndGroupBy workflow normally
[info]    ...
\`\`\`

### Any related issues, documentation, discussions?

Diagnostic for the scala build wall-time discussion. Findings will feed a follow-up that either consolidates redundant e2e workflows or fixes the underlying retry flake the suite documents.

### How was this PR tested?

No new tests. The instrumentation runs as part of the existing \`DataProcessingSpec\` execution under the python/scala/agent-service \`Build\` matrix. After this PR's CI run, the scala job log under \`build / scala (ubuntu-22.04, 11)\` will contain the sorted timing table.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7, 1M context)