### PR TITLE
test(amber): add unit test coverage for WorkerPortExecution

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/controller/execution/WorkerPortExecutionSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/controller/execution/WorkerPortExecutionSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.architecture.controller.execution
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class WorkerPortExecutionSpec extends AnyFlatSpec {
+
+  "WorkerPortExecution" should "be incomplete by default" in {
+    assert(!WorkerPortExecution().completed)
+  }
+
+  "WorkerPortExecution.setCompleted" should "flip the completed flag to true" in {
+    val wpe = WorkerPortExecution()
+    wpe.setCompleted()
+    assert(wpe.completed)
+  }
+
+  it should "be idempotent on repeated calls" in {
+    val wpe = WorkerPortExecution()
+    wpe.setCompleted()
+    wpe.setCompleted()
+    assert(wpe.completed)
+  }
+
+  it should "not affect a separate WorkerPortExecution instance" in {
+    val a = WorkerPortExecution()
+    val b = WorkerPortExecution()
+    a.setCompleted()
+    assert(a.completed)
+    assert(!b.completed)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `WorkerPortExecutionSpec` covering the per-worker-per-port completion flag in `WorkerPortExecution`:

- Default `completed` is `false`
- `setCompleted` flips it to `true`
- Repeated `setCompleted` calls are idempotent
- Separate instances do not share state

### Any related issues, documentation, discussions?

Closes #4771

### How was this PR tested?

`sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.architecture.controller.execution.WorkerPortExecutionSpec"` — 4/4 tests pass.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)