### PR TITLE
chore(ci): add codecov.yml — carryforward, ignore generated/test paths, loosen status checks

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -69,6 +69,7 @@ ci:
       - any-glob-to-any-file:
           - '.github/**'
           - '.asf.yaml'
+          - 'codecov.yml'
 
 dev:
   - changed-files:

--- a/codecov.yml
+++ b/codecov.yml
@@ -14,12 +14,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A PR that touches only one stack (e.g. python-only) doesn't trigger
-# the other build jobs and so doesn't upload the other flags. Without
-# carryforward those flags come back as `?` in the Codecov comment and
-# the project rollup looks empty. Carryforward inherits each flag's
-# latest report from the base branch when the current PR didn't
-# refresh it.
+# Codecov configuration for apache/texera. The repo uploads four flags
+# (frontend, scala, python, agent-service); without an explicit config,
+# defaults bite us in three places that this file fixes:
+#   1. Single-stack PRs leave non-uploaded flags as `?` in the comment
+#      and drop them from the rollup. Carry forward instead.
+#   2. Coverage of generated code (protobuf), build output, and the
+#      tests themselves dilutes the "real" coverage figure. Ignore
+#      those paths.
+#   3. Default status checks fail on any project drop and require 100%
+#      patch coverage, so non-test refactors get a red Codecov check
+#      even when behavior is preserved. Allow 1% slack on project and
+#      keep patch coverage informational.
+
 flag_management:
   default_rules:
+    # If the current PR didn't run the job for a given flag, inherit
+    # the latest report on the base branch instead of showing `?`.
     carryforward: true
+
+ignore:
+  # Generated protobuf — line counts swamp real code.
+  - "amber/src/main/python/proto/**"
+  - "**/src_managed/**"          # sbt JOOQ / scalapb-generated sources
+  # Build / install output — never source-of-truth.
+  - "**/target/**"
+  - "frontend/dist/**"
+  - "frontend/.angular/**"
+  # Test files don't count toward source coverage.
+  - "**/test_*.py"
+  - "**/*.spec.ts"
+  - "**/src/test/**"             # sbt test source roots
+
+coverage:
+  status:
+    project:
+      default:
+        # Don't drop below the base-branch baseline, but tolerate
+        # ≤1% jitter from re-runs / flaky tests / ignore-rule churn.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # Surface patch coverage in the Codecov report but don't gate
+        # PRs on it: a 100%-patch policy blocks plenty of legitimate
+        # refactors / config-only changes that have no tests to add.
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# A PR that touches only one stack (e.g. python-only) doesn't trigger
+# the other build jobs and so doesn't upload the other flags. Without
+# carryforward those flags come back as `?` in the Codecov comment and
+# the project rollup looks empty. Carryforward inherits each flag's
+# latest report from the base branch when the current PR didn't
+# refresh it.
+flag_management:
+  default_rules:
+    carryforward: true


### PR DESCRIPTION
## What changes were proposed in this PR?

Add a `codecov.yml` at the repo root that addresses three default-behavior pain points at once:

### 1. Carryforward for unrefreshed flags

```yaml
flag_management:
  default_rules:
    carryforward: true
```

A PR that touches only one stack (e.g. python-only) doesn't trigger the other build jobs, so without carryforward the other flags come back as `?` in the comment and drop from the rollup. With this, each flag inherits its latest base-branch report when the current PR didn't refresh it.

### 2. Ignore generated / build / test paths

```yaml
ignore:
  - "amber/src/main/python/proto/**"
  - "**/src_managed/**"
  - "**/target/**"
  - "frontend/dist/**"
  - "frontend/.angular/**"
  - "**/test_*.py"
  - "**/*.spec.ts"
  - "**/src/test/**"
```

Generated protobuf, sbt `src_managed/**` (JOOQ + scalapb), build output, and test files don't represent product code and shouldn't dilute the coverage figure (or sit on Codecov's reports as "uncovered").

### 3. Loosen status checks

```yaml
coverage:
  status:
    project:
      default:
        target: auto
        threshold: 1%
    patch:
      default:
        informational: true
```

- `project`: still gates against the base-branch baseline (`target: auto`) but tolerates ≤1% jitter (re-runs, flaky tests, ignore-rule churn).
- `patch`: surface patch coverage in the comment, but don't gate PRs on it. The default 100%-patch policy blocks plenty of legitimate refactors / config-only changes.

## Any related issues, documentation, discussions?

Closes #4689. Symptom that prompted this: #4685's Codecov comment, where `scala`, `frontend`, `agent-service` came back as `?` because the python-only PR didn't refresh them.

## How was this PR tested?

YAML parses locally. Carryforward, ignore, and status-threshold behavior is observable on this PR's own Codecov comment and on subsequent PRs:
- [ ] This PR (config-only, no source change) should produce a Codecov comment where every flag carries forward as `0.00%` change rather than `?`.
- [ ] Generated/test paths should disappear from the per-file coverage drilldown after Codecov re-ingests on top of this config.
- [ ] Future single-line refactor PRs should not get a red Codecov status check from a 0% patch coverage figure.

## Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (Claude Code)