### PR TITLE
chore(docker, 1.1): add ASF Incubator disclaimer to Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM node:18-alpine AS nodegui
 
 WORKDIR /gui

--- a/bin/access-control-service.dockerfile
+++ b/bin/access-control-service.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/agent-service.dockerfile
+++ b/bin/agent-service.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM oven/bun:1-alpine
 
 WORKDIR /app

--- a/bin/computing-unit-master.dockerfile
+++ b/bin/computing-unit-master.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/computing-unit-worker.dockerfile
+++ b/bin/computing-unit-worker.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/config-service.dockerfile
+++ b/bin/config-service.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/file-service.dockerfile
+++ b/bin/file-service.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/pylsp/Dockerfile
+++ b/bin/pylsp/Dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 # Use an official Python runtime as a parent image
 FROM python:3.10-slim
 

--- a/bin/texera-web-application.dockerfile
+++ b/bin/texera-web-application.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM node:22-bookworm AS build-frontend
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/bin/workflow-compiling-service.dockerfile
+++ b/bin/workflow-compiling-service.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/workflow-computing-unit-managing-service.dockerfile
+++ b/bin/workflow-computing-unit-managing-service.dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11 AS build
 
 # Set working directory

--- a/bin/y-websocket-server/Dockerfile
+++ b/bin/y-websocket-server/Dockerfile
@@ -15,6 +15,15 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Apache Texera is an effort undergoing incubation at The Apache Software
+# Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+# required of all newly accepted projects until a further review indicates
+# that the infrastructure, communications, and decision-making process have
+# stabilized in a manner consistent with other successful ASF projects.
+# While incubation status is not necessarily a reflection of the
+# completeness or stability of the code, it does indicate that the project
+# has yet to be fully endorsed by the ASF.
+
 # Use an official Node runtime as a parent image
 FROM node:latest
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Manual backport of #4925 to `release/v1.1.0-incubating`. Auto-backport failed because `bin/texera-web-application.dockerfile` diverged on main (Node 22 → 24 in #4658, landed 2026-05-02). Conflict resolved by keeping the release branch's `FROM node:22-bookworm` and inserting the disclaimer block above it. The other 11 Dockerfiles applied cleanly.

### Any related issues, documentation, discussions?

Backport of #4925. Closes the auto-backport failure noted at https://github.com/apache/texera/actions/runs/25336814980/job/74284062316.

### How was this PR tested?

Comment-only change; no functional impact. `git diff --stat upstream/release/v1.1.0-incubating` shows 12 Dockerfiles touched, +9 each (+108 / 0).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)