### PR TITLE
ci(release): gate RC creation on strict-mode build of the tagged commit

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -36,7 +36,17 @@ on:
         default: 'ghcr.io/apache'
 
 jobs:
+  # Strict-mode build of the tagged commit. Gates RC artifact creation: if
+  # the tag doesn't compile or has license-binary drift, no RC is produced.
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      checkout_ref: ${{ github.event.inputs.tag }}
+      mode: release
+    secrets: inherit
+
   create-rc:
+    needs: build
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.vars.outputs.version }}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add a \`build\` job at the top of \`create-release-candidate.yml\` that calls the reusable \`build.yml\` with:

- \`checkout_ref: \${{ github.event.inputs.tag }}\` — build the tagged commit (\`build.yml\` already accepts this input).
- \`mode: release\` — strict license-binary check, no \`--ignore-transitive-version\` (the third mode added in #4734 alongside \`PR\` and \`nightly\`).

\`create-rc\` now depends on \`build\` via \`needs: build\`. If the tag doesn't compile or has license-binary drift, no RC tarball is produced and nothing is signed/uploaded to ASF SVN.


### Any related issues, documentation, discussions?

Closes #4856.


### How was this PR tested?


### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)