### PR TITLE
chore(license): trim DISCLAIMER to canonical ASF Incubator template

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -6,9 +6,3 @@ stabilized in a manner consistent with other successful ASF projects.
 While incubation status is not necessarily a reflection of the
 completeness or stability of the code, it does indicate that the project
 has yet to be fully endorsed by the ASF.
-
-If you are planning to incorporate this work into your product/project,
-please be aware that you will need to conduct a thorough licensing
-review to determine the overall implications of including this work.
-For the current status of this project through the Apache Incubator,
-visit: https://incubator.apache.org/projects/texera.html

--- a/bin/single-node/DISCLAIMER
+++ b/bin/single-node/DISCLAIMER
@@ -6,9 +6,3 @@ stabilized in a manner consistent with other successful ASF projects.
 While incubation status is not necessarily a reflection of the
 completeness or stability of the code, it does indicate that the project
 has yet to be fully endorsed by the ASF.
-
-If you are planning to incorporate this work into your product/project,
-please be aware that you will need to conduct a thorough licensing
-review to determine the overall implications of including this work.
-For the current status of this project through the Apache Incubator,
-visit: https://incubator.apache.org/projects/texera.html


### PR DESCRIPTION
### What changes were proposed in this PR?

Drop the non-canonical second paragraph (licensing-review caveat + incubator status URL) from `DISCLAIMER` and its verbatim copy at `bin/single-node/DISCLAIMER`. Only the first paragraph is part of the standard ASF Incubator disclaimer template. The trimmed file flows automatically into JAR `META-INF/` entries and all Docker images via existing sbt + Dockerfile copy steps — no other code changes needed.

Follow-up to the disclaimer/licensing cleanup in 47bb2e43b1e2fce66598188909905b8e66c1aa46 / #4288 (and rename in #4555), which left this section untrimmed.

### Any related issues, documentation, discussions?

Closes #4926. Related: #4288, #4555.

### How was this PR tested?

Text-only change to release artifacts metadata.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)