### PR TITLE
fix: replace bare Option.get in getPortId with descriptive IllegalStateException    

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/AmberFIFOChannel.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/AmberFIFOChannel.scala
@@ -117,6 +117,10 @@ class AmberFIFOChannel(val channelId: ChannelIdentity) extends AmberLogging {
   }
 
   def getPortId: PortIdentity = {
-    this.portId.get
+    this.portId.getOrElse(
+      throw new IllegalStateException(
+        s"portId has not been set for channel $channelId; call setPortId before getPortId"
+      )
+    )
   }
 }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/AmberFIFOChannelSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/AmberFIFOChannelSpec.scala
@@ -184,12 +184,13 @@ class AmberFIFOChannelSpec extends AnyFlatSpec {
   // PortId association
   // ---------------------------------------------------------------------------
 
-  "AmberFIFOChannel.getPortId" should "throw when no portId has been set" in {
+  "AmberFIFOChannel.getPortId" should "throw IllegalStateException with a descriptive message when no portId has been set" in {
     val ch = new AmberFIFOChannel(cid)
-    // Option.get on None
-    assertThrows[NoSuchElementException] {
+    val ex = intercept[IllegalStateException] {
       ch.getPortId
     }
+    assert(ex.getMessage.contains("portId has not been set"))
+    assert(ex.getMessage.contains(cid.toString))
   }
 
   it should "return the most recently configured portId" in {


### PR DESCRIPTION
### What changes were proposed in this PR?
  AmberFIFOChannel.getPortId called this.portId.get on an Option[PortIdentity] that defaults to None. Calling getPortId before setPortId threw a bare NoSuchElementException with no message, giving callers no indication of which channel was misconfigured or what setup step was missed.
                                                                                                                                                                                                                                    
  Replaced .get with .getOrElse(throw new IllegalStateException(...)) so the exception identifies the channel and points the caller at the missing setPortId call.    

### Any related issues, documentation, discussions?
Closes: #4818


### How was this PR tested?
 Updated the existing AmberFIFOChannelSpec test that covered this path — it previously asserted NoSuchElementException and now asserts IllegalStateException with message content checks ("portId has not been set" and the channel ID string). All 13 specs pass.
                                    

### Was this PR authored or co-authored using generative AI tooling?
Co-Authored with Claude Opus 4.7 in compliance with ASF