### PR TITLE
docs(license): bundle full third-party MIT license texts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -205,16 +205,15 @@ THIRD-PARTY DEPENDENCIES
 --------------------------------------------------------------------------------
 
 This product bundles source code and assets from third-party projects.
-See licenses/ for the full text of these licenses:
-  - licenses/LICENSE-MIT.txt
 
-MIT License (licenses/LICENSE-MIT.txt)
+MIT License
 --------------------------------------
 
 This product bundles code derived from mbknor-jackson-jsonschema:
   - common/workflow-operator/src/main/scala/com/kjetland/jackson/jsonSchema/
   Copyright (c) 2016 Kjell Tore Eliassen (mbknor)
   Source: https://github.com/mbknor/mbknor-jackson-jsonschema
+  License: MIT License (licenses-3rd-party-code/mbknor-jackson-jsonschema.txt)
 
 This product bundles code derived from Google Angular formly examples:
   - frontend/src/app/common/formly/array.type.ts
@@ -223,6 +222,7 @@ This product bundles code derived from Google Angular formly examples:
   - frontend/src/app/common/formly/null.type.ts
   Copyright (c) 2018 Google Inc. All Rights Reserved.
   Source: https://angular.io
+  License: MIT License (licenses-3rd-party-code/angular.md)
 
 This product bundles code derived from TypeFox monaco-languageclient:
   - pyright-language-service/src/main.ts
@@ -230,10 +230,11 @@ This product bundles code derived from TypeFox monaco-languageclient:
   - pyright-language-service/src/server-commons.ts
   Copyright (c) 2024 TypeFox and others.
   Source: https://github.com/TypeFox/monaco-languageclient
+  License: MIT License (licenses-3rd-party-code/monaco-languageclient.txt)
 
 This product includes SVG icons from SVGRepo:
   - frontend/src/assets/svg/operator-view-result.svg
   - frontend/src/assets/svg/operator-reuse-cache-valid.svg
   - frontend/src/assets/svg/operator-reuse-cache-invalid.svg
   Source: https://www.svgrepo.com
-  License: MIT License
+  License: MIT License (licenses/LICENSE-MIT.txt)

--- a/licenses-3rd-party-code/angular.md
+++ b/licenses-3rd-party-code/angular.md
@@ -1,0 +1,9 @@
+# The MIT License
+
+Copyright (c) 2010-2026 Google LLC. [https://angular.dev/license](/license)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses-3rd-party-code/mbknor-jackson-jsonschema.txt
+++ b/licenses-3rd-party-code/mbknor-jackson-jsonschema.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 NextGenTel
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses-3rd-party-code/monaco-languageclient.txt
+++ b/licenses-3rd-party-code/monaco-languageclient.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright 2018 - present TypeFox GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### What changes were proposed in this PR?

Add a new top-level `licenses-3rd-party-code/` directory containing the upstream MIT license text (with original copyright) for each piece of third-party **source code** we bundle, and reference each from the root `LICENSE`. Keeps source-bundle licenses separate from binary-dependency licenses (the latter live under `licenses/`).

| Bundled component | License file |
| --- | --- |
| mbknor-jackson-jsonschema | `licenses-3rd-party-code/mbknor-jackson-jsonschema.txt` |
| Google Angular formly examples | `licenses-3rd-party-code/angular.md` |
| TypeFox monaco-languageclient | `licenses-3rd-party-code/monaco-languageclient.txt` |
| SVGRepo icons | `licenses/LICENSE-MIT.txt` (generic — SVGRepo ships no project-specific license) |

In `LICENSE`:
- Each bundled-component entry now carries an explicit `License:` line pointing to its file.
- The umbrella `MIT License (licenses/LICENSE-MIT.txt)` header is reduced to `MIT License` since per-entry pointers are now exact.

### Any related issues, documentation, discussions?

Closes #4923.

### How was this PR tested?

Doc-only change. Verified all four `License:` paths exist in the working tree.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)