### PR TITLE
fix(frontend): convert RegistrationRequestModalComponent to standalone

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -187,7 +187,6 @@ import { FormlyRepeatDndComponent } from "./common/formly/repeat-dnd/repeat-dnd.
 import { NzInputNumberModule } from "ng-zorro-antd/input-number";
 import { NzGridModule } from "ng-zorro-antd/grid";
 import { NzCheckboxModule } from "ng-zorro-antd/checkbox";
-import { RegistrationRequestModalComponent } from "./common/service/user/registration-request-modal/registration-request-modal.component";
 import { UserComputingUnitComponent } from "./dashboard/component/user/user-computing-unit/user-computing-unit.component";
 import { UserComputingUnitListItemComponent } from "./dashboard/component/user/user-computing-unit/user-computing-unit-list-item/user-computing-unit-list-item.component";
 
@@ -286,7 +285,6 @@ registerLocaleData(en);
     HubSearchResultComponent,
     ComputingUnitSelectionComponent,
     AdminSettingsComponent,
-    RegistrationRequestModalComponent,
     MarkdownDescriptionComponent,
     UserComputingUnitComponent,
     UserComputingUnitListItemComponent,

--- a/frontend/src/app/common/service/user/registration-request-modal/registration-request-modal.component.ts
+++ b/frontend/src/app/common/service/user/registration-request-modal/registration-request-modal.component.ts
@@ -17,14 +17,17 @@
  * under the License.
  */
 
-import { Component, Inject, Input, TemplateRef, ViewChild } from "@angular/core";
+import { Component, Inject, TemplateRef, ViewChild } from "@angular/core";
+import { FormsModule } from "@angular/forms";
 import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { NzInputModule } from "ng-zorro-antd/input";
 
 @Component({
   selector: "texera-registration-request-modal",
   templateUrl: "./registration-request-modal.component.html",
   styleUrls: ["./registration-request-modal.component.scss"],
-  standalone: false,
+  standalone: true,
+  imports: [FormsModule, NzInputModule],
 })
 
 // Component for registration form modal


### PR DESCRIPTION
### What changes were proposed in this PR?

Convert `RegistrationRequestModalComponent` to a standalone component with explicit `imports: [FormsModule, NzInputModule]`. Remove from `AppModule.declarations` and drop the unused import.

The component is opened via `NzModalService.create({ nzContent: RegistrationRequestModalComponent })` from `auth.service.ts`. That continues to work for standalone components — no behavior change at runtime.

### Any related issues, documentation, discussions?

Closes #4865.

After this and #4862 land, the 13 service specs currently excluded for the auth → modal template-check chain can come off the exclusion list in a follow-up.

### How was this PR tested?

`yarn run build` produces a clean prod bundle. CI exercises the full prod build path.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)