### PR TITLE
chore(frontend): move `--code-coverage` from build.yml into test:ci script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: ./bin/licensing/check_binary_deps.py ${{ inputs.mode == 'PR' && '--ignore-transitive-version' || '' }} npm frontend/dist/3rdpartylicenses.json
       - name: Run frontend unit tests
-        run: yarn --cwd frontend run test:ci --code-coverage
+        run: yarn --cwd frontend run test:ci
       - name: Upload frontend coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && always()
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "build:ci": "node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js build --configuration=production --progress=false --source-map=false",
     "analyze": "ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/stats.json",
     "test": "ng test --watch=false",
-    "test:ci": "node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test --watch=false --progress=false",
+    "test:ci": "node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test --watch=false --progress=false --code-coverage",
     "prettier:fix": "prettier --write ./src",
     "lint": "eslint ./src",
     "eslint:fix": "yarn eslint --fix ./src",


### PR DESCRIPTION
### What changes were proposed in this PR?

Move the `--code-coverage` flag from `.github/workflows/build.yml` into the `test:ci` script in `frontend/package.json`. No behavior change. Future frontend test-flag tweaks live in `package.json`, not the CI file.

### Any related issues, documentation, discussions?

Prep for #4862 — the Vitest migration's CI yml diff disappears with this in first.

### How was this PR tested?

Same `nx test ... --code-coverage` command runs from a different location; CI exercises it.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)