### PR TITLE
fix(frontend): remove stray ']="true"' in user-dataset search input

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
@@ -45,7 +45,6 @@
       nzMode="tags"
       nzPlaceHolder="Search all dataset"
       nzVariant="borderless"
-      ]="true"
       [nzOpen]="false"
       ngDefaultControl
       [(ngModel)]="filters.masterFilterList"


### PR DESCRIPTION
### What changes were proposed in this PR?

Delete a stray `]="true"` line in `frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html`.

**Root cause.** The standalone-conversion codemod from [#4873](https://github.com/apache/texera/pull/4873) (commit [`3dd556a`](https://github.com/apache/texera/commit/3dd556a61c)) partially stripped an Angular property binding off the `<nz-select>` in this template, leaving a bare `]="true"` with no matching `[<attribute>` opening.

**Symptom.** During `UserDatasetComponent` initialization Angular calls `element.setAttribute(']', 'true')`, which the browser rejects with:

```
InvalidCharacterError: Invalid qualified name: ']'
    at setAttribute (_dom_renderer-chunk.mjs:587)
    at UserDatasetComponent_Template — user-dataset.component.html:41
```

This blocks rendering of **both** `/dashboard/user/dataset` and `/dashboard/user/workflow` (both routes load the same template chunk), so users hit a blank page after login.

**Fix.** Delete the orphan line. Surrounding `[nzOpen]`, `[(ngModel)]`, `[nzAllowClear]` bindings render fine on their own.

#### Before / after diff

```diff
       nzVariant="borderless"
-      ]="true"
       [nzOpen]="false"
       ngDefaultControl
       [(ngModel)]="filters.masterFilterList"
       [nzAllowClear]="true">
```

---

### Any related issues, documentation, discussions?

- Regression introduced by commit [`3dd556a`](https://github.com/apache/texera/commit/3dd556a61c) (PR [#4873](https://github.com/apache/texera/pull/4873) — "refactor(frontend): convert all components to standalone").
- No tracking issue was filed — the fix is one line and the root cause is mechanical (codemod off-by-one).

---

### How was this PR tested?

1. **Formatting** (per `CONTRIBUTING.md` "yarn format:fix"). Ran the project's prettier-eslint pipeline against the changed file:
   ```
   yarn prettier-eslint --list-different \
     src/app/dashboard/component/user/user-dataset/user-dataset.component.html
   ```
   → exit 0, no diff. The file already conforms to the project format.

2. **Production build.** `yarn build` (≡ `ng build --configuration=production`) → **exit 0**. 

---

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7

The bug was diagnosed with assistance from Claude Code (Anthropic Claude Opus 4.7), which read the FileService server-side stack trace and Safari console error, traced the regression to commit [`3dd556a`](https://github.com/apache/texera/commit/3dd556a61c) via `git blame`, and authored this PR description. The one-line code change was reviewed and verified manually.
