### PR TITLE
chore(licensing): bump pytz to 2026.2 in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -275,7 +275,7 @@ Python packages:
   - pytest==7.4.0
   - pytest-reraise==2.1.2
   - pytest-timeout==2.2.0
-  - pytz==2026.1.post1
+  - pytz==2026.2
   - pyyaml==6.0.3
   - readerwriterlock==1.0.9
   - rich==14.3.4


### PR DESCRIPTION
### What changes were proposed in this PR?

Bump `pytz` from `2026.1.post1` to `2026.2` in `amber/LICENSE-binary-python` so the manifest matches the runtime image's bundled version. One-line change.

### Any related issues, documentation, discussions?

Closes #4905. Same pattern as the earlier `tifffile` drift (#4855) — transitive calver bump that strict mode catches.

### How was this PR tested?

Drift signature from the strict-mode run:

\`\`\`
DRIFT (transitive) Python packages — claimed versions differ from bundled:
  ~ pytz: LICENSE-binary=2026.1.post1  bundled=2026.2
\`\`\`

PR-time check on this PR runs with `--ignore-transitive-version` and should pass; the next strict-mode run on `main` post-merge confirms the fix end-to-end.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-7)