### PR TITLE
[hackathon] Row-Level Data Lineage: trace any result row back to its source CSV row 

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/admin/settings/AdminSettingsResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/admin/settings/AdminSettingsResource.scala
@@ -48,11 +48,18 @@ class AdminSettingsResource {
   @GET
   @Path("{key}")
   def getSetting(@PathParam("key") keyParam: String): AdminSettingsPojo = {
-    ctx
+    val stored = ctx
       .select(key, value)
       .from(siteSettings)
       .where(key.eq(keyParam))
       .fetchOneInto(classOf[AdminSettingsPojo])
+
+    if (stored != null) stored
+    else
+      DefaultsConfig.allDefaults
+        .get(keyParam)
+        .map(AdminSettingsPojo(keyParam, _))
+        .orNull
   }
 
   @PUT

--- a/bin/single-node/nginx.conf
+++ b/bin/single-node/nginx.conf
@@ -33,6 +33,12 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
         }
 
+        location /api/workflow-to-python {
+            proxy_pass http://workflow-compiling-service:9090;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
         location /api/dataset {
             proxy_pass http://file-service:9092;
             proxy_set_header Host $host;

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/StandaloneCodeGenerator.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/StandaloneCodeGenerator.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator
+
+trait StandaloneCodeGenerator {
+
+  def generateStandaloneCode(): String
+
+  def producesDataFrame(): Boolean = true
+}

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDesc.scala
@@ -23,10 +23,11 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PhysicalOp}
+import org.apache.texera.amber.operator.StandaloneCodeGenerator
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 
-class SpecializedFilterOpDesc extends FilterOpDesc {
+class SpecializedFilterOpDesc extends FilterOpDesc with StandaloneCodeGenerator {
 
   @JsonProperty(value = "predicates", required = true)
   @JsonPropertyDescription("multiple predicates in OR")
@@ -59,5 +60,37 @@ class SpecializedFilterOpDesc extends FilterOpDesc {
       List(OutputPort()),
       supportReconfiguration = true
     )
+  }
+
+  override def generateStandaloneCode(): String = {
+    if (predicates.isEmpty) return "out1df = in1df.copy()"
+    val conditions = predicates.map { p =>
+      val col = p.attribute
+      p.condition match {
+        case ComparisonType.IS_NULL     => s"""(in1df["$col"].isna())"""
+        case ComparisonType.IS_NOT_NULL => s"""(in1df["$col"].notna())"""
+        case other =>
+          val op = other.getName // returns "=", ">=", "<", etc. (see ComparisonType.java)
+          val pyOp = if (op == "=") "==" else op
+          s"""(in1df["$col"] $pyOp ${coerceValue(p.value)})"""
+      }
+    }
+    s"out1df = in1df[${conditions.mkString(" | ")}].reset_index(drop=True)"
+  }
+
+  // Try numeric coercion so generated code compares column values against the right type.
+  // Strings that don't parse fall through to a quoted string literal.
+  private def coerceValue(raw: String): String = {
+    try {
+      raw.toInt.toString
+    } catch {
+      case _: NumberFormatException =>
+        try {
+          raw.toDouble.toString
+        } catch {
+          case _: NumberFormatException =>
+            s""""${raw.replace("\"", "\\\"")}""""
+        }
+    }
   }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sort/SortOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sort/SortOpDesc.scala
@@ -23,9 +23,9 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import org.apache.texera.amber.core.tuple.Schema
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.PythonTemplateBuilderStringContext
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
-import org.apache.texera.amber.operator.PythonOperatorDescriptor
+import org.apache.texera.amber.operator.{PythonOperatorDescriptor, StandaloneCodeGenerator}
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-class SortOpDesc extends PythonOperatorDescriptor {
+class SortOpDesc extends PythonOperatorDescriptor with StandaloneCodeGenerator {
   @JsonProperty(required = true)
   @JsonPropertyDescription("column to perform sorting on")
   var attributes: List[SortCriteriaUnit] = _
@@ -73,4 +73,11 @@ class SortOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort(blocking = true))
     )
 
+  override def generateStandaloneCode(): String = {
+    val cols = attributes.map(c => s""""${c.attributeName}"""").mkString("[", ", ", "]")
+    val ascending = attributes
+      .map(c => if (c.sortPreference == SortPreference.ASC) "True" else "False")
+      .mkString("[", ", ", "]")
+    s"out1df = in1df.sort_values(by=$cols, ascending=$ascending)"
+  }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -36,6 +36,15 @@ import java.io.{IOException, InputStreamReader}
 import java.net.URI
 import java.nio.file.Paths
 
+object CSVScanSourceOpDesc {
+  // Hidden column emitted by CSV scan carrying the 1-indexed source row
+  // position within the parsed CSV body. The "__" prefix marks it as a
+  // lineage/internal field; downstream pass-through operators (Filter,
+  // Projection, Map) propagate it unchanged so a result row can be traced
+  // back to its origin in the source file.
+  val LineageOriginRowColumn: String = "__lineage_origin_row"
+}
+
 class CSVScanSourceOpDesc extends ScanSourceOpDesc with StandaloneCodeGenerator {
 
   @JsonProperty(defaultValue = ",")
@@ -48,6 +57,15 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc with StandaloneCodeGenerator 
   @JsonSchemaTitle("Header")
   @JsonPropertyDescription("whether the CSV file contains a header line")
   var hasHeader: Boolean = true
+
+  @JsonProperty(defaultValue = "false")
+  @JsonSchemaTitle("Track row-level lineage")
+  @JsonPropertyDescription(
+    "emit an extra __lineage_origin_row column tagging each output tuple " +
+      "with its 1-indexed source row in the parsed CSV body; lineage is " +
+      "propagated unchanged through pass-through operators (Filter, Sort)"
+  )
+  var trackLineage: Boolean = false
 
   fileTypeName = Option("CSV")
 
@@ -118,9 +136,13 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc with StandaloneCodeGenerator 
           .getOrElse((1 to attributeTypeList.length).map(i => "column-" + i).toArray)
       else (1 to attributeTypeList.length).map(i => "column-" + i).toArray
 
-    header.indices.foldLeft(Schema()) { (schema, i) =>
+    val dataSchema = header.indices.foldLeft(Schema()) { (schema, i) =>
       schema.add(header(i), attributeTypeList(i))
     }
+
+    if (trackLineage)
+      dataSchema.add(CSVScanSourceOpDesc.LineageOriginRowColumn, AttributeType.LONG)
+    else dataSchema
 
   }
 

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -28,13 +28,15 @@ import org.apache.texera.amber.core.tuple.AttributeTypeUtils.inferSchemaFromRows
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
+import org.apache.texera.amber.operator.StandaloneCodeGenerator
 import org.apache.texera.amber.operator.source.scan.ScanSourceOpDesc
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 
 import java.io.{IOException, InputStreamReader}
 import java.net.URI
+import java.nio.file.Paths
 
-class CSVScanSourceOpDesc extends ScanSourceOpDesc {
+class CSVScanSourceOpDesc extends ScanSourceOpDesc with StandaloneCodeGenerator {
 
   @JsonProperty(defaultValue = ",")
   @JsonSchemaTitle("Delimiter")
@@ -122,4 +124,38 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
 
   }
 
+  override def generateStandaloneCode(): String = {
+    // Strip to just the basename. The standalone script assumes the CSV
+    // lives in the same directory as the script (Texera's resolved URIs
+    // can't be used directly outside the system).
+    val rawPath = fileName.getOrElse("")
+    val basename = Paths.get(new URI(rawPath).getPath).getFileName.toString
+
+    val sep = customDelimiter.getOrElse(",")
+    // Texera's encoding enum uses values like UTF_8; pandas expects utf-8.
+    val encoding = fileEncoding.toString.replace("_", "-").toLowerCase
+    val headerArg = if (hasHeader) "0" else "None"
+
+    val args = scala.collection.mutable.ArrayBuffer[String]()
+    args += s"""filepath_or_buffer="$basename""""
+    args += s"""sep="$sep""""
+    args += s"""encoding="$encoding""""
+    args += s"header=$headerArg"
+
+    offset.foreach { o =>
+      // With a header, skip offset rows after row 0; without, skip offset rows from the start.
+      if (hasHeader) args += s"skiprows=range(1, ${o + 1})"
+      else args += s"skiprows=$o"
+    }
+    limit.foreach(l => args += s"nrows=$l")
+
+    val readCall = s"out1df = pd.read_csv(${args.mkString(", ")})"
+
+    if (hasHeader) readCall
+    else {
+      // Match Texera's fallback column naming when there's no header
+      s"""$readCall
+         |out1df.columns = [f"column-{i + 1}" for i in range(len(out1df.columns))]""".stripMargin
+    }
+  }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpExec.scala
@@ -36,6 +36,13 @@ class CSVScanSourceOpExec private[csv] (descString: String) extends SourceOperat
   var nextRow: Array[String] = _
   var numRowGenerated = 0
   private val schema: Schema = desc.sourceSchema()
+  // When lineage tracking is on, `schema` carries an extra __lineage_origin_row
+  // column appended after the data columns. `dataSchema` is the column shape
+  // seen by AttributeTypeUtils.parseFields (must match the raw row's cell count);
+  // the lineage value is appended after parsing.
+  private val dataSchema: Schema =
+    if (desc.trackLineage) schema.remove(CSVScanSourceOpDesc.LineageOriginRowColumn)
+    else schema
 
   override def produceTuple(): Iterator[TupleLike] = {
 
@@ -60,11 +67,14 @@ class CSVScanSourceOpExec private[csv] (descString: String) extends SourceOperat
       .drop(desc.offset.getOrElse(0))
       .map(row => {
         try {
-          TupleLike(
-            ArraySeq.unsafeWrapArray(
-              AttributeTypeUtils.parseFields(row.asInstanceOf[Array[Any]], schema)
-            ): _*
-          )
+          val parsed =
+            AttributeTypeUtils.parseFields(row.asInstanceOf[Array[Any]], dataSchema)
+          val fields: Array[Any] =
+            // 1-indexed source row within the parsed CSV body (post-header, post-offset
+            // applied transparently via the underlying parser's progress counter).
+            if (desc.trackLineage) parsed :+ numRowGenerated.toLong
+            else parsed
+          TupleLike(ArraySeq.unsafeWrapArray(fields): _*)
         } catch {
           case _: Throwable => null
         }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -25,7 +25,7 @@ import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.PythonTemplateBuilderStringContext
 import org.apache.texera.amber.pybuilder.PyStringTypes.EncodableString
 import org.apache.texera.amber.core.workflow.PortIdentity
-import org.apache.texera.amber.operator.PythonOperatorDescriptor
+import org.apache.texera.amber.operator.{PythonOperatorDescriptor, StandaloneCodeGenerator}
 import org.apache.texera.amber.operator.metadata.annotations.AutofillAttributeName
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder
@@ -42,7 +42,7 @@ import javax.validation.constraints.NotNull
   }
 }
 """)
-class BarChartOpDesc extends PythonOperatorDescriptor {
+class BarChartOpDesc extends PythonOperatorDescriptor with StandaloneCodeGenerator {
 
   @JsonProperty(value = "value", required = true)
   @JsonSchemaTitle("Value Column")
@@ -154,4 +154,30 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
     finalCode.encode
   }
 
+  // Output is an HTML chart, not a tabular DataFrame.
+  // The translator skips it in the leaf-DataFrame print block.
+  override def producesDataFrame(): Boolean = false
+
+  override def generateStandaloneCode(): String = {
+    val hasCategory = categoryColumn.nonEmpty && categoryColumn != "No Selection"
+    val colorArg = if (hasCategory) s""""$categoryColumn"""" else "None"
+    val patternArg = if (pattern.nonEmpty) s""""$pattern"""" else "None"
+
+    val barArgs =
+      if (horizontalOrientation)
+        s"""y="$fields", x="$value", color=$colorArg, pattern_shape=$patternArg, orientation='h'"""
+      else
+        s"""y="$value", x="$fields", color=$colorArg, pattern_shape=$patternArg"""
+
+    s"""in1df = in1df.dropna(subset=["$value", "$fields"])
+       |if not in1df.empty and "$fields" != "$value":
+       |    fig = go.Figure(px.bar(in1df, $barArgs))
+       |    fig.update_layout(margin=dict(l=0, r=0, t=0, b=0))
+       |    fig.write_html("output.html")
+       |    print("Bar chart saved to output.html")
+       |elif "$fields" == "$value":
+       |    print("Bar chart error: Fields should not have the same value.")
+       |elif in1df.empty:
+       |    print("Bar chart error: Table should not have any empty/null values or fields.")""".stripMargin
+  }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/csv/CSVScanSourceOpDescSpec.scala
@@ -160,4 +160,25 @@ class CSVScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(csvScanSourceOpDesc.customDelimiter.contains(","))
   }
 
+  it should "append __lineage_origin_row when trackLineage is enabled" in {
+    csvScanSourceOpDesc.fileName = Some(TestOperators.CountrySalesSmallMultiLineCsvPath)
+    csvScanSourceOpDesc.customDelimiter = Some(",")
+    csvScanSourceOpDesc.hasHeader = true
+    csvScanSourceOpDesc.trackLineage = true
+    csvScanSourceOpDesc.setResolvedFileName(FileResolver.resolve(csvScanSourceOpDesc.fileName.get))
+
+    val schema: Schema = csvScanSourceOpDesc.sourceSchema()
+
+    // 14 inferred data columns + 1 lineage column
+    assert(schema.getAttributes.length == 15)
+    assert(schema.containsAttribute(CSVScanSourceOpDesc.LineageOriginRowColumn))
+    assert(
+      schema.getAttribute(CSVScanSourceOpDesc.LineageOriginRowColumn).getType == AttributeType.LONG
+    )
+    // lineage column must come last so it doesn't shift indices of user columns
+    assert(
+      schema.getAttributes.last.getName == CSVScanSourceOpDesc.LineageOriginRowColumn
+    )
+  }
+
 }

--- a/frontend/proxy.config.json
+++ b/frontend/proxy.config.json
@@ -25,6 +25,11 @@
     "secure": false,
     "changeOrigin": true
   },
+  "/api/workflow-to-python": {
+    "target": "http://localhost:9090",
+    "secure": false,
+    "changeOrigin": true
+  },
   "/api/dataset": {
     "target": "http://localhost:9092",
     "secure": false,

--- a/frontend/src/app/dashboard/service/user/workflow-to-python/workflow-to-python.service.ts
+++ b/frontend/src/app/dashboard/service/user/workflow-to-python/workflow-to-python.service.ts
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpClient, HttpHeaders } from "@angular/common/http";
+import { Injectable } from "@angular/core";
+import { Observable } from "rxjs";
+import { AppSettings } from "../../../../common/app-setting";
+import { LogicalPlan } from "../../../../workspace/types/execute-workflow.interface";
+
+export const WORKFLOW_TO_PYTHON_ENDPOINT = "workflow-to-python";
+
+export interface WorkflowToPythonResponse {
+  type: "success" | "failure";
+  pythonCode?: string;
+  errorMessage?: string;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class WorkflowToPythonService {
+  constructor(private httpClient: HttpClient) {}
+
+  public convertToPython(logicalPlan: LogicalPlan): Observable<WorkflowToPythonResponse> {
+    const body = {
+      operators: logicalPlan.operators,
+      links: logicalPlan.links,
+      opsToReuseResult: [],
+      opsToViewResult: [],
+    };
+
+    return this.httpClient.post<WorkflowToPythonResponse>(
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_TO_PYTHON_ENDPOINT}`,
+      body,
+      {
+        headers: new HttpHeaders({
+          "Content-Type": "application/json",
+        }),
+      }
+    );
+  }
+}

--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -142,6 +142,15 @@
             nzType="download"></i>
         </button>
         <button
+          (click)="onClickExportAsPython()"
+          [disabled]="isTranslatingToPython"
+          nz-button
+          title="export as Python script">
+          <i
+            nz-icon
+            nzType="code"></i>
+        </button>
+        <button
           (click)="onClickEditDescription()"
           nz-button
           title="change description">

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -48,6 +48,7 @@ import { isDefined } from "../../../common/util/predicate";
 import { NzModalService } from "ng-zorro-antd/modal";
 import { ResultExportationComponent } from "../result-exportation/result-exportation.component";
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
+import { WorkflowToPythonService } from "../../../dashboard/service/user/workflow-to-python/workflow-to-python.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
 import { PanelService } from "../../service/panel/panel.service";
 import { DASHBOARD_USER_WORKFLOW } from "../../../app-routing.constant";
@@ -189,7 +190,8 @@ export class MenuComponent implements OnInit, OnDestroy {
     private panelService: PanelService,
     private computingUnitStatusService: ComputingUnitStatusService,
     protected config: GuiConfigService,
-    private router: Router
+    private router: Router,
+    private workflowToPythonService: WorkflowToPythonService
   ) {
     workflowWebsocketService
       .subscribeToEvent("ExecutionDurationUpdateEvent")
@@ -644,6 +646,36 @@ export class MenuComponent implements OnInit, OnDestroy {
     };
     return false;
   };
+
+  public isTranslatingToPython = false;
+
+  public onClickExportAsPython(): void {
+    const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(
+      this.validationWorkflowService.getValidTexeraGraph(),
+      undefined
+    );
+
+    this.isTranslatingToPython = true;
+    this.workflowToPythonService.convertToPython(logicalPlan).subscribe({
+      next: response => {
+        this.isTranslatingToPython = false;
+        if (response.type === "success") {
+          this.modalService.create({
+            nzTitle: "Workflow as Python Script",
+            nzContent: `<pre style="max-height:70vh;overflow:auto;white-space:pre-wrap">${response.pythonCode}</pre>`,
+            nzFooter: null,
+            nzWidth: 800,
+          });
+        } else {
+          this.notificationService.error(response.errorMessage ?? "Failed to translate workflow to Python.");
+        }
+      },
+      error: () => {
+        this.isTranslatingToPython = false;
+        this.notificationService.error("Request failed while translating workflow to Python.");
+      },
+    });
+  }
 
   public onClickExportWorkflow(): void {
     const workflowContent: WorkflowContent = this.workflowActionService.getWorkflowContent();

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -98,7 +98,6 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
   styleUrls: ["menu.component.scss"],
   imports: [
     NgIf,
-    NzSpaceCompactItemDirective,
     NzButtonComponent,
     ɵNzTransitionPatchDirective,
     NzIconDirective,

--- a/frontend/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/frontend/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -83,6 +83,16 @@
             nzWidth="widthPercent">
             {{ column.header }}
           </th>
+          <th
+            *ngIf="hasLineageColumn"
+            ngClass="header-size"
+            style="text-align: center; width: 70px"
+            nz-tooltip="Each row carries a lineage tag from its source. Click to trace it.">
+            <i
+              nz-icon
+              nzType="branches"></i>
+            Why?
+          </th>
         </tr>
         <tr
           *ngIf="tableStats && prevTableStats"
@@ -149,12 +159,14 @@
               </ng-container>
             </div>
           </th>
+          <th *ngIf="hasLineageColumn"></th>
         </tr>
       </thead>
       <tbody>
         <tr
           *ngFor="let row of basicTable.data; let i = index"
-          class="table-row-hover">
+          class="table-row-hover"
+          [class.lineage-highlighted-row]="i === highlightedRowIndex">
           <td
             *ngFor="let column of currentColumns; let columnIndex = index"
             class="table-cell"
@@ -170,6 +182,22 @@
               <i
                 nz-icon
                 nzType="cloud-download"></i>
+            </button>
+          </td>
+          <td
+            *ngIf="hasLineageColumn"
+            class="lineage-cell"
+            style="text-align: center; width: 70px">
+            <button
+              *ngIf="hasLineage(row)"
+              (click)="onWhyButtonClick(row); $event.stopPropagation()"
+              nz-button
+              nzType="link"
+              nz-tooltip="Show where this row came from"
+              title="Why is this row here?">
+              <i
+                nz-icon
+                nzType="question-circle"></i>
             </button>
           </td>
         </tr>

--- a/frontend/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
+++ b/frontend/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
@@ -21,6 +21,26 @@
   margin: 16px 0;
 }
 
+// Transient highlight applied to a source row when the user clicks
+// "Jump to source row" in the lineage modal. Cleared after a few seconds
+// by ResultTableFrameComponent's timer.
+:host ::ng-deep tr.lineage-highlighted-row > td {
+  background-color: #fff3a8;
+  animation: lineage-highlight-pulse 0.6s ease-out 2;
+}
+
+@keyframes lineage-highlight-pulse {
+  0% {
+    background-color: #fff3a8;
+  }
+  50% {
+    background-color: #ffd84d;
+  }
+  100% {
+    background-color: #fff3a8;
+  }
+}
+
 // make the pagination button to the left
 :host ::ng-deep .ant-table-pagination-right {
   justify-content: left;

--- a/frontend/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/frontend/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -47,6 +47,11 @@ import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
+import {
+  LineageHighlightRequest,
+  LineageHighlightService,
+} from "../../../service/workflow-result/lineage-highlight.service";
 
 /**
  * The Component will display the result in an excel table format,
@@ -78,6 +83,7 @@ import { NzIconDirective } from "ng-zorro-antd/icon";
     NgClass,
     NzTbodyComponent,
     NzCellEllipsisDirective,
+    NzTooltipDirective,
   ],
 })
 export class ResultTableFrameComponent implements OnInit, OnChanges {
@@ -109,6 +115,27 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
   widthPercent: string = "";
   isOperatorFinished: boolean = false;
 
+  /**
+   * 0-indexed row position (within the currently displayed page) that should be
+   * temporarily highlighted to satisfy a `LineageHighlightService` request. -1
+   * means no row is currently highlighted. Cleared after a few seconds.
+   */
+  highlightedRowIndex: number = -1;
+  private highlightClearTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * The `__lineage_origin_row` value we're trying to locate. We can't rely on
+   * positional math (page = floor(N/pageSize)) because the underlying Iceberg
+   * storage doesn't guarantee insertion order on read — page 9 row 5 might not
+   * be the row whose lineage value is 45. Instead, we navigate to a best-
+   * guess page, inspect the actual lineage values that come back, and iterate
+   * outward (binary-search-style) until we find the target row or exhaust the
+   * attempt budget.
+   */
+  private pendingHighlightSourceRow: number | null = null;
+  private highlightSearchAttempts = 0;
+  private highlightVisitedPages: Set<number> = new Set();
+  private static readonly HIGHLIGHT_MAX_ATTEMPTS = 15;
+
   constructor(
     private modalService: NzModalService,
     private workflowActionService: WorkflowActionService,
@@ -117,7 +144,8 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
     private changeDetectorRef: ChangeDetectorRef,
     private sanitizer: DomSanitizer,
     private workflowStatusService: WorkflowStatusService,
-    private guiConfigService: GuiConfigService
+    private guiConfigService: GuiConfigService,
+    private lineageHighlightService: LineageHighlightService
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -133,6 +161,9 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
         this.tableStats = paginatedResultService.getStats();
         this.prevTableStats = this.tableStats;
       }
+      // If a lineage-highlight request was set before this component swapped in
+      // for the source operator, apply it now.
+      this.applyLineageHighlightIfApplicable(this.lineageHighlightService.getPending());
     }
   }
 
@@ -189,6 +220,12 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
           }
         }
       });
+
+    // React to lineage "jump to source row" requests broadcast from elsewhere.
+    this.lineageHighlightService
+      .pendingHighlight()
+      .pipe(untilDestroyed(this))
+      .subscribe(req => this.applyLineageHighlightIfApplicable(req));
 
     this.resizeService.currentSize.pipe(untilDestroyed(this)).subscribe(size => {
       this.panelHeight = size.height;
@@ -425,12 +462,20 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
 
     let columns: { columnKey: any; columnText: string }[];
 
-    const columnKeys = Object.keys(resultData[0]).filter(x => x !== "_id");
+    // Hide internal/lineage columns (anything prefixed with "__") from the visible
+    // table — they remain on the row object so per-row affordances (e.g. the "Why?"
+    // lineage button) can still access them.
+    const columnKeys = Object.keys(resultData[0]).filter(x => x !== "_id" && !x.startsWith("__"));
     columns = columnKeys.map(v => ({ columnKey: v, columnText: v }));
 
     // generate columnDef from first row, column definition is in order
     this.currentColumns = this.generateColumns(columns);
     this.totalNumTuples = totalRowCount;
+
+    // If a "Jump to source row" request is waiting on this operator, resolve it
+    // now against the freshly loaded rows (Iceberg's read order isn't
+    // guaranteed, so we match by `__lineage_origin_row` value, not position).
+    this.resolvePendingHighlight();
   }
 
   /**
@@ -444,6 +489,253 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
       header: col.columnText,
       getCell: (row: IndexableObject) => row[col.columnKey].toString(),
     }));
+  }
+
+  // Column name emitted by source operators when "Track row-level lineage" is on.
+  // Must stay in sync with CSVScanSourceOpDesc.LineageOriginRowColumn (Scala).
+  static readonly LINEAGE_ORIGIN_ROW_COLUMN = "__lineage_origin_row";
+
+  /**
+   * Whether the currently displayed result rows carry a lineage tag. Used to
+   * conditionally render the per-row "Why?" button in the template.
+   */
+  hasLineage(row: IndexableObject): boolean {
+    return row[ResultTableFrameComponent.LINEAGE_ORIGIN_ROW_COLUMN] !== undefined;
+  }
+
+  /**
+   * True when the currently displayed result rows carry a lineage tag. Used to
+   * decide whether to render the extra "Why?" table column at all.
+   */
+  get hasLineageColumn(): boolean {
+    return this.currentResult.length > 0 && this.hasLineage(this.currentResult[0]);
+  }
+
+  /**
+   * Walks upstream via input links (BFS) from the given operator and returns
+   * the closest ancestor that emits row-level lineage (currently, a
+   * `CSVFileScan` with `trackLineage` enabled). Returns `undefined` if no such
+   * source is reachable — for example because lineage was lost across a
+   * Projection or Python UDF, or because the user enabled the checkbox after
+   * the workflow was last run.
+   */
+  private findUpstreamLineageSource(operatorID: string): { id: string; sourceFile?: string } | undefined {
+    const graph = this.workflowActionService.getTexeraGraph();
+    const visited = new Set<string>();
+    const queue: string[] = [operatorID];
+    while (queue.length > 0) {
+      const id = queue.shift()!;
+      if (visited.has(id)) continue;
+      visited.add(id);
+      const op = graph.getOperator(id);
+      if (op) {
+        const props = op.operatorProperties ?? {};
+        if (op.operatorType === "CSVFileScan" && props["trackLineage"] === true) {
+          return { id, sourceFile: props["fileName"] as string | undefined };
+        }
+      }
+      for (const link of graph.getInputLinksByOperatorId(id)) {
+        queue.push(link.source.operatorID);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Apply a pending lineage-highlight request iff it targets *this* operator's
+   * result panel. Navigates to the page that *probably* contains the source row
+   * (based on emission-order math) and stores the lineage value so
+   * `setupResultTable` can find the actual row by matching its
+   * `__lineage_origin_row` field — Iceberg may not preserve insertion order on
+   * read, so positional navigation alone can land on the wrong row.
+   */
+  private applyLineageHighlightIfApplicable(req: LineageHighlightRequest | null): void {
+    if (!req || !this.operatorId || req.operatorID !== this.operatorId) return;
+    const rowOneIndexed = req.sourceRow;
+    if (!Number.isFinite(rowOneIndexed) || rowOneIndexed < 1) return;
+
+    // Fresh request: reset the iterative search state.
+    this.pendingHighlightSourceRow = rowOneIndexed;
+    this.highlightSearchAttempts = 0;
+    this.highlightVisitedPages = new Set();
+    this.lineageHighlightService.clear();
+
+    // Best-guess page from emission order; if Iceberg returns rows out of
+    // insertion order we'll iterate outward in resolvePendingHighlight.
+    // NOTE: don't pre-add the user's previous page to visitedPages — the search
+    // may legitimately need to walk back into it. Only pages actually inspected
+    // for the target value should be marked visited.
+    const targetPage = Math.floor((rowOneIndexed - 1) / this.pageSize) + 1;
+    if (this.currentPageIndex !== targetPage) {
+      this.currentPageIndex = targetPage;
+      this.changePaginatedResultData();
+    } else {
+      this.resolvePendingHighlight();
+    }
+  }
+
+  /**
+   * Searches the currently loaded page for the row whose `__lineage_origin_row`
+   * matches `pendingHighlightSourceRow`. If found, marks its index for the
+   * highlight class and schedules a clear timer. If not found, leaves the
+   * pending value in place — a subsequent page load (e.g. user-driven) can
+   * still resolve it. Called from `setupResultTable` after the table data is
+   * refreshed.
+   */
+  private resolvePendingHighlight(): void {
+    if (this.pendingHighlightSourceRow === null) return;
+    const target = this.pendingHighlightSourceRow;
+    const col = ResultTableFrameComponent.LINEAGE_ORIGIN_ROW_COLUMN;
+
+    const lineageVals: number[] = this.currentResult
+      .map(r => Number(r[col]))
+      .filter(v => Number.isFinite(v));
+    const idx = this.currentResult.findIndex(r => Number(r[col]) === target);
+
+    // Diagnostic — visible in DevTools Console.
+    // eslint-disable-next-line no-console
+    console.log(
+      `[lineage] resolve attempt ${this.highlightSearchAttempts + 1}: ` +
+        `target=${target}, page=${this.currentPageIndex}, pageSize=${this.pageSize}, ` +
+        `matchIdx=${idx}, valsOnPage=`,
+      lineageVals
+    );
+
+    if (idx >= 0) {
+      this.highlightedRowIndex = idx;
+      this.pendingHighlightSourceRow = null;
+      if (this.highlightClearTimer) clearTimeout(this.highlightClearTimer);
+      this.highlightClearTimer = setTimeout(() => {
+        this.highlightedRowIndex = -1;
+        this.changeDetectorRef.detectChanges();
+      }, 6000);
+      this.changeDetectorRef.detectChanges();
+      return;
+    }
+
+    // Not on this page — pick the next page to fetch based on whether target
+    // is below or above the values we see. Caps at a few attempts to avoid
+    // hammering the backend if values are scattered chaotically.
+    this.highlightSearchAttempts++;
+    this.highlightVisitedPages.add(this.currentPageIndex);
+
+    if (lineageVals.length === 0) {
+      this.giveUpHighlight(target, "no lineage values found on this page");
+      return;
+    }
+    if (this.highlightSearchAttempts >= ResultTableFrameComponent.HIGHLIGHT_MAX_ATTEMPTS) {
+      this.giveUpHighlight(
+        target,
+        `gave up after ${this.highlightSearchAttempts} page fetches`
+      );
+      return;
+    }
+
+    const minVal = Math.min(...lineageVals);
+    const maxVal = Math.max(...lineageVals);
+    const totalPages = Math.max(1, Math.ceil(this.totalNumTuples / this.pageSize));
+
+    let nextPage: number;
+    if (target < minVal) {
+      const stepRows = Math.max(this.pageSize, minVal - target);
+      const stepPages = Math.max(1, Math.ceil(stepRows / this.pageSize));
+      nextPage = Math.max(1, this.currentPageIndex - stepPages);
+    } else if (target > maxVal) {
+      const stepRows = Math.max(this.pageSize, target - maxVal);
+      const stepPages = Math.max(1, Math.ceil(stepRows / this.pageSize));
+      nextPage = Math.min(totalPages, this.currentPageIndex + stepPages);
+    } else {
+      // Target is between min and max but not present — page is sparse w.r.t.
+      // lineage. Step one page in the direction of the side with more room.
+      nextPage =
+        target - minVal < maxVal - target
+          ? Math.max(1, this.currentPageIndex - 1)
+          : Math.min(totalPages, this.currentPageIndex + 1);
+    }
+
+    if (this.highlightVisitedPages.has(nextPage)) {
+      // Already tried — give up rather than loop.
+      this.giveUpHighlight(target, `would revisit page ${nextPage}`);
+      return;
+    }
+
+    this.currentPageIndex = nextPage;
+    this.changePaginatedResultData();
+  }
+
+  private giveUpHighlight(target: number, reason: string): void {
+    this.pendingHighlightSourceRow = null;
+    // eslint-disable-next-line no-console
+    console.warn(`[lineage] gave up locating source row ${target}: ${reason}`);
+    this.modalService.warning({
+      nzTitle: "Couldn't locate the source row",
+      nzContent:
+        `Tried up to ${this.highlightSearchAttempts} pages without finding a row ` +
+        `whose __lineage_origin_row equals ${target}. Iceberg's read order ` +
+        `made the search inconclusive. Last attempted page: ${this.currentPageIndex}.`,
+      nzOkText: "OK",
+    });
+  }
+
+  /**
+   * Opens a modal explaining where the selected row came from. If a lineage-
+   * emitting source operator can be located upstream, the modal also offers a
+   * "Jump to source row" action that selects that operator and asks its result
+   * panel to scroll to + highlight the originating row.
+   */
+  onWhyButtonClick(row: IndexableObject): void {
+    const lineageValue = row[ResultTableFrameComponent.LINEAGE_ORIGIN_ROW_COLUMN];
+    if (lineageValue === undefined || this.operatorId === undefined) return;
+    const sourceRowNum = Number(lineageValue);
+    if (!Number.isFinite(sourceRowNum)) return;
+
+    const operator = this.workflowActionService.getTexeraGraph().getOperator(this.operatorId);
+    const opLabel = operator?.customDisplayName?.trim() || operator?.operatorType || "this operator";
+
+    const upstream = this.findUpstreamLineageSource(this.operatorId);
+    const sourceFile = upstream?.sourceFile;
+    const sourceLabel = sourceFile
+      ? sourceFile.split("/").pop() ?? sourceFile
+      : "the source operator";
+
+    const escape = (s: string) => s.replace(/[&<>"']/g, c =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]!));
+
+    const footer: any[] = [
+      {
+        label: "Close",
+        onClick: () => modalRef.destroy(),
+      },
+    ];
+    if (upstream) {
+      footer.push({
+        label: "Jump to source row",
+        type: "primary",
+        onClick: () => {
+          this.workflowActionService.highlightOperators(false, upstream.id);
+          this.lineageHighlightService.requestHighlight(upstream.id, sourceRowNum);
+          modalRef.destroy();
+        },
+      });
+    }
+
+    const modalRef: NzModalRef = this.modalService.create({
+      nzTitle: "Why is this row here?",
+      nzContent: `
+        <div style="line-height: 1.6">
+          <p>This row of <b>${escape(opLabel)}</b> originated from
+          <b>row ${escape(String(sourceRowNum))}</b> of
+          <b>${escape(sourceLabel)}</b>.</p>
+          <p style="color:#888;font-size:12px;margin-top:12px">
+            The 1-indexed source position was carried through every
+            pass-through operator (Filter, Sort) in this workflow's pipeline.
+            Many-to-one operators (Join, Aggregate, GroupBy) and Python UDFs
+            do not propagate lineage in this version.
+          </p>
+        </div>`,
+      nzFooter: footer,
+      nzWidth: 520,
+    });
   }
 
   downloadData(data: any, rowIndex: number, columnIndex: number, columnName: string): void {

--- a/frontend/src/app/workspace/service/workflow-result/lineage-highlight.service.ts
+++ b/frontend/src/app/workspace/service/workflow-result/lineage-highlight.service.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+
+export interface LineageHighlightRequest {
+  /** The operator whose result panel should show the highlighted row. */
+  operatorID: string;
+  /** 1-indexed source-row position emitted by the lineage-tracking source operator. */
+  sourceRow: number;
+}
+
+/**
+ * Shared bus that lets a downstream "Why?" click ask the upstream source
+ * operator's result panel to scroll to and highlight the row that produced
+ * the clicked tuple. The publisher (lineage modal) and subscriber
+ * (`ResultTableFrameComponent`) are not aware of each other.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class LineageHighlightService {
+  private readonly pending$ = new BehaviorSubject<LineageHighlightRequest | null>(null);
+
+  /** Current pending request (may be null). Subscribers receive the latest value on subscribe. */
+  pendingHighlight(): Observable<LineageHighlightRequest | null> {
+    return this.pending$.asObservable();
+  }
+
+  getPending(): LineageHighlightRequest | null {
+    return this.pending$.getValue();
+  }
+
+  requestHighlight(operatorID: string, sourceRow: number): void {
+    this.pending$.next({ operatorID, sourceRow });
+  }
+
+  /** Called by the subscriber once the highlight has been applied. */
+  clear(): void {
+    if (this.pending$.getValue() !== null) this.pending$.next(null);
+  }
+}

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
@@ -20,39 +20,30 @@
 package org.apache.texera.amber.translator
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.texera.amber.compiler.model.LogicalPlanPojo
+import org.apache.texera.amber.compiler.model.LogicalPlan
 import org.apache.texera.amber.operator.StandaloneCodeGenerator
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
 
 class WorkflowToPythonTranslator extends LazyLogging {
 
-  def translate(pojo: LogicalPlanPojo): String = {
-    // TODO: filter disabled operators
-    val activeOperators = pojo.operators
-    val links = pojo.links
-
-    val opIds = activeOperators.map(_.operatorIdentifier.id)
+  def translate(logicalPlan: LogicalPlan): String = {
+    val links = logicalPlan.links
 
     val incoming = mutable.Map[String, ArrayBuffer[String]]()
     val outgoing = mutable.Map[String, ArrayBuffer[String]]()
-    opIds.foreach { id =>
-      incoming(id) = ArrayBuffer.empty
-      outgoing(id) = ArrayBuffer.empty
+    logicalPlan.operators.foreach { op =>
+      incoming(op.operatorIdentifier.id) = ArrayBuffer.empty
+      outgoing(op.operatorIdentifier.id) = ArrayBuffer.empty
     }
     links.foreach { link =>
       val src = link.fromOpId.id
       val tgt = link.toOpId.id
-      // only wire links between active operators
-      if (incoming.contains(src) && outgoing.contains(tgt)) {
-        outgoing(src) += tgt
-        incoming(tgt) += src
-      }
+      outgoing(src) += tgt
+      incoming(tgt) += src
     }
-
-    val opById = activeOperators.map(op => op.operatorIdentifier.id -> op).toMap
-    val order = topoSort(opIds, outgoing)
 
     val outputVar = mutable.Map[String, String]()
     var varCounter = 1
@@ -64,8 +55,12 @@ class WorkflowToPythonTranslator extends LazyLogging {
     lines += "import plotly.io"
     lines += ""
 
-    for (opId <- order) {
-      val op = opById(opId)
+    // getTopologicalOpIds() uses jgrapht internally — no need for a custom topo sort
+    val topoOrder = logicalPlan.getTopologicalOpIds.asScala.toList
+
+    for (opIdentity <- topoOrder) {
+      val op = logicalPlan.getOperator(opIdentity)
+      val opId = opIdentity.id
       val displayName = op.operatorInfo.userFriendlyName
       val inVars = incoming(opId).map(outputVar).toList
       val outVar = s"df$varCounter"
@@ -91,9 +86,9 @@ class WorkflowToPythonTranslator extends LazyLogging {
       lines += ""
     }
 
-    val leafIds = order.filter(id => outgoing(id).isEmpty)
+    val leafIds = topoOrder.map(_.id).filter(id => outgoing(id).isEmpty)
     val dataFrameLeaves = leafIds.filter { id =>
-      opById(id) match {
+      logicalPlan.getOperator(id) match {
         case gen: StandaloneCodeGenerator => gen.producesDataFrame()
         case _                            => false
       }
@@ -103,7 +98,7 @@ class WorkflowToPythonTranslator extends LazyLogging {
       lines += "# --- Output ---"
       for (opId <- dataFrameLeaves) {
         val varName = outputVar(opId)
-        val displayName = opById(opId).operatorInfo.userFriendlyName
+        val displayName = logicalPlan.getOperator(opId).operatorInfo.userFriendlyName
         lines += s"""print("\\n[$displayName] $varName:")"""
         lines += s"print($varName.head())"
         lines += ""
@@ -111,35 +106,6 @@ class WorkflowToPythonTranslator extends LazyLogging {
     }
 
     lines.mkString("\n")
-  }
-
-  private def topoSort(
-      opIds: List[String],
-      outgoing: mutable.Map[String, ArrayBuffer[String]]
-  ): List[String] = {
-    val inDegree = mutable.Map[String, Int]()
-    opIds.foreach(id => inDegree(id) = 0)
-    opIds.foreach(id => outgoing(id).foreach(tgt => inDegree(tgt) += 1))
-
-    val queue = mutable.Queue[String]()
-    opIds.filter(id => inDegree(id) == 0).foreach(queue.enqueue)
-
-    val order = ArrayBuffer[String]()
-    while (queue.nonEmpty) {
-      val curr = queue.dequeue()
-      order += curr
-      outgoing(curr).foreach { next =>
-        inDegree(next) -= 1
-        if (inDegree(next) == 0) queue.enqueue(next)
-      }
-    }
-
-    if (order.length != opIds.length)
-      throw new IllegalArgumentException(
-        "Workflow contains a cycle or disconnected operators."
-      )
-
-    order.toList
   }
 
   // Replaces in1df/out1df placeholders with concrete variable names.

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
@@ -30,60 +30,59 @@ import scala.jdk.CollectionConverters._
 class WorkflowToPythonTranslator extends LazyLogging {
 
   def translate(logicalPlan: LogicalPlan): String = {
-    val links = logicalPlan.links
-
     val incoming = mutable.Map[String, ArrayBuffer[String]]()
     val outgoing = mutable.Map[String, ArrayBuffer[String]]()
+
     logicalPlan.operators.foreach { op =>
-      incoming(op.operatorIdentifier.id) = ArrayBuffer.empty
-      outgoing(op.operatorIdentifier.id) = ArrayBuffer.empty
+      val id = op.operatorIdentifier.id
+      incoming(id) = ArrayBuffer.empty
+      outgoing(id) = ArrayBuffer.empty
     }
-    links.foreach { link =>
-      val src = link.fromOpId.id
-      val tgt = link.toOpId.id
-      outgoing(src) += tgt
-      incoming(tgt) += src
+
+    logicalPlan.links.foreach { link =>
+      outgoing(link.fromOpId.id) += link.toOpId.id
+      incoming(link.toOpId.id) += link.fromOpId.id
     }
 
     val outputVar = mutable.Map[String, String]()
     var varCounter = 1
-    val lines = ArrayBuffer[String]()
+    val script = ArrayBuffer[String]()
 
-    lines += "import pandas as pd"
-    lines += "import plotly.express as px"
-    lines += "import plotly.graph_objects as go"
-    lines += "import plotly.io"
-    lines += ""
+    script += "import pandas as pd"
+    script += "import plotly.express as px"
+    script += "import plotly.graph_objects as go"
+    script += "import plotly.io"
+    script += ""
 
     // getTopologicalOpIds() uses jgrapht internally — no need for a custom topo sort
     val topoOrder = logicalPlan.getTopologicalOpIds.asScala.toList
 
     for (opIdentity <- topoOrder) {
-      val op = logicalPlan.getOperator(opIdentity)
       val opId = opIdentity.id
+      val op = logicalPlan.getOperator(opIdentity)
       val displayName = op.operatorInfo.userFriendlyName
       val inVars = incoming(opId).map(outputVar).toList
       val outVar = s"df$varCounter"
       varCounter += 1
       outputVar(opId) = outVar
 
-      lines += s"# [$displayName]"
+      script += s"# [$displayName]"
 
       // Each operator is already the correct concrete subclass (e.g. BarChartOpDesc)
       // because Jackson uses @JsonSubTypes on LogicalOp to deserialize the pojo.
       op match {
         case gen: StandaloneCodeGenerator =>
-          lines += substituteVars(gen.generateStandaloneCode(), inVars, outVar)
+          script += substituteVars(gen.generateStandaloneCode(), inVars, outVar)
 
         case _ =>
           logger.warn(
             s"Operator '$displayName' does not implement StandaloneCodeGenerator. Skipping."
           )
-          lines += s"# TODO: '$displayName' is not yet supported by the translator."
-          lines += s"# $outVar = <output of $displayName>"
+          script += s"# TODO: '$displayName' is not yet supported by the translator."
+          script += s"# $outVar = <output of $displayName>"
       }
 
-      lines += ""
+      script += ""
     }
 
     val leafIds = topoOrder.map(_.id).filter(id => outgoing(id).isEmpty)
@@ -95,17 +94,17 @@ class WorkflowToPythonTranslator extends LazyLogging {
     }
 
     if (dataFrameLeaves.nonEmpty) {
-      lines += "# --- Output ---"
+      script += "# --- Output ---"
       for (opId <- dataFrameLeaves) {
         val varName = outputVar(opId)
         val displayName = logicalPlan.getOperator(opId).operatorInfo.userFriendlyName
-        lines += s"""print("\\n[$displayName] $varName:")"""
-        lines += s"print($varName.head())"
-        lines += ""
+        script += s"""print("\\n[$displayName] $varName:")"""
+        script += s"print($varName.head())"
+        script += ""
       }
     }
 
-    lines.mkString("\n")
+    script.mkString("\n")
   }
 
   // Replaces in1df/out1df placeholders with concrete variable names.

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.translator
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.texera.amber.compiler.model.LogicalPlanPojo
+import org.apache.texera.amber.operator.StandaloneCodeGenerator
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+class WorkflowToPythonTranslator extends LazyLogging {
+
+  def translate(pojo: LogicalPlanPojo): String = {
+    // TODO: filter disabled operators
+    val activeOperators = pojo.operators
+    val links = pojo.links
+
+    val opIds = activeOperators.map(_.operatorIdentifier.id)
+
+    val incoming = mutable.Map[String, ArrayBuffer[String]]()
+    val outgoing = mutable.Map[String, ArrayBuffer[String]]()
+    opIds.foreach { id =>
+      incoming(id) = ArrayBuffer.empty
+      outgoing(id) = ArrayBuffer.empty
+    }
+    links.foreach { link =>
+      val src = link.fromOpId.id
+      val tgt = link.toOpId.id
+      // only wire links between active operators
+      if (incoming.contains(src) && outgoing.contains(tgt)) {
+        outgoing(src) += tgt
+        incoming(tgt) += src
+      }
+    }
+
+    val opById = activeOperators.map(op => op.operatorIdentifier.id -> op).toMap
+    val order = topoSort(opIds, outgoing)
+
+    val outputVar = mutable.Map[String, String]()
+    var varCounter = 1
+    val lines = ArrayBuffer[String]()
+
+    lines += "import pandas as pd"
+    lines += "import plotly.express as px"
+    lines += "import plotly.graph_objects as go"
+    lines += "import plotly.io"
+    lines += ""
+
+    for (opId <- order) {
+      val op = opById(opId)
+      val displayName = op.operatorInfo.userFriendlyName
+      val inVars = incoming(opId).map(outputVar).toList
+      val outVar = s"df$varCounter"
+      varCounter += 1
+      outputVar(opId) = outVar
+
+      lines += s"# [$displayName]"
+
+      // Each operator is already the correct concrete subclass (e.g. BarChartOpDesc)
+      // because Jackson uses @JsonSubTypes on LogicalOp to deserialize the pojo.
+      op match {
+        case gen: StandaloneCodeGenerator =>
+          lines += substituteVars(gen.generateStandaloneCode(), inVars, outVar)
+
+        case _ =>
+          logger.warn(
+            s"Operator '$displayName' does not implement StandaloneCodeGenerator. Skipping."
+          )
+          lines += s"# TODO: '$displayName' is not yet supported by the translator."
+          lines += s"# $outVar = <output of $displayName>"
+      }
+
+      lines += ""
+    }
+
+    val leafIds = order.filter(id => outgoing(id).isEmpty)
+    val dataFrameLeaves = leafIds.filter { id =>
+      opById(id) match {
+        case gen: StandaloneCodeGenerator => gen.producesDataFrame()
+        case _                            => false
+      }
+    }
+
+    if (dataFrameLeaves.nonEmpty) {
+      lines += "# --- Output ---"
+      for (opId <- dataFrameLeaves) {
+        val varName = outputVar(opId)
+        val displayName = opById(opId).operatorInfo.userFriendlyName
+        lines += s"""print("\\n[$displayName] $varName:")"""
+        lines += s"print($varName.head())"
+        lines += ""
+      }
+    }
+
+    lines.mkString("\n")
+  }
+
+  private def topoSort(
+      opIds: List[String],
+      outgoing: mutable.Map[String, ArrayBuffer[String]]
+  ): List[String] = {
+    val inDegree = mutable.Map[String, Int]()
+    opIds.foreach(id => inDegree(id) = 0)
+    opIds.foreach(id => outgoing(id).foreach(tgt => inDegree(tgt) += 1))
+
+    val queue = mutable.Queue[String]()
+    opIds.filter(id => inDegree(id) == 0).foreach(queue.enqueue)
+
+    val order = ArrayBuffer[String]()
+    while (queue.nonEmpty) {
+      val curr = queue.dequeue()
+      order += curr
+      outgoing(curr).foreach { next =>
+        inDegree(next) -= 1
+        if (inDegree(next) == 0) queue.enqueue(next)
+      }
+    }
+
+    if (order.length != opIds.length)
+      throw new IllegalArgumentException(
+        "Workflow contains a cycle or disconnected operators."
+      )
+
+    order.toList
+  }
+
+  // Replaces in1df/out1df placeholders with concrete variable names.
+  // Reverse index order prevents partial matches (e.g. in1df inside in10df).
+  private def substituteVars(code: String, inVars: List[String], outVar: String): String = {
+    var result = code
+
+    inVars.zipWithIndex.reverse.foreach {
+      case (varName, idx) =>
+        result = result.replaceAll(s"\\bin${idx + 1}df\\b", varName)
+    }
+
+    result.replaceAll("""\bout1df\b""", outVar)
+  }
+}

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
@@ -68,10 +68,12 @@ class WorkflowToPythonTranslator extends LazyLogging {
 
       script += s"# [$displayName]"
 
-      // Each operator is already the correct concrete subclass (e.g. BarChartOpDesc)
-      // because Jackson uses @JsonSubTypes on LogicalOp to deserialize the pojo.
+      // Jackson deserializes each operator into its concrete subclass via @JsonSubTypes on LogicalOp,
+      // so the pattern match below will resolve to the correct descriptor (e.g. BarChartOpDesc).
       op match {
         case gen: StandaloneCodeGenerator =>
+          // generateStandaloneCode() returns a code block using in1df/out1df as placeholder
+          // variable names, which substituteVars() replaces with the actual assigned variable names.
           script += substituteVars(gen.generateStandaloneCode(), inVars, outVar)
 
         case _ =>
@@ -85,6 +87,8 @@ class WorkflowToPythonTranslator extends LazyLogging {
       script += ""
     }
 
+    // Print leaf operator outputs that produce DataFrames so the script
+    // gives visible output when run locally.
     val leafIds = topoOrder.map(_.id).filter(id => outgoing(id).isEmpty)
     val dataFrameLeaves = leafIds.filter { id =>
       logicalPlan.getOperator(id) match {
@@ -108,7 +112,7 @@ class WorkflowToPythonTranslator extends LazyLogging {
   }
 
   // Replaces in1df/out1df placeholders with concrete variable names.
-  // Reverse index order prevents partial matches (e.g. in1df inside in10df).
+  // Substitutes in reverse index order to prevent partial matches (e.g. in1df inside in10df).
   private def substituteVars(code: String, inVars: List[String], outVar: String): String = {
     var result = code
 

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/service/WorkflowCompilingService.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/service/WorkflowCompilingService.scala
@@ -26,7 +26,7 @@ import io.dropwizard.core.setup.{Bootstrap, Environment}
 import org.apache.texera.amber.config.StorageConfig
 import org.apache.texera.amber.util.ObjectMapperUtils
 import org.apache.texera.dao.SqlServer
-import org.apache.texera.service.resource.{HealthCheckResource, WorkflowCompilationResource}
+import org.apache.texera.service.resource.{HealthCheckResource, WorkflowCompilationResource, WorkflowToPythonResource}
 import org.eclipse.jetty.servlet.FilterHolder
 
 import java.nio.file.Path
@@ -63,6 +63,9 @@ class WorkflowCompilingService extends Application[WorkflowCompilingServiceConfi
 
     // register the compilation endpoint
     environment.jersey.register(classOf[WorkflowCompilationResource])
+
+    // register the workflow-to-python endpoint
+    environment.jersey.register(classOf[WorkflowToPythonResource])
 
     // Route request logs through SLF4J, controlled by TEXERA_SERVICE_LOG_LEVEL
     val requestLogger = org.slf4j.LoggerFactory.getLogger("org.eclipse.jetty.server.RequestLog")

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/service/resource/WorkflowToPythonResource.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/service/resource/WorkflowToPythonResource.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.service.resource
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import com.typesafe.scalalogging.LazyLogging
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.{Consumes, POST, Path, Produces}
+import com.fasterxml.jackson.databind.JsonNode
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "type"
+)
+@JsonSubTypes(
+  Array(
+    new JsonSubTypes.Type(value = classOf[WorkflowToPythonSuccess], name = "success"),
+    new JsonSubTypes.Type(value = classOf[WorkflowToPythonFailure], name = "failure")
+  )
+)
+sealed trait WorkflowToPythonResponse
+
+case class WorkflowToPythonSuccess(pythonCode: String) extends WorkflowToPythonResponse
+
+case class WorkflowToPythonFailure(errorMessage: String) extends WorkflowToPythonResponse
+
+@Consumes(Array(MediaType.APPLICATION_JSON))
+@Produces(Array(MediaType.APPLICATION_JSON))
+@RolesAllowed(Array("REGULAR", "ADMIN"))
+@Path("/workflow-to-python")
+class WorkflowToPythonResource extends LazyLogging {
+
+  @POST
+  @Path("")
+  def convertWorkflowToPython(
+                               workflowJson: JsonNode
+                             ): WorkflowToPythonResponse = {
+    // TODO: plug in WorkflowToPythonTranslator when available
+    WorkflowToPythonSuccess(
+      """print("workflow-to-python endpoint works")"""
+    )
+// Placeholder, need to be replaced by error checking after the full implementation of translator is plugged in
+  }
+}

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/service/resource/WorkflowToPythonResource.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/service/resource/WorkflowToPythonResource.scala
@@ -24,7 +24,8 @@ import com.typesafe.scalalogging.LazyLogging
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs.core.MediaType
 import jakarta.ws.rs.{Consumes, POST, Path, Produces}
-import com.fasterxml.jackson.databind.JsonNode
+import org.apache.texera.amber.compiler.model.{LogicalPlan, LogicalPlanPojo}
+import org.apache.texera.amber.translator.WorkflowToPythonTranslator
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,
@@ -49,15 +50,21 @@ case class WorkflowToPythonFailure(errorMessage: String) extends WorkflowToPytho
 @Path("/workflow-to-python")
 class WorkflowToPythonResource extends LazyLogging {
 
+  private val translator = new WorkflowToPythonTranslator()
+
   @POST
   @Path("")
   def convertWorkflowToPython(
-                               workflowJson: JsonNode
-                             ): WorkflowToPythonResponse = {
-    // TODO: plug in WorkflowToPythonTranslator when available
-    WorkflowToPythonSuccess(
-      """print("workflow-to-python endpoint works")"""
-    )
-// Placeholder, need to be replaced by error checking after the full implementation of translator is plugged in
+      logicalPlanPojo: LogicalPlanPojo
+  ): WorkflowToPythonResponse = {
+    try {
+      val logicalPlan = LogicalPlan(logicalPlanPojo)
+      val pythonCode = translator.translate(logicalPlan)
+      WorkflowToPythonSuccess(pythonCode)
+    } catch {
+      case e: Exception =>
+        logger.error("Failed to translate workflow to Python", e)
+        WorkflowToPythonFailure(e.getMessage)
+    }
   }
 }


### PR DESCRIPTION

https://github.com/user-attachments/assets/b040d38f-499d-44d5-b8f2-e83b9cd7718e

 ### What changes were proposed in this PR?                                                                                                                                         
                                                                                                                                                                                     
  **Why this matters.** When a Filter or Sort produces a surprising row in Texera today, the user has no way to ask *"where did this row come from?"* — the link back to the source  
  CSV is gone. Debugging filter logic, auditing results, and building trust in a pipeline all hit this wall.                                                                         
                                                                                                                                                                                     
  **What this PR adds.** An opt-in **"Track row-level lineage"** checkbox on the CSV File Scan source operator. When enabled, every output tuple carries an invisible tag identifying
   its source row. The result panel shows a **"Why?"** button on each downstream row — one click opens a modal explaining where it came from, plus a **"Jump to source row"** action
  that highlights the originating row in the source CSV's result panel with a yellow pulse.                                                                                          
                                                                                                                                                                                   
  The lineage tag rides automatically through every 1-to-1 operator (Filter, Sort) with zero per-operator changes. Internal columns are hidden from the visible table, so the user   
  only sees the new "Why?" affordance — not the plumbing.
                                                                                                                                                                                     
  **Concrete user scenarios this enables:**                                                                                                                                        
  - *Debugging:* "Why did this row survive my filter?" → click → see source row 1847 → check the raw data → either confirm the filter is right or spot the bug.
  - *Trust / audit:* "Where did this number on my dashboard come from?" → click → answered without re-running anything.                                                              
  - *Learning:* a new user clicks any output and the workflow visually explains itself.                                                                                              
                                                                                                                                                                                     
  Bundled side-fix: the dashboard sidebar (Workflows / Datasets / Compute / …) previously stayed empty when only the main amber service was running. Fixed by falling back to        
  `default.conf` defaults when `site_settings` has no row.                                                                                                                           
                                                                                                                                                                                     
  **Out of scope for v1** (called out in the modal copy so users aren't surprised): Projection drops the lineage column unless explicitly preserved; PythonUDF / Join / Aggregate /  
  GroupBy don't propagate it yet; only CSVScanSource emits the tag.
                                                                                                                                                                                     
  ### Any related issues, documentation, discussions?                                                                                                                                
   
  Authored for the dkNET-Texera hackathon (UCI, May 2026).                                                                                                                           
                                                                                                                                                                                   
                             
  **Automated:** new unit test in `CSVScanSourceOpDescSpec` verifies the lineage column is appended with the correct name + type + position when `trackLineage = true`. Existing
  tests cover the default (off) behavior.                                                                                                                                            
                                         
  **Manual end-to-end:**                                                                                                                                                             
  1. CSV File Scan on `TMDb_updated.csv`, **check "Track row-level lineage"**, wire to a Filter (`original_language = "en"`), Run.                                                   
  2. On the CSV result panel: no `__lineage_origin_row` column visible, but a new "Why?" column on the right — clicking `?` on the i-th row shows "row i of TMDb_updated.csv".
  3. On the Filter result panel: click `?` on a surviving row → modal shows the source row number → "Jump to source row" → CSV operator selected, page navigated, originating row    
  pulses yellow.                                                                                                                                                                     
  4. Negative case: route `CSV → Projection → Filter` — confirm "Why?" disappears on the Filter result (lineage was dropped by Projection, as documented).                           
                                                                                                                                                                                     
  ### Was this PR authored or co-authored using generative AI tooling?                                                                                                               
                                                                                                                                                                                   
  Generated-by: Claude Code (claude-opus-4-7, 1M context)            

