### PR TITLE
chore(ci): show Codecov carryforward flags in PR comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -60,3 +60,12 @@ coverage:
         # PRs on it: a 100%-patch policy blocks plenty of legitimate
         # refactors / config-only changes that have no tests to add.
         informational: true
+
+comment:
+  # `flag_management.default_rules.carryforward: true` above already
+  # backfills missing flags from main, but Codecov's default still
+  # hides those rows from the PR comment. Show them so a frontend-only
+  # or python-only PR's table lists every flag — fresh-data rows track
+  # the patch and carryforward'd rows render with `<ø>` to make their
+  # unchanged status obvious.
+  show_carryforward_flags: true


### PR DESCRIPTION
### What changes were proposed in this PR?

The labeler routes each PR to a subset of CI stacks, so most PRs upload coverage for only one or two flags and the rest are carried forward from main (already configured via `flag_management.default_rules.carryforward: true`). Codecov's default still **hides** those carry-forward rows from the PR comment, which makes the table look empty on a frontend-only or python-only PR. Add `comment.show_carryforward_flags: true` so the table shows every flag — fresh-data rows track the patch and carryforward'd rows render with `<ø>` to flag their unchanged status.

### Any related issues, documentation, discussions?

Closes #4972.

### How was this PR tested?

`curl https://codecov.io/validate` against the file returns "Valid!" with the new key parsed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (Claude Code)