### PR TITLE
ci: add a strict license-binary checker that files a tracking issue on license drift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,13 +57,17 @@ on:
         type: boolean
         default: true
       mode:
-        # Strictness of the license-binary check. Valid values:
+        # Context this build runs in; controls strictness of the
+        # license-binary check. Valid values:
         #   PR      — pass --ignore-transitive-version (default; PR-time
         #             builds keep going on benign upstream bumps in
         #             transitive deps).
-        #   release — strict exact-match (no flag); used by the nightly
-        #             workflow license-binary-nightly.yml so transitive
-        #             drift on `main` still surfaces before each release.
+        #   nightly — strict exact-match (no flag); used by the scheduled
+        #             license-binary-checker.yml so transitive drift on
+        #             `main` still surfaces between releases.
+        #   release — strict exact-match (no flag); used when cutting a
+        #             release candidate so the documented LICENSE-binary
+        #             matches the bundled jars / packages exactly.
         # workflow_call inputs cannot enforce enums; any value other than
         # "PR" falls through to strict, which is the safer side.
         required: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,15 +56,19 @@ on:
         required: false
         type: boolean
         default: true
-      ignore_transitive_version:
-        # Pass `--ignore-transitive-version` to check_binary_deps.py. PR
-        # builds keep the default (true) so benign upstream bumps on
-        # transitive deps don't block merges; the nightly workflow
-        # (license-binary-nightly.yml) reuses this build.yml with the
-        # input set to false to perform the strict exact-match check.
+      mode:
+        # Strictness of the license-binary check. Valid values:
+        #   PR      — pass --ignore-transitive-version (default; PR-time
+        #             builds keep going on benign upstream bumps in
+        #             transitive deps).
+        #   release — strict exact-match (no flag); used by the nightly
+        #             workflow license-binary-nightly.yml so transitive
+        #             drift on `main` still surfaces before each release.
+        # workflow_call inputs cannot enforce enums; any value other than
+        # "PR" falls through to strict, which is the safer side.
         required: false
-        type: boolean
-        default: true
+        type: string
+        default: PR
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -121,7 +125,7 @@ jobs:
         run: yarn --cwd frontend run build:ci
       - name: Check bundled npm packages against per-module LICENSE-binary files
         if: matrix.os == 'ubuntu-latest'
-        run: ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} npm frontend/dist/3rdpartylicenses.json
+        run: ./bin/licensing/check_binary_deps.py ${{ inputs.mode == 'PR' && '--ignore-transitive-version' || '' }} npm frontend/dist/3rdpartylicenses.json
       - name: Run frontend unit tests
         run: yarn --cwd frontend run test:ci --code-coverage
       - name: Upload frontend coverage to Codecov
@@ -216,7 +220,7 @@ jobs:
           unzip -q amber/target/universal/amber-*.zip -d /tmp/dists/
 
           check_exit=0
-          ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} jar \
+          ./bin/licensing/check_binary_deps.py ${{ inputs.mode == 'PR' && '--ignore-transitive-version' || '' }} jar \
             --license-binary amber/LICENSE-binary-java \
             /tmp/dists/amber-*/lib || check_exit=$?
           ./bin/licensing/audit_jar_licenses.py /tmp/dists/amber-*/lib || true
@@ -337,7 +341,7 @@ jobs:
           unzip -q ${{ matrix.service }}/target/universal/${{ matrix.service }}-*.zip -d /tmp/dists/
 
           check_exit=0
-          ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} jar \
+          ./bin/licensing/check_binary_deps.py ${{ inputs.mode == 'PR' && '--ignore-transitive-version' || '' }} jar \
             --license-binary ${{ matrix.service }}/LICENSE-binary \
             /tmp/dists/${{ matrix.service }}-*/lib || check_exit=$?
           ./bin/licensing/audit_jar_licenses.py /tmp/dists/${{ matrix.service }}-*/lib || true
@@ -396,7 +400,7 @@ jobs:
         run: pip-licenses --format=csv --ignore-packages pip-licenses prettytable wcwidth > /tmp/pip-licenses.csv
       - name: Check installed Python packages against per-module LICENSE-binary files
         if: matrix.python-version == '3.12'
-        run: ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} python /tmp/pip-licenses.csv
+        run: ./bin/licensing/check_binary_deps.py ${{ inputs.mode == 'PR' && '--ignore-transitive-version' || '' }} python /tmp/pip-licenses.csv
       - name: Create iceberg catalog database
         run: psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
         env:
@@ -457,7 +461,7 @@ jobs:
           bun run bin/collect-licenses.ts > dist/3rdpartylicenses.json
       - name: Check bundled agent-service packages against per-module LICENSE-binary files
         if: matrix.os == 'ubuntu-latest'
-        run: ../bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} agent-npm dist/3rdpartylicenses.json
+        run: ../bin/licensing/check_binary_deps.py ${{ inputs.mode == 'PR' && '--ignore-transitive-version' || '' }} agent-npm dist/3rdpartylicenses.json
       - name: Install development dependencies
         run: bun install --frozen-lockfile
       - name: Lint with Prettier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,15 @@ on:
         required: false
         type: boolean
         default: true
+      ignore_transitive_version:
+        # Pass `--ignore-transitive-version` to check_binary_deps.py. PR
+        # builds keep the default (true) so benign upstream bumps on
+        # transitive deps don't block merges; the nightly workflow
+        # (license-binary-nightly.yml) reuses this build.yml with the
+        # input set to false to perform the strict exact-match check.
+        required: false
+        type: boolean
+        default: true
 
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
@@ -112,7 +121,7 @@ jobs:
         run: yarn --cwd frontend run build:ci
       - name: Check bundled npm packages against per-module LICENSE-binary files
         if: matrix.os == 'ubuntu-latest'
-        run: ./bin/licensing/check_binary_deps.py --ignore-transitive-version npm frontend/dist/3rdpartylicenses.json
+        run: ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} npm frontend/dist/3rdpartylicenses.json
       - name: Run frontend unit tests
         run: yarn --cwd frontend run test:ci --code-coverage
       - name: Upload frontend coverage to Codecov
@@ -207,7 +216,7 @@ jobs:
           unzip -q amber/target/universal/amber-*.zip -d /tmp/dists/
 
           check_exit=0
-          ./bin/licensing/check_binary_deps.py --ignore-transitive-version jar \
+          ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} jar \
             --license-binary amber/LICENSE-binary-java \
             /tmp/dists/amber-*/lib || check_exit=$?
           ./bin/licensing/audit_jar_licenses.py /tmp/dists/amber-*/lib || true
@@ -328,7 +337,7 @@ jobs:
           unzip -q ${{ matrix.service }}/target/universal/${{ matrix.service }}-*.zip -d /tmp/dists/
 
           check_exit=0
-          ./bin/licensing/check_binary_deps.py jar \
+          ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} jar \
             --license-binary ${{ matrix.service }}/LICENSE-binary \
             /tmp/dists/${{ matrix.service }}-*/lib || check_exit=$?
           ./bin/licensing/audit_jar_licenses.py /tmp/dists/${{ matrix.service }}-*/lib || true
@@ -387,7 +396,7 @@ jobs:
         run: pip-licenses --format=csv --ignore-packages pip-licenses prettytable wcwidth > /tmp/pip-licenses.csv
       - name: Check installed Python packages against per-module LICENSE-binary files
         if: matrix.python-version == '3.12'
-        run: ./bin/licensing/check_binary_deps.py --ignore-transitive-version python /tmp/pip-licenses.csv
+        run: ./bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} python /tmp/pip-licenses.csv
       - name: Create iceberg catalog database
         run: psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
         env:
@@ -448,7 +457,7 @@ jobs:
           bun run bin/collect-licenses.ts > dist/3rdpartylicenses.json
       - name: Check bundled agent-service packages against per-module LICENSE-binary files
         if: matrix.os == 'ubuntu-latest'
-        run: ../bin/licensing/check_binary_deps.py --ignore-transitive-version agent-npm dist/3rdpartylicenses.json
+        run: ../bin/licensing/check_binary_deps.py ${{ inputs.ignore_transitive_version && '--ignore-transitive-version' || '' }} agent-npm dist/3rdpartylicenses.json
       - name: Install development dependencies
         run: bun install --frozen-lockfile
       - name: Lint with Prettier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,19 +57,8 @@ on:
         type: boolean
         default: true
       mode:
-        # Context this build runs in; controls strictness of the
-        # license-binary check. Valid values:
-        #   PR      — pass --ignore-transitive-version (default; PR-time
-        #             builds keep going on benign upstream bumps in
-        #             transitive deps).
-        #   nightly — strict exact-match (no flag); used by the scheduled
-        #             license-binary-checker.yml so transitive drift on
-        #             `main` still surfaces between releases.
-        #   release — strict exact-match (no flag); used when cutting a
-        #             release candidate so the documented LICENSE-binary
-        #             matches the bundled jars / packages exactly.
-        # workflow_call inputs cannot enforce enums; any value other than
-        # "PR" falls through to strict, which is the safer side.
+        # PR (default) | nightly | release. Only "PR" passes
+        # --ignore-transitive-version to check_binary_deps.py.
         required: false
         type: string
         default: PR

--- a/.github/workflows/license-binary-checker.yml
+++ b/.github/workflows/license-binary-checker.yml
@@ -61,6 +61,20 @@ jobs:
             const runUrl =
               `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
+            // Ensure the tracking label exists (idempotent). Without this,
+            // first-run on a fork would have to silently auto-create it with
+            // a random color via issues.create.
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo, name: TRACKING_LABEL, color: 'fbca04',
+                description:
+                  'Tracking issue for license-binary drift between bundled ' +
+                  'artifacts and per-module LICENSE-binary files',
+              });
+            } catch (err) {
+              if (err.status !== 422) throw err;
+            }
+
             // Walk every job in the current run (which includes the called
             // build.yml jobs, prefixed with the calling job id `build`).
             const jobs = await github.paginate(

--- a/.github/workflows/license-binary-checker.yml
+++ b/.github/workflows/license-binary-checker.yml
@@ -15,19 +15,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: License-binary nightly
+name: License Binary Checker
 
+# Scheduled (cron) drift checker for per-module LICENSE-binary files.
+#
 # PR builds run check_binary_deps.py with --ignore-transitive-version
 # (#4691, #4693) so a benign upstream version bump on a transitive dep
-# does not block merges. This workflow runs the same build.yml every
-# night on `main` with `mode: release`, exercising
-# the strict exact-match check on every ecosystem. On drift, it files
-# (or updates / closes) a single tracking issue identified by the
-# stable label `license-binary-drift`. Sub-task of #4688.
+# does not block merges. This workflow runs the same build.yml on a
+# daily cron with `mode: nightly`, exercising the strict exact-match
+# check on every ecosystem. On drift, it files (or updates / closes) a
+# single tracking issue identified by the stable label
+# `license-binary-drift`. Sub-task of #4688.
 #
 # Reusing build.yml (rather than duplicating its dist-producing steps)
-# guarantees PR and nightly runs go through identical code paths — the
-# only difference between them is the value of one input.
+# guarantees PR and scheduled runs go through identical code paths —
+# the only difference between them is the value of one input.
 on:
   schedule:
     # 11:00 UTC daily = 04:00 PDT / 03:00 PST. Picked so the run lands
@@ -46,19 +48,19 @@ permissions:
   actions: read
 
 concurrency:
-  group: license-binary-nightly
+  group: license-binary-checker
   cancel-in-progress: false
 
 jobs:
   # Reuse the same build.yml that PRs go through; the only difference is
-  # mode: release, which flips every license-binary check from relaxed
+  # mode: nightly, which flips every license-binary check from relaxed
   # (`--ignore-transitive-version`) to strict exact-match. secrets:
   # inherit so the called jobs keep access to NX_CLOUD_ACCESS_TOKEN,
   # CODECOV_TOKEN, etc.
   build:
     uses: ./.github/workflows/build.yml
     with:
-      mode: release
+      mode: nightly
     secrets: inherit
 
   report:
@@ -69,9 +71,16 @@ jobs:
       - name: File or update tracking issue
         uses: actions/github-script@v8
         with:
+          # Same pattern as .github/workflows/issue-triage.yml — the
+          # default GITHUB_TOKEN authors actions as `github-actions[bot]`,
+          # which becomes the issue creator. The `permissions:` block at
+          # the top of this workflow grants this token `issues: write`
+          # (for create/update/close + comment) and `actions: read` (for
+          # listJobsForWorkflowRun); no fine-grained PAT is needed.
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const TRACKING_LABEL = 'license-binary-drift';
-            const TITLE = 'License-binary drift detected (nightly)';
+            const TITLE = 'License-binary drift detected';
 
             // The license-check step names in build.yml all contain either
             // "LICENSE-binary" or "binary licenses". Match both forms,
@@ -147,17 +156,20 @@ jobs:
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: issue.number,
                   body:
-                    `Closed automatically: nightly run ${runUrl} found no ` +
-                    `license-binary drift across any ecosystem.`,
+                    `Closed automatically: scheduled run ${runUrl} found ` +
+                    `no license-binary drift across any ecosystem.`,
                 });
                 core.info(`Closed stale tracking issue #${issue.number}`);
               }
               return;
             }
 
-            // Build the issue body. Per-ecosystem diffs aren't repeated here
-            // (would require parsing workflow logs); we link to each failed
-            // job so the reviewer can click through to the script's output.
+            // Build the issue body following the same Markdown shape that
+            // .github/ISSUE_TEMPLATE/task-template.yaml renders to when a
+            // human files a Task issue (### Task Summary, ### Task Type,
+            // Apache CoC footer). Per-ecosystem diffs aren't repeated
+            // here — clicking through to each failed job's logs gets the
+            // script's full output.
             const failureLines = licenseFailures.map(
               (f) => `- ❌ \`${f.job}\` — ${f.step} — [view logs](${f.url})`
             );
@@ -165,21 +177,32 @@ jobs:
               (s) => `- ✅ \`${s.job}\` — ${s.step}`
             );
             const body =
-              `Nightly strict license-binary check ran on ` +
+              `### Task Summary\n\n` +
+              `Strict license-binary check found drift on ` +
               `\`${context.sha.slice(0, 7)}\`.\n\n` +
               `Workflow run: ${runUrl}\n\n` +
               `PR builds run \`build.yml\` with \`mode: PR\` so transitive ` +
-              `version bumps don't block merges; this nightly job runs ` +
-              `the same \`build.yml\` with \`mode: release\` (strict ` +
-              `exact-match) and reports any drift here. To resolve ` +
-              `drift, refresh the ` +
-              `relevant per-module \`LICENSE-binary\` file(s) to match the ` +
-              `bundled versions.\n\n` +
-              `### License checks that failed\n\n` +
+              `version bumps don't block merges; this scheduled job runs ` +
+              `the same \`build.yml\` with \`mode: nightly\` (strict ` +
+              `exact-match) and reports any drift here. To resolve drift, ` +
+              `refresh the relevant per-module \`LICENSE-binary\` file(s) ` +
+              `to match the bundled versions.\n\n` +
+              `#### License checks that failed\n\n` +
               failureLines.join('\n') +
               (successLines.length > 0
-                ? `\n\n### License checks that passed\n\n${successLines.join('\n')}`
-                : '');
+                ? `\n\n#### License checks that passed\n\n${successLines.join('\n')}`
+                : '') +
+              `\n\n### Task Type\n\n` +
+              `- [ ] Refactor / Cleanup\n` +
+              `- [x] DevOps / Deployment / CI\n` +
+              `- [ ] Testing / QA\n` +
+              `- [ ] Documentation\n` +
+              `- [ ] Performance\n` +
+              `- [ ] Other\n\n` +
+              `---\n\n` +
+              `By submitting this issue, you agree to follow the ` +
+              `[Apache Code of Conduct]` +
+              `(https://www.apache.org/foundation/policies/conduct).`;
 
             if (existing.length > 0) {
               const issue = existing[0];
@@ -199,7 +222,10 @@ jobs:
             } else {
               const { data: created } = await github.rest.issues.create({
                 owner, repo, title: TITLE, body,
-                labels: [TRACKING_LABEL, 'ci'],
+                // `triage` mirrors the default label that
+                // ISSUE_TEMPLATE/task-template.yaml applies; the other
+                // two are this workflow's stable identifier + ci scope.
+                labels: [TRACKING_LABEL, 'ci', 'triage'],
               });
               core.info(`Filed new tracking issue #${created.number}`);
             }

--- a/.github/workflows/license-binary-checker.yml
+++ b/.github/workflows/license-binary-checker.yml
@@ -61,20 +61,6 @@ jobs:
             const runUrl =
               `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
 
-            // Ensure the tracking label exists (idempotent). Without this,
-            // first-run on a fork would have to silently auto-create it with
-            // a random color via issues.create.
-            try {
-              await github.rest.issues.createLabel({
-                owner, repo, name: TRACKING_LABEL, color: 'fbca04',
-                description:
-                  'Tracking issue for license-binary drift between bundled ' +
-                  'artifacts and per-module LICENSE-binary files',
-              });
-            } catch (err) {
-              if (err.status !== 422) throw err;
-            }
-
             // Walk every job in the current run (which includes the called
             // build.yml jobs, prefixed with the calling job id `build`).
             const jobs = await github.paginate(

--- a/.github/workflows/license-binary-checker.yml
+++ b/.github/workflows/license-binary-checker.yml
@@ -17,46 +17,25 @@
 
 name: License Binary Checker
 
-# Scheduled (cron) drift checker for per-module LICENSE-binary files.
-#
-# PR builds run check_binary_deps.py with --ignore-transitive-version
-# (#4691, #4693) so a benign upstream version bump on a transitive dep
-# does not block merges. This workflow runs the same build.yml on a
-# daily cron with `mode: nightly`, exercising the strict exact-match
-# check on every ecosystem. On drift, it files (or updates / closes) a
-# single tracking issue identified by the stable label
-# `license-binary-drift`. Sub-task of #4688.
-#
-# Reusing build.yml (rather than duplicating its dist-producing steps)
-# guarantees PR and scheduled runs go through identical code paths —
-# the only difference between them is the value of one input.
+# Scheduled drift checker for per-module LICENSE-binary files. Calls
+# build.yml with mode=nightly (strict) and files / updates / closes
+# one tracking issue (label `license-binary-drift`). Sub-task of #4688.
 on:
   schedule:
-    # 11:00 UTC daily = 04:00 PDT / 03:00 PST. Picked so the run lands
-    # outside US-Pacific working hours; if that's still too frequent we
-    # can drop to every 48–72 h. GitHub cron is fixed UTC, so the local
-    # clock-time shifts by an hour at DST transitions.
+    # 11:00 UTC daily = 04:00 PDT / 03:00 PST.
     - cron: "0 11 * * *"
   workflow_dispatch:
 
 permissions:
   contents: read
-  # Required so the report job can create / update / close the tracking
-  # issue. The reusable build workflow does not need elevated permissions.
-  issues: write
-  # Needed for listJobsForWorkflowRun in the report step.
-  actions: read
+  issues: write          # create / update / close the tracking issue
+  actions: read          # listJobsForWorkflowRun in the report step
 
 concurrency:
   group: license-binary-checker
   cancel-in-progress: false
 
 jobs:
-  # Reuse the same build.yml that PRs go through; the only difference is
-  # mode: nightly, which flips every license-binary check from relaxed
-  # (`--ignore-transitive-version`) to strict exact-match. secrets:
-  # inherit so the called jobs keep access to NX_CLOUD_ACCESS_TOKEN,
-  # CODECOV_TOKEN, etc.
   build:
     uses: ./.github/workflows/build.yml
     with:
@@ -71,21 +50,11 @@ jobs:
       - name: File or update tracking issue
         uses: actions/github-script@v8
         with:
-          # Same pattern as .github/workflows/issue-triage.yml — the
-          # default GITHUB_TOKEN authors actions as `github-actions[bot]`,
-          # which becomes the issue creator. The `permissions:` block at
-          # the top of this workflow grants this token `issues: write`
-          # (for create/update/close + comment) and `actions: read` (for
-          # listJobsForWorkflowRun); no fine-grained PAT is needed.
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const TRACKING_LABEL = 'license-binary-drift';
             const TITLE = 'License-binary drift detected';
-
-            // The license-check step names in build.yml all contain either
-            // "LICENSE-binary" or "binary licenses". Match both forms,
-            // case-insensitively, and ignore non-license-related failures
-            // (flaky tests, network blips) so they don't surface as drift.
+            // Match license-check step names; ignore unrelated failures.
             const LICENSE_STEP_RE = /license[-\s]?binary|binary licenses/i;
 
             const { owner, repo } = context.repo;
@@ -122,15 +91,11 @@ jobs:
               `${licenseFailures.length} failed.`
             );
 
-            // Find the existing open tracking issue (stable label).
             const { data: existing } = await github.rest.issues.listForRepo({
               owner, repo, state: 'open', labels: TRACKING_LABEL, per_page: 5,
             });
 
-            // Only file / update / close issues for runs against the default
-            // branch. Manual workflow_dispatch runs against feature branches
-            // still exercise the build.yml strict-mode check (useful for
-            // testing locally) but should not surface tracking issues.
+            // Only manage issues for runs against the default branch.
             const defaultBranch = context.payload.repository.default_branch;
             const isDefaultBranch =
               context.ref === `refs/heads/${defaultBranch}` ||
@@ -164,35 +129,19 @@ jobs:
               return;
             }
 
-            // Build the issue body following the same Markdown shape that
-            // .github/ISSUE_TEMPLATE/task-template.yaml renders to when a
-            // human files a Task issue (### Task Summary, ### Task Type,
-            // Apache CoC footer). Per-ecosystem diffs aren't repeated
-            // here — clicking through to each failed job's logs gets the
-            // script's full output.
+            // Body shape mirrors ISSUE_TEMPLATE/task-template.yaml.
             const failureLines = licenseFailures.map(
-              (f) => `- ❌ \`${f.job}\` — ${f.step} — [view logs](${f.url})`
-            );
-            const successLines = licenseSuccesses.map(
-              (s) => `- ✅ \`${s.job}\` — ${s.step}`
+              (f) => `- \`${f.job}\` — ${f.step} ([logs](${f.url}))`
             );
             const body =
               `### Task Summary\n\n` +
-              `Strict license-binary check found drift on ` +
-              `\`${context.sha.slice(0, 7)}\`.\n\n` +
-              `Workflow run: ${runUrl}\n\n` +
-              `PR builds run \`build.yml\` with \`mode: PR\` so transitive ` +
-              `version bumps don't block merges; this scheduled job runs ` +
-              `the same \`build.yml\` with \`mode: nightly\` (strict ` +
-              `exact-match) and reports any drift here. To resolve drift, ` +
-              `refresh the relevant per-module \`LICENSE-binary\` file(s) ` +
-              `to match the bundled versions.\n\n` +
-              `#### License checks that failed\n\n` +
+              `License-binary drift on \`${context.sha.slice(0, 7)}\` ` +
+              `([run](${runUrl})).\n\n` +
+              `**Where:**\n\n` +
               failureLines.join('\n') +
-              (successLines.length > 0
-                ? `\n\n#### License checks that passed\n\n${successLines.join('\n')}`
-                : '') +
-              `\n\n### Task Type\n\n` +
+              `\n\n**How to resolve:** refresh the per-module ` +
+              `\`LICENSE-binary\` file(s) to match the bundled versions.\n\n` +
+              `### Task Type\n\n` +
               `- [ ] Refactor / Cleanup\n` +
               `- [x] DevOps / Deployment / CI\n` +
               `- [ ] Testing / QA\n` +
@@ -211,7 +160,6 @@ jobs:
                 title: TITLE, body,
               });
               core.info(`Updated tracking issue #${issue.number}`);
-              // Close any extras so we converge on a single tracking issue.
               for (const extra of existing.slice(1)) {
                 await github.rest.issues.update({
                   owner, repo, issue_number: extra.number,
@@ -222,9 +170,6 @@ jobs:
             } else {
               const { data: created } = await github.rest.issues.create({
                 owner, repo, title: TITLE, body,
-                // `triage` mirrors the default label that
-                // ISSUE_TEMPLATE/task-template.yaml applies; the other
-                // two are this workflow's stable identifier + ci scope.
                 labels: [TRACKING_LABEL, 'ci', 'triage'],
               });
               core.info(`Filed new tracking issue #${created.number}`);

--- a/.github/workflows/license-binary-nightly.yml
+++ b/.github/workflows/license-binary-nightly.yml
@@ -30,8 +30,11 @@ name: License-binary nightly
 # only difference between them is the value of one input.
 on:
   schedule:
-    # 07:00 UTC daily — late evening US-Pacific, early morning Europe.
-    - cron: "0 7 * * *"
+    # 11:00 UTC daily = 04:00 PDT / 03:00 PST. Picked so the run lands
+    # outside US-Pacific working hours; if that's still too frequent we
+    # can drop to every 48–72 h. GitHub cron is fixed UTC, so the local
+    # clock-time shifts by an hour at DST transitions.
+    - cron: "0 11 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/license-binary-nightly.yml
+++ b/.github/workflows/license-binary-nightly.yml
@@ -20,7 +20,7 @@ name: License-binary nightly
 # PR builds run check_binary_deps.py with --ignore-transitive-version
 # (#4691, #4693) so a benign upstream version bump on a transitive dep
 # does not block merges. This workflow runs the same build.yml every
-# night on `main` with `ignore_transitive_version: false`, exercising
+# night on `main` with `mode: release`, exercising
 # the strict exact-match check on every ecosystem. On drift, it files
 # (or updates / closes) a single tracking issue identified by the
 # stable label `license-binary-drift`. Sub-task of #4688.
@@ -48,13 +48,14 @@ concurrency:
 
 jobs:
   # Reuse the same build.yml that PRs go through; the only difference is
-  # ignore_transitive_version: false, which flips every license-binary
-  # check from relaxed to strict. secrets: inherit so the called jobs
-  # keep access to NX_CLOUD_ACCESS_TOKEN, CODECOV_TOKEN, etc.
+  # mode: release, which flips every license-binary check from relaxed
+  # (`--ignore-transitive-version`) to strict exact-match. secrets:
+  # inherit so the called jobs keep access to NX_CLOUD_ACCESS_TOKEN,
+  # CODECOV_TOKEN, etc.
   build:
     uses: ./.github/workflows/build.yml
     with:
-      ignore_transitive_version: false
+      mode: release
     secrets: inherit
 
   report:
@@ -164,11 +165,11 @@ jobs:
               `Nightly strict license-binary check ran on ` +
               `\`${context.sha.slice(0, 7)}\`.\n\n` +
               `Workflow run: ${runUrl}\n\n` +
-              `PR builds run \`build.yml\` with ` +
-              `\`ignore_transitive_version: true\` so transitive version ` +
-              `bumps don't block merges; this nightly job runs the same ` +
-              `\`build.yml\` with that input flipped to \`false\` and ` +
-              `reports any drift here. To resolve drift, refresh the ` +
+              `PR builds run \`build.yml\` with \`mode: PR\` so transitive ` +
+              `version bumps don't block merges; this nightly job runs ` +
+              `the same \`build.yml\` with \`mode: release\` (strict ` +
+              `exact-match) and reports any drift here. To resolve ` +
+              `drift, refresh the ` +
               `relevant per-module \`LICENSE-binary\` file(s) to match the ` +
               `bundled versions.\n\n` +
               `### License checks that failed\n\n` +

--- a/.github/workflows/license-binary-nightly.yml
+++ b/.github/workflows/license-binary-nightly.yml
@@ -17,12 +17,17 @@
 
 name: License-binary nightly
 
-# PR builds run check_binary_deps.py with --ignore-transitive-version so a
-# benign upstream version bump on a transitive dep does not block merges
-# (#4691, #4693). This workflow runs the same checks **without** that flag
-# every night on `main`, then files (or updates / closes) a single tracking
-# issue so transitive drift is still visible and actionable before each
-# release. Sub-task of #4688; sibling of #4691 (PR-time relaxation).
+# PR builds run check_binary_deps.py with --ignore-transitive-version
+# (#4691, #4693) so a benign upstream version bump on a transitive dep
+# does not block merges. This workflow runs the same build.yml every
+# night on `main` with `ignore_transitive_version: false`, exercising
+# the strict exact-match check on every ecosystem. On drift, it files
+# (or updates / closes) a single tracking issue identified by the
+# stable label `license-binary-drift`. Sub-task of #4688.
+#
+# Reusing build.yml (rather than duplicating its dist-producing steps)
+# guarantees PR and nightly runs go through identical code paths — the
+# only difference between them is the value of one input.
 on:
   schedule:
     # 07:00 UTC daily — late evening US-Pacific, early morning Europe.
@@ -31,384 +36,165 @@ on:
 
 permissions:
   contents: read
-  # Required so the report job can create / update / close the tracking issue.
+  # Required so the report job can create / update / close the tracking
+  # issue. The reusable build workflow does not need elevated permissions.
   issues: write
+  # Needed for listJobsForWorkflowRun in the report step.
+  actions: read
 
 concurrency:
   group: license-binary-nightly
   cancel-in-progress: false
 
 jobs:
-  # ---------------------------------------------------------------------------
-  # frontend-npm: build the prod webpack bundle, run the npm license check
-  # in strict mode against frontend/dist/3rdpartylicenses.json. Mirrors the
-  # corresponding step in build.yml's `frontend` job.
-  # ---------------------------------------------------------------------------
-  frontend-npm:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Setup node
-        uses: actions/setup-node@v5
-        with:
-          node-version: 20.19.0
-      - uses: actions/cache@v5
-        with:
-          path: frontend/.yarn/cache
-          key: ${{ runner.os }}-x64-20.19.0-yarn-cache-v4-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-x64-20.19.0-yarn-cache-v4-
-      - name: Prepare Yarn 4.14.1
-        run: corepack enable && corepack prepare yarn@4.14.1 --activate
-      - name: Install dependency
-        timeout-minutes: 20
-        run: yarn --cwd frontend install --immutable --inline-builds --network-timeout=100000
-      - name: Prod build
-        run: yarn --cwd frontend run build:ci
-      - name: License check (strict)
-        id: check
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          ./bin/licensing/check_binary_deps.py npm frontend/dist/3rdpartylicenses.json \
-            2>&1 | tee /tmp/result.txt
-      - name: Persist result
-        if: always()
-        run: |
-          echo "${{ steps.check.outcome }}" > /tmp/status.txt
-      - name: Upload result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: result-frontend-npm
-          path: |
-            /tmp/result.txt
-            /tmp/status.txt
+  # Reuse the same build.yml that PRs go through; the only difference is
+  # ignore_transitive_version: false, which flips every license-binary
+  # check from relaxed to strict. secrets: inherit so the called jobs
+  # keep access to NX_CLOUD_ACCESS_TOKEN, CODECOV_TOKEN, etc.
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      ignore_transitive_version: false
+    secrets: inherit
 
-  # ---------------------------------------------------------------------------
-  # agent-npm: install agent-service prod deps, regenerate the bundled
-  # 3rdpartylicenses.json via bin/collect-licenses.ts, run the agent-npm
-  # license check in strict mode. Mirrors build.yml's `agent_service` job.
-  # ---------------------------------------------------------------------------
-  agent-npm:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: agent-service
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Setup Bun
-        run: |
-          curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.3
-          echo "$HOME/.bun/bin" >> $GITHUB_PATH
-      - name: Install production dependencies
-        run: bun install --production --frozen-lockfile
-      - name: Generate agent-service license manifest
-        run: |
-          mkdir -p dist
-          bun run bin/collect-licenses.ts > dist/3rdpartylicenses.json
-      - name: License check (strict)
-        id: check
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          ../bin/licensing/check_binary_deps.py agent-npm dist/3rdpartylicenses.json \
-            2>&1 | tee /tmp/result.txt
-      - name: Persist result
-        if: always()
-        working-directory: ${{ github.workspace }}
-        run: |
-          echo "${{ steps.check.outcome }}" > /tmp/status.txt
-      - name: Upload result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: result-agent-npm
-          path: |
-            /tmp/result.txt
-            /tmp/status.txt
-
-  # ---------------------------------------------------------------------------
-  # python: install runtime + operator deps, snapshot via pip-licenses, run
-  # the python license check in strict mode. Mirrors build.yml's `python` job
-  # (the python-3.12 row, which is the one that produces the manifest).
-  # ---------------------------------------------------------------------------
-  python:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
-          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
-          pip install pip-licenses
-      - name: Generate pip-licenses manifest
-        run: pip-licenses --format=csv --ignore-packages pip-licenses prettytable wcwidth > /tmp/pip-licenses.csv
-      - name: License check (strict)
-        id: check
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          ./bin/licensing/check_binary_deps.py python /tmp/pip-licenses.csv \
-            2>&1 | tee /tmp/result.txt
-      - name: Persist result
-        if: always()
-        run: |
-          echo "${{ steps.check.outcome }}" > /tmp/status.txt
-      - name: Upload result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: result-python
-          path: |
-            /tmp/result.txt
-            /tmp/status.txt
-
-  # ---------------------------------------------------------------------------
-  # jar: build the amber dist + every platform service dist, run the jar
-  # license check in strict mode against the union of all `lib/` directories.
-  # The default LICENSE-binary used by the script is the on-the-fly concat
-  # of all per-module files, so this validates that every bundled jar
-  # (across every module) is claimed somewhere in the per-module set.
-  # Per-service placement errors are still caught by build.yml on every PR;
-  # the nightly's job is exact-version drift, which the unified check
-  # surfaces just as well and at a fraction of the matrix cost.
-  # ---------------------------------------------------------------------------
-  jar:
-    runs-on: ubuntu-22.04
-    services:
-      postgres:
-        # DAO transitively pulled in by every dist runs JOOQ codegen at
-        # compile time and needs the texera schema to exist.
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd="pg_isready -U postgres"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=5
-    env:
-      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-      JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-      - name: Setup JDK
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 11
-      - name: Create Databases
-        run: |
-          psql -h localhost -U postgres -f sql/texera_ddl.sql
-          psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
-          psql -h localhost -U postgres -f sql/texera_lakefs.sql
-        env:
-          PGPASSWORD: postgres
-      - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
-      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
-        with:
-          extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
-      - name: Build all dists
-        run: |
-          sbt \
-            "WorkflowExecutionService/dist" \
-            "ConfigService/dist" \
-            "AccessControlService/dist" \
-            "FileService/dist" \
-            "ComputingUnitManagingService/dist" \
-            "WorkflowCompilingService/dist"
-      - name: Unzip dists
-        run: |
-          set -euo pipefail
-          mkdir -p /tmp/dists
-          unzip -q amber/target/universal/amber-*.zip -d /tmp/dists/
-          for svc in config-service access-control-service file-service computing-unit-managing-service workflow-compiling-service; do
-            unzip -q "$svc/target/universal/$svc-"*.zip -d /tmp/dists/
-          done
-      - name: License check (strict)
-        id: check
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          shopt -s nullglob
-          lib_paths=(
-            /tmp/dists/access-control-service-*/lib
-            /tmp/dists/config-service-*/lib
-            /tmp/dists/file-service-*/lib
-            /tmp/dists/computing-unit-managing-service-*/lib
-            /tmp/dists/workflow-compiling-service-*/lib
-            /tmp/dists/amber-*/lib
-          )
-          ./bin/licensing/check_binary_deps.py jar "${lib_paths[@]}" \
-            2>&1 | tee /tmp/result.txt
-      - name: Persist result
-        if: always()
-        run: |
-          echo "${{ steps.check.outcome }}" > /tmp/status.txt
-      - name: Upload result
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: result-jar
-          path: |
-            /tmp/result.txt
-            /tmp/status.txt
-
-  # ---------------------------------------------------------------------------
-  # report: aggregate per-ecosystem results into a single tracking issue.
-  # Stable identification via the `license-binary-drift` label so consecutive
-  # nightly runs update the same issue rather than spamming new ones; on a
-  # clean run, close the open tracking issue so the steady state is empty.
-  # ---------------------------------------------------------------------------
   report:
     if: always()
-    needs: [frontend-npm, agent-npm, python, jar]
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - name: Download all results
-        uses: actions/download-artifact@v4
-        with:
-          path: /tmp/results
-          pattern: result-*
       - name: File or update tracking issue
         uses: actions/github-script@v8
         with:
           script: |
-            const fs = require('fs');
-            const path = require('path');
-
             const TRACKING_LABEL = 'license-binary-drift';
             const TITLE = 'License-binary drift detected (nightly)';
 
-            // Aggregate per-ecosystem outcomes from the downloaded artifacts.
-            const ecosystems = ['frontend-npm', 'agent-npm', 'python', 'jar'];
-            const sections = [];
-            let anyDrift = false;
-            for (const eco of ecosystems) {
-              const dir = `/tmp/results/result-${eco}`;
-              const statusPath = path.join(dir, 'status.txt');
-              const resultPath = path.join(dir, 'result.txt');
-              const status = fs.existsSync(statusPath)
-                ? fs.readFileSync(statusPath, 'utf8').trim()
-                : 'missing';
-              const output = fs.existsSync(resultPath)
-                ? fs.readFileSync(resultPath, 'utf8')
-                : '(no output captured)';
-              const ok = status === 'success';
-              if (!ok) anyDrift = true;
-              const heading = ok ? `✅ ${eco}` : `❌ ${eco}`;
-              sections.push(
-                `### ${heading}\n\n` +
-                '```\n' +
-                output.trim() +
-                '\n```'
-              );
+            // The license-check step names in build.yml all contain either
+            // "LICENSE-binary" or "binary licenses". Match both forms,
+            // case-insensitively, and ignore non-license-related failures
+            // (flaky tests, network blips) so they don't surface as drift.
+            const LICENSE_STEP_RE = /license[-\s]?binary|binary licenses/i;
+
+            const { owner, repo } = context.repo;
+            const runUrl =
+              `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            // Walk every job in the current run (which includes the called
+            // build.yml jobs, prefixed with the calling job id `build`).
+            const jobs = await github.paginate(
+              github.rest.actions.listJobsForWorkflowRun,
+              { owner, repo, run_id: context.runId, per_page: 100 }
+            );
+
+            const licenseFailures = [];
+            const licenseSuccesses = [];
+            for (const job of jobs) {
+              for (const step of job.steps || []) {
+                if (!LICENSE_STEP_RE.test(step.name)) continue;
+                if (step.conclusion === 'failure') {
+                  licenseFailures.push({
+                    job: job.name,
+                    step: step.name,
+                    url: job.html_url,
+                  });
+                } else if (step.conclusion === 'success') {
+                  licenseSuccesses.push({ job: job.name, step: step.name });
+                }
+              }
             }
 
-            const runUrl =
-              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
-              `/actions/runs/${context.runId}`;
-            const body =
-              `Nightly strict license-binary check ran on \`${context.sha.slice(0, 7)}\`.\n\n` +
-              `Workflow run: ${runUrl}\n\n` +
-              `PR builds run with \`--ignore-transitive-version\` so transitive\n` +
-              `version bumps don't block merges; this nightly job runs the same\n` +
-              `checks without that flag and reports any drift here. To resolve\n` +
-              `drift, refresh the relevant per-module \`LICENSE-binary\` file(s)\n` +
-              `to match the bundled versions.\n\n` +
-              sections.join('\n\n');
+            const anyDrift = licenseFailures.length > 0;
+            core.info(
+              `License-check steps: ${licenseSuccesses.length} ok, ` +
+              `${licenseFailures.length} failed.`
+            );
 
-            // Find an existing open tracking issue (stable label).
+            // Find the existing open tracking issue (stable label).
             const { data: existing } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: TRACKING_LABEL,
-              per_page: 5,
+              owner, repo, state: 'open', labels: TRACKING_LABEL, per_page: 5,
             });
 
-            // Only file/update issues for runs against the default branch.
-            // Manual workflow_dispatch runs against feature branches still log
-            // results to the workflow output but should not surface issues.
+            // Only file / update / close issues for runs against the default
+            // branch. Manual workflow_dispatch runs against feature branches
+            // still exercise the build.yml strict-mode check (useful for
+            // testing locally) but should not surface tracking issues.
+            const defaultBranch = context.payload.repository.default_branch;
             const isDefaultBranch =
-              context.ref === `refs/heads/${context.payload.repository.default_branch}` ||
+              context.ref === `refs/heads/${defaultBranch}` ||
               context.eventName === 'schedule';
             if (!isDefaultBranch) {
               core.info(
-                `Not on default branch (ref=${context.ref}); skipping issue creation. ` +
-                `Drift detected: ${anyDrift}.`
+                `Not on default branch (ref=${context.ref}); ` +
+                `skipping issue management. Drift detected: ${anyDrift}.`
               );
               return;
             }
 
             if (!anyDrift) {
-              if (existing.length > 0) {
-                for (const issue of existing) {
-                  await github.rest.issues.update({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issue.number,
-                    state: 'closed',
-                    state_reason: 'completed',
-                  });
-                  await github.rest.issues.createComment({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issue.number,
-                    body: `Closed automatically: nightly run ${runUrl} found no drift.`,
-                  });
-                  core.info(`Closed stale tracking issue #${issue.number}`);
-                }
-              } else {
+              if (existing.length === 0) {
                 core.info('No drift, no existing tracking issue. Nothing to do.');
+                return;
+              }
+              for (const issue of existing) {
+                await github.rest.issues.update({
+                  owner, repo, issue_number: issue.number,
+                  state: 'closed', state_reason: 'completed',
+                });
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: issue.number,
+                  body:
+                    `Closed automatically: nightly run ${runUrl} found no ` +
+                    `license-binary drift across any ecosystem.`,
+                });
+                core.info(`Closed stale tracking issue #${issue.number}`);
               }
               return;
             }
 
+            // Build the issue body. Per-ecosystem diffs aren't repeated here
+            // (would require parsing workflow logs); we link to each failed
+            // job so the reviewer can click through to the script's output.
+            const failureLines = licenseFailures.map(
+              (f) => `- ❌ \`${f.job}\` — ${f.step} — [view logs](${f.url})`
+            );
+            const successLines = licenseSuccesses.map(
+              (s) => `- ✅ \`${s.job}\` — ${s.step}`
+            );
+            const body =
+              `Nightly strict license-binary check ran on ` +
+              `\`${context.sha.slice(0, 7)}\`.\n\n` +
+              `Workflow run: ${runUrl}\n\n` +
+              `PR builds run \`build.yml\` with ` +
+              `\`ignore_transitive_version: true\` so transitive version ` +
+              `bumps don't block merges; this nightly job runs the same ` +
+              `\`build.yml\` with that input flipped to \`false\` and ` +
+              `reports any drift here. To resolve drift, refresh the ` +
+              `relevant per-module \`LICENSE-binary\` file(s) to match the ` +
+              `bundled versions.\n\n` +
+              `### License checks that failed\n\n` +
+              failureLines.join('\n') +
+              (successLines.length > 0
+                ? `\n\n### License checks that passed\n\n${successLines.join('\n')}`
+                : '');
+
             if (existing.length > 0) {
               const issue = existing[0];
               await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                title: TITLE,
-                body,
+                owner, repo, issue_number: issue.number,
+                title: TITLE, body,
               });
               core.info(`Updated tracking issue #${issue.number}`);
-              // If somehow more than one is open, close the extras.
+              // Close any extras so we converge on a single tracking issue.
               for (const extra of existing.slice(1)) {
                 await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: extra.number,
-                  state: 'closed',
-                  state_reason: 'not_planned',
+                  owner, repo, issue_number: extra.number,
+                  state: 'closed', state_reason: 'not_planned',
                 });
                 core.info(`Closed duplicate tracking issue #${extra.number}`);
               }
             } else {
               const { data: created } = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: TITLE,
-                body,
+                owner, repo, title: TITLE, body,
                 labels: [TRACKING_LABEL, 'ci'],
               });
               core.info(`Filed new tracking issue #${created.number}`);

--- a/.github/workflows/license-binary-nightly.yml
+++ b/.github/workflows/license-binary-nightly.yml
@@ -1,0 +1,415 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: License-binary nightly
+
+# PR builds run check_binary_deps.py with --ignore-transitive-version so a
+# benign upstream version bump on a transitive dep does not block merges
+# (#4691, #4693). This workflow runs the same checks **without** that flag
+# every night on `main`, then files (or updates / closes) a single tracking
+# issue so transitive drift is still visible and actionable before each
+# release. Sub-task of #4688; sibling of #4691 (PR-time relaxation).
+on:
+  schedule:
+    # 07:00 UTC daily — late evening US-Pacific, early morning Europe.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  # Required so the report job can create / update / close the tracking issue.
+  issues: write
+
+concurrency:
+  group: license-binary-nightly
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # frontend-npm: build the prod webpack bundle, run the npm license check
+  # in strict mode against frontend/dist/3rdpartylicenses.json. Mirrors the
+  # corresponding step in build.yml's `frontend` job.
+  # ---------------------------------------------------------------------------
+  frontend-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20.19.0
+      - uses: actions/cache@v5
+        with:
+          path: frontend/.yarn/cache
+          key: ${{ runner.os }}-x64-20.19.0-yarn-cache-v4-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-x64-20.19.0-yarn-cache-v4-
+      - name: Prepare Yarn 4.14.1
+        run: corepack enable && corepack prepare yarn@4.14.1 --activate
+      - name: Install dependency
+        timeout-minutes: 20
+        run: yarn --cwd frontend install --immutable --inline-builds --network-timeout=100000
+      - name: Prod build
+        run: yarn --cwd frontend run build:ci
+      - name: License check (strict)
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ./bin/licensing/check_binary_deps.py npm frontend/dist/3rdpartylicenses.json \
+            2>&1 | tee /tmp/result.txt
+      - name: Persist result
+        if: always()
+        run: |
+          echo "${{ steps.check.outcome }}" > /tmp/status.txt
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-frontend-npm
+          path: |
+            /tmp/result.txt
+            /tmp/status.txt
+
+  # ---------------------------------------------------------------------------
+  # agent-npm: install agent-service prod deps, regenerate the bundled
+  # 3rdpartylicenses.json via bin/collect-licenses.ts, run the agent-npm
+  # license check in strict mode. Mirrors build.yml's `agent_service` job.
+  # ---------------------------------------------------------------------------
+  agent-npm:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: agent-service
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup Bun
+        run: |
+          curl -fsSL https://bun.sh/install | bash -s -- bun-v1.3.3
+          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      - name: Install production dependencies
+        run: bun install --production --frozen-lockfile
+      - name: Generate agent-service license manifest
+        run: |
+          mkdir -p dist
+          bun run bin/collect-licenses.ts > dist/3rdpartylicenses.json
+      - name: License check (strict)
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ../bin/licensing/check_binary_deps.py agent-npm dist/3rdpartylicenses.json \
+            2>&1 | tee /tmp/result.txt
+      - name: Persist result
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: |
+          echo "${{ steps.check.outcome }}" > /tmp/status.txt
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-agent-npm
+          path: |
+            /tmp/result.txt
+            /tmp/status.txt
+
+  # ---------------------------------------------------------------------------
+  # python: install runtime + operator deps, snapshot via pip-licenses, run
+  # the python license check in strict mode. Mirrors build.yml's `python` job
+  # (the python-3.12 row, which is the one that produces the manifest).
+  # ---------------------------------------------------------------------------
+  python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f amber/requirements.txt ]; then pip install -r amber/requirements.txt; fi
+          if [ -f amber/operator-requirements.txt ]; then pip install -r amber/operator-requirements.txt; fi
+          pip install pip-licenses
+      - name: Generate pip-licenses manifest
+        run: pip-licenses --format=csv --ignore-packages pip-licenses prettytable wcwidth > /tmp/pip-licenses.csv
+      - name: License check (strict)
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          ./bin/licensing/check_binary_deps.py python /tmp/pip-licenses.csv \
+            2>&1 | tee /tmp/result.txt
+      - name: Persist result
+        if: always()
+        run: |
+          echo "${{ steps.check.outcome }}" > /tmp/status.txt
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-python
+          path: |
+            /tmp/result.txt
+            /tmp/status.txt
+
+  # ---------------------------------------------------------------------------
+  # jar: build the amber dist + every platform service dist, run the jar
+  # license check in strict mode against the union of all `lib/` directories.
+  # The default LICENSE-binary used by the script is the on-the-fly concat
+  # of all per-module files, so this validates that every bundled jar
+  # (across every module) is claimed somewhere in the per-module set.
+  # Per-service placement errors are still caught by build.yml on every PR;
+  # the nightly's job is exact-version drift, which the unified check
+  # surfaces just as well and at a fraction of the matrix cost.
+  # ---------------------------------------------------------------------------
+  jar:
+    runs-on: ubuntu-22.04
+    services:
+      postgres:
+        # DAO transitively pulled in by every dist runs JOOQ codegen at
+        # compile time and needs the texera schema to exist.
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    env:
+      JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+      JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: Create Databases
+        run: |
+          psql -h localhost -U postgres -f sql/texera_ddl.sql
+          psql -h localhost -U postgres -f sql/iceberg_postgres_catalog.sql
+          psql -h localhost -U postgres -f sql/texera_lakefs.sql
+        env:
+          PGPASSWORD: postgres
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+        with:
+          extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
+      - name: Build all dists
+        run: |
+          sbt \
+            "WorkflowExecutionService/dist" \
+            "ConfigService/dist" \
+            "AccessControlService/dist" \
+            "FileService/dist" \
+            "ComputingUnitManagingService/dist" \
+            "WorkflowCompilingService/dist"
+      - name: Unzip dists
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/dists
+          unzip -q amber/target/universal/amber-*.zip -d /tmp/dists/
+          for svc in config-service access-control-service file-service computing-unit-managing-service workflow-compiling-service; do
+            unzip -q "$svc/target/universal/$svc-"*.zip -d /tmp/dists/
+          done
+      - name: License check (strict)
+        id: check
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          shopt -s nullglob
+          lib_paths=(
+            /tmp/dists/access-control-service-*/lib
+            /tmp/dists/config-service-*/lib
+            /tmp/dists/file-service-*/lib
+            /tmp/dists/computing-unit-managing-service-*/lib
+            /tmp/dists/workflow-compiling-service-*/lib
+            /tmp/dists/amber-*/lib
+          )
+          ./bin/licensing/check_binary_deps.py jar "${lib_paths[@]}" \
+            2>&1 | tee /tmp/result.txt
+      - name: Persist result
+        if: always()
+        run: |
+          echo "${{ steps.check.outcome }}" > /tmp/status.txt
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: result-jar
+          path: |
+            /tmp/result.txt
+            /tmp/status.txt
+
+  # ---------------------------------------------------------------------------
+  # report: aggregate per-ecosystem results into a single tracking issue.
+  # Stable identification via the `license-binary-drift` label so consecutive
+  # nightly runs update the same issue rather than spamming new ones; on a
+  # clean run, close the open tracking issue so the steady state is empty.
+  # ---------------------------------------------------------------------------
+  report:
+    if: always()
+    needs: [frontend-npm, agent-npm, python, jar]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/results
+          pattern: result-*
+      - name: File or update tracking issue
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const TRACKING_LABEL = 'license-binary-drift';
+            const TITLE = 'License-binary drift detected (nightly)';
+
+            // Aggregate per-ecosystem outcomes from the downloaded artifacts.
+            const ecosystems = ['frontend-npm', 'agent-npm', 'python', 'jar'];
+            const sections = [];
+            let anyDrift = false;
+            for (const eco of ecosystems) {
+              const dir = `/tmp/results/result-${eco}`;
+              const statusPath = path.join(dir, 'status.txt');
+              const resultPath = path.join(dir, 'result.txt');
+              const status = fs.existsSync(statusPath)
+                ? fs.readFileSync(statusPath, 'utf8').trim()
+                : 'missing';
+              const output = fs.existsSync(resultPath)
+                ? fs.readFileSync(resultPath, 'utf8')
+                : '(no output captured)';
+              const ok = status === 'success';
+              if (!ok) anyDrift = true;
+              const heading = ok ? `✅ ${eco}` : `❌ ${eco}`;
+              sections.push(
+                `### ${heading}\n\n` +
+                '```\n' +
+                output.trim() +
+                '\n```'
+              );
+            }
+
+            const runUrl =
+              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const body =
+              `Nightly strict license-binary check ran on \`${context.sha.slice(0, 7)}\`.\n\n` +
+              `Workflow run: ${runUrl}\n\n` +
+              `PR builds run with \`--ignore-transitive-version\` so transitive\n` +
+              `version bumps don't block merges; this nightly job runs the same\n` +
+              `checks without that flag and reports any drift here. To resolve\n` +
+              `drift, refresh the relevant per-module \`LICENSE-binary\` file(s)\n` +
+              `to match the bundled versions.\n\n` +
+              sections.join('\n\n');
+
+            // Find an existing open tracking issue (stable label).
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: TRACKING_LABEL,
+              per_page: 5,
+            });
+
+            // Only file/update issues for runs against the default branch.
+            // Manual workflow_dispatch runs against feature branches still log
+            // results to the workflow output but should not surface issues.
+            const isDefaultBranch =
+              context.ref === `refs/heads/${context.payload.repository.default_branch}` ||
+              context.eventName === 'schedule';
+            if (!isDefaultBranch) {
+              core.info(
+                `Not on default branch (ref=${context.ref}); skipping issue creation. ` +
+                `Drift detected: ${anyDrift}.`
+              );
+              return;
+            }
+
+            if (!anyDrift) {
+              if (existing.length > 0) {
+                for (const issue of existing) {
+                  await github.rest.issues.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    state: 'closed',
+                    state_reason: 'completed',
+                  });
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    body: `Closed automatically: nightly run ${runUrl} found no drift.`,
+                  });
+                  core.info(`Closed stale tracking issue #${issue.number}`);
+                }
+              } else {
+                core.info('No drift, no existing tracking issue. Nothing to do.');
+              }
+              return;
+            }
+
+            if (existing.length > 0) {
+              const issue = existing[0];
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                title: TITLE,
+                body,
+              });
+              core.info(`Updated tracking issue #${issue.number}`);
+              // If somehow more than one is open, close the extras.
+              for (const extra of existing.slice(1)) {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: extra.number,
+                  state: 'closed',
+                  state_reason: 'not_planned',
+                });
+                core.info(`Closed duplicate tracking issue #${extra.number}`);
+              }
+            } else {
+              const { data: created } = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: TITLE,
+                body,
+                labels: [TRACKING_LABEL, 'ci'],
+              });
+              core.info(`Filed new tracking issue #${created.number}`);
+            }


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR:

- add a new parameter to `build.yml` to tune the mode of the license checking
- add a new CI: `license-binary-nightly.yml` that include one `build` job that does `uses: ./.github/workflows/build.yml` with `mode` to be `release`, and one `report` job that will raise an issue if there is a drift on the license binary.


### Any related issues, documentation, discussions?

Resolves #4692. 

### How was this PR tested?

Verified using my personal fork:

https://github.com/bobbai00/texera/issues/6
https://github.com/bobbai00/texera/actions/runs/25273894144

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)