### PR TITLE
test(amber, 1.1): drop stale Thread.sleep(1000) after COMPLETED state

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/DataProcessingSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/DataProcessingSpec.scala
@@ -129,8 +129,6 @@ class DataProcessingSpec
               uri.nonEmpty
             })
             .map(terminalOpId => {
-              //TODO: remove the delay after fixing the issue of reporting "completed" status too early.
-              Thread.sleep(1000)
               val uri = getResultUriByLogicalPortId(
                 workflowContext.executionId,
                 terminalOpId,

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/ReconfigurationSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/ReconfigurationSpec.scala
@@ -132,8 +132,6 @@ class ReconfigurationSpec
               uri.nonEmpty
             })
             .map(terminalOpId => {
-              //TODO: remove the delay after fixing the issue of reporting "completed" status too early.
-              Thread.sleep(1000)
               val uri = getResultUriByLogicalPortId(
                 workflow.context.executionId,
                 terminalOpId,


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport [#4680](https://github.com/apache/texera/pull/4680) (commit `598ed0f7f037b96ebe5549759158e46ba736b372` on `main`) onto `release/v1.1.0-incubating`.

Removes the dead `Thread.sleep(1000)` + TODO inside the result-reading block in `ReconfigurationSpec.scala` and `DataProcessingSpec.scala`, matching what already landed on `main`.

### Any related issues, documentation, discussions?

Backports #4680. Unblocks the backport leg of #4871.

### How was this PR tested?

Cherry-pick of an already-reviewed and merged commit; applies cleanly. CI on this PR exercises the change against the release branch's full Python matrix.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)