### PR TITLE
test(amber): add unit test coverage for DataFrame equality and inMemSize

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/common/ambermessage/DataPayloadSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/common/ambermessage/DataPayloadSpec.scala
@@ -24,11 +24,13 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class DataPayloadSpec extends AnyFlatSpec {
 
-  private val schema: Schema =
-    Schema().add(new Attribute("v", AttributeType.INTEGER))
+  private val vAttr = new Attribute("v", AttributeType.INTEGER)
+  private val schema: Schema = Schema().add(vAttr)
 
+  // Use the schema's Attribute when adding fields so the helper is always
+  // consistent with the schema under test.
   private def tuple(v: Int): Tuple =
-    Tuple.builder(schema).add(new Attribute("v", AttributeType.INTEGER), Integer.valueOf(v)).build()
+    Tuple.builder(schema).add(schema.getAttribute("v"), Integer.valueOf(v)).build()
 
   "DataFrame.inMemSize" should "be zero for an empty frame" in {
     assert(DataFrame(Array.empty).inMemSize == 0L)
@@ -41,7 +43,12 @@ class DataPayloadSpec extends AnyFlatSpec {
     assert(df.inMemSize == a.inMemSize + b.inMemSize)
   }
 
-  "DataFrame.equals" should "consider two empty frames equal" in {
+  "DataFrame.equals" should "be reflexive on a single empty frame instance" in {
+    val df = DataFrame(Array.empty)
+    assert(df == df)
+  }
+
+  it should "consider two distinct empty frames equal" in {
     assert(DataFrame(Array.empty) == DataFrame(Array.empty))
   }
 

--- a/amber/src/test/scala/org/apache/texera/amber/engine/common/ambermessage/DataPayloadSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/common/ambermessage/DataPayloadSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.common.ambermessage
+
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema, Tuple}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DataPayloadSpec extends AnyFlatSpec {
+
+  private val schema: Schema =
+    Schema().add(new Attribute("v", AttributeType.INTEGER))
+
+  private def tuple(v: Int): Tuple =
+    Tuple.builder(schema).add(new Attribute("v", AttributeType.INTEGER), Integer.valueOf(v)).build()
+
+  "DataFrame.inMemSize" should "be zero for an empty frame" in {
+    assert(DataFrame(Array.empty).inMemSize == 0L)
+  }
+
+  it should "be the sum of inMemSize across the contained tuples" in {
+    val a = tuple(1)
+    val b = tuple(2)
+    val df = DataFrame(Array(a, b))
+    assert(df.inMemSize == a.inMemSize + b.inMemSize)
+  }
+
+  "DataFrame.equals" should "consider two empty frames equal" in {
+    assert(DataFrame(Array.empty) == DataFrame(Array.empty))
+  }
+
+  it should "reject comparison against non-DataFrame values" in {
+    val df = DataFrame(Array(tuple(1)))
+    assert(!df.equals("not a dataframe"))
+    assert(!df.equals(null))
+  }
+
+  it should "reject frames whose lengths differ" in {
+    val a = DataFrame(Array(tuple(1)))
+    val b = DataFrame(Array(tuple(1), tuple(2)))
+    assert(a != b)
+  }
+
+  it should "treat element-wise equal frames as equal" in {
+    val a = DataFrame(Array(tuple(1), tuple(2)))
+    val b = DataFrame(Array(tuple(1), tuple(2)))
+    assert(a == b)
+  }
+
+  it should "respect element order" in {
+    val a = DataFrame(Array(tuple(1), tuple(2)))
+    val b = DataFrame(Array(tuple(2), tuple(1)))
+    assert(a != b)
+  }
+
+  it should "reject frames whose elements differ" in {
+    val a = DataFrame(Array(tuple(1)))
+    val b = DataFrame(Array(tuple(2)))
+    assert(a != b)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `DataPayloadSpec` covering the custom `equals` and `inMemSize` of `DataFrame`:

- `inMemSize`: zero for an empty frame; sum of contained tuple sizes otherwise
- `equals` is reflexive on a single empty-frame instance (`df == df`)
- `equals` returns true for two distinct empty-frame instances
- `equals` rejects non-`DataFrame` values and `null`
- `equals` rejects frames whose lengths differ
- `equals` treats element-wise equal frames as equal
- `equals` respects element order
- `equals` rejects frames whose elements differ

### Any related issues, documentation, discussions?

Closes #4783

### How was this PR tested?

`sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.common.ambermessage.DataPayloadSpec"` — 9/9 tests pass.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)