### PR TITLE
chore: ignore local .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ agent-service/.yarn/
 agent-service/.yarnrc.yml
 agent-service/yarn.lock
 agent-service/CLAUDE.md
+
+# Ignoring local Claude Code artifacts (settings, worktrees, scratch)
+.claude/


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `.claude/` to `.gitignore` so locally-generated Claude Code artifacts (settings, launch configs, helper scripts, worktree pointers) don't get committed again. [c1b6ae0543](https://github.com/apache/texera/commit/c1b6ae0543042578dfd9d227fa67b11f51dc4244) recently had to remove four such files; this PR closes the gap so it doesn't recur. Root-level `CLAUDE.md` (which delegates to `AGENTS.md`) is unaffected.

### Any related issues, documentation, discussions?

Closes #4981.

### How was this PR tested?

- `git check-ignore -v .claude/settings.local.json` → matched by the new `.claude/` rule
- Root `CLAUDE.md` still tracked (`git ls-files CLAUDE.md` returns `CLAUDE.md`)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)