### PR TITLE
docs: add Codecov coverage badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
   <img alt="Static Badge" src="https://img.shields.io/badge/Workflow_Versions-357K-blue">
   <img alt="Static Badge" src="https://img.shields.io/badge/Deployments-7-blue">
   <img alt="Static Badge" src="https://img.shields.io/badge/Largest_Deployment-100_nodes,_400_cores-green">
+  <a href="https://app.codecov.io/gh/apache/texera"><img alt="Coverage" src="https://img.shields.io/codecov/c/github/apache/texera/main?logo=codecov&label=coverage"></a>
 </p>
 
 Apache Texera (Incubating) is an open-source platform for human-AI collaborative data science using visual workflows. It enables human analysts to construct, execute, and refine data analysis tasks through an intuitive GUI, assisted by AI agents that understand natural-language instructions. Texera is well suited for a wide range of applications, including “AI for Science,” by making advanced AI and data science capabilities accessible to a broader community. It can run on a laptop for local use or be deployed in the cloud to support scalable processing of large datasets.


### PR DESCRIPTION
### What changes were proposed in this PR?

Add a Codecov coverage badge to the existing `<p align="center">` stats block in `README.md`. The badge links to https://app.codecov.io/gh/apache/texera so reviewers / contributors can see the current overall coverage and click through to the per-flag breakdown without leaving the repo home page.

<img width="882" height="212" alt="CleanShot 2026-05-02 at 17 31 13" src="https://github.com/user-attachments/assets/6a81f5af-3e47-4f87-a388-2a9e0f6a563d" />

### Any related issues, documentation, discussions?

Closes #4713. 

### How was this PR tested?

This is a one-line README change; rendered the new line in the GitHub markdown preview locally. The badge URL is already producing a non-`unknown` value (the dashboard returns `46%` for the latest main commits), so the rendered badge will be a real number on first view, not the placeholder.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7, 1M context)
