### PR TITLE
fix: SourceOperator is_source default broken by name mangling

### DIFF
--- a/amber/src/main/python/core/models/operator.py
+++ b/amber/src/main/python/core/models/operator.py
@@ -74,7 +74,7 @@ class Operator(ABC):
     def decode_python_template(self, data: Union[str, bytes]) -> str:
         return self._get_template_decoder().decode(data)
 
-    __internal_is_source: bool = False
+    _internal_is_source: bool = False
 
     @property
     @overrides.final
@@ -85,12 +85,12 @@ class Operator(ABC):
 
         :return:
         """
-        return self.__internal_is_source
+        return self._internal_is_source
 
     @is_source.setter
     @overrides.final
     def is_source(self, value: bool) -> None:
-        self.__internal_is_source = value
+        self._internal_is_source = value
 
     def open(self) -> None:
         """
@@ -164,7 +164,7 @@ class TupleOperatorV2(Operator):
 
 
 class SourceOperator(TupleOperatorV2):
-    __internal_is_source = True
+    _internal_is_source = True
 
     @abstractmethod
     def produce(self) -> Iterator[Union[TupleLike, TableLike, None]]:
@@ -267,7 +267,6 @@ class TableOperator(TupleOperatorV2):
 
     def __init__(self):
         super().__init__()
-        self.__internal_is_source: bool = False
         self.__table_data: Mapping[int, List[Tuple]] = defaultdict(list)
 
     @overrides.final

--- a/amber/src/main/python/core/models/operator.py
+++ b/amber/src/main/python/core/models/operator.py
@@ -74,7 +74,7 @@ class Operator(ABC):
     def decode_python_template(self, data: Union[str, bytes]) -> str:
         return self._get_template_decoder().decode(data)
 
-    _internal_is_source: bool = False
+    __internal_is_source: bool = False
 
     @property
     @overrides.final
@@ -85,12 +85,12 @@ class Operator(ABC):
 
         :return:
         """
-        return self._internal_is_source
+        return self.__internal_is_source
 
     @is_source.setter
     @overrides.final
     def is_source(self, value: bool) -> None:
-        self._internal_is_source = value
+        self.__internal_is_source = value
 
     def open(self) -> None:
         """
@@ -164,7 +164,7 @@ class TupleOperatorV2(Operator):
 
 
 class SourceOperator(TupleOperatorV2):
-    _internal_is_source = True
+    _Operator__internal_is_source = True
 
     @abstractmethod
     def produce(self) -> Iterator[Union[TupleLike, TableLike, None]]:
@@ -267,6 +267,7 @@ class TableOperator(TupleOperatorV2):
 
     def __init__(self):
         super().__init__()
+        self._Operator__internal_is_source: bool = False
         self.__table_data: Mapping[int, List[Tuple]] = defaultdict(list)
 
     @overrides.final

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -154,30 +154,9 @@ class TestIsSourceProperty:
         op.is_source = False
         assert op.is_source is False
 
-    def test_source_operator_class_attr_storage_diverges_from_property_read(
-        self,
-    ):
-        # Documents the underlying defect without claiming a contract: the class
-        # attribute is stored under one mangled name, the property reads from
-        # another, so they cannot agree. Asserting the two attributes directly
-        # decouples this from the eventual is_source-on-SourceOperator fix.
-        src = _ConcreteSource()
-        # The mangled attribute SourceOperator set — present but unused:
-        assert getattr(src, "_SourceOperator__internal_is_source") is True
-        # The attribute Operator.is_source actually reads — still the default:
-        assert getattr(src, "_Operator__internal_is_source") is False
-
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known bug: SourceOperator's __internal_is_source class attribute "
-            "is name-mangled to _SourceOperator__internal_is_source, while "
-            "Operator.is_source reads _Operator__internal_is_source. The "
-            "intended contract is is_source=True on SourceOperator instances; "
-            "this xfail flips to XPASS when the bug is fixed."
-        ),
-    )
-    def test_source_operator_subclass_should_report_is_source_true(self):
+    def test_source_operator_subclass_reports_is_source_true(self):
+        # The class-level _internal_is_source = True on SourceOperator must
+        # propagate through the is_source property without name mangling.
         src = _ConcreteSource()
         assert src.is_source is True
 

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -155,8 +155,6 @@ class TestIsSourceProperty:
         assert op.is_source is False
 
     def test_source_operator_subclass_reports_is_source_true(self):
-        # The class-level _internal_is_source = True on SourceOperator must
-        # propagate through the is_source property without name mangling.
         src = _ConcreteSource()
         assert src.is_source is True
 


### PR DESCRIPTION

### What changes were proposed in this PR?

  Fixes a name-mangling bug in amber/src/main/python/core/models/operator.py.
  
  Operator declared __internal_is_source (double underscore), which Python rewrites per class. So SourceOperator.__internal_is_source = True was stored as _SourceOperator__internal_is_source, while the property kept reading
  _Operator__internal_is_source. Result: SourceOperator subclasses defaulted to is_source = False, and only worked because ExecutorManager called the setter afterward.

  Fix:

 in SourceOperator and TableOperator.__init__, write to the base-class mangled slot directly via _Operator__internal_is_source. Operator keeps the __internal_is_source double-underscore form. Also removed a dead, mangled line in TableOperator.__init__.

### Any related issues, documentation, or discussions?
Closes: #4736 


### How was this PR tested?
  Updated amber/src/test/python/core/models/test_operator.py:
  - Removed the bug-pinning test that asserted on the old divergent mangled attributes.
  - Removed the xfail marker from the contract test, which now passes: SourceOperator() reports is_source is True.

  All 29 tests in test_operator.py pass.


### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.7 in Compliance with ASF
