### PR TITLE
test: tighten any types in spec mocks to Mocked<T>

### DIFF
--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
@@ -30,6 +30,7 @@ import { StubUserService } from "../../../../common/service/user/stub-user.servi
 import { UserService } from "../../../../common/service/user/user.service";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
 import type { Mocked } from "vitest";
+import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
 describe("ListItemComponent", () => {
   let component: ListItemComponent;
   let fixture: ComponentFixture<ListItemComponent>;
@@ -56,7 +57,7 @@ describe("ListItemComponent", () => {
 
   it("should update workflow name successfully", () => {
     const newName = "New Workflow Name";
-    component.entry = { id: 1, name: "Old Name", type: "workflow" } as any;
+    component.entry = { id: 1, name: "Old Name", type: "workflow" } as unknown as DashboardEntry;
     workflowPersistService.updateWorkflowName.mockReturnValue(of({} as Response));
 
     component.confirmUpdateCustomName(newName);
@@ -68,7 +69,7 @@ describe("ListItemComponent", () => {
 
   it("should handle error when updating workflow name", () => {
     const newName = "New Workflow Name";
-    component.entry = { id: 1, name: "Old Name", type: "workflow" } as any;
+    component.entry = { id: 1, name: "Old Name", type: "workflow" } as unknown as DashboardEntry;
     component.originalName = "Old Name";
     workflowPersistService.updateWorkflowName.mockReturnValue(throwError(() => new Error("Error")));
 
@@ -81,7 +82,7 @@ describe("ListItemComponent", () => {
 
   it("should update workflow description successfully", () => {
     const newDescription = "New Description";
-    component.entry = { id: 1, description: "Old Description", type: "workflow" } as any;
+    component.entry = { id: 1, description: "Old Description", type: "workflow" } as unknown as DashboardEntry;
     workflowPersistService.updateWorkflowDescription.mockReturnValue(of({} as Response));
 
     component.confirmUpdateCustomDescription(newDescription);
@@ -93,7 +94,7 @@ describe("ListItemComponent", () => {
 
   it("should handle error when updating workflow description", () => {
     const newDescription = "New Description";
-    component.entry = { id: 1, description: "Old Description", type: "workflow" } as any;
+    component.entry = { id: 1, description: "Old Description", type: "workflow" } as unknown as DashboardEntry;
     component.originalDescription = "Old Description";
     workflowPersistService.updateWorkflowDescription.mockReturnValue(throwError(() => new Error("Error")));
 

--- a/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit.component.spec.ts
@@ -32,10 +32,11 @@ import { WorkflowComputingUnitManagingService } from "../../../../common/service
 import { ComputingUnitStatusService } from "../../../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
 import { MockComputingUnitStatusService } from "../../../../common/service/computing-unit/computing-unit-status/mock-computing-unit-status.service";
 import { of } from "rxjs";
+import type { Mocked } from "vitest";
 describe("UserComputingUnitComponent", () => {
   let component: UserComputingUnitComponent;
   let fixture: ComponentFixture<UserComputingUnitComponent>;
-  let mockComputingUnitService: any;
+  let mockComputingUnitService: Mocked<WorkflowComputingUnitManagingService>;
 
   beforeEach(async () => {
     mockComputingUnitService = {
@@ -43,7 +44,7 @@ describe("UserComputingUnitComponent", () => {
       getComputingUnitLimitOptions: vi.fn(),
       createKubernetesBasedComputingUnit: vi.fn(),
       createLocalComputingUnit: vi.fn(),
-    } as any;
+    } as unknown as Mocked<WorkflowComputingUnitManagingService>;
     mockComputingUnitService.getComputingUnitTypes.mockReturnValue(of({ typeOptions: [] }));
     mockComputingUnitService.getComputingUnitLimitOptions.mockReturnValue(
       of({ cpuLimitOptions: [], memoryLimitOptions: [], gpuLimitOptions: [] })

--- a/frontend/src/app/dashboard/component/user/user-quota/user-quota.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-quota/user-quota.component.spec.ts
@@ -24,10 +24,11 @@ import { UserQuotaService } from "../../../service/user/quota/user-quota.service
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
 import { of } from "rxjs";
+import type { Mocked } from "vitest";
 describe("UserQuotaComponent", () => {
   let component: UserQuotaComponent;
   let fixture: ComponentFixture<UserQuotaComponent>;
-  let mockUserQuotaService: any;
+  let mockUserQuotaService: Mocked<UserQuotaService>;
 
   beforeEach(() => {
     mockUserQuotaService = {
@@ -36,7 +37,7 @@ describe("UserQuotaComponent", () => {
       getAccessWorkflows: vi.fn(),
       getExecutionQuota: vi.fn(),
       deleteExecutionCollection: vi.fn(),
-    };
+    } as unknown as Mocked<UserQuotaService>;
     mockUserQuotaService.getCreatedDatasets.mockReturnValue(of([]));
     mockUserQuotaService.getCreatedWorkflows.mockReturnValue(of([]));
     mockUserQuotaService.getAccessWorkflows.mockReturnValue(of([]));

--- a/frontend/src/app/dashboard/component/user/user-workflow/user-workflow-list-item/user-workflow-list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-workflow/user-workflow-list-item/user-workflow-list-item.component.spec.ts
@@ -34,6 +34,7 @@ import { provideRouter } from "@angular/router";
 import { DashboardEntry } from "../../../../type/dashboard-entry";
 import { NzTooltipModule } from "ng-zorro-antd/tooltip";
 import { commonTestProviders } from "../../../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
 
 // UserWorkflowListItemComponent is rooted at <nz-list-item>; instantiating it
 // outside an <nz-list> host throws "No provider found for NzListComponent".
@@ -57,7 +58,7 @@ class TestHostComponent {
 describe("UserWorkflowListItemComponent", () => {
   let component: UserWorkflowListItemComponent;
   let fixture: ComponentFixture<TestHostComponent>;
-  const fileSaverServiceSpy = { saveAs: vi.fn() } as any;
+  const fileSaverServiceSpy = { saveAs: vi.fn() } as unknown as Mocked<FileSaverService>;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [TestHostComponent, NzModalModule, HttpClientTestingModule, NzTooltipModule],

--- a/frontend/src/app/dashboard/component/user/user-workflow/user-workflow.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-workflow/user-workflow.component.spec.ts
@@ -61,14 +61,15 @@ import { NzModalService } from "ng-zorro-antd/modal";
 import { NzButtonModule } from "ng-zorro-antd/button";
 import { DownloadService } from "../../../service/user/download/download.service";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
 describe("SavedWorkflowSectionComponent", () => {
   let component: UserWorkflowComponent;
   let fixture: ComponentFixture<UserWorkflowComponent>;
 
-  let downloadServiceSpy: any;
+  let downloadServiceSpy: Mocked<DownloadService>;
 
   beforeEach(async () => {
-    downloadServiceSpy = { downloadWorkflowsAsZip: vi.fn() } as any;
+    downloadServiceSpy = { downloadWorkflowsAsZip: vi.fn() } as unknown as Mocked<DownloadService>;
 
     await TestBed.configureTestingModule({
       providers: [

--- a/frontend/src/app/workspace/component/code-editor-dialog/breakpoint-condition-input/breakpoint-condition-input.component.spec.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/breakpoint-condition-input/breakpoint-condition-input.component.spec.ts
@@ -24,14 +24,19 @@ import { BreakpointConditionInputComponent } from "./breakpoint-condition-input.
 import { UdfDebugService } from "../../../service/operator-debug/udf-debug.service";
 import { SimpleChanges } from "@angular/core";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
+import type { editor } from "monaco-editor";
 describe("BreakpointConditionInputComponent", () => {
   let component: BreakpointConditionInputComponent;
   let fixture: ComponentFixture<BreakpointConditionInputComponent>;
-  let mockUdfDebugService: any;
+  let mockUdfDebugService: Mocked<UdfDebugService>;
 
   beforeEach(async () => {
     // Create a mock UdfDebugService
-    mockUdfDebugService = { getCondition: vi.fn(), doUpdateBreakpointCondition: vi.fn() };
+    mockUdfDebugService = {
+      getCondition: vi.fn(),
+      doUpdateBreakpointCondition: vi.fn(),
+    } as unknown as Mocked<UdfDebugService>;
 
     await TestBed.configureTestingModule({
       imports: [BreakpointConditionInputComponent, CommonModule, FormsModule],
@@ -51,7 +56,7 @@ describe("BreakpointConditionInputComponent", () => {
       getScrollTop: () => 5,
       getScrollLeft: () => 0,
       dispose: vi.fn(),
-    } as any;
+    } as unknown as editor.IStandaloneCodeEditor;
 
     // Set required inputs
     component.operatorId = "test-operator";

--- a/frontend/src/app/workspace/component/code-editor-dialog/code-debugger.component.spec.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/code-debugger.component.spec.ts
@@ -27,12 +27,15 @@ import * as Y from "yjs";
 import { BreakpointInfo } from "../../types/workflow-common.interface";
 import { OperatorState, OperatorStatistics } from "../../types/execute-workflow.interface";
 import { commonTestProviders } from "../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
+import type { MonacoBreakpoint } from "monaco-breakpoints";
+import type * as monaco from "monaco-editor";
 describe("CodeDebuggerComponent", () => {
   let component: CodeDebuggerComponent;
   let fixture: ComponentFixture<CodeDebuggerComponent>;
 
-  let mockWorkflowStatusService: any;
-  let mockUdfDebugService: any;
+  let mockWorkflowStatusService: Mocked<WorkflowStatusService>;
+  let mockUdfDebugService: Mocked<UdfDebugService>;
 
   let statusUpdateStream: Subject<Record<string, OperatorStatistics>>;
   let debugState: Y.Map<BreakpointInfo>;
@@ -44,10 +47,13 @@ describe("CodeDebuggerComponent", () => {
     statusUpdateStream = new Subject<Record<string, OperatorStatistics>>();
     debugState = new Y.Map<BreakpointInfo>();
 
-    mockWorkflowStatusService = { getStatusUpdateStream: vi.fn() };
+    mockWorkflowStatusService = { getStatusUpdateStream: vi.fn() } as unknown as Mocked<WorkflowStatusService>;
     mockWorkflowStatusService.getStatusUpdateStream.mockReturnValue(statusUpdateStream.asObservable());
 
-    mockUdfDebugService = { getDebugState: vi.fn(), doModifyBreakpoint: vi.fn() };
+    mockUdfDebugService = {
+      getDebugState: vi.fn(),
+      doModifyBreakpoint: vi.fn(),
+    } as unknown as Mocked<UdfDebugService>;
     mockUdfDebugService.getDebugState.mockReturnValue(debugState);
 
     await TestBed.configureTestingModule({
@@ -65,7 +71,7 @@ describe("CodeDebuggerComponent", () => {
 
     // Set required input properties
     component.currentOperatorId = operatorId;
-    component.monacoEditor = { dispose: vi.fn() } as any;
+    component.monacoEditor = { dispose: vi.fn() } as unknown as monaco.editor.IStandaloneCodeEditor;
 
     // Trigger change detection to ensure view updates
     fixture.detectChanges();
@@ -206,7 +212,7 @@ describe("CodeDebuggerComponent", () => {
         [1, "breakpoint1"],
         [2, "breakpoint2"],
       ]),
-    } as any;
+    } as unknown as MonacoBreakpoint;
 
     // Simulate a right click on line 1, it should switch to 1
     component["onMouseRightClick"](1);

--- a/frontend/src/app/workspace/component/menu/menu.component.spec.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.spec.ts
@@ -43,6 +43,10 @@ import { ExecutionState } from "../../types/execute-workflow.interface";
 import { ComputingUnitState } from "../../../common/type/computing-unit-connection.interface";
 import { mockPoint, mockScanPredicate } from "../../service/workflow-graph/model/mock-workflow-data";
 import { saveAs } from "file-saver";
+import type { ModalOptions } from "ng-zorro-antd/modal";
+import { ComputingUnitSelectionComponent } from "../power-button/computing-unit-selection.component";
+import { WorkflowContent } from "../../../common/type/workflow";
+import type { Mocked } from "vitest";
 
 vi.mock("file-saver", () => ({ saveAs: vi.fn() }));
 
@@ -304,7 +308,7 @@ describe("MenuComponent", () => {
       component.computingUnitSelectionComponent = {
         newComputingUnitName: "",
         showAddComputeUnitModalVisible: vi.fn(),
-      } as any;
+      } as unknown as Mocked<ComputingUnitSelectionComponent>;
     });
 
     it("does nothing when the workflow is invalid", () => {
@@ -368,7 +372,12 @@ describe("MenuComponent", () => {
 
   describe("onClickExportWorkflow (save)", () => {
     it("serializes the workflow content as JSON and downloads it under the workflow name", () => {
-      const fakeContent = { operators: [{ operatorID: "op1" }], links: [], commentBoxes: [], settings: {} } as any;
+      const fakeContent = {
+        operators: [{ operatorID: "op1" }],
+        links: [],
+        commentBoxes: [],
+        settings: {},
+      } as unknown as WorkflowContent;
       vi.spyOn(workflowActionService, "getWorkflowContent").mockReturnValue(fakeContent);
       component.currentWorkflowName = "my-workflow";
 
@@ -448,7 +457,7 @@ describe("MenuComponent", () => {
       await component.onClickOpenShareAccess();
 
       expect(createSpy).toHaveBeenCalledTimes(1);
-      const config = createSpy.mock.calls[0][0] as any;
+      const config = createSpy.mock.calls[0][0] as ModalOptions;
       expect(config.nzTitle).toBe("Share this workflow with others");
       expect(config.nzData).toEqual(
         expect.objectContaining({
@@ -484,7 +493,7 @@ describe("MenuComponent", () => {
 
   it("onClickEditDescription opens the markdown description modal seeded with the current description", () => {
     vi.spyOn(workflowActionService, "getWorkflow").mockReturnValue({
-      content: { operators: [], links: [], commentBoxes: [], settings: {} } as any,
+      content: { operators: [], links: [], commentBoxes: [], settings: {} } as unknown as WorkflowContent,
       name: "wf",
       description: "hello world",
       wid: 1,
@@ -503,7 +512,7 @@ describe("MenuComponent", () => {
     component.onClickEditDescription();
 
     expect(createSpy).toHaveBeenCalledTimes(1);
-    const config = createSpy.mock.calls[0][0] as any;
+    const config = createSpy.mock.calls[0][0] as ModalOptions;
     expect(config.nzTitle).toBe("Edit Workflow Description");
     expect(config.nzData).toEqual({ description: "hello world" });
   });
@@ -516,7 +525,7 @@ describe("MenuComponent", () => {
     component.onClickExportExecutionResult();
 
     expect(createSpy).toHaveBeenCalledTimes(1);
-    const config = createSpy.mock.calls[0][0] as any;
+    const config = createSpy.mock.calls[0][0] as ModalOptions;
     expect(config.nzTitle).toBe("Export All Operators Result");
     expect(config.nzData).toEqual(expect.objectContaining({ workflowName: "report-wf", sourceTriggered: "menu" }));
   });

--- a/frontend/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
@@ -35,14 +35,16 @@ import { ValidationWorkflowService } from "src/app/workspace/service/validation/
 import { NzModalModule, NzModalService } from "ng-zorro-antd/modal";
 import { commonTestProviders } from "../../../../../common/testing/test-utils"; // Import NzModalModule and NzModalService
 import type { Mocked } from "vitest";
+import { JointGraphWrapper } from "src/app/workspace/service/workflow-graph/model/joint-graph-wrapper";
+import { WorkflowGraph } from "src/app/workspace/service/workflow-graph/model/workflow-graph";
 describe("ContextMenuComponent", () => {
   let component: ContextMenuComponent;
   let fixture: ComponentFixture<ContextMenuComponent>;
   let workflowActionService: Mocked<WorkflowActionService>;
   let workflowResultService: Mocked<WorkflowResultService>;
   let workflowResultExportService: Mocked<WorkflowResultExportService>;
-  let operatorMenuService: any; // We'll define this more precisely below
-  let jointGraphWrapperSpy: any;
+  let operatorMenuService: Mocked<OperatorMenuService>;
+  let jointGraphWrapperSpy: Mocked<JointGraphWrapper>;
   let validationWorkflowService: Mocked<ValidationWorkflowService>;
 
   beforeEach(async () => {
@@ -51,7 +53,7 @@ describe("ContextMenuComponent", () => {
       getCurrentHighlightedOperatorIDs: vi.fn(),
       getCurrentHighlightedCommentBoxIDs: vi.fn(),
       getCurrentHighlightedLinkIDs: vi.fn(),
-    };
+    } as unknown as Mocked<JointGraphWrapper>;
 
     jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.mockReturnValue([]);
     jointGraphWrapperSpy.getCurrentHighlightedCommentBoxIDs.mockReturnValue([]);
@@ -99,7 +101,7 @@ describe("ContextMenuComponent", () => {
       viewResultHighlightedOperators: vi.fn(),
       reuseResultHighlightedOperator: vi.fn(),
       executeUpToOperator: vi.fn(),
-    };
+    } as unknown as Mocked<OperatorMenuService>;
 
     const validationWorkflowServiceSpy = { validateOperator: vi.fn() };
 
@@ -188,10 +190,10 @@ describe("ContextMenuComponent", () => {
   });
 
   describe("canExecuteOperator", () => {
-    let texeraGraphSpy: any;
+    let texeraGraphSpy: Mocked<WorkflowGraph>;
 
     beforeEach(() => {
-      texeraGraphSpy = workflowActionService.getTexeraGraph() as any;
+      texeraGraphSpy = workflowActionService.getTexeraGraph() as unknown as Mocked<WorkflowGraph>;
       jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.mockReturnValue(["op1"]);
       component.isWorkflowModifiable = true;
       validationWorkflowService.validateOperator.mockReturnValue({ isValid: true });

--- a/frontend/src/app/workspace/service/operator-debug/udf-debug.service.spec.ts
+++ b/frontend/src/app/workspace/service/operator-debug/udf-debug.service.spec.ts
@@ -33,12 +33,13 @@ import * as Y from "yjs";
 import { ConsoleUpdateEvent } from "../../types/workflow-common.interface";
 import { TexeraWebsocketEvent } from "../../types/workflow-websocket.interface";
 import { commonTestProviders } from "../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
 describe("UdfDebugServiceSpec", () => {
   let service: UdfDebugService;
   let workflowActionService: WorkflowActionService;
-  let mockWorkflowWebsocketService: any;
-  let mockWorkflowStatusService: any;
-  let mockExecuteWorkflowService: any;
+  let mockWorkflowWebsocketService: Mocked<WorkflowWebsocketService>;
+  let mockWorkflowStatusService: Mocked<WorkflowStatusService>;
+  let mockExecuteWorkflowService: Mocked<ExecuteWorkflowService>;
   let statusUpdateStream: Subject<Record<string, OperatorStatistics>>;
   let consoleUpdateEventStream: Subject<ConsoleUpdateEvent>;
   let texeraGraph: WorkflowGraphReadonly;
@@ -46,9 +47,12 @@ describe("UdfDebugServiceSpec", () => {
 
   beforeEach(() => {
     // Create mock services
-    mockWorkflowWebsocketService = { send: vi.fn(), subscribeToEvent: vi.fn() };
-    mockWorkflowStatusService = { getStatusUpdateStream: vi.fn() };
-    mockExecuteWorkflowService = { getWorkerIds: vi.fn() };
+    mockWorkflowWebsocketService = {
+      send: vi.fn(),
+      subscribeToEvent: vi.fn(),
+    } as unknown as Mocked<WorkflowWebsocketService>;
+    mockWorkflowStatusService = { getStatusUpdateStream: vi.fn() } as unknown as Mocked<WorkflowStatusService>;
+    mockExecuteWorkflowService = { getWorkerIds: vi.fn() } as unknown as Mocked<ExecuteWorkflowService>;
 
     // Initialize the mock streams
     statusUpdateStream = new Subject();

--- a/frontend/src/app/workspace/service/preset/preset.service.spec.ts
+++ b/frontend/src/app/workspace/service/preset/preset.service.spec.ts
@@ -114,7 +114,7 @@ describe("PresetService", () => {
 
   describe("preset I/O", () => {
     it("emits an event on applyPresetStream when a preset is applied", () => {
-      const seen: any[] = [];
+      const seen: { type: string; target: string; preset: Preset }[] = [];
       const sub = presetService.applyPresetStream.subscribe(value => seen.push(value));
 
       const preset: Preset = { presetProperty: "applied" };
@@ -125,7 +125,7 @@ describe("PresetService", () => {
     });
 
     it("emits an event on savePresetsStream when presets are saved", () => {
-      const seen: any[] = [];
+      const seen: { type: string; target: string; presets: Preset[] }[] = [];
       const sub = presetService.savePresetsStream.subscribe(value => seen.push(value));
 
       const presets: Preset[] = [{ presetProperty: "v1" }];

--- a/frontend/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
@@ -31,6 +31,8 @@ import { DownloadService } from "src/app/dashboard/service/user/download/downloa
 import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.service";
 import { commonTestProviders } from "../../../common/testing/test-utils";
 import type { Mocked } from "vitest";
+import { JointGraphWrapper } from "../workflow-graph/model/joint-graph-wrapper";
+import { WorkflowGraph } from "../workflow-graph/model/workflow-graph";
 describe("WorkflowResultExportService", () => {
   let service: WorkflowResultExportService;
   let workflowWebsocketServiceSpy: Mocked<WorkflowWebsocketService>;
@@ -41,8 +43,8 @@ describe("WorkflowResultExportService", () => {
   let downloadServiceSpy: Mocked<DownloadService>;
   let datasetServiceSpy: Mocked<DatasetService>;
 
-  let jointGraphWrapperSpy: any;
-  let texeraGraphSpy: any;
+  let jointGraphWrapperSpy: Mocked<JointGraphWrapper>;
+  let texeraGraphSpy: Mocked<WorkflowGraph>;
 
   beforeEach(() => {
     // Create spies for the required services
@@ -50,7 +52,7 @@ describe("WorkflowResultExportService", () => {
       getCurrentHighlightedOperatorIDs: vi.fn(),
       getJointOperatorHighlightStream: vi.fn(),
       getJointOperatorUnhighlightStream: vi.fn(),
-    };
+    } as unknown as Mocked<JointGraphWrapper>;
     jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.mockReturnValue([]);
     jointGraphWrapperSpy.getJointOperatorHighlightStream.mockReturnValue(of());
     jointGraphWrapperSpy.getJointOperatorUnhighlightStream.mockReturnValue(of());
@@ -64,7 +66,7 @@ describe("WorkflowResultExportService", () => {
       getLinkDeleteStream: vi.fn(),
       getDisabledOperatorsChangedStream: vi.fn(),
       getAllLinks: vi.fn(),
-    };
+    } as unknown as Mocked<WorkflowGraph>;
     texeraGraphSpy.getAllOperators.mockReturnValue([]);
     texeraGraphSpy.getOperatorAddStream.mockReturnValue(of());
     texeraGraphSpy.getOperatorDeleteStream.mockReturnValue(of());

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
@@ -23,6 +23,7 @@ import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websock
 import { firstValueFrom, of, Subject } from "rxjs";
 import { SchemaAttribute } from "../../types/workflow-compiling.interface";
 import { commonTestProviders } from "../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
 describe("WorkflowResultService", () => {
   let service: WorkflowResultService;
 
@@ -40,10 +41,13 @@ describe("WorkflowResultService", () => {
 
 describe("OperatorPaginationResultService", () => {
   let service: OperatorPaginationResultService;
-  let mockWorkflowWebsocketService: any;
+  let mockWorkflowWebsocketService: Mocked<WorkflowWebsocketService>;
 
   beforeEach(() => {
-    mockWorkflowWebsocketService = { subscribeToEvent: vi.fn(), send: vi.fn() };
+    mockWorkflowWebsocketService = {
+      subscribeToEvent: vi.fn(),
+      send: vi.fn(),
+    } as unknown as Mocked<WorkflowWebsocketService>;
     mockWorkflowWebsocketService.subscribeToEvent.mockReturnValue(new Subject());
 
     service = new OperatorPaginationResultService("testOperator", mockWorkflowWebsocketService);


### PR DESCRIPTION
### What changes were proposed in this PR?
  - Replace `let mockX: any;` declarations in 13 active spec files with `Mocked<T>` from Vitest.
  - Replace `{...} as any` mock-literal casts with `as unknown as Mocked<T>` (or the appropriate concrete type for component property assignments and partial fixtures).
  - Replace `seen: any[]` accumulators in `preset.service.spec.ts` with the actual stream event types.
  - Skip the two pre-existing out-of-scope patterns: `(svc as any).privateField` private-member access and `as any as joint.dia.Link` JointJS partial-mocks.


### Any related issues, documentation, or discussions?
Closes: #4867 

### How was this PR tested?
 - `tsc --project src/tsconfig.spec.json --noEmit` passes with no errors.
  - No runtime test behavior changed — only type annotations and casts.

### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.7 in compliance with ASF
