### PR TITLE
fix(ci): retry Auto Queue while mergeStateStatus is UNKNOWN, gate on approval and resolved threads

### DIFF
--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -24,9 +24,12 @@
 #   * workflow_dispatch: manual smoke test.
 #
 # Strategy: scan open auto-merge PRs targeting main, try updateBranch on each
-# eligible candidate from oldest. Retry with backoff up to ~2min, since
-# mergeable / mergeStateStatus are computed asynchronously and can be UNKNOWN
-# right after a base-branch push.
+# eligible candidate from oldest. A PR is eligible only if it would actually
+# merge once CI passes — auto-merge enabled, not a draft, not conflicting,
+# reviewDecision=APPROVED, and zero unresolved review threads. This avoids
+# burning CI on PRs blocked on review.
+# Retry with backoff up to ~2min, since mergeable / mergeStateStatus are
+# computed asynchronously and can be UNKNOWN right after a base-branch push.
 #
 # Token: needs AUTO_MERGE_TOKEN with contents:write + pull_requests:write so
 # the resulting push retriggers required CI on the PR. Falls back to
@@ -81,7 +84,11 @@ jobs:
                       isDraft
                       mergeable
                       mergeStateStatus
+                      reviewDecision
                       autoMergeRequest { enabledAt }
+                      reviewThreads(first: 100) {
+                        nodes { isResolved }
+                      }
                     }
                   }
                 }
@@ -91,6 +98,14 @@ jobs:
               if (!p.autoMergeRequest) return 'skip: auto-merge not enabled';
               if (p.isDraft) return 'skip: draft';
               if (p.mergeable === 'CONFLICTING') return 'skip: mergeable=CONFLICTING';
+              if (p.reviewDecision !== 'APPROVED') {
+                return `skip: reviewDecision=${p.reviewDecision || 'NONE'}`;
+              }
+              const threads = p.reviewThreads?.nodes ?? [];
+              const unresolved = threads.filter((t) => !t.isResolved).length;
+              if (unresolved > 0) {
+                return `skip: ${unresolved} unresolved review thread(s)`;
+              }
               return `eligible: mergeable=${p.mergeable} state=${p.mergeStateStatus}`;
             }
 

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -23,13 +23,16 @@
 #     last main push).
 #   * workflow_dispatch: manual smoke test.
 #
-# Strategy: scan open auto-merge PRs targeting main, try updateBranch on each
-# eligible candidate from oldest. A PR is eligible only if it would actually
-# merge once CI passes — auto-merge enabled, not a draft, not conflicting,
-# reviewDecision=APPROVED, and zero unresolved review threads. This avoids
-# burning CI on PRs blocked on review.
-# Retry with backoff up to ~2min, since mergeable / mergeStateStatus are
-# computed asynchronously and can be UNKNOWN right after a base-branch push.
+# Strategy: scan open PRs targeting main and pick the oldest eligible PR with
+# mergeStateStatus=BEHIND, then call updateBranch on it. A PR is eligible only
+# if it would actually merge once CI passes — auto-merge enabled, not a draft,
+# not conflicting, reviewDecision=APPROVED, and zero unresolved review threads.
+# This avoids burning CI on PRs blocked on review.
+#
+# mergeStateStatus is computed asynchronously and is UNKNOWN for a window
+# after a base-branch push. If at least one eligible PR is UNKNOWN, retry
+# with backoff up to ~2min to let it settle. If everything is settled and
+# nothing is BEHIND, exit without retrying — there's no work.
 #
 # Token: needs AUTO_MERGE_TOKEN with contents:write + pull_requests:write so
 # the resulting push retriggers required CI on the PR. Falls back to
@@ -126,61 +129,70 @@ jobs:
               const all = data.repository.pullRequests.nodes;
               core.info(`Scanned ${all.length} open PR(s) targeting main.`);
 
-              const eligible = [];
+              const behind = [];
+              const unknown = [];
               for (const p of all) {
                 const verdict = classify(p);
                 core.info(`  #${p.number} ${verdict} — ${p.title}`);
-                if (verdict.startsWith('eligible')) eligible.push(p);
+                if (!verdict.startsWith('eligible')) continue;
+                if (p.mergeStateStatus === 'BEHIND') behind.push(p);
+                else if (p.mergeStateStatus === 'UNKNOWN') unknown.push(p);
               }
 
-              if (eligible.length === 0) {
-                core.info('No eligible auto-merge PRs this attempt.');
+              core.info(
+                `Eligible: ${behind.length} BEHIND, ${unknown.length} UNKNOWN, ` +
+                `rest already up-to-date or otherwise blocked.`
+              );
+
+              if (behind.length > 0) {
+                let updated = null;
+                for (const pr of behind) {
+                  core.info(`→ updateBranch #${pr.number}`);
+                  try {
+                    const res = await github.rest.pulls.updateBranch({
+                      owner, repo, pull_number: pr.number,
+                    });
+                    core.info(
+                      `✓ #${pr.number} updateBranch dispatched (HTTP ${res.status}).`
+                    );
+                    updated = pr.number;
+                    break;
+                  } catch (e) {
+                    core.warning(
+                      `✗ #${pr.number} updateBranch failed ` +
+                      `(status ${e.status ?? '?'}): ${e.message}`
+                    );
+                  }
+                }
+                core.endGroup();
+                if (updated !== null) {
+                  core.info(`Done: #${updated} updated on attempt ${attempt + 1}.`);
+                  return;
+                }
+                core.info(
+                  'All BEHIND PRs failed updateBranch this attempt; retrying after backoff.'
+                );
+                continue;
+              }
+
+              if (unknown.length > 0) {
+                core.info(
+                  `No BEHIND PRs yet; ${unknown.length} eligible PR(s) ` +
+                  'still UNKNOWN — retrying after backoff to let GitHub settle.'
+                );
                 core.endGroup();
                 continue;
               }
 
               core.info(
-                `${eligible.length} eligible PR(s); trying updateBranch from oldest.`
+                'No BEHIND or UNKNOWN eligible PRs — nothing to do this run.'
               );
-
-              let updated = null;
-              for (const pr of eligible) {
-                core.info(
-                  `→ updateBranch #${pr.number} (state=${pr.mergeStateStatus})`
-                );
-                try {
-                  const res = await github.rest.pulls.updateBranch({
-                    owner, repo, pull_number: pr.number,
-                  });
-                  core.info(
-                    `✓ #${pr.number} updateBranch dispatched (HTTP ${res.status}).`
-                  );
-                  updated = pr.number;
-                  break;
-                } catch (e) {
-                  core.warning(
-                    `✗ #${pr.number} updateBranch did not apply ` +
-                    `(status ${e.status ?? '?'}): ${e.message}`
-                  );
-                }
-              }
-
               core.endGroup();
-
-              if (updated !== null) {
-                core.info(
-                  `Done: #${updated} updated on attempt ${attempt + 1}.`
-                );
-                return;
-              }
-
-              if (attempt + 1 < BACKOFFS_MS.length) {
-                core.info('No PR updated; will retry after backoff.');
-              }
+              return;
             }
 
             const totalS = Math.round((Date.now() - start) / 1000);
             core.info(
-              `Exhausted ${BACKOFFS_MS.length} attempt(s) over ${totalS}s; ` +
-              `no PR updated this run.`
+              `Exhausted ${BACKOFFS_MS.length} attempt(s) over ${totalS}s ` +
+              `without finding a BEHIND PR to update.`
             );

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -35,7 +35,7 @@
 # the resulting push retriggers required CI on the PR. Falls back to
 # GITHUB_TOKEN, in which case auto-merge will not actually fire (GITHUB_TOKEN
 # pushes don't trigger downstream workflows).
-name: AutoQueue
+name: Auto Queue
 
 on:
   push:

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -15,17 +15,30 @@
 # limitations under the License.
 
 # Temporary stand-in for GitHub Merge Queue.
-# After every push to main, picks the oldest auto-merge-enabled PR and runs
-# updateBranch on it; if that's a no-op or fails, falls through to the next
-# eligible PR. If a PAT/App token with workflow write is provided as
-# AUTO_MERGE_TOKEN, the resulting push retriggers the PR's required checks
-# and lets auto-merge fire. With GITHUB_TOKEN only, the branch is updated
-# but downstream workflows on the PR are not retriggered.
+#
+# Triggers:
+#   * push to main: advance the queue right after a merge.
+#   * hourly cron: catch PRs that became BEHIND while no merge happened
+#     (e.g. a force-push to base, or a PR enabling auto-merge after the
+#     last main push).
+#   * workflow_dispatch: manual smoke test.
+#
+# Strategy: scan open auto-merge PRs targeting main, try updateBranch on each
+# eligible candidate from oldest. Retry with backoff up to ~2min, since
+# mergeable / mergeStateStatus are computed asynchronously and can be UNKNOWN
+# right after a base-branch push.
+#
+# Token: needs AUTO_MERGE_TOKEN with contents:write + pull_requests:write so
+# the resulting push retriggers required CI on the PR. Falls back to
+# GITHUB_TOKEN, in which case auto-merge will not actually fire (GITHUB_TOKEN
+# pushes don't trigger downstream workflows).
 name: AutoQueue
 
 on:
   push:
     branches: [main]
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 permissions:
@@ -45,6 +58,13 @@ jobs:
           github-token: ${{ secrets.AUTO_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
+
+            const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+            // 0, 10, 20, 30, 30, 30 = 120s total wall-clock budget across
+            // attempts. Short ramp catches the common case where
+            // mergeStateStatus settles within ~30s of a base-branch push;
+            // the tail keeps trying for the rare slow case.
+            const BACKOFFS_MS = [0, 10000, 20000, 30000, 30000, 30000];
 
             const query = `
               query($owner:String!, $name:String!) {
@@ -67,31 +87,85 @@ jobs:
                 }
               }`;
 
-            const data = await github.graphql(query, { owner, name: repo });
-            // mergeStateStatus is computed asynchronously and is often UNKNOWN
-            // when this workflow fires moments after a push to main. Don't
-            // gate on BEHIND — instead try updateBranch on each eligible PR
-            // and let GitHub tell us whether work was done.
-            const eligible = data.repository.pullRequests.nodes.filter(p =>
-              p.autoMergeRequest && !p.isDraft && p.mergeable !== 'CONFLICTING'
-            );
-
-            if (eligible.length === 0) {
-              core.info('No eligible auto-merge PRs.');
-              return;
+            function classify(p) {
+              if (!p.autoMergeRequest) return 'skip: auto-merge not enabled';
+              if (p.isDraft) return 'skip: draft';
+              if (p.mergeable === 'CONFLICTING') return 'skip: mergeable=CONFLICTING';
+              return `eligible: mergeable=${p.mergeable} state=${p.mergeStateStatus}`;
             }
 
-            for (const pr of eligible) {
-              core.info(`Trying PR #${pr.number} (state=${pr.mergeStateStatus}): ${pr.title}`);
-              try {
-                const res = await github.rest.pulls.updateBranch({
-                  owner, repo, pull_number: pr.number,
-                });
-                core.info(`PR #${pr.number} update-branch dispatched (HTTP ${res.status}).`);
+            const start = Date.now();
+
+            for (let attempt = 0; attempt < BACKOFFS_MS.length; attempt++) {
+              if (BACKOFFS_MS[attempt] > 0) {
+                const elapsedS = Math.round((Date.now() - start) / 1000);
+                core.info(
+                  `Waiting ${BACKOFFS_MS[attempt] / 1000}s before attempt ` +
+                  `${attempt + 1}/${BACKOFFS_MS.length} (elapsed ${elapsedS}s).`
+                );
+                await sleep(BACKOFFS_MS[attempt]);
+              }
+
+              core.startGroup(`Attempt ${attempt + 1}/${BACKOFFS_MS.length}`);
+              const data = await github.graphql(query, { owner, name: repo });
+              const all = data.repository.pullRequests.nodes;
+              core.info(`Scanned ${all.length} open PR(s) targeting main.`);
+
+              const eligible = [];
+              for (const p of all) {
+                const verdict = classify(p);
+                core.info(`  #${p.number} ${verdict} — ${p.title}`);
+                if (verdict.startsWith('eligible')) eligible.push(p);
+              }
+
+              if (eligible.length === 0) {
+                core.info('No eligible auto-merge PRs this attempt.');
+                core.endGroup();
+                continue;
+              }
+
+              core.info(
+                `${eligible.length} eligible PR(s); trying updateBranch from oldest.`
+              );
+
+              let updated = null;
+              for (const pr of eligible) {
+                core.info(
+                  `→ updateBranch #${pr.number} (state=${pr.mergeStateStatus})`
+                );
+                try {
+                  const res = await github.rest.pulls.updateBranch({
+                    owner, repo, pull_number: pr.number,
+                  });
+                  core.info(
+                    `✓ #${pr.number} updateBranch dispatched (HTTP ${res.status}).`
+                  );
+                  updated = pr.number;
+                  break;
+                } catch (e) {
+                  core.warning(
+                    `✗ #${pr.number} updateBranch did not apply ` +
+                    `(status ${e.status ?? '?'}): ${e.message}`
+                  );
+                }
+              }
+
+              core.endGroup();
+
+              if (updated !== null) {
+                core.info(
+                  `Done: #${updated} updated on attempt ${attempt + 1}.`
+                );
                 return;
-              } catch (e) {
-                core.warning(`PR #${pr.number} updateBranch did not apply: ${e.message}`);
+              }
+
+              if (attempt + 1 < BACKOFFS_MS.length) {
+                core.info('No PR updated; will retry after backoff.');
               }
             }
 
-            core.info('No eligible PR could be updated this run.');
+            const totalS = Math.round((Date.now() - start) / 1000);
+            core.info(
+              `Exhausted ${BACKOFFS_MS.length} attempt(s) over ${totalS}s; ` +
+              `no PR updated this run.`
+            );

--- a/.github/workflows/auto-queue.yml
+++ b/.github/workflows/auto-queue.yml
@@ -15,11 +15,12 @@
 # limitations under the License.
 
 # Temporary stand-in for GitHub Merge Queue.
-# After every push to main, picks the oldest auto-merge-enabled PR whose head
-# is behind main and merges main into it. If a PAT/App token with workflow
-# write is provided as AUTO_MERGE_TOKEN, the resulting push will retrigger the
-# PR's required checks and let auto-merge fire. With GITHUB_TOKEN only, the
-# branch is updated but downstream workflows on the PR are not retriggered.
+# After every push to main, picks the oldest auto-merge-enabled PR and runs
+# updateBranch on it; if that's a no-op or fails, falls through to the next
+# eligible PR. If a PAT/App token with workflow write is provided as
+# AUTO_MERGE_TOKEN, the resulting push retriggers the PR's required checks
+# and lets auto-merge fire. With GITHUB_TOKEN only, the branch is updated
+# but downstream workflows on the PR are not retriggered.
 name: AutoQueue
 
 on:
@@ -67,26 +68,30 @@ jobs:
               }`;
 
             const data = await github.graphql(query, { owner, name: repo });
-            const candidates = data.repository.pullRequests.nodes.filter(p =>
-              p.autoMergeRequest &&
-              !p.isDraft &&
-              p.mergeable !== 'CONFLICTING' &&
-              p.mergeStateStatus === 'BEHIND'
+            // mergeStateStatus is computed asynchronously and is often UNKNOWN
+            // when this workflow fires moments after a push to main. Don't
+            // gate on BEHIND — instead try updateBranch on each eligible PR
+            // and let GitHub tell us whether work was done.
+            const eligible = data.repository.pullRequests.nodes.filter(p =>
+              p.autoMergeRequest && !p.isDraft && p.mergeable !== 'CONFLICTING'
             );
 
-            if (candidates.length === 0) {
-              core.info('No auto-merge PRs need updating.');
+            if (eligible.length === 0) {
+              core.info('No eligible auto-merge PRs.');
               return;
             }
 
-            const pr = candidates[0];
-            core.info(`Updating PR #${pr.number}: ${pr.title}`);
-
-            try {
-              await github.rest.pulls.updateBranch({
-                owner, repo, pull_number: pr.number,
-              });
-              core.info(`PR #${pr.number} update-branch dispatched.`);
-            } catch (e) {
-              core.setFailed(`updateBranch failed for #${pr.number}: ${e.message}`);
+            for (const pr of eligible) {
+              core.info(`Trying PR #${pr.number} (state=${pr.mergeStateStatus}): ${pr.title}`);
+              try {
+                const res = await github.rest.pulls.updateBranch({
+                  owner, repo, pull_number: pr.number,
+                });
+                core.info(`PR #${pr.number} update-branch dispatched (HTTP ${res.status}).`);
+                return;
+              } catch (e) {
+                core.warning(`PR #${pr.number} updateBranch did not apply: ${e.message}`);
+              }
             }
+
+            core.info('No eligible PR could be updated this run.');


### PR DESCRIPTION
## What changes were proposed in this PR?

Iterates on `.github/workflows/auto-queue.yml` so it actually picks up the candidate PR after a push to main:

- **Backoff retries on `UNKNOWN`**: query → categorize eligible PRs into `BEHIND` / `UNKNOWN`. If any are `UNKNOWN`, sleep and retry up to ~120s (delays `0/10/20/30/30/30s`); GitHub recomputes `mergeStateStatus` asynchronously after a base-branch push, so the first scan often sees `UNKNOWN` for everything. Stop retrying as soon as a `BEHIND` PR is updated, or as soon as nothing is `UNKNOWN` and nothing is `BEHIND` (don't waste the 2-min budget).
- **Hourly cron** (`schedule: 0 * * * *`): catches PRs that go `BEHIND` between merges (force-push to base, late auto-merge enable, etc.).
- **Tighter eligibility**: also require `reviewDecision === 'APPROVED'` and zero unresolved review threads. Avoids burning CI on PRs that wouldn't merge even with a green build.
- **Verbose logging**: per-PR verdict line (`skip: <reason>` or `eligible: mergeable=… state=…`), per-attempt grouped output, every `updateBranch` call with HTTP status, retry/backoff announcements, final summary with elapsed seconds. Each attempt is wrapped in `core.startGroup` so the Actions UI collapses them.
- **Workflow display name**: `AutoQueue` → `Auto Queue`.

### Eligibility, in plain terms

A PR is acted on only if **all** of the following hold:

- Auto-merge is enabled.
- Not a draft.
- Not conflicting.
- `reviewDecision === 'APPROVED'`.
- No unresolved review threads.
- `mergeStateStatus === 'BEHIND'` (UNKNOWN triggers retry; CLEAN/BLOCKED/etc. are no-ops).

## Any related issues, documentation, discussions?

Follow-up to #4672. Same `AUTO_MERGE_TOKEN` PAT contract.

Originally observed in [run 25248773692](https://github.com/apache/texera/actions/runs/25248773692/job/74037400879): the workflow fired ~3s after a push to main, when GitHub had not yet recomputed `mergeStateStatus`. PR #4652 was a real candidate but came back as `UNKNOWN`, so the strict filter dropped it and the run logged "No auto-merge PRs need updating". The retry loop here is the targeted fix.

## How was this PR tested?

Workflow runs only on push-to-main, schedule, and `workflow_dispatch`. Will observe behavior on the next merge and on the next scheduled run after this lands.

## Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (Claude Code)