### PR TITLE
chore: drop `labels: ["triage"]` from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -16,7 +16,6 @@
 
 name: Bug Report
 description: File a bug report.
-labels: ["triage"]
 type: "Bug"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature-template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature-template.yaml
@@ -16,7 +16,6 @@
 
 name: Feature Request
 description: Suggest a new feature or improvement.
-labels: ["triage"]
 type: "Feature"
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/task-template.yaml
+++ b/.github/ISSUE_TEMPLATE/task-template.yaml
@@ -16,7 +16,6 @@
 
 name: Task
 description: Create a new development or maintenance task.
-labels: ["triage"]
 type: "Task"
 body:
   - type: markdown


### PR DESCRIPTION
### What changes were proposed in this PR?

Follow-up to PR #4899, which retired the `triage` label workflow in favor of the search filter `is:issue is:open no:assignee`. The three issue templates still carried `labels: ["triage"]` at the top, so every new issue opened via the templates re-acquired the label even though no workflow consumes it anymore.

Drop the line in `bug-template.yaml`, `task-template.yaml`, and `feature-template.yaml` (one line each).

### Any related issues, documentation, discussions?

Closes #4917. Sequel to #4899.

After this lands, the `triage` label itself can be deleted from the repo:

```
gh api -X DELETE /repos/apache/texera/labels/triage
```

That removes the chip from every issue that still carries it.

### How was this PR tested?

YAML parse on all three templates. Behavior verifiable post-merge by opening a new issue from any template and confirming no `triage` label is attached.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)