### PR TITLE
ci: fix merge queue ruleset payload

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,7 +66,7 @@ github:
     rebase:  false
 
   rulesets:
-    - name: merge-queue-texera
+    - name: Merge Queue
       target: branch
       enforcement: active
       conditions:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,10 +66,8 @@ github:
     rebase:  false
 
   rulesets:
-    - name: Merge Queue
+    - name: merge-queue-texera
       target: branch
-      source_type: Repository
-      source:
       enforcement: active
       conditions:
         ref_name:
@@ -90,6 +88,8 @@ github:
             check_response_timeout_minutes: 30
         - type: pull_request
           parameters:
+            allowed_merge_methods:
+              - squash
             dismiss_stale_reviews_on_push: false
             require_code_owner_review: false
             require_last_push_approval: false
@@ -99,14 +99,10 @@ github:
         - type: required_status_checks
           parameters:
             strict_required_status_checks_policy: false
-            do_not_enforce_on_create: false
             required_status_checks:
               - context: Required Checks
-                integration_id: -1
               - context: Check License Headers
-                integration_id: -1
               - context: Validate PR title
-                integration_id: -1
 
 notifications:
   commits:              commits@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR is a follow-up to #5036 to keep enabling GitHub merge queue while making the ruleset payload accepted by the GitHub repository rulesets API after ASF Infra reported validation errors for the rules array.

Merge queue support:
- Keep the `merge_queue` rule in `.asf.yaml`; this PR does not remove or disable merge queue.
- Keep the ruleset display/reconciliation name as `Merge Queue`.
- Keep the same merge queue behavior: squash merge, up to 5 entries, `ALLGREEN`, and a 30-minute check response timeout.

Payload compatibility changes:
- Remove `source_type` and `source` from the raw ruleset payload because they are response fields and are not needed in the create request body.
- Add `allowed_merge_methods: [squash]` to the `pull_request` rule so the pull request rule explicitly matches the repository merge policy.
- Remove `do_not_enforce_on_create` from the `required_status_checks` rule to keep the payload aligned with the asfyaml raw ruleset example.
- Remove `integration_id: -1` from required status checks because direct GitHub API validation rejected `-1` as an invalid integration id, while omitting the field is accepted.

Validation notes:
- Direct API validation on a personal fork rejected `merge_queue`, which appears to be because merge queue is only available for organization-owned repositories.
- Retested on the organization-owned public repository `Texera/Udon` using the `Yicong-Huang` admin account.
- A minimal disabled `merge_queue` ruleset was created successfully on `Texera/Udon` and deleted immediately afterward.
- The full #5050 payload, including the ruleset name `Merge Queue`, was also created successfully as a disabled ruleset on `Texera/Udon` and deleted immediately afterward.
- This confirms the updated payload shape supports `merge_queue` in an org-owned repository context.

### Any related issues, documentation, discussions?
Related to #4553 and follow-up to #5036.

### How was this PR tested?
Ran local configuration checks:

```bash
ruby -e 'require "yaml"; cfg=YAML.load_file(".asf.yaml"); rs=cfg.dig("github", "rulesets").find { |r| r["name"] == "Merge Queue" }; abort "missing ruleset" unless rs; abort "unexpected source fields" if rs.key?("source_type") || rs.key?("source"); pr=rs["rules"].find { |r| r["type"] == "pull_request" }; abort "missing allowed_merge_methods" unless pr.dig("parameters", "allowed_merge_methods") == ["squash"]; status=rs["rules"].find { |r| r["type"] == "required_status_checks" }; abort "unexpected do_not_enforce_on_create" if status["parameters"].key?("do_not_enforce_on_create"); abort "unexpected integration_id" if status["parameters"]["required_status_checks"].any? { |c| c.key?("integration_id") }; puts "ruleset sanity ok"'
git diff --check
```

Also validated against the GitHub repository rulesets API on `Texera/Udon`:
- Created and deleted a temporary disabled minimal `merge_queue` ruleset.
- Created and deleted a temporary disabled ruleset using the full #5050 payload with the name `Merge Queue`.

No automated runtime tests were added because this PR only changes repository configuration.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: OpenAI Codex (GPT-5)
