### PR TITLE
fix: don't re-throw in jsdom-svg-polyfill uncaughtException handler

### DIFF
--- a/frontend/src/jsdom-svg-polyfill.ts
+++ b/frontend/src/jsdom-svg-polyfill.ts
@@ -191,8 +191,12 @@ function isBenignIconError(err: unknown): boolean {
   );
 }
 process.on("uncaughtException", err => {
-  if (!isBenignIconError(err)) throw err;
+  if (isBenignIconError(err)) return;
+  // Re-throwing inside `uncaughtException` aborts the Node process, which
+  // crashes the Vitest worker mid-run and leaves the runner hanging.
+  console.error(err);
 });
 process.on("unhandledRejection", reason => {
-  if (!isBenignIconError(reason)) throw reason;
+  if (isBenignIconError(reason)) return;
+  console.error(reason);
 });


### PR DESCRIPTION

### What changes were proposed in this PR?
  Replace the `throw err` / `throw reason` inside the `process.on("uncaughtException")` and `process.on("unhandledRejection")` handlers in `frontend/src/jsdom-svg-polyfill.ts` with `console.error(...)`.
  
  Re-throwing in `uncaughtException` aborts the Node process, crashing the Vitest worker mid-run and leaving the runner hanging until the CI timeout. Logging instead lets Vitest's own error handling fail the offending spec
  without killing sibling tests in the same worker.

### Any related issues, documentation, or discussions?
Closes: #4998
### How was this PR tested?
  Ran `yarn ng test --watch=false` locally — full suite passes cleanly. CI runs on the branch that no longer hangs.

### Was this PR authored or co-authored using generative AI tooling?
Discovered with Claude Opus 4.7 in compliance with ASF