### PR TITLE
refactor(config): drop unused rest-uri key from storage.conf

### DIFF
--- a/common/config/src/main/resources/storage.conf
+++ b/common/config/src/main/resources/storage.conf
@@ -24,9 +24,6 @@ storage {
             type = postgres # either hadoop, rest, or postgres
             type = ${?STORAGE_ICEBERG_CATALOG_TYPE}
 
-            rest-uri = ""
-            rest-uri = ${?STORAGE_ICEBERG_CATALOG_REST_URI} # the uri of the rest catalog, not needed unless using REST catalog
-
             rest {
                 uri = "http://localhost:8181/catalog"
                 uri = ${?STORAGE_ICEBERG_CATALOG_REST_URI}


### PR DESCRIPTION
### What changes were proposed in this PR?

Delete the two `rest-uri` lines from
`common/config/src/main/resources/storage.conf`:

```
rest-uri = ""
rest-uri = ${?STORAGE_ICEBERG_CATALOG_REST_URI}
```

This hyphenated flat key (`storage.iceberg.catalog.rest-uri`) is not read
by any Scala code. The active key is the nested
`storage.iceberg.catalog.rest.uri` (a few lines below in the `rest { … }`
block), which already consumes the same `STORAGE_ICEBERG_CATALOG_REST_URI`
env var.

| Key | Read by Scala? |
| --- | --- |
| `storage.iceberg.catalog.rest-uri` (deleted) | No |
| `storage.iceberg.catalog.rest.uri` (kept) | `StorageConfig.icebergRESTCatalogUri` |

### Any related issues, documentation, discussions?

Closes #4989

### How was this PR tested?

```
sbt "Config/compile"
[success] Total time: 3 s
```

Pure config-cleanup; no Scala / Python / shell consumer of the deleted
key. The `STORAGE_ICEBERG_CATALOG_REST_URI` env var continues to flow into
amber/CU through the nested `rest.uri` key.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)
