### PR TITLE
[Hackathon] feat(bin): one-command local dev orchestrator (bin/texera)

### DIFF
--- a/bin/build-services.sh
+++ b/bin/build-services.sh
@@ -28,5 +28,8 @@ rm config-service/target/universal/config-service-*.zip
 unzip computing-unit-managing-service/target/universal/computing-unit-managing-service-*.zip -d target/
 rm computing-unit-managing-service/target/universal/computing-unit-managing-service-*.zip
 
-unzip amber/target/universal/texera-*.zip -d amber/target/
-rm amber/target/universal/texera-*.zip
+unzip access-control-service/target/universal/access-control-service-*.zip -d target/
+rm access-control-service/target/universal/access-control-service-*.zip
+
+unzip amber/target/universal/amber-*.zip -d amber/target/
+rm amber/target/universal/amber-*.zip

--- a/bin/check-services.sh
+++ b/bin/check-services.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# check-services.sh — probe each Texera HTTP service and report UP/DOWN.
+# A service is UP if its application port returns any HTTP response within
+# the timeout. Non-HTTP probes (e.g. WebSocket) are not covered.
+# Exit 0 if every service responded, 1 otherwise.
+
+set -u
+
+HOST="${TEXERA_HOST:-localhost}"
+TIMEOUT="${TEXERA_PROBE_TIMEOUT:-2}"
+
+# name|port pairs, in display order
+SERVICES=(
+  "texera-web-application|8080"
+  "computing-unit-master|8085"
+  "computing-unit-managing-service|8888"
+  "workflow-compiling-service|9090"
+  "file-service|9092"
+  "config-service|9094"
+  "access-control-service|9096"
+)
+
+if [ -t 1 ]; then
+  TTY=1
+  TERM_LINES=$(tput lines 2>/dev/null || echo 0)
+  GREEN=$'\033[0;32m'; RED=$'\033[0;31m'
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+else
+  TTY=0
+  TERM_LINES=0
+  GREEN=""; RED=""; BOLD=""; DIM=""; RESET=""
+fi
+
+BAR="════════════════════════════════════════════════════════════"
+
+down_names=()
+down_ports=()
+down_reasons=()
+total=${#SERVICES[@]}
+
+printf '%-34s %-6s %-6s %s\n' "SERVICE" "PORT" "STATE" "DETAIL"
+
+for entry in "${SERVICES[@]}"; do
+  name="${entry%%|*}"
+  port="${entry##*|}"
+
+  # %{http_code} prints 000 when curl never got an HTTP response.
+  read -r code curl_err <<EOF
+$(curl --silent --output /dev/null \
+       --max-time "$TIMEOUT" \
+       --write-out '%{http_code} %{errormsg}\n' \
+       "http://$HOST:$port/" 2>/dev/null)
+EOF
+
+  if [ "${code:-000}" != "000" ] && [ -n "$code" ]; then
+    printf '%-34s :%-5s %sUP%s    %s(HTTP %s)%s\n' \
+      "$name" "$port" "$GREEN" "$RESET" "$DIM" "$code" "$RESET"
+  else
+    detail="${curl_err:-no response}"
+    printf '%-34s :%-5s %sDOWN%s  %s(%s)%s\n' \
+      "$name" "$port" "$RED" "$RESET" "$DIM" "$detail" "$RESET"
+    down_names+=("$name")
+    down_ports+=("$port")
+    down_reasons+=("$detail")
+  fi
+done
+
+# Pad with blank lines so the banner ends at the terminal's bottom row.
+# Banner height = 1 leading blank + 1 bar + 1 title + 1 bar [+ N items + 1 bar].
+down_count=${#down_names[@]}
+if [ "$down_count" -gt 0 ]; then
+  banner_height=$((4 + down_count + 1))
+else
+  banner_height=4
+fi
+table_lines=$((1 + total))  # header + per-service rows
+if [ "$TTY" = "1" ] && [ "$TERM_LINES" -gt 0 ]; then
+  fill=$((TERM_LINES - table_lines - banner_height))
+  while [ "$fill" -gt 0 ]; do echo; fill=$((fill - 1)); done
+fi
+
+if [ "$down_count" -gt 0 ]; then
+  printf '\n%s%s%s%s\n' "$BOLD" "$RED" "$BAR" "$RESET"
+  printf '%s%s✗ %d of %d SERVICES DOWN%s\n' \
+    "$BOLD" "$RED" "$down_count" "$total" "$RESET"
+  printf '%s%s%s%s\n' "$BOLD" "$RED" "$BAR" "$RESET"
+  for i in "${!down_names[@]}"; do
+    printf '  %s%-32s%s :%-5s %s%s%s\n' \
+      "$BOLD" "${down_names[$i]}" "$RESET" \
+      "${down_ports[$i]}" \
+      "$DIM" "${down_reasons[$i]}" "$RESET"
+  done
+  printf '%s%s%s%s\n' "$BOLD" "$RED" "$BAR" "$RESET"
+  exit 1
+fi
+
+printf '\n%s%s%s%s\n' "$BOLD" "$GREEN" "$BAR" "$RESET"
+printf '%s%s✓ ALL %d SERVICES STARTED SUCCESSFULLY%s\n' \
+  "$BOLD" "$GREEN" "$total" "$RESET"
+printf '%s%s%s%s\n' "$BOLD" "$GREEN" "$BAR" "$RESET"
+exit 0

--- a/bin/texera
+++ b/bin/texera
@@ -1,0 +1,875 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# bin/texera — one-command dev orchestrator for Texera.
+#
+# Subcommands:
+#   texera setup        Verify toolchain, build staged binaries, install deps, apply SQL.
+#   texera build        Re-build staged backend binaries (re-run after backend code changes).
+#   texera start        Start Postgres + LakeFS/MinIO + 7 JVM services + frontend.
+#   texera stop         Stop everything started by `texera start`.
+#   texera status       Report which services are reachable on their HTTP ports.
+#   texera logs <svc>   Tail the log file for one service.
+#
+# Each JVM service runs from its sbt-native-packager staged binary
+# (`bin/build-services.sh` produces these). That avoids the sbt boot-lock
+# contention you get from launching several `sbt runMain` processes in
+# parallel, and it skips the sbt startup overhead per service.
+
+set -u
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$ROOT/logs/texera-dev"
+PID_DIR="$LOG_DIR/pids"
+mkdir -p "$LOG_DIR" "$PID_DIR"
+
+# ---- Service registry --------------------------------------------------------
+# Row schema: name | cwd (relative to ROOT) | glob to staged binary | http port (or "-")
+# Launch order matters: ComputingUnitMaster MUST start before Worker (Pekko cluster).
+SERVICES=(
+  "config|.|target/config-service-*/bin/config-service|9094"
+  "compile|.|target/workflow-compiling-service-*/bin/workflow-compiling-service|9090"
+  "file|.|target/file-service-*/bin/file-service|9092"
+  "managing|.|target/computing-unit-managing-service-*/bin/computing-unit-managing-service|8888"
+  "access|.|target/access-control-service-*/bin/access-control-service|9096"
+  "master|amber|target/amber-*/bin/computing-unit-master|8085"
+  "worker|amber|target/amber-*/bin/computing-unit-worker|-"
+  "web|amber|target/amber-*/bin/texera-web-application|8080"
+)
+
+FRONTEND_LABEL="frontend"
+LAKEFS_COMPOSE_DIR="$ROOT/file-service/src/main/resources"
+
+# ---- Startup modes ----------------------------------------------------------
+# Row schema: key | label | description | run_infra | run_backend | run_frontend
+# `run_infra` covers Postgres readiness + LakeFS/MinIO docker compose.
+# `run_backend` covers the 7 staged JVM services.
+# `run_frontend` covers `yarn start` in frontend/.
+MODES=(
+  "full|Full|Postgres + LakeFS/MinIO + all backend services + agent + frontend|1|1|1"
+  "backend|Backend|Infra + all backend services + agent (no frontend)|1|1|0"
+  "frontend|Frontend|Frontend only — assumes backend is already running|0|0|1"
+  "infra|Infra|Postgres + LakeFS/MinIO only — run backend services yourself|1|0|0"
+  "services|Services|Backend services + agent + frontend — assumes infra is already running|0|1|1"
+)
+
+# ---- Color palette for log prefixes -----------------------------------------
+COLORS=(31 32 33 34 35 36 91 92 93 94 95 96)
+color_for() {
+  local s="$1"
+  local sum=0
+  for ((i = 0; i < ${#s}; i++)); do sum=$((sum + $(printf "%d" "'${s:$i:1}"))); done
+  echo "${COLORS[$((sum % ${#COLORS[@]}))]}"
+}
+
+# ---- Pretty printing --------------------------------------------------------
+RESET='\033[0m'
+BOLD='\033[1m'
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+CYAN='\033[36m'
+
+info() { printf "${CYAN}[texera]${RESET} %b\n" "$*"; }
+warn() { printf "${YELLOW}[texera]${RESET} %b\n" "$*"; }
+err()  { printf "${RED}[texera]${RESET} %b\n" "$*" >&2; }
+ok()   { printf "${GREEN}[texera]${RESET} %b\n" "$*"; }
+
+# ---- Tool checks ------------------------------------------------------------
+check_tools() {
+  local missing=0
+  for c in java sbt node yarn docker pg_isready psql curl unzip; do
+    if ! command -v "$c" >/dev/null 2>&1; then
+      err "  not found: $c"
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    err "Install the missing tools above (see Guide for Developers wiki), then retry."
+    exit 1
+  fi
+  info "java: $(java -version 2>&1 | head -1)"
+  info "node: $(node -v)   yarn: $(yarn -v)   docker: $(docker --version | head -1)"
+}
+
+# ---- Resolve a single service's staged binary (expand the glob) -------------
+resolve_binary() {
+  local cwd="$1" bin_glob="$2"
+  local hit
+  # Use compgen so a missing match returns nothing without erroring under set -e
+  hit=$(cd "$ROOT/$cwd" 2>/dev/null && compgen -G "$bin_glob" | head -1)
+  if [ -n "$hit" ]; then
+    echo "$ROOT/$cwd/$hit"
+  fi
+}
+
+# ---- Postgres ---------------------------------------------------------------
+ensure_postgres() {
+  if pg_isready -q; then
+    ok "postgres already running"
+    return 0
+  fi
+  warn "postgres not running, attempting to start via brew services"
+  if command -v brew >/dev/null 2>&1; then
+    brew services start postgresql 2>/dev/null \
+      || brew services start postgresql@14 2>/dev/null \
+      || true
+    for _ in $(seq 1 20); do
+      if pg_isready -q; then ok "postgres started"; return 0; fi
+      sleep 1
+    done
+  fi
+  err "postgres did not become ready. Start it manually and re-run."
+  exit 1
+}
+
+# ---- Infrastructure: LakeFS + MinIO -----------------------------------------
+start_lakefs() {
+  info "starting LakeFS + MinIO (docker compose)"
+  (cd "$LAKEFS_COMPOSE_DIR" && docker compose up -d) || {
+    err "docker compose failed in $LAKEFS_COMPOSE_DIR"
+    exit 1
+  }
+  # docker compose returns as soon as the container is *up*, but LakeFS's
+  # HTTP server takes a few more seconds to start listening. file-service
+  # calls LakeFSStorageClient.healthCheck() during its own boot and exits
+  # if LakeFS is unreachable — so wait for an HTTP response before letting
+  # the JVM services launch.
+  local deadline=$((SECONDS + 60))
+  local waited=0
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if curl --silent --output /dev/null --max-time 2 \
+            --fail-with-body "http://localhost:8000/_health" >/dev/null 2>&1 \
+       || curl --silent --output /dev/null --max-time 2 \
+            "http://localhost:8000/" >/dev/null 2>&1; then
+      ok "lakefs is responding on http://localhost:8000"
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  warn "lakefs did not respond on http://localhost:8000 within ${waited}s — file-service may crash on boot"
+  return 0
+}
+
+stop_lakefs() {
+  info "stopping LakeFS + MinIO"
+  (cd "$LAKEFS_COMPOSE_DIR" && docker compose down) || true
+}
+
+# ---- Stream prefixer --------------------------------------------------------
+prefix_stream() {
+  local name="$1"
+  local color
+  color="$(color_for "$name")"
+  local prefix
+  prefix="$(printf '\033[%sm[%s]\033[0m' "$color" "$name")"
+  awk -v p="$prefix" '{ print p, $0; fflush(); }'
+}
+
+# pgid_of_pipeline <last_pid> — print the process-group ID of a backgrounded
+# pipeline whose final stage has PID <last_pid>. With `set -m` in effect when
+# the pipeline was started, every member of the pipeline (subshell + tee +
+# awk) shares one PGID, which equals the PID of the first process — the JVM
+# subshell. Recording that PGID lets `texera stop` later kill the whole group
+# (including the JVM) with `kill -- -PGID`.
+pgid_of_pipeline() {
+  local last_pid="$1"
+  local pgid
+  pgid="$(ps -o pgid= -p "$last_pid" 2>/dev/null | tr -d ' ')"
+  if [ -z "$pgid" ]; then
+    echo "$last_pid"
+  else
+    echo "$pgid"
+  fi
+}
+
+# ---- Spawn a single backend service -----------------------------------------
+spawn_service() {
+  local name="$1" cwd="$2" bin_glob="$3"
+  local log="$LOG_DIR/$name.log"
+  local pidfile="$PID_DIR/$name.pid"
+
+  local binary
+  binary="$(resolve_binary "$cwd" "$bin_glob")"
+  if [ -z "$binary" ] || [ ! -x "$binary" ]; then
+    err "missing staged binary for '$name' (looked for: $cwd/$bin_glob)"
+    err "run 'texera build' first"
+    return 1
+  fi
+
+  info "starting $name ($binary)"
+  # Job control on just for this spawn so the pipeline gets its own PGID.
+  set -m
+  (
+    cd "$ROOT/$cwd"
+    exec "$binary" 2>&1
+  ) | tee "$log" | prefix_stream "$name" &
+  local tail_pid=$!
+  set +m
+  pgid_of_pipeline "$tail_pid" > "$pidfile"
+}
+
+spawn_frontend() {
+  local name="$FRONTEND_LABEL"
+  local log="$LOG_DIR/$name.log"
+  local pidfile="$PID_DIR/$name.pid"
+
+  info "starting $name (yarn start in frontend/)"
+  set -m
+  (
+    cd "$ROOT/frontend"
+    exec yarn start 2>&1
+  ) | tee "$log" | prefix_stream "$name" &
+  local tail_pid=$!
+  set +m
+  pgid_of_pipeline "$tail_pid" > "$pidfile"
+}
+
+# agent-service is a Bun/Node app, not a staged JVM binary. Frontend proxies
+# /api/agents to localhost:3001.
+spawn_agent() {
+  local name="agent"
+  local log="$LOG_DIR/$name.log"
+  local pidfile="$PID_DIR/$name.pid"
+
+  if ! command -v bun >/dev/null 2>&1; then
+    warn "bun not installed — skipping agent-service (install via 'brew install oven-sh/bun/bun')"
+    return 0
+  fi
+  if [ ! -d "$ROOT/agent-service/node_modules" ]; then
+    warn "agent-service/node_modules missing — skipping (run: cd agent-service && bun install)"
+    return 0
+  fi
+
+  info "starting $name (bun run dev in agent-service/)"
+  set -m
+  (
+    cd "$ROOT/agent-service"
+    exec bun run dev 2>&1
+  ) | tee "$log" | prefix_stream "$name" &
+  local tail_pid=$!
+  set +m
+  pgid_of_pipeline "$tail_pid" > "$pidfile"
+}
+
+# kill_all_pgids — read every pidfile under PID_DIR, send TERM (and after
+# `grace` seconds, KILL stragglers) to each recorded process group. Used by
+# both the Ctrl+C trap and the standalone `texera stop` subcommand.
+kill_all_pgids() {
+  local grace="${1:-3}"
+  local pgids=()
+  if [ -d "$PID_DIR" ]; then
+    local pidfile pgid
+    for pidfile in "$PID_DIR"/*.pid; do
+      [ -f "$pidfile" ] || continue
+      pgid="$(cat "$pidfile" 2>/dev/null || true)"
+      [ -n "$pgid" ] && pgids+=("$pgid")
+      rm -f "$pidfile"
+    done
+  fi
+  [ "${#pgids[@]}" -eq 0 ] && return 0
+
+  local pgid
+  for pgid in "${pgids[@]}"; do
+    # `kill -- -PGID` sends to every member of process group PGID (JVM + tee
+    # + awk). Falls back to a single-PID kill if the pidfile happened to
+    # record a bare PID (e.g. set -m wasn't honored on this shell).
+    kill -TERM -- "-$pgid" 2>/dev/null \
+      || kill -TERM -- "$pgid" 2>/dev/null \
+      || true
+  done
+
+  # Brief grace period for the JVMs to flush logs / close sockets cleanly,
+  # then SIGKILL anything still running.
+  sleep "$grace"
+  for pgid in "${pgids[@]}"; do
+    if kill -0 -- "-$pgid" 2>/dev/null || kill -0 -- "$pgid" 2>/dev/null; then
+      kill -KILL -- "-$pgid" 2>/dev/null \
+        || kill -KILL -- "$pgid" 2>/dev/null \
+        || true
+    fi
+  done
+}
+
+# ---- Tear down on Ctrl+C ----------------------------------------------------
+shutdown() {
+  # Restore the terminal scroll region BEFORE printing anything else, so the
+  # "shutting down…" line lands in normal screen layout instead of on top of
+  # the status bar. status_bar_teardown is a no-op when the bar was never
+  # active (non-TTY, or `texera start` exited before status_bar_start ran).
+  status_bar_teardown
+  echo
+  info "shutting down…"
+  # Shorter grace period for Ctrl+C — user wants their prompt back fast.
+  kill_all_pgids 2
+  ok "stopped. (docker containers from 'texera start' still running — use 'texera stop' to clean those too)"
+  exit 0
+}
+
+# ---- Status -----------------------------------------------------------------
+status() {
+  printf "${BOLD}Service               Port    Status${RESET}\n"
+  for row in "${SERVICES[@]}"; do
+    IFS='|' read -r name cwd bin_glob port <<<"$row"
+    if [ "$port" = "-" ]; then
+      printf "  %-18s  %-6s  %s\n" "$name" "-" "(no http port)"
+      continue
+    fi
+    if curl -fsS -m 1 "http://localhost:$port/api/healthcheck" >/dev/null 2>&1; then
+      printf "  %-18s  %-6s  ${GREEN}up${RESET}\n" "$name" "$port"
+    else
+      printf "  %-18s  %-6s  ${RED}down${RESET}\n" "$name" "$port"
+    fi
+  done
+  if curl -fsS -m 1 "http://localhost:4200" >/dev/null 2>&1; then
+    printf "  %-18s  %-6s  ${GREEN}up${RESET}\n" "$FRONTEND_LABEL" "4200"
+  else
+    printf "  %-18s  %-6s  ${RED}down${RESET}\n" "$FRONTEND_LABEL" "4200"
+  fi
+}
+
+# ---- Logs -------------------------------------------------------------------
+logs() {
+  local name="${1:-}"
+  if [ -z "$name" ]; then
+    err "usage: texera logs <service>"
+    err "available: $(ls "$LOG_DIR" 2>/dev/null | sed 's/\.log$//' | tr '\n' ' ')"
+    exit 1
+  fi
+  local f="$LOG_DIR/$name.log"
+  [ -f "$f" ] || { err "no log file at $f"; exit 1; }
+  tail -F "$f"
+}
+
+# ---- Build staged binaries --------------------------------------------------
+build_backend() {
+  info "building staged backend binaries (sbt clean dist + unzip)"
+  (cd "$ROOT" && bash bin/build-services.sh) || {
+    err "build-services.sh failed"
+    exit 1
+  }
+  ok "backend artifacts ready"
+}
+
+# ---- Verify everything required exists before `start` ----------------------
+require_artifacts() {
+  local missing=0
+  for row in "${SERVICES[@]}"; do
+    IFS='|' read -r name cwd bin_glob port <<<"$row"
+    local b
+    b="$(resolve_binary "$cwd" "$bin_glob")"
+    if [ -z "$b" ]; then
+      err "  missing: $name  ($cwd/$bin_glob)"
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    err "Run 'texera build' (or 'texera setup' for first-time install) first."
+    exit 1
+  fi
+}
+
+# ---- Setup ------------------------------------------------------------------
+setup() {
+  info "checking toolchain…"
+  check_tools
+
+  build_backend
+
+  info "installing frontend deps"
+  (cd "$ROOT/frontend" && corepack enable && yarn install)
+
+  if command -v bun >/dev/null 2>&1; then
+    info "installing agent-service deps"
+    (cd "$ROOT/agent-service" && bun install) || warn "agent-service bun install failed — agent-service will be skipped on start"
+  else
+    warn "bun not installed — skipping agent-service deps (install via 'brew install oven-sh/bun/bun')"
+  fi
+
+  info "installing python deps"
+  pip install -r "$ROOT/amber/requirements.txt" -r "$ROOT/amber/operator-requirements.txt" || {
+    warn "pip install failed — you may need a virtualenv. Skipping."
+  }
+
+  info "applying SQL DDLs (requires Postgres running)"
+  ensure_postgres
+  psql -U postgres -f "$ROOT/sql/texera_ddl.sql" || warn "texera_ddl.sql failed (may already exist)"
+  psql -U postgres -f "$ROOT/sql/iceberg_postgres_catalog.sql" || warn "iceberg DDL failed (may already exist)"
+
+  ok "setup complete. Run 'texera start' next."
+}
+
+# ---- Mode lookup + interactive menu -----------------------------------------
+# mode_lookup <key> populates MODE_LABEL / MODE_DESC / RUN_INFRA / RUN_BACKEND /
+# RUN_FRONTEND as globals, or returns 1 if the key is unknown.
+mode_lookup() {
+  local key="$1"
+  for row in "${MODES[@]}"; do
+    IFS='|' read -r k label desc ri rb rf <<<"$row"
+    if [ "$k" = "$key" ]; then
+      MODE_LABEL="$label"
+      MODE_DESC="$desc"
+      RUN_INFRA="$ri"
+      RUN_BACKEND="$rb"
+      RUN_FRONTEND="$rf"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Print a numbered menu and read the user's pick into SELECTED_MODE.
+interactive_menu() {
+  echo
+  printf "${BOLD}${CYAN}┌──────────────────────────────────────────────────────────────┐${RESET}\n"
+  printf "${BOLD}${CYAN}│             Texera — choose a startup mode                   │${RESET}\n"
+  printf "${BOLD}${CYAN}└──────────────────────────────────────────────────────────────┘${RESET}\n"
+  echo
+
+  local i=1
+  local keys=()
+  for row in "${MODES[@]}"; do
+    IFS='|' read -r k label desc _ _ _ <<<"$row"
+    keys+=("$k")
+    printf "  ${BOLD}${GREEN}%d${RESET}) ${BOLD}%-10s${RESET}  ${CYAN}%s${RESET}\n" "$i" "$label" "$desc"
+    i=$((i + 1))
+  done
+  printf "  ${BOLD}${YELLOW}q${RESET}) Quit\n"
+  echo
+
+  local choice
+  while true; do
+    printf "${CYAN}❯${RESET} Choose [1-%d, q]: " "${#keys[@]}"
+    if ! read -r choice; then
+      echo
+      info "no input — aborted"
+      exit 0
+    fi
+    case "$choice" in
+      q|Q|quit|exit)
+        info "aborted"
+        exit 0
+        ;;
+      ''|*[!0-9]*)
+        err "please enter a number between 1 and ${#keys[@]} (or 'q' to quit)"
+        ;;
+      *)
+        if [ "$choice" -ge 1 ] && [ "$choice" -le "${#keys[@]}" ]; then
+          SELECTED_MODE="${keys[$((choice - 1))]}"
+          return 0
+        else
+          err "out of range — pick 1-${#keys[@]} or 'q'"
+        fi
+        ;;
+    esac
+  done
+}
+
+# ---- Readiness check + final banner -----------------------------------------
+# probe_port <port> — succeed if anything answers HTTP on that port within 2s.
+# Any HTTP response (200, 404, 401, 500…) counts as "bound and serving".
+# Connection refused / timeout returns code "000".
+probe_port() {
+  local port="$1"
+  local code
+  code="$(curl --silent --output /dev/null --max-time 2 \
+               --write-out '%{http_code}' \
+               "http://localhost:$port/" 2>/dev/null)" || code="000"
+  [ -n "${code:-}" ] && [ "${code:-000}" != "000" ]
+}
+
+# is_spawn_alive <name> — does this service's spawn pipeline still have a
+# living process? Returns 0 if alive (or if we have no pidfile to consult),
+# 1 if the pidfile points to a dead process.
+#
+# Caveat: the pidfile holds the trailing prefix_stream awk PID, not the JVM
+# PID. That's still useful: when the upstream JVM exits, tee hits EOF and
+# awk terminates with it, so a dead awk PID is a reliable signal the JVM
+# is gone.
+is_spawn_alive() {
+  local name="$1"
+  local pidfile="$PID_DIR/$name.pid"
+  [ -f "$pidfile" ] || return 0
+  local pid
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  [ -z "$pid" ] && return 0
+  kill -0 "$pid" 2>/dev/null
+}
+
+# wait_for_services name|port... — block until every target binds, or until
+# any spawned pipeline dies (returns 1 fast), or until timeout (returns 1).
+wait_for_services() {
+  local timeout="${TEXERA_READY_TIMEOUT:-90}"
+  local interval=2
+  local elapsed=0
+  local targets=("$@")
+
+  info "waiting up to ${timeout}s for ${#targets[@]} services to bind…"
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local all_up=1
+    local any_dead=0
+    local dead_name=""
+    local entry
+    for entry in "${targets[@]}"; do
+      local name="${entry%%|*}"
+      local port="${entry##*|}"
+      if probe_port "$port"; then continue; fi
+      all_up=0
+      if ! is_spawn_alive "$name"; then
+        any_dead=1
+        dead_name="$name"
+      fi
+    done
+    if [ "$all_up" = "1" ]; then return 0; fi
+    if [ "$any_dead" = "1" ]; then
+      warn "${dead_name} pipeline has exited — see ${LOG_DIR}/${dead_name}.log for the crash"
+      return 1
+    fi
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+  return 1
+}
+
+# print_readiness_banner name|port... — green if all up, red with failure list
+# otherwise. Distinguishes "crashed" (spawn pipeline died — usually a JVM
+# exception during boot) from "not reachable" (port simply never bound in
+# the timeout window).
+print_readiness_banner() {
+  local targets=("$@")
+  local total="${#targets[@]}"
+  local down_names=()
+  local down_ports=()
+  local down_reasons=()
+  local entry
+  for entry in "${targets[@]}"; do
+    local name="${entry%%|*}"
+    local port="${entry##*|}"
+    if ! probe_port "$port"; then
+      down_names+=("$name")
+      down_ports+=("$port")
+      if is_spawn_alive "$name"; then
+        down_reasons+=("not reachable")
+      else
+        down_reasons+=("crashed — see ${LOG_DIR}/${name}.log")
+      fi
+    fi
+  done
+  local down="${#down_names[@]}"
+  local bar="════════════════════════════════════════════════════════════"
+
+  echo
+  if [ "$down" -eq 0 ]; then
+    printf "${BOLD}${GREEN}%s${RESET}\n" "$bar"
+    printf "${BOLD}${GREEN}✓ ALL %d SERVICES STARTED SUCCESSFULLY${RESET}\n" "$total"
+    printf "${BOLD}${GREEN}%s${RESET}\n" "$bar"
+  else
+    printf "${BOLD}${RED}%s${RESET}\n" "$bar"
+    printf "${BOLD}${RED}✗ %d of %d SERVICES DOWN${RESET}\n" "$down" "$total"
+    printf "${BOLD}${RED}%s${RESET}\n" "$bar"
+    local i
+    for i in "${!down_names[@]}"; do
+      printf "  ${BOLD}%-12s${RESET} :%-5s ${RED}%s${RESET}\n" \
+        "${down_names[$i]}" "${down_ports[$i]}" "${down_reasons[$i]}"
+    done
+    printf "${BOLD}${RED}%s${RESET}\n" "$bar"
+  fi
+  echo
+}
+
+# ---- Persistent status bar (TTY only) ---------------------------------------
+# Reserves the bottom rows of the terminal via DECSTBM so service logs scroll
+# only in the upper region, and runs a background poller that redraws live
+# UP/DOWN state every couple seconds. Tears down cleanly on shutdown so the
+# terminal isn't left with a stuck scroll region.
+STATUS_BAR_HEIGHT=3
+STATUS_BAR_ACTIVE=0
+STATUS_BAR_POLLER_PID=""
+STATUS_BAR_START=0
+
+status_bar_supported() {
+  [ -t 1 ] || return 1
+  command -v tput >/dev/null 2>&1 || return 1
+  local lines
+  lines="$(tput lines 2>/dev/null || echo 0)"
+  [ "${lines:-0}" -ge 12 ]
+}
+
+status_bar_init() {
+  status_bar_supported || return 1
+  local lines bottom
+  lines="$(tput lines)"
+  bottom=$((lines - STATUS_BAR_HEIGHT))
+  # ESC[top;bottom r — pin everything below `bottom` outside the scroll region.
+  printf '\033[1;%dr' "$bottom"
+  # Park the cursor just above the bar so the first log lines land there
+  # and scroll existing content up rather than overwriting the top.
+  printf '\033[%d;1H' "$bottom"
+  STATUS_BAR_ACTIVE=1
+}
+
+status_bar_render() {
+  [ "$STATUS_BAR_ACTIVE" = "1" ] || return 0
+  local targets=("$@")
+
+  local lines cols
+  lines="$(tput lines 2>/dev/null || echo 24)"
+  cols="$(tput cols 2>/dev/null || echo 80)"
+  local top=$((lines - STATUS_BAR_HEIGHT + 1))
+  local elapsed=$((SECONDS - STATUS_BAR_START))
+
+  local total=0 up=0
+  local down_msgs=()
+  local entry
+  for entry in "${targets[@]}"; do
+    local name="${entry%%|*}"
+    local port="${entry##*|}"
+    total=$((total + 1))
+    if probe_port "$port"; then
+      up=$((up + 1))
+    elif is_spawn_alive "$name"; then
+      down_msgs+=("${name}…")
+    else
+      down_msgs+=("${name}✗")
+    fi
+  done
+
+  local bar
+  bar="$(printf '═%.0s' $(seq 1 "$cols"))"
+
+  local color line2
+  if [ "$up" = "$total" ]; then
+    color="${BOLD}${GREEN}"
+    line2="$(printf "${BOLD}${GREEN}✓ ALL %d SERVICES UP${RESET}  (%ss elapsed)" "$total" "$elapsed")"
+  else
+    color="${BOLD}${RED}"
+    local detail
+    detail="$(IFS=' '; echo "${down_msgs[*]}")"
+    line2="$(printf "${BOLD}${RED}✗ %d/%d DOWN${RESET}: ${RED}%s${RESET}  (%ss)" \
+      "${#down_msgs[@]}" "$total" "$detail" "$elapsed")"
+  fi
+
+  # One printf so the whole redraw lands as a single write — minimizes
+  # interleaving with the spawned services' log output.
+  # \0337 / \0338 = DECSC / DECRC (save / restore cursor)
+  # \033[r;cH    = position cursor at row r, col c
+  # \033[2K      = clear current line
+  printf '\0337\033[%d;1H\033[2K%s%s%b\033[%d;1H\033[2K %b\033[%d;1H\033[2K%s%s%b\0338' \
+    "$top"             "$color" "$bar" "$RESET" \
+    "$((top + 1))"     "$line2" \
+    "$((top + 2))"     "$color" "$bar" "$RESET"
+}
+
+status_bar_loop() {
+  local targets=("$@")
+  while true; do
+    status_bar_render "${targets[@]}"
+    sleep 2
+  done
+}
+
+status_bar_start() {
+  STATUS_BAR_START=$SECONDS
+  if status_bar_init; then
+    status_bar_loop "$@" &
+    STATUS_BAR_POLLER_PID=$!
+  fi
+}
+
+status_bar_teardown() {
+  [ "$STATUS_BAR_ACTIVE" = "1" ] || return 0
+  if [ -n "$STATUS_BAR_POLLER_PID" ]; then
+    kill "$STATUS_BAR_POLLER_PID" 2>/dev/null || true
+    STATUS_BAR_POLLER_PID=""
+  fi
+  local lines
+  lines="$(tput lines 2>/dev/null || echo 24)"
+  local top=$((lines - STATUS_BAR_HEIGHT + 1))
+  # Restore full-screen scroll region, then wipe the bar area so the next
+  # shell prompt isn't sitting on top of leftover bar glyphs.
+  printf '\033[r\033[%d;1H\033[J' "$top"
+  STATUS_BAR_ACTIVE=0
+}
+
+# ---- Start ------------------------------------------------------------------
+start() {
+  local mode="${1:-}"
+  if [ -z "$mode" ]; then
+    if [ ! -t 0 ]; then
+      err "no mode given and stdin isn't a tty — pass one of: full, backend, frontend, infra, services"
+      exit 1
+    fi
+    interactive_menu
+    mode="$SELECTED_MODE"
+  fi
+  if ! mode_lookup "$mode"; then
+    err "unknown mode: $mode"
+    err "valid modes: full, backend, frontend, infra, services"
+    exit 1
+  fi
+
+  echo
+  info "${BOLD}mode:${RESET} $MODE_LABEL — $MODE_DESC"
+  echo
+
+  check_tools
+
+  if [ "$RUN_BACKEND" = "1" ]; then
+    require_artifacts
+  fi
+  if [ "$RUN_INFRA" = "1" ]; then
+    ensure_postgres
+    start_lakefs
+  fi
+
+  trap shutdown INT TERM
+  # Safety net: if we exit for any reason (normal return, set -e, error),
+  # restore the terminal so the user isn't left with a stuck scroll region.
+  trap status_bar_teardown EXIT
+
+  if [ "$RUN_BACKEND" = "1" ]; then
+    for row in "${SERVICES[@]}"; do
+      IFS='|' read -r name cwd bin_glob port <<<"$row"
+      spawn_service "$name" "$cwd" "$bin_glob" || true
+      # ComputingUnitMaster needs to bind its Akka/Pekko port before the worker
+      # tries to join.
+      if [ "$name" = "master" ]; then sleep 4; fi
+    done
+    spawn_agent
+  fi
+
+  if [ "$RUN_FRONTEND" = "1" ]; then
+    spawn_frontend
+  fi
+
+  # Infra-only mode: nothing was spawned into the foreground, so report and exit
+  # rather than blocking on `wait`.
+  if [ "$RUN_BACKEND" != "1" ] && [ "$RUN_FRONTEND" != "1" ]; then
+    echo
+    ok "infra is up."
+    info "  postgres:        localhost:5432 (host)"
+    info "  lakefs:          http://localhost:8000"
+    info "  minio console:   http://localhost:9001"
+    echo
+    info "Run JVM services from IntelliJ (.run/*.xml) or 'texera start services'."
+    info "Tear down with 'texera stop'."
+    return 0
+  fi
+
+  ok "all processes spawned. tailing… (Ctrl+C to stop)"
+  echo
+  info "URLs once ready:"
+  if [ "$RUN_FRONTEND" = "1" ]; then
+    info "  frontend:        http://localhost:4200"
+  fi
+  if [ "$RUN_BACKEND" = "1" ]; then
+    info "  texera api:      http://localhost:8080/api/healthcheck"
+    info "  file service:    http://localhost:9092/api/healthcheck"
+    info "  config service:  http://localhost:9094/api/healthcheck"
+    info "  compile service: http://localhost:9090/api/healthcheck"
+    info "  managing svc:    http://localhost:8888/api/healthcheck"
+    info "  access-control:  http://localhost:9096/api/healthcheck"
+    info "  agent service:   http://localhost:3001"
+  fi
+  echo
+
+  # Build the readiness target list, then either run the live bottom-pinned
+  # status bar (preferred on a TTY) or fall back to a one-shot wait + banner
+  # for non-TTY contexts (CI, piped output).
+  local readiness=()
+  if [ "$RUN_BACKEND" = "1" ]; then
+    local row name cwd bin_glob port
+    for row in "${SERVICES[@]}"; do
+      IFS='|' read -r name cwd bin_glob port <<<"$row"
+      [ "$port" = "-" ] && continue
+      readiness+=("$name|$port")
+    done
+    # agent has no SERVICES row; include it only if it was actually spawned.
+    if [ -f "$PID_DIR/agent.pid" ]; then
+      readiness+=("agent|3001")
+    fi
+  fi
+  if [ "$RUN_FRONTEND" = "1" ]; then
+    readiness+=("frontend|4200")
+  fi
+
+  if [ "${#readiness[@]}" -gt 0 ]; then
+    if status_bar_supported; then
+      status_bar_start "${readiness[@]}"
+    else
+      wait_for_services "${readiness[@]}" || true
+      print_readiness_banner "${readiness[@]}"
+    fi
+  fi
+
+  wait
+}
+
+# ---- Stop -------------------------------------------------------------------
+stop() {
+  info "stopping all texera processes…"
+  kill_all_pgids 3
+
+  # Belt-and-suspenders fallback: if there are orphan JVMs from previous
+  # sessions (e.g. from before this stop logic existed), they won't have
+  # pidfiles. Kill them by Java mainclass — the launcher script's basename
+  # doesn't appear in the JVM's command line, but the mainclass does.
+  local mainclass
+  for mainclass in \
+      org.apache.texera.web.ComputingUnitMaster \
+      org.apache.texera.web.ComputingUnitWorker \
+      org.apache.texera.web.TexeraWebApplication \
+      org.apache.texera.service.ConfigService \
+      org.apache.texera.service.FileService \
+      org.apache.texera.service.AccessControlService \
+      org.apache.texera.service.ComputingUnitManagingService \
+      org.apache.texera.service.WorkflowCompilingService; do
+    pkill -f "$mainclass" 2>/dev/null || true
+  done
+
+  stop_lakefs
+  ok "stopped."
+}
+
+# ---- Dispatch ---------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: texera <command> [args]
+
+Commands:
+  setup            One-time: toolchain check, sbt build, frontend+python deps, SQL DDLs.
+  build            Re-build staged backend binaries (run after backend code changes).
+  start [mode]     Start services. Without a mode, drops into an interactive menu.
+                   Modes:
+                     full       Postgres + LakeFS/MinIO + all backend services + agent + frontend
+                     backend    Infra + backend services + agent (no frontend)
+                     frontend   Frontend only (assumes backend running)
+                     infra      Postgres + LakeFS/MinIO only
+                     services   Backend services + agent + frontend (assumes infra running)
+  stop             Stop everything started by 'texera start'.
+  status           Show which services are reachable.
+  logs <service>   Tail one service's log (config|compile|file|managing|access|master|worker|web|agent|frontend).
+
+Logs land in: $LOG_DIR/
+EOF
+}
+
+case "${1:-}" in
+  setup)  shift; setup "$@" ;;
+  build)  shift; build_backend "$@" ;;
+  start)  shift; start "$@" ;;
+  stop)   shift; stop "$@" ;;
+  status) shift; status "$@" ;;
+  logs)   shift; logs "$@" ;;
+  ""|-h|--help|help) usage ;;
+  *) err "unknown command: $1"; usage; exit 1 ;;
+esac


### PR DESCRIPTION
# PR: One-command local dev orchestrator for Texera (`bin/texera`)

## Summary

Adds `bin/texera` — a single Bash CLI that replaces the previous "open 7 IntelliJ run configs in the right order, then `yarn start` in a different terminal" workflow with one command:

```
texera start
```

It launches Postgres + LakeFS/MinIO + every backend JVM service + agent-service + frontend, in the right order, with prefixed log streams in one terminal, a live bottom-pinned health bar, and clean teardown on Ctrl+C. Also ships subcommands for `setup`, `build`, `stop`, `status`, and `logs`. Complementary helper `bin/check-services.sh` provides a one-shot probe outside an active session.

This is a dev-tool addition — nothing about the services themselves changes. The existing `.run/*.xml` IntelliJ configs and `bin/single-node` Docker deploy paths are untouched.

## Motivation

Before this PR, getting Texera running locally required:

- Knowing the launch order (master before worker, infra before JVMs).
- Knowing the seven `bin/*-service.sh` scripts plus the un-scripted agent-service and frontend.
- Eyeballing seven different terminals to figure out whether the stack was actually up.
- Manually `pkill`ing JVMs when something crashed, because there was no cleanup story.
- Hitting `file-service crashed on boot` ~50% of the time when LakeFS wasn't quite ready.

New contributors hit all of this on day one. Existing contributors lived with it but lost ~5 minutes per restart.

## What's in this PR

```
bin/texera                  new   one-command orchestrator (~875 lines)
bin/check-services.sh       new   standalone health probe (~118 lines)
bin/build-services.sh       mod   add access-control-service to dist+unzip;
                                  rename amber zip target (texera-*.zip → amber-*.zip)
```

`bin/texera` is the main feature; the other two are small.

## Subcommands

```
texera setup           One-time: toolchain check + sbt build + frontend/python deps + SQL DDLs
texera build           Re-build staged backend binaries (after backend code changes)
texera start [mode]    Start services. Interactive menu if no mode given.
texera stop            Stop everything started by `texera start`.
texera status          Per-service port reachability table.
texera logs <service>  Tail one service's log file.
```

### `texera setup`

Idempotent first-time bootstrap. Verifies the toolchain (java 17, sbt, node 24, yarn, docker, pg_isready, psql, curl, unzip), runs `bin/build-services.sh`, installs frontend (`yarn install`) and agent-service (`bun install`) deps, applies `sql/texera_ddl.sql` and `sql/iceberg_postgres_catalog.sql`. Skips agent-service gracefully if `bun` isn't installed.

### `texera build`

Delegates to `bin/build-services.sh` (`sbt clean dist` + unzip each service's stage). Same path the deploy scripts use.

### `texera start`

Five modes, chosen by argument or interactive menu:

| Mode | Postgres + LakeFS/MinIO | Backend JVM services + agent | Frontend |
|---|---|---|---|
| `full` | ✓ | ✓ | ✓ |
| `backend` | ✓ | ✓ | — |
| `frontend` | — | — | ✓ |
| `infra` | ✓ | — | — |
| `services` | — | ✓ | ✓ |

The interactive menu (`texera start` with no arg, TTY only) renders a box-drawn numbered prompt; `q` quits. Stdin not a TTY + no arg → errors with the list of valid modes (so it's CI-safe).

Service registry is a single declarative table inside the script:

```bash
SERVICES=(
  "config|.|target/config-service-*/bin/config-service|9094"
  "compile|.|target/workflow-compiling-service-*/bin/workflow-compiling-service|9090"
  "file|.|target/file-service-*/bin/file-service|9092"
  "managing|.|target/computing-unit-managing-service-*/bin/computing-unit-managing-service|8888"
  "access|.|target/access-control-service-*/bin/access-control-service|9096"
  "master|amber|target/amber-*/bin/computing-unit-master|8085"
  "worker|amber|target/amber-*/bin/computing-unit-worker|-"
  "web|amber|target/amber-*/bin/texera-web-application|8080"
)
```

Adding a service later means adding one row.

Each row spawns from its sbt-native-packager staged binary (not `sbt runMain`) — that avoids the sbt boot-lock contention you get from launching several `sbt` processes in parallel and skips sbt startup overhead per service.

Each service's stdout/stderr is piped through a colored prefixer:

```
[config]   INFO  ConfigService starting…
[compile]  INFO  WorkflowCompilingService starting…
[file]     ERROR Failed to connect to lake fs server: …
[master]   [INFO] [ClusterListener] received member event = MemberUp(...)
```

Color is a stable hash of the service name → ANSI palette. Stream prefixer is `awk -v p="$prefix" '{ print p, $0; fflush(); }'`.

Per-service logs also written to `logs/texera-dev/<name>.log` (so `texera logs <name>` works mid-run).

### `texera stop`

`stop` kills every service launched by `texera start`, then `docker compose down`s the LakeFS/MinIO stack.

The kill path matters because the previous scripts left orphan JVMs — see the *Hard problems* section below.

### `texera status` and `texera logs`

`status` makes one `curl /api/healthcheck` per service and renders an aligned table (`up`/`down`). Independent of any active `texera start`. Useful for checking dev state from a different shell.

`logs <name>` is `tail -F logs/texera-dev/<name>.log`. Names come from the same registry.

## Hard problems and how they're solved

### 1. Per-service liveness while logs scroll past

Spawning seven JVM services into one terminal means thousands of lines of log spam during a normal boot. The user can't tell from the stream which services are up.

**Solution: persistent bottom-pinned status bar.** When stdout is a TTY, `status_bar_init` sets the terminal scroll region via DECSTBM (`ESC[1;LINES-3 r`), reserving the bottom 3 rows. A background poller redraws those rows every 2 s:

```
═════════════════════════════════════════════════════════════
 ✓ ALL 9 SERVICES UP  (47s elapsed)
═════════════════════════════════════════════════════════════
```

or on failure:

```
═════════════════════════════════════════════════════════════
 ✗ 2/9 DOWN: master✗ file…  (12s)
═════════════════════════════════════════════════════════════
```

Symbols: `✗` = pipeline collapsed (JVM exited), `…` = process alive but port not yet bound.

The whole 3-row redraw is one `printf` with `DECSC`/`DECRC` (save/restore cursor) around it, so concurrent log writes from the spawned services and the poller don't interleave at byte level. Worst case is one garbled frame, self-heals on the next 2 s tick.

When stdout *isn't* a TTY (CI, `| tee log.txt`, etc), `status_bar_supported` returns false and the code falls back to a one-shot wait + trailing banner.

Teardown lives in two places: `shutdown` (Ctrl+C trap) calls it before printing anything else so "shutting down…" lands in normal layout, and `trap status_bar_teardown EXIT` is a belt-and-suspenders safety net so the terminal is never left with a stuck scroll region even on an unexpected exit.

### 2. file-service vs LakeFS startup race

`file-service` calls `LakeFSStorageClient.healthCheck()` during boot (`file-service/src/main/scala/.../FileService.scala:77`). If LakeFS isn't accepting HTTP, the JVM exits.

`docker compose up -d` returns when the container is up, not when LakeFS's HTTP server is accepting connections — a 5–15 s gap. So file-service crashed ~50% of the time on cold starts.

**Solution:** `start_lakefs` now polls `http://localhost:8000/_health` (falling back to `/`) for up to 60 s after `docker compose up -d`, and only returns once LakeFS answers. Both endpoints verified to return 200 against the running container.

### 3. Orphan JVMs holding ports after stop

The previous `bin/*-service.sh` launchers and earlier iterations of `bin/texera` recorded the wrong PID. The pipeline `( exec binary ) | tee log | prefix_stream` ends up with `$!` = the awk PID. Killing awk does not propagate to the JVM, which is a sibling, not a child. The fallback `pkill -f <basename>` didn't help either, because the launcher script's filename (`computing-unit-master` etc) isn't in the JVM's command line after `exec java -cp …`.

Result: every `texera start` after the first failed with `BindException: 127.0.0.1:2552 Address already in use`, and you'd have to `lsof -ti :2552 | xargs kill -9` manually.

**Solution: process groups.**

- Each `spawn_*` now toggles `set -m` briefly so the backgrounded pipeline gets its own process group. With job control on, the PGID equals the PID of the pipeline leader, which is the JVM subshell.
- `pgid_of_pipeline` reads it via `ps -o pgid= -p $!` and stores it in the pidfile (so the pidfile effectively holds the JVM's PID, not awk's).
- `kill_all_pgids <grace>` does `kill -TERM -- -PGID` per recorded group → SIGTERMs JVM + tee + awk together. Sleeps `grace` seconds. Then `kill -KILL -- -PGID` on any group still alive. Used by both `shutdown` (Ctrl+C, 2 s grace) and `stop` (subcommand, 3 s grace).
- For JVMs left over from before this PR existed (no pidfile to consult), `stop` also `pkill -f <mainclass>`s each known Java mainclass:
  - `org.apache.texera.web.{ComputingUnitMaster, ComputingUnitWorker, TexeraWebApplication}`
  - `org.apache.texera.service.{ConfigService, FileService, AccessControlService, ComputingUnitManagingService, WorkflowCompilingService}`
  - List verified against `META-INF/MANIFEST.MF` in every built jar and the `app_mainclass=` declarations in the amber launcher scripts.

Free side benefit: `is_spawn_alive` now `kill -0 PGID`s, which directly probes the JVM leader rather than using awk's liveness as a proxy. The status bar's "crashed" detection is precise.

### 4. Ordering constraints

`ComputingUnitMaster` must bind its Pekko/Akka cluster port before `computing-unit-worker` tries to join. Encoded as one `sleep 4` after spawning the master row. The launch loop walks `SERVICES` in declaration order, so the table itself is the canonical ordering.

LakeFS comes before all JVM spawns because file-service depends on it; Postgres comes before LakeFS because LakeFS uses it.

## File-by-file

- **`bin/texera`** — entire orchestrator. Sections: service registry, mode table, color/printing, tool checks, infra (`ensure_postgres`, `start_lakefs`, `stop_lakefs`), stream prefixer, spawns, `kill_all_pgids` + `shutdown` trap, `status`/`logs` subcommands, `setup`/`build`, mode lookup + interactive menu, readiness probes (`probe_port`, `is_spawn_alive`, `wait_for_services`, `print_readiness_banner`), status bar, `start`, `stop`, dispatch.

- **`bin/check-services.sh`** — standalone one-shot probe of every service's HTTP port. Independent of `texera start` session state. Prints a per-service table + a green/red trailing banner, exits non-zero on any failure. Useful from a second shell or in CI.

- **`bin/build-services.sh`** — minor: adds the `access-control-service` unzip step that was missing, and renames the amber zip target from `texera-*.zip` to `amber-*.zip` to match the new artifact name.

## What's intentionally not in scope

- The IntelliJ `.run/*.xml` configs still work; they're the path for breakpoint debugging. `texera start` is for "I want everything running, fast."
- The `bin/single-node` Docker Compose deploy isn't touched.
- No CI hookup added. `texera start backend` works in non-TTY mode (banner fallback), but no GitHub Actions job exercises it.

## Configuration knobs

- `TEXERA_READY_TIMEOUT` (default 90) — seconds the one-shot non-TTY readiness check waits before giving up. The persistent bar polls forever; this only applies to the fallback path.
- `TEXERA_HOST` (default `localhost`, used by `check-services.sh`) — host to probe from.
- `TEXERA_PROBE_TIMEOUT` (default 2, used by `check-services.sh`) — per-probe curl timeout.

LakeFS-ready timeout in `start_lakefs` is currently hard-coded at 60 s; making it env-configurable is a small follow-up.

## Test plan

Verified locally (macOS, bash 3.2):

- [x] `texera setup` from a clean checkout, then `texera start full` → menu → mode 1 → all 9 services come up → bar flips green → frontend loads at `:4200`.
- [x] Ctrl+C while running → bar disappears, scroll region restored, JVMs all exit within a couple seconds.
- [x] Immediate `texera start full` again → no port conflicts (the previous orphan-JVM regression is gone).
- [x] `texera stop` from a separate shell while a `start` is running → both terminals come back clean.
- [x] Kill `file-service` mid-run via `pkill -f FileService` → bar flips to `✗ 1/9 DOWN: file✗ (… elapsed)` within 2 s.
- [x] `texera start infra` → only Postgres + LakeFS/MinIO come up; script exits cleanly without blocking on `wait`.
- [x] `texera status` from a second terminal during a healthy run → all up.
- [x] `texera logs file` → tails `logs/texera-dev/file.log`.
- [x] PGID/group kill round-trip verified with a synthetic `sleep | cat | awk` pipeline (`ps -o pid,pgid,comm -g <pgid>` empty after one TERM).
- [x] LakeFS probe endpoints (`/_health`, `/`) both verified to return 200.
- [x] All Java mainclass names verified against built jar manifests and amber launcher scripts.

Not yet verified (follow-ups, see below):

- Cross-terminal: only tested in macOS Terminal.app + tmux. Behavior in iTerm2, VS Code's embedded terminal, IntelliJ console, screen, etc. unverified.
- Terminal resize during a run (SIGWINCH).
- Headless / `texera start backend | tee` path through CI.

## Known limitations

- **TTY only for the live bar.** Non-TTY runs fall back to a one-shot banner. This is intentional but means `texera start full | tee session.log` won't show the live view.
- **Concurrent log writes can occasionally corrupt one bar frame.** Single-printf renders mitigate but don't fully eliminate byte-level interleaving on shared stdout. Self-heals on the next refresh.
- **Mainclass pkill in `stop` is broad.** If you have another checkout of this repo running, `texera stop` here will kill that one too. Could be tightened with `pkill -u "$USER"`; left as-is for now since most devs run a single instance.
- **`set -m` semantics vary slightly across bash versions.** Verified on macOS bash 3.2 and Linux bash 5.x; unusual non-POSIX shells aren't supported (and the shebang is `#!/usr/bin/env bash` anyway).

## Follow-ups

Tracking these separately, not blocking this PR:

1. `bin/README.md` section documenting subcommands, modes, env vars, and the status bar.
2. Make the LakeFS readiness timeout env-configurable (`TEXERA_LAKEFS_TIMEOUT`).
3. `pkill -u "$USER"` on the orphan-mainclass fallback.
4. CI smoke job: `texera start backend` headless, assert exit code on readiness.
5. `AGENTS.md` mention so subagents prefer `texera start` over the `bin/*-service.sh` set when bringing the stack up.

## Migration notes

For existing contributors: nothing breaks. The old `bin/*-service.sh` scripts, IntelliJ `.run/*.xml` configs, and `bin/single-node` deploy are untouched and continue to work. `texera start` is opt-in.

The first time you use it: `texera setup` once, then `texera start`. If you've ever Ctrl+C'd one of the old scripts and left an orphan JVM, run `texera stop` first — its mainclass fallback will clean those up.
