### PR TITLE
fix: raise when presigned URL response is missing or malformed

### DIFF
--- a/amber/src/main/python/pytexera/storage/dataset_file_document.py
+++ b/amber/src/main/python/pytexera/storage/dataset_file_document.py
@@ -80,8 +80,7 @@ class DatasetFileDocument:
             payload = response.json()
         except ValueError as e:
             raise RuntimeError(
-                f"Failed to get presigned URL: invalid JSON response: "
-                f"{response.text}"
+                f"Failed to get presigned URL: invalid JSON response: {response.text}"
             ) from e
 
         presigned_url = payload.get("presignedUrl")

--- a/amber/src/main/python/pytexera/storage/dataset_file_document.py
+++ b/amber/src/main/python/pytexera/storage/dataset_file_document.py
@@ -76,7 +76,22 @@ class DatasetFileDocument:
                 f"Failed to get presigned URL: {response.status_code} {response.text}"
             )
 
-        return response.json().get("presignedUrl")
+        try:
+            payload = response.json()
+        except ValueError as e:
+            raise RuntimeError(
+                f"Failed to get presigned URL: invalid JSON response: "
+                f"{response.text}"
+            ) from e
+
+        presigned_url = payload.get("presignedUrl")
+        if not isinstance(presigned_url, str) or not presigned_url:
+            raise RuntimeError(
+                f"Failed to get presigned URL: 'presignedUrl' missing from "
+                f"response: {response.text}"
+            )
+
+        return presigned_url
 
     def read_file(self) -> io.BytesIO:
         """

--- a/amber/src/test/python/pytexera/storage/test_dataset_file_document.py
+++ b/amber/src/test/python/pytexera/storage/test_dataset_file_document.py
@@ -137,13 +137,12 @@ class TestGetPresignedUrl:
             with pytest.raises(RuntimeError, match=r"403.*forbidden"):
                 doc.get_presigned_url()
 
-    def test_returns_none_when_response_body_lacks_presigned_url_key(self, monkeypatch):
-        # Pins current behavior: a 200 with no "presignedUrl" key yields None
-        # rather than raising. read_file() will then call requests.get(None).
+    def test_raises_when_response_body_lacks_presigned_url_key(self, monkeypatch):
         doc = self._make_doc(monkeypatch)
         with patch("pytexera.storage.dataset_file_document.requests.get") as mock_get:
             mock_get.return_value = make_response(200, body={"other": "value"})
-            assert doc.get_presigned_url() is None
+            with pytest.raises(RuntimeError, match="'presignedUrl' missing"):
+                doc.get_presigned_url()
 
 
 class TestReadFile:

--- a/amber/src/test/python/pytexera/storage/test_dataset_file_document.py
+++ b/amber/src/test/python/pytexera/storage/test_dataset_file_document.py
@@ -144,6 +144,31 @@ class TestGetPresignedUrl:
             with pytest.raises(RuntimeError, match="'presignedUrl' missing"):
                 doc.get_presigned_url()
 
+    def test_raises_when_response_body_is_not_valid_json(self, monkeypatch):
+        doc = self._make_doc(monkeypatch)
+        with patch("pytexera.storage.dataset_file_document.requests.get") as mock_get:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.side_effect = ValueError("Expecting value")
+            response.text = "<html>not json</html>"
+            mock_get.return_value = response
+            with pytest.raises(RuntimeError, match="invalid JSON response"):
+                doc.get_presigned_url()
+
+    def test_raises_when_presigned_url_is_empty_string(self, monkeypatch):
+        doc = self._make_doc(monkeypatch)
+        with patch("pytexera.storage.dataset_file_document.requests.get") as mock_get:
+            mock_get.return_value = make_response(200, body={"presignedUrl": ""})
+            with pytest.raises(RuntimeError, match="'presignedUrl' missing"):
+                doc.get_presigned_url()
+
+    def test_raises_when_presigned_url_is_not_a_string(self, monkeypatch):
+        doc = self._make_doc(monkeypatch)
+        with patch("pytexera.storage.dataset_file_document.requests.get") as mock_get:
+            mock_get.return_value = make_response(200, body={"presignedUrl": None})
+            with pytest.raises(RuntimeError, match="'presignedUrl' missing"):
+                doc.get_presigned_url()
+
 
 class TestReadFile:
     def _make_doc(self, monkeypatch):


### PR DESCRIPTION
### What changes were proposed in this PR?
  `DatasetFileDocument.get_presigned_url` previously returned `response.json().get("presignedUrl")` on a 200 response, so a body that omitted the key (or wasn't valid JSON) silently returned `None`. This PR parses the JSON inside a try/except block and validates that `presignedUrl` is a non-empty string; otherwise, it raises `RuntimeError` with the response body.
  ### Any related issues, documentation, or discussions?
  Closes: #4725
  ### How was this PR tested?
  Manually reproduced the missing-key case (mocked 200 + empty JSON) and confirmed the new `RuntimeError` is raised at the presign step instead of a downstream `requests.get(None)` failure. 

  ### Was this PR authored or co-authored using generative AI tooling?
  Co-authored with Claude Opus 4.7 in compliance with ASF