### PR TITLE
chore(licensing): bump tifffile to 2026.5.2 in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -319,7 +319,7 @@ Python packages:
   - scipy==1.17.1
   - sympy==1.14.0
   - threadpoolctl==3.6.0
-  - tifffile==2026.4.11
+  - tifffile==2026.5.2
   - torch==2.8.0
   - zstandard==0.25.0
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Bump `tifffile` from `2026.4.11` to `2026.5.2` in `amber/LICENSE-binary-python` so it matches the version actually bundled in the runtime image. One-line change.

### Any related issues, documentation, discussions?

Closes #4854 

The drift is transitive: `tifffile` is pulled in by `scikit-image`, which is declared in `amber/operator-requirements.txt`. PR-time builds tolerate transitive calver bumps via `--ignore-transitive-version`; the nightly strict run is what flagged it. Once this PR merges, the next nightly run will auto-close the tracking issue.

### How was this PR tested?

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)