### PR TITLE
[Hackathon] feat(frontend): theme system with 8 presets, animations, and easter eggs

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,145 @@
+# PR: Theme system — 8 presets, animations, sounds, easter eggs
+
+## Summary
+
+Adds a runtime theme system that retints the entire Texera frontend (dashboard chrome, sidebar, workspace canvas, operator boxes, links, modals, forms, Monaco editor) and a small "delight" layer (confetti on workflow success, animated edge/operator entrance, opt-in chimes, Konami easter egg). 8 built-in themes — Light, Dark, Sepia, Solarized Dark, Gruvbox, Synthwave, Forest, Cyberpunk — picked from a submenu in the user-icon dropdown. Theme preference persists per-user via the existing `/api/user/config` endpoint (with localStorage fallback for logged-out / pre-auth paint).
+
+Also includes a small fix to `bin/texera`: `stop` now sweeps known ports (1234/4200/3001/8080–9096) to kill orphaned children whose process group was lost — previously a leaked y-websocket on port 1234 from a prior `start` would block the next `start`'s frontend with `EADDRINUSE`.
+
+## Motivation
+
+Texera looks the same to every user, and it's been an opaque "operate this tool" experience rather than something users feel ownership over. Three goals:
+
+1. **Accessibility** — dark-mode-OS users see a flash of light theme and have no way to fix it. Sepia / Solarized address eye-strain for long workflow-authoring sessions.
+2. **Personality** — a research/data-science tool people spend hours in should be customizable enough to feel "theirs." Synthwave / Cyberpunk / Forest / Gruvbox each give the same workspace a completely different visual identity without breaking any chrome.
+3. **Hackathon: dkNet-AI Apache Texera Agent Hackathon** — built as a "make using Texera enjoyable instead of it being just a tool" submission.
+
+## What's in the box
+
+### Theme contract (`frontend/src/styles/_tokens.scss`)
+
+~45 CSS custom properties on `:root`, semantically named so themes can re-interpret freely:
+
+- **Surfaces** — `--tx-bg-base`, `--tx-bg-surface`, `--tx-bg-elevated`, `--tx-bg-canvas`, `--tx-bg-hover`, `--tx-bg-active`, `--tx-bg-overlay`
+- **Text** — `--tx-text-primary` / `secondary` / `tertiary` / `disabled` / `inverse`
+- **Borders** — `--tx-border-subtle` / `default` / `strong`
+- **Primary** — `--tx-primary` / `hover` / `active` / `soft` / `fg`
+- **Semantic** — `--tx-success`, `--tx-warning`, `--tx-danger`, `--tx-info` (+ `*-soft` variants)
+- **Shadows** — `--tx-shadow-sm` / `md` / `lg`
+- **Typography & layout** — `--tx-font-ui`, `--tx-font-mono`, `--tx-radius-{sm,md,lg}`
+- **Motion** — `--tx-motion-{fast,default,slow}`, `--tx-motion-ease`
+- **Workspace canvas** — `--tx-canvas-bg`, `--tx-canvas-grid`, `--tx-op-body-bg`, `--tx-op-body-stroke`, `--tx-op-label`, `--tx-op-sublabel`, `--tx-op-port`, `--tx-link-stroke`, `--tx-link-handle`, `--tx-minimap-border`, `--tx-monaco-theme`
+
+A universal CSS transition on `background-color / border-color / color / fill / stroke / box-shadow` gives every theme switch a ~200ms crossfade instead of a hard cut. `prefers-reduced-motion` users get instant switches.
+
+### Theme service (`frontend/src/app/common/service/theme/theme.service.ts`)
+
+- Applies tokens to `:root` via `style.setProperty`
+- Sets `color-scheme` so the browser picks correct defaults for scrollbars, form controls, etc.
+- Exposes a `data-theme` attribute on `:root` so non-token CSS can branch
+- First paint: `prefers-color-scheme: dark` → Dark, otherwise Light
+- Subsequent: loads persisted theme from user-config (logged in) or localStorage (anonymous)
+- Re-resolves on login/logout
+- Calls `monaco.editor.setTheme()` when Monaco is loaded, so the code editor flips with everything else
+
+### 8 built-in themes (`frontend/src/app/common/service/theme/themes.ts`)
+
+Each theme is a flat `Record<string, string>` of token overrides — anything unspecified inherits from the defaults. Includes canvas-specific overrides so the workspace fits each theme's palette (Synthwave: pink links on cyan ports; Cyberpunk: red ports on cyan links; Solarized uses Ethan Schoonover's official base-0X codes; Gruvbox uses Pavel Pertsev's palette).
+
+### ng-zorro chrome retint (`frontend/src/styles.scss`, +~280 lines)
+
+ng-zorro ships as a pre-built minified stylesheet — we can't customize its `.less` variables without forking the build. Instead, the high-visibility classes are overridden using token variables:
+
+- Layouts, sider, top header, footer
+- Menus (top nav, sidebar, dropdowns, submenu popups in CDK overlays, `.ant-menu-light` for sider's `nzTheme="light"`)
+- Modals (content, header, footer, mask, close)
+- Cards & tables (headers, hover states)
+- Inputs, selects, picker, textareas, checkboxes, radios
+- Buttons (default / primary / link / dashed / text — including **disabled states**, which previously hardcoded `#f5f5f5` and looked pale-white on any dark theme)
+- Tabs (used by result panel + property editor)
+- Tooltips, popovers, collapse panels
+
+### Workspace canvas
+
+JointJS doesn't render `background.color` or grid dots through CSS — both are baked in as inline styles / canvas-rendered images at paper construction. So `WorkflowEditorComponent` now:
+
+- Injects `ThemeService` and subscribes to the active-theme stream
+- On every theme change reads `--tx-canvas-bg` and `--tx-canvas-grid` from `:root` via `getComputedStyle`
+- Calls `paper.drawBackground({color})` + `paper.drawGrid({name:"fixedDot", args:{color, ...}})` to redraw
+
+Operator boxes, port circles, link strokes, and operator labels are themed via CSS overrides on JointJS-generated SVG (`.operator-element rect.body`, `.joint-link path.connection`, etc.). SVG attribute fills lose to CSS rules at the same level, so no changes are needed in `JointUIService`.
+
+### Monaco editor
+
+`CodeEditorComponent` now injects `ThemeService` and:
+- At init, sets `workbench.colorTheme` to `"Default Light Modern"` or `"Default Dark Modern"` based on the active theme's `mode`
+- `ThemeService.applyToDom` calls global `monaco.editor.setTheme("vs"/"vs-dark")` so already-open editors flip too
+
+### Motion + sound layer (`frontend/src/app/common/service/motion/motion.service.ts`)
+
+- Confetti on workflow execution `Completed` — canvas-based, no library dep. Particles sample `--tx-primary` / `--tx-success` / `--tx-warning` / `--tx-info` / `--tx-danger` so the burst matches the active theme.
+- Shake on `Failed`
+- WebAudio-synthesized chimes (success: ascending C major triad; fail: descending tritone)
+- Link draw-in animation (stroke-dashoffset 0→length)
+- Operator settle animation (scale 0.6→1.08→1.0 with overshoot)
+- 800ms "arm" timer so existing operators/links of a workflow opened from persistence don't all animate at once
+- `prefers-reduced-motion` default for motion; sound is **off by default**
+
+### Easter egg
+
+Type `↑ ↑ ↓ ↓ ← → ← → B A` anywhere → locks to Synthwave, three confetti volleys over 4.5s, plays the success chord, then restores your previous theme.
+
+### Preferences UI
+
+Two new submenus under the user-icon avatar:
+- **Theme** — all 8 presets, checkmark on active
+- **Preferences** — Animations on/off, Sound effects on/off
+
+Both pieces persist per-user the same way the theme does.
+
+## Files changed (high-level)
+
+### New
+- `frontend/src/styles/_tokens.scss` — token contract + crossfade transitions
+- `frontend/src/app/common/service/theme/theme.service.ts` — apply, persist, monaco sync
+- `frontend/src/app/common/service/theme/themes.ts` — 8 presets
+- `frontend/src/app/common/service/motion/motion.service.ts` — confetti, chimes, Konami
+
+### Modified
+- `frontend/src/styles.scss` — ng-zorro retint + workspace JointJS CSS overrides + disabled-state retint
+- `frontend/src/app/app.component.ts` — eager-instantiate `ThemeService` and `MotionService`
+- `frontend/src/app/dashboard/component/user/user-icon/user-icon.component.{ts,html}` — Theme & Preferences submenus
+- `frontend/src/app/dashboard/component/user/list-item/list-item.component.scss` — workflow/dataset/project list rows tokenized
+- `frontend/src/app/dashboard/component/dashboard.component.scss`, `button-style.scss` — top nav, primary action button
+- `frontend/src/app/workspace/component/workspace.component.scss` — top menu + canvas wrapper
+- `frontend/src/app/workspace/component/left-panel/left-panel.component.scss` — operator picker
+- `frontend/src/app/workspace/component/property-editor/property-editor.component.scss` — right panel
+- `frontend/src/app/workspace/component/result-panel/result-panel.component.scss` — bottom panel
+- `frontend/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.scss` — minimap nav border
+- `frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts` — paper bg/grid redraw on theme change, motion hooks
+- `frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.ts` — initial `colorTheme` matches theme mode
+- `bin/texera` — `stop` now port-sweeps known ports as a safety net against orphaned children (fixes a leaked y-websocket lockout from the previous PR)
+
+## Test plan
+
+- [ ] Cold start: `prefers-color-scheme: dark` user sees Dark on first paint (no flash of Light)
+- [ ] Switch through all 8 themes from the user-icon menu → dashboard chrome (top nav, sider, list-item rows, modals) flips with crossfade
+- [ ] Open a workflow → workspace top menu, left panel, right panel, result panel, minimap border, canvas background, grid dots, operator boxes, link strokes, port circles, labels all match the active theme
+- [ ] Open the code editor → Monaco theme follows (Default Dark/Light Modern at init; flips live on theme change)
+- [ ] Run a workflow → confetti from center + chord (with sound enabled)
+- [ ] Drop a new operator → it scales in with overshoot
+- [ ] Draw a new link → it draws itself in over ~380ms
+- [ ] Toggle Animations off → entrance animations + confetti suppressed; theme transitions still crossfade
+- [ ] Toggle Sound off → no chimes
+- [ ] Theme persists across reload (logged out: localStorage; logged in: user-config)
+- [ ] Log in / log out → theme follows the account preference correctly
+- [ ] Konami code from anywhere → Synthwave + confetti volleys + chord; reverts after ~4.5s
+- [ ] Disabled buttons (e.g. greyed-out run/stop/pause in workspace) recede into the theme on every preset, not pale white
+- [ ] `texera stop && texera start full` after an interrupted run no longer dies on `EADDRINUSE: ::1:1234`
+
+## Out of scope / future
+
+- **Theme builder** — explicitly deferred; the 8 presets cover the common cases
+- **Hub sharing** — no builder = nothing user-made to share
+- **Time-of-day auto theme switching** — deliberately not shipped (annoying for demos; user can pick manually)
+- **Operator node skin variants** (flat / glossy / rounded / sticker), **edge router variants**, **canvas pattern toggles** — these were part of the original phase 2 plan but tied to the theme builder; bringing them back is mechanical once a builder exists

--- a/bin/build-services.sh
+++ b/bin/build-services.sh
@@ -28,5 +28,8 @@ rm config-service/target/universal/config-service-*.zip
 unzip computing-unit-managing-service/target/universal/computing-unit-managing-service-*.zip -d target/
 rm computing-unit-managing-service/target/universal/computing-unit-managing-service-*.zip
 
-unzip amber/target/universal/texera-*.zip -d amber/target/
-rm amber/target/universal/texera-*.zip
+unzip access-control-service/target/universal/access-control-service-*.zip -d target/
+rm access-control-service/target/universal/access-control-service-*.zip
+
+unzip amber/target/universal/amber-*.zip -d amber/target/
+rm amber/target/universal/amber-*.zip

--- a/bin/check-services.sh
+++ b/bin/check-services.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# check-services.sh — probe each Texera HTTP service and report UP/DOWN.
+# A service is UP if its application port returns any HTTP response within
+# the timeout. Non-HTTP probes (e.g. WebSocket) are not covered.
+# Exit 0 if every service responded, 1 otherwise.
+
+set -u
+
+HOST="${TEXERA_HOST:-localhost}"
+TIMEOUT="${TEXERA_PROBE_TIMEOUT:-2}"
+
+# name|port pairs, in display order
+SERVICES=(
+  "texera-web-application|8080"
+  "computing-unit-master|8085"
+  "computing-unit-managing-service|8888"
+  "workflow-compiling-service|9090"
+  "file-service|9092"
+  "config-service|9094"
+  "access-control-service|9096"
+)
+
+if [ -t 1 ]; then
+  TTY=1
+  TERM_LINES=$(tput lines 2>/dev/null || echo 0)
+  GREEN=$'\033[0;32m'; RED=$'\033[0;31m'
+  BOLD=$'\033[1m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+else
+  TTY=0
+  TERM_LINES=0
+  GREEN=""; RED=""; BOLD=""; DIM=""; RESET=""
+fi
+
+BAR="════════════════════════════════════════════════════════════"
+
+down_names=()
+down_ports=()
+down_reasons=()
+total=${#SERVICES[@]}
+
+printf '%-34s %-6s %-6s %s\n' "SERVICE" "PORT" "STATE" "DETAIL"
+
+for entry in "${SERVICES[@]}"; do
+  name="${entry%%|*}"
+  port="${entry##*|}"
+
+  # %{http_code} prints 000 when curl never got an HTTP response.
+  read -r code curl_err <<EOF
+$(curl --silent --output /dev/null \
+       --max-time "$TIMEOUT" \
+       --write-out '%{http_code} %{errormsg}\n' \
+       "http://$HOST:$port/" 2>/dev/null)
+EOF
+
+  if [ "${code:-000}" != "000" ] && [ -n "$code" ]; then
+    printf '%-34s :%-5s %sUP%s    %s(HTTP %s)%s\n' \
+      "$name" "$port" "$GREEN" "$RESET" "$DIM" "$code" "$RESET"
+  else
+    detail="${curl_err:-no response}"
+    printf '%-34s :%-5s %sDOWN%s  %s(%s)%s\n' \
+      "$name" "$port" "$RED" "$RESET" "$DIM" "$detail" "$RESET"
+    down_names+=("$name")
+    down_ports+=("$port")
+    down_reasons+=("$detail")
+  fi
+done
+
+# Pad with blank lines so the banner ends at the terminal's bottom row.
+# Banner height = 1 leading blank + 1 bar + 1 title + 1 bar [+ N items + 1 bar].
+down_count=${#down_names[@]}
+if [ "$down_count" -gt 0 ]; then
+  banner_height=$((4 + down_count + 1))
+else
+  banner_height=4
+fi
+table_lines=$((1 + total))  # header + per-service rows
+if [ "$TTY" = "1" ] && [ "$TERM_LINES" -gt 0 ]; then
+  fill=$((TERM_LINES - table_lines - banner_height))
+  while [ "$fill" -gt 0 ]; do echo; fill=$((fill - 1)); done
+fi
+
+if [ "$down_count" -gt 0 ]; then
+  printf '\n%s%s%s%s\n' "$BOLD" "$RED" "$BAR" "$RESET"
+  printf '%s%s✗ %d of %d SERVICES DOWN%s\n' \
+    "$BOLD" "$RED" "$down_count" "$total" "$RESET"
+  printf '%s%s%s%s\n' "$BOLD" "$RED" "$BAR" "$RESET"
+  for i in "${!down_names[@]}"; do
+    printf '  %s%-32s%s :%-5s %s%s%s\n' \
+      "$BOLD" "${down_names[$i]}" "$RESET" \
+      "${down_ports[$i]}" \
+      "$DIM" "${down_reasons[$i]}" "$RESET"
+  done
+  printf '%s%s%s%s\n' "$BOLD" "$RED" "$BAR" "$RESET"
+  exit 1
+fi
+
+printf '\n%s%s%s%s\n' "$BOLD" "$GREEN" "$BAR" "$RESET"
+printf '%s%s✓ ALL %d SERVICES STARTED SUCCESSFULLY%s\n' \
+  "$BOLD" "$GREEN" "$total" "$RESET"
+printf '%s%s%s%s\n' "$BOLD" "$GREEN" "$BAR" "$RESET"
+exit 0

--- a/bin/texera
+++ b/bin/texera
@@ -1,0 +1,875 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to you under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+
+# bin/texera — one-command dev orchestrator for Texera.
+#
+# Subcommands:
+#   texera setup        Verify toolchain, build staged binaries, install deps, apply SQL.
+#   texera build        Re-build staged backend binaries (re-run after backend code changes).
+#   texera start        Start Postgres + LakeFS/MinIO + 7 JVM services + frontend.
+#   texera stop         Stop everything started by `texera start`.
+#   texera status       Report which services are reachable on their HTTP ports.
+#   texera logs <svc>   Tail the log file for one service.
+#
+# Each JVM service runs from its sbt-native-packager staged binary
+# (`bin/build-services.sh` produces these). That avoids the sbt boot-lock
+# contention you get from launching several `sbt runMain` processes in
+# parallel, and it skips the sbt startup overhead per service.
+
+set -u
+set -o pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$ROOT/logs/texera-dev"
+PID_DIR="$LOG_DIR/pids"
+mkdir -p "$LOG_DIR" "$PID_DIR"
+
+# ---- Service registry --------------------------------------------------------
+# Row schema: name | cwd (relative to ROOT) | glob to staged binary | http port (or "-")
+# Launch order matters: ComputingUnitMaster MUST start before Worker (Pekko cluster).
+SERVICES=(
+  "config|.|target/config-service-*/bin/config-service|9094"
+  "compile|.|target/workflow-compiling-service-*/bin/workflow-compiling-service|9090"
+  "file|.|target/file-service-*/bin/file-service|9092"
+  "managing|.|target/computing-unit-managing-service-*/bin/computing-unit-managing-service|8888"
+  "access|.|target/access-control-service-*/bin/access-control-service|9096"
+  "master|amber|target/amber-*/bin/computing-unit-master|8085"
+  "worker|amber|target/amber-*/bin/computing-unit-worker|-"
+  "web|amber|target/amber-*/bin/texera-web-application|8080"
+)
+
+FRONTEND_LABEL="frontend"
+LAKEFS_COMPOSE_DIR="$ROOT/file-service/src/main/resources"
+
+# ---- Startup modes ----------------------------------------------------------
+# Row schema: key | label | description | run_infra | run_backend | run_frontend
+# `run_infra` covers Postgres readiness + LakeFS/MinIO docker compose.
+# `run_backend` covers the 7 staged JVM services.
+# `run_frontend` covers `yarn start` in frontend/.
+MODES=(
+  "full|Full|Postgres + LakeFS/MinIO + all backend services + agent + frontend|1|1|1"
+  "backend|Backend|Infra + all backend services + agent (no frontend)|1|1|0"
+  "frontend|Frontend|Frontend only — assumes backend is already running|0|0|1"
+  "infra|Infra|Postgres + LakeFS/MinIO only — run backend services yourself|1|0|0"
+  "services|Services|Backend services + agent + frontend — assumes infra is already running|0|1|1"
+)
+
+# ---- Color palette for log prefixes -----------------------------------------
+COLORS=(31 32 33 34 35 36 91 92 93 94 95 96)
+color_for() {
+  local s="$1"
+  local sum=0
+  for ((i = 0; i < ${#s}; i++)); do sum=$((sum + $(printf "%d" "'${s:$i:1}"))); done
+  echo "${COLORS[$((sum % ${#COLORS[@]}))]}"
+}
+
+# ---- Pretty printing --------------------------------------------------------
+RESET='\033[0m'
+BOLD='\033[1m'
+RED='\033[31m'
+GREEN='\033[32m'
+YELLOW='\033[33m'
+CYAN='\033[36m'
+
+info() { printf "${CYAN}[texera]${RESET} %b\n" "$*"; }
+warn() { printf "${YELLOW}[texera]${RESET} %b\n" "$*"; }
+err()  { printf "${RED}[texera]${RESET} %b\n" "$*" >&2; }
+ok()   { printf "${GREEN}[texera]${RESET} %b\n" "$*"; }
+
+# ---- Tool checks ------------------------------------------------------------
+check_tools() {
+  local missing=0
+  for c in java sbt node yarn docker pg_isready psql curl unzip; do
+    if ! command -v "$c" >/dev/null 2>&1; then
+      err "  not found: $c"
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    err "Install the missing tools above (see Guide for Developers wiki), then retry."
+    exit 1
+  fi
+  info "java: $(java -version 2>&1 | head -1)"
+  info "node: $(node -v)   yarn: $(yarn -v)   docker: $(docker --version | head -1)"
+}
+
+# ---- Resolve a single service's staged binary (expand the glob) -------------
+resolve_binary() {
+  local cwd="$1" bin_glob="$2"
+  local hit
+  # Use compgen so a missing match returns nothing without erroring under set -e
+  hit=$(cd "$ROOT/$cwd" 2>/dev/null && compgen -G "$bin_glob" | head -1)
+  if [ -n "$hit" ]; then
+    echo "$ROOT/$cwd/$hit"
+  fi
+}
+
+# ---- Postgres ---------------------------------------------------------------
+ensure_postgres() {
+  if pg_isready -q; then
+    ok "postgres already running"
+    return 0
+  fi
+  warn "postgres not running, attempting to start via brew services"
+  if command -v brew >/dev/null 2>&1; then
+    brew services start postgresql 2>/dev/null \
+      || brew services start postgresql@14 2>/dev/null \
+      || true
+    for _ in $(seq 1 20); do
+      if pg_isready -q; then ok "postgres started"; return 0; fi
+      sleep 1
+    done
+  fi
+  err "postgres did not become ready. Start it manually and re-run."
+  exit 1
+}
+
+# ---- Infrastructure: LakeFS + MinIO -----------------------------------------
+start_lakefs() {
+  info "starting LakeFS + MinIO (docker compose)"
+  (cd "$LAKEFS_COMPOSE_DIR" && docker compose up -d) || {
+    err "docker compose failed in $LAKEFS_COMPOSE_DIR"
+    exit 1
+  }
+  # docker compose returns as soon as the container is *up*, but LakeFS's
+  # HTTP server takes a few more seconds to start listening. file-service
+  # calls LakeFSStorageClient.healthCheck() during its own boot and exits
+  # if LakeFS is unreachable — so wait for an HTTP response before letting
+  # the JVM services launch.
+  local deadline=$((SECONDS + 60))
+  local waited=0
+  while [ "$SECONDS" -lt "$deadline" ]; do
+    if curl --silent --output /dev/null --max-time 2 \
+            --fail-with-body "http://localhost:8000/_health" >/dev/null 2>&1 \
+       || curl --silent --output /dev/null --max-time 2 \
+            "http://localhost:8000/" >/dev/null 2>&1; then
+      ok "lakefs is responding on http://localhost:8000"
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  warn "lakefs did not respond on http://localhost:8000 within ${waited}s — file-service may crash on boot"
+  return 0
+}
+
+stop_lakefs() {
+  info "stopping LakeFS + MinIO"
+  (cd "$LAKEFS_COMPOSE_DIR" && docker compose down) || true
+}
+
+# ---- Stream prefixer --------------------------------------------------------
+prefix_stream() {
+  local name="$1"
+  local color
+  color="$(color_for "$name")"
+  local prefix
+  prefix="$(printf '\033[%sm[%s]\033[0m' "$color" "$name")"
+  awk -v p="$prefix" '{ print p, $0; fflush(); }'
+}
+
+# pgid_of_pipeline <last_pid> — print the process-group ID of a backgrounded
+# pipeline whose final stage has PID <last_pid>. With `set -m` in effect when
+# the pipeline was started, every member of the pipeline (subshell + tee +
+# awk) shares one PGID, which equals the PID of the first process — the JVM
+# subshell. Recording that PGID lets `texera stop` later kill the whole group
+# (including the JVM) with `kill -- -PGID`.
+pgid_of_pipeline() {
+  local last_pid="$1"
+  local pgid
+  pgid="$(ps -o pgid= -p "$last_pid" 2>/dev/null | tr -d ' ')"
+  if [ -z "$pgid" ]; then
+    echo "$last_pid"
+  else
+    echo "$pgid"
+  fi
+}
+
+# ---- Spawn a single backend service -----------------------------------------
+spawn_service() {
+  local name="$1" cwd="$2" bin_glob="$3"
+  local log="$LOG_DIR/$name.log"
+  local pidfile="$PID_DIR/$name.pid"
+
+  local binary
+  binary="$(resolve_binary "$cwd" "$bin_glob")"
+  if [ -z "$binary" ] || [ ! -x "$binary" ]; then
+    err "missing staged binary for '$name' (looked for: $cwd/$bin_glob)"
+    err "run 'texera build' first"
+    return 1
+  fi
+
+  info "starting $name ($binary)"
+  # Job control on just for this spawn so the pipeline gets its own PGID.
+  set -m
+  (
+    cd "$ROOT/$cwd"
+    exec "$binary" 2>&1
+  ) | tee "$log" | prefix_stream "$name" &
+  local tail_pid=$!
+  set +m
+  pgid_of_pipeline "$tail_pid" > "$pidfile"
+}
+
+spawn_frontend() {
+  local name="$FRONTEND_LABEL"
+  local log="$LOG_DIR/$name.log"
+  local pidfile="$PID_DIR/$name.pid"
+
+  info "starting $name (yarn start in frontend/)"
+  set -m
+  (
+    cd "$ROOT/frontend"
+    exec yarn start 2>&1
+  ) | tee "$log" | prefix_stream "$name" &
+  local tail_pid=$!
+  set +m
+  pgid_of_pipeline "$tail_pid" > "$pidfile"
+}
+
+# agent-service is a Bun/Node app, not a staged JVM binary. Frontend proxies
+# /api/agents to localhost:3001.
+spawn_agent() {
+  local name="agent"
+  local log="$LOG_DIR/$name.log"
+  local pidfile="$PID_DIR/$name.pid"
+
+  if ! command -v bun >/dev/null 2>&1; then
+    warn "bun not installed — skipping agent-service (install via 'brew install oven-sh/bun/bun')"
+    return 0
+  fi
+  if [ ! -d "$ROOT/agent-service/node_modules" ]; then
+    warn "agent-service/node_modules missing — skipping (run: cd agent-service && bun install)"
+    return 0
+  fi
+
+  info "starting $name (bun run dev in agent-service/)"
+  set -m
+  (
+    cd "$ROOT/agent-service"
+    exec bun run dev 2>&1
+  ) | tee "$log" | prefix_stream "$name" &
+  local tail_pid=$!
+  set +m
+  pgid_of_pipeline "$tail_pid" > "$pidfile"
+}
+
+# kill_all_pgids — read every pidfile under PID_DIR, send TERM (and after
+# `grace` seconds, KILL stragglers) to each recorded process group. Used by
+# both the Ctrl+C trap and the standalone `texera stop` subcommand.
+kill_all_pgids() {
+  local grace="${1:-3}"
+  local pgids=()
+  if [ -d "$PID_DIR" ]; then
+    local pidfile pgid
+    for pidfile in "$PID_DIR"/*.pid; do
+      [ -f "$pidfile" ] || continue
+      pgid="$(cat "$pidfile" 2>/dev/null || true)"
+      [ -n "$pgid" ] && pgids+=("$pgid")
+      rm -f "$pidfile"
+    done
+  fi
+  [ "${#pgids[@]}" -eq 0 ] && return 0
+
+  local pgid
+  for pgid in "${pgids[@]}"; do
+    # `kill -- -PGID` sends to every member of process group PGID (JVM + tee
+    # + awk). Falls back to a single-PID kill if the pidfile happened to
+    # record a bare PID (e.g. set -m wasn't honored on this shell).
+    kill -TERM -- "-$pgid" 2>/dev/null \
+      || kill -TERM -- "$pgid" 2>/dev/null \
+      || true
+  done
+
+  # Brief grace period for the JVMs to flush logs / close sockets cleanly,
+  # then SIGKILL anything still running.
+  sleep "$grace"
+  for pgid in "${pgids[@]}"; do
+    if kill -0 -- "-$pgid" 2>/dev/null || kill -0 -- "$pgid" 2>/dev/null; then
+      kill -KILL -- "-$pgid" 2>/dev/null \
+        || kill -KILL -- "$pgid" 2>/dev/null \
+        || true
+    fi
+  done
+}
+
+# ---- Tear down on Ctrl+C ----------------------------------------------------
+shutdown() {
+  # Restore the terminal scroll region BEFORE printing anything else, so the
+  # "shutting down…" line lands in normal screen layout instead of on top of
+  # the status bar. status_bar_teardown is a no-op when the bar was never
+  # active (non-TTY, or `texera start` exited before status_bar_start ran).
+  status_bar_teardown
+  echo
+  info "shutting down…"
+  # Shorter grace period for Ctrl+C — user wants their prompt back fast.
+  kill_all_pgids 2
+  ok "stopped. (docker containers from 'texera start' still running — use 'texera stop' to clean those too)"
+  exit 0
+}
+
+# ---- Status -----------------------------------------------------------------
+status() {
+  printf "${BOLD}Service               Port    Status${RESET}\n"
+  for row in "${SERVICES[@]}"; do
+    IFS='|' read -r name cwd bin_glob port <<<"$row"
+    if [ "$port" = "-" ]; then
+      printf "  %-18s  %-6s  %s\n" "$name" "-" "(no http port)"
+      continue
+    fi
+    if curl -fsS -m 1 "http://localhost:$port/api/healthcheck" >/dev/null 2>&1; then
+      printf "  %-18s  %-6s  ${GREEN}up${RESET}\n" "$name" "$port"
+    else
+      printf "  %-18s  %-6s  ${RED}down${RESET}\n" "$name" "$port"
+    fi
+  done
+  if curl -fsS -m 1 "http://localhost:4200" >/dev/null 2>&1; then
+    printf "  %-18s  %-6s  ${GREEN}up${RESET}\n" "$FRONTEND_LABEL" "4200"
+  else
+    printf "  %-18s  %-6s  ${RED}down${RESET}\n" "$FRONTEND_LABEL" "4200"
+  fi
+}
+
+# ---- Logs -------------------------------------------------------------------
+logs() {
+  local name="${1:-}"
+  if [ -z "$name" ]; then
+    err "usage: texera logs <service>"
+    err "available: $(ls "$LOG_DIR" 2>/dev/null | sed 's/\.log$//' | tr '\n' ' ')"
+    exit 1
+  fi
+  local f="$LOG_DIR/$name.log"
+  [ -f "$f" ] || { err "no log file at $f"; exit 1; }
+  tail -F "$f"
+}
+
+# ---- Build staged binaries --------------------------------------------------
+build_backend() {
+  info "building staged backend binaries (sbt clean dist + unzip)"
+  (cd "$ROOT" && bash bin/build-services.sh) || {
+    err "build-services.sh failed"
+    exit 1
+  }
+  ok "backend artifacts ready"
+}
+
+# ---- Verify everything required exists before `start` ----------------------
+require_artifacts() {
+  local missing=0
+  for row in "${SERVICES[@]}"; do
+    IFS='|' read -r name cwd bin_glob port <<<"$row"
+    local b
+    b="$(resolve_binary "$cwd" "$bin_glob")"
+    if [ -z "$b" ]; then
+      err "  missing: $name  ($cwd/$bin_glob)"
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    err "Run 'texera build' (or 'texera setup' for first-time install) first."
+    exit 1
+  fi
+}
+
+# ---- Setup ------------------------------------------------------------------
+setup() {
+  info "checking toolchain…"
+  check_tools
+
+  build_backend
+
+  info "installing frontend deps"
+  (cd "$ROOT/frontend" && corepack enable && yarn install)
+
+  if command -v bun >/dev/null 2>&1; then
+    info "installing agent-service deps"
+    (cd "$ROOT/agent-service" && bun install) || warn "agent-service bun install failed — agent-service will be skipped on start"
+  else
+    warn "bun not installed — skipping agent-service deps (install via 'brew install oven-sh/bun/bun')"
+  fi
+
+  info "installing python deps"
+  pip install -r "$ROOT/amber/requirements.txt" -r "$ROOT/amber/operator-requirements.txt" || {
+    warn "pip install failed — you may need a virtualenv. Skipping."
+  }
+
+  info "applying SQL DDLs (requires Postgres running)"
+  ensure_postgres
+  psql -U postgres -f "$ROOT/sql/texera_ddl.sql" || warn "texera_ddl.sql failed (may already exist)"
+  psql -U postgres -f "$ROOT/sql/iceberg_postgres_catalog.sql" || warn "iceberg DDL failed (may already exist)"
+
+  ok "setup complete. Run 'texera start' next."
+}
+
+# ---- Mode lookup + interactive menu -----------------------------------------
+# mode_lookup <key> populates MODE_LABEL / MODE_DESC / RUN_INFRA / RUN_BACKEND /
+# RUN_FRONTEND as globals, or returns 1 if the key is unknown.
+mode_lookup() {
+  local key="$1"
+  for row in "${MODES[@]}"; do
+    IFS='|' read -r k label desc ri rb rf <<<"$row"
+    if [ "$k" = "$key" ]; then
+      MODE_LABEL="$label"
+      MODE_DESC="$desc"
+      RUN_INFRA="$ri"
+      RUN_BACKEND="$rb"
+      RUN_FRONTEND="$rf"
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Print a numbered menu and read the user's pick into SELECTED_MODE.
+interactive_menu() {
+  echo
+  printf "${BOLD}${CYAN}┌──────────────────────────────────────────────────────────────┐${RESET}\n"
+  printf "${BOLD}${CYAN}│             Texera — choose a startup mode                   │${RESET}\n"
+  printf "${BOLD}${CYAN}└──────────────────────────────────────────────────────────────┘${RESET}\n"
+  echo
+
+  local i=1
+  local keys=()
+  for row in "${MODES[@]}"; do
+    IFS='|' read -r k label desc _ _ _ <<<"$row"
+    keys+=("$k")
+    printf "  ${BOLD}${GREEN}%d${RESET}) ${BOLD}%-10s${RESET}  ${CYAN}%s${RESET}\n" "$i" "$label" "$desc"
+    i=$((i + 1))
+  done
+  printf "  ${BOLD}${YELLOW}q${RESET}) Quit\n"
+  echo
+
+  local choice
+  while true; do
+    printf "${CYAN}❯${RESET} Choose [1-%d, q]: " "${#keys[@]}"
+    if ! read -r choice; then
+      echo
+      info "no input — aborted"
+      exit 0
+    fi
+    case "$choice" in
+      q|Q|quit|exit)
+        info "aborted"
+        exit 0
+        ;;
+      ''|*[!0-9]*)
+        err "please enter a number between 1 and ${#keys[@]} (or 'q' to quit)"
+        ;;
+      *)
+        if [ "$choice" -ge 1 ] && [ "$choice" -le "${#keys[@]}" ]; then
+          SELECTED_MODE="${keys[$((choice - 1))]}"
+          return 0
+        else
+          err "out of range — pick 1-${#keys[@]} or 'q'"
+        fi
+        ;;
+    esac
+  done
+}
+
+# ---- Readiness check + final banner -----------------------------------------
+# probe_port <port> — succeed if anything answers HTTP on that port within 2s.
+# Any HTTP response (200, 404, 401, 500…) counts as "bound and serving".
+# Connection refused / timeout returns code "000".
+probe_port() {
+  local port="$1"
+  local code
+  code="$(curl --silent --output /dev/null --max-time 2 \
+               --write-out '%{http_code}' \
+               "http://localhost:$port/" 2>/dev/null)" || code="000"
+  [ -n "${code:-}" ] && [ "${code:-000}" != "000" ]
+}
+
+# is_spawn_alive <name> — does this service's spawn pipeline still have a
+# living process? Returns 0 if alive (or if we have no pidfile to consult),
+# 1 if the pidfile points to a dead process.
+#
+# Caveat: the pidfile holds the trailing prefix_stream awk PID, not the JVM
+# PID. That's still useful: when the upstream JVM exits, tee hits EOF and
+# awk terminates with it, so a dead awk PID is a reliable signal the JVM
+# is gone.
+is_spawn_alive() {
+  local name="$1"
+  local pidfile="$PID_DIR/$name.pid"
+  [ -f "$pidfile" ] || return 0
+  local pid
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  [ -z "$pid" ] && return 0
+  kill -0 "$pid" 2>/dev/null
+}
+
+# wait_for_services name|port... — block until every target binds, or until
+# any spawned pipeline dies (returns 1 fast), or until timeout (returns 1).
+wait_for_services() {
+  local timeout="${TEXERA_READY_TIMEOUT:-90}"
+  local interval=2
+  local elapsed=0
+  local targets=("$@")
+
+  info "waiting up to ${timeout}s for ${#targets[@]} services to bind…"
+  while [ "$elapsed" -lt "$timeout" ]; do
+    local all_up=1
+    local any_dead=0
+    local dead_name=""
+    local entry
+    for entry in "${targets[@]}"; do
+      local name="${entry%%|*}"
+      local port="${entry##*|}"
+      if probe_port "$port"; then continue; fi
+      all_up=0
+      if ! is_spawn_alive "$name"; then
+        any_dead=1
+        dead_name="$name"
+      fi
+    done
+    if [ "$all_up" = "1" ]; then return 0; fi
+    if [ "$any_dead" = "1" ]; then
+      warn "${dead_name} pipeline has exited — see ${LOG_DIR}/${dead_name}.log for the crash"
+      return 1
+    fi
+    sleep "$interval"
+    elapsed=$((elapsed + interval))
+  done
+  return 1
+}
+
+# print_readiness_banner name|port... — green if all up, red with failure list
+# otherwise. Distinguishes "crashed" (spawn pipeline died — usually a JVM
+# exception during boot) from "not reachable" (port simply never bound in
+# the timeout window).
+print_readiness_banner() {
+  local targets=("$@")
+  local total="${#targets[@]}"
+  local down_names=()
+  local down_ports=()
+  local down_reasons=()
+  local entry
+  for entry in "${targets[@]}"; do
+    local name="${entry%%|*}"
+    local port="${entry##*|}"
+    if ! probe_port "$port"; then
+      down_names+=("$name")
+      down_ports+=("$port")
+      if is_spawn_alive "$name"; then
+        down_reasons+=("not reachable")
+      else
+        down_reasons+=("crashed — see ${LOG_DIR}/${name}.log")
+      fi
+    fi
+  done
+  local down="${#down_names[@]}"
+  local bar="════════════════════════════════════════════════════════════"
+
+  echo
+  if [ "$down" -eq 0 ]; then
+    printf "${BOLD}${GREEN}%s${RESET}\n" "$bar"
+    printf "${BOLD}${GREEN}✓ ALL %d SERVICES STARTED SUCCESSFULLY${RESET}\n" "$total"
+    printf "${BOLD}${GREEN}%s${RESET}\n" "$bar"
+  else
+    printf "${BOLD}${RED}%s${RESET}\n" "$bar"
+    printf "${BOLD}${RED}✗ %d of %d SERVICES DOWN${RESET}\n" "$down" "$total"
+    printf "${BOLD}${RED}%s${RESET}\n" "$bar"
+    local i
+    for i in "${!down_names[@]}"; do
+      printf "  ${BOLD}%-12s${RESET} :%-5s ${RED}%s${RESET}\n" \
+        "${down_names[$i]}" "${down_ports[$i]}" "${down_reasons[$i]}"
+    done
+    printf "${BOLD}${RED}%s${RESET}\n" "$bar"
+  fi
+  echo
+}
+
+# ---- Persistent status bar (TTY only) ---------------------------------------
+# Reserves the bottom rows of the terminal via DECSTBM so service logs scroll
+# only in the upper region, and runs a background poller that redraws live
+# UP/DOWN state every couple seconds. Tears down cleanly on shutdown so the
+# terminal isn't left with a stuck scroll region.
+STATUS_BAR_HEIGHT=3
+STATUS_BAR_ACTIVE=0
+STATUS_BAR_POLLER_PID=""
+STATUS_BAR_START=0
+
+status_bar_supported() {
+  [ -t 1 ] || return 1
+  command -v tput >/dev/null 2>&1 || return 1
+  local lines
+  lines="$(tput lines 2>/dev/null || echo 0)"
+  [ "${lines:-0}" -ge 12 ]
+}
+
+status_bar_init() {
+  status_bar_supported || return 1
+  local lines bottom
+  lines="$(tput lines)"
+  bottom=$((lines - STATUS_BAR_HEIGHT))
+  # ESC[top;bottom r — pin everything below `bottom` outside the scroll region.
+  printf '\033[1;%dr' "$bottom"
+  # Park the cursor just above the bar so the first log lines land there
+  # and scroll existing content up rather than overwriting the top.
+  printf '\033[%d;1H' "$bottom"
+  STATUS_BAR_ACTIVE=1
+}
+
+status_bar_render() {
+  [ "$STATUS_BAR_ACTIVE" = "1" ] || return 0
+  local targets=("$@")
+
+  local lines cols
+  lines="$(tput lines 2>/dev/null || echo 24)"
+  cols="$(tput cols 2>/dev/null || echo 80)"
+  local top=$((lines - STATUS_BAR_HEIGHT + 1))
+  local elapsed=$((SECONDS - STATUS_BAR_START))
+
+  local total=0 up=0
+  local down_msgs=()
+  local entry
+  for entry in "${targets[@]}"; do
+    local name="${entry%%|*}"
+    local port="${entry##*|}"
+    total=$((total + 1))
+    if probe_port "$port"; then
+      up=$((up + 1))
+    elif is_spawn_alive "$name"; then
+      down_msgs+=("${name}…")
+    else
+      down_msgs+=("${name}✗")
+    fi
+  done
+
+  local bar
+  bar="$(printf '═%.0s' $(seq 1 "$cols"))"
+
+  local color line2
+  if [ "$up" = "$total" ]; then
+    color="${BOLD}${GREEN}"
+    line2="$(printf "${BOLD}${GREEN}✓ ALL %d SERVICES UP${RESET}  (%ss elapsed)" "$total" "$elapsed")"
+  else
+    color="${BOLD}${RED}"
+    local detail
+    detail="$(IFS=' '; echo "${down_msgs[*]}")"
+    line2="$(printf "${BOLD}${RED}✗ %d/%d DOWN${RESET}: ${RED}%s${RESET}  (%ss)" \
+      "${#down_msgs[@]}" "$total" "$detail" "$elapsed")"
+  fi
+
+  # One printf so the whole redraw lands as a single write — minimizes
+  # interleaving with the spawned services' log output.
+  # \0337 / \0338 = DECSC / DECRC (save / restore cursor)
+  # \033[r;cH    = position cursor at row r, col c
+  # \033[2K      = clear current line
+  printf '\0337\033[%d;1H\033[2K%s%s%b\033[%d;1H\033[2K %b\033[%d;1H\033[2K%s%s%b\0338' \
+    "$top"             "$color" "$bar" "$RESET" \
+    "$((top + 1))"     "$line2" \
+    "$((top + 2))"     "$color" "$bar" "$RESET"
+}
+
+status_bar_loop() {
+  local targets=("$@")
+  while true; do
+    status_bar_render "${targets[@]}"
+    sleep 2
+  done
+}
+
+status_bar_start() {
+  STATUS_BAR_START=$SECONDS
+  if status_bar_init; then
+    status_bar_loop "$@" &
+    STATUS_BAR_POLLER_PID=$!
+  fi
+}
+
+status_bar_teardown() {
+  [ "$STATUS_BAR_ACTIVE" = "1" ] || return 0
+  if [ -n "$STATUS_BAR_POLLER_PID" ]; then
+    kill "$STATUS_BAR_POLLER_PID" 2>/dev/null || true
+    STATUS_BAR_POLLER_PID=""
+  fi
+  local lines
+  lines="$(tput lines 2>/dev/null || echo 24)"
+  local top=$((lines - STATUS_BAR_HEIGHT + 1))
+  # Restore full-screen scroll region, then wipe the bar area so the next
+  # shell prompt isn't sitting on top of leftover bar glyphs.
+  printf '\033[r\033[%d;1H\033[J' "$top"
+  STATUS_BAR_ACTIVE=0
+}
+
+# ---- Start ------------------------------------------------------------------
+start() {
+  local mode="${1:-}"
+  if [ -z "$mode" ]; then
+    if [ ! -t 0 ]; then
+      err "no mode given and stdin isn't a tty — pass one of: full, backend, frontend, infra, services"
+      exit 1
+    fi
+    interactive_menu
+    mode="$SELECTED_MODE"
+  fi
+  if ! mode_lookup "$mode"; then
+    err "unknown mode: $mode"
+    err "valid modes: full, backend, frontend, infra, services"
+    exit 1
+  fi
+
+  echo
+  info "${BOLD}mode:${RESET} $MODE_LABEL — $MODE_DESC"
+  echo
+
+  check_tools
+
+  if [ "$RUN_BACKEND" = "1" ]; then
+    require_artifacts
+  fi
+  if [ "$RUN_INFRA" = "1" ]; then
+    ensure_postgres
+    start_lakefs
+  fi
+
+  trap shutdown INT TERM
+  # Safety net: if we exit for any reason (normal return, set -e, error),
+  # restore the terminal so the user isn't left with a stuck scroll region.
+  trap status_bar_teardown EXIT
+
+  if [ "$RUN_BACKEND" = "1" ]; then
+    for row in "${SERVICES[@]}"; do
+      IFS='|' read -r name cwd bin_glob port <<<"$row"
+      spawn_service "$name" "$cwd" "$bin_glob" || true
+      # ComputingUnitMaster needs to bind its Akka/Pekko port before the worker
+      # tries to join.
+      if [ "$name" = "master" ]; then sleep 4; fi
+    done
+    spawn_agent
+  fi
+
+  if [ "$RUN_FRONTEND" = "1" ]; then
+    spawn_frontend
+  fi
+
+  # Infra-only mode: nothing was spawned into the foreground, so report and exit
+  # rather than blocking on `wait`.
+  if [ "$RUN_BACKEND" != "1" ] && [ "$RUN_FRONTEND" != "1" ]; then
+    echo
+    ok "infra is up."
+    info "  postgres:        localhost:5432 (host)"
+    info "  lakefs:          http://localhost:8000"
+    info "  minio console:   http://localhost:9001"
+    echo
+    info "Run JVM services from IntelliJ (.run/*.xml) or 'texera start services'."
+    info "Tear down with 'texera stop'."
+    return 0
+  fi
+
+  ok "all processes spawned. tailing… (Ctrl+C to stop)"
+  echo
+  info "URLs once ready:"
+  if [ "$RUN_FRONTEND" = "1" ]; then
+    info "  frontend:        http://localhost:4200"
+  fi
+  if [ "$RUN_BACKEND" = "1" ]; then
+    info "  texera api:      http://localhost:8080/api/healthcheck"
+    info "  file service:    http://localhost:9092/api/healthcheck"
+    info "  config service:  http://localhost:9094/api/healthcheck"
+    info "  compile service: http://localhost:9090/api/healthcheck"
+    info "  managing svc:    http://localhost:8888/api/healthcheck"
+    info "  access-control:  http://localhost:9096/api/healthcheck"
+    info "  agent service:   http://localhost:3001"
+  fi
+  echo
+
+  # Build the readiness target list, then either run the live bottom-pinned
+  # status bar (preferred on a TTY) or fall back to a one-shot wait + banner
+  # for non-TTY contexts (CI, piped output).
+  local readiness=()
+  if [ "$RUN_BACKEND" = "1" ]; then
+    local row name cwd bin_glob port
+    for row in "${SERVICES[@]}"; do
+      IFS='|' read -r name cwd bin_glob port <<<"$row"
+      [ "$port" = "-" ] && continue
+      readiness+=("$name|$port")
+    done
+    # agent has no SERVICES row; include it only if it was actually spawned.
+    if [ -f "$PID_DIR/agent.pid" ]; then
+      readiness+=("agent|3001")
+    fi
+  fi
+  if [ "$RUN_FRONTEND" = "1" ]; then
+    readiness+=("frontend|4200")
+  fi
+
+  if [ "${#readiness[@]}" -gt 0 ]; then
+    if status_bar_supported; then
+      status_bar_start "${readiness[@]}"
+    else
+      wait_for_services "${readiness[@]}" || true
+      print_readiness_banner "${readiness[@]}"
+    fi
+  fi
+
+  wait
+}
+
+# ---- Stop -------------------------------------------------------------------
+stop() {
+  info "stopping all texera processes…"
+  kill_all_pgids 3
+
+  # Belt-and-suspenders fallback: if there are orphan JVMs from previous
+  # sessions (e.g. from before this stop logic existed), they won't have
+  # pidfiles. Kill them by Java mainclass — the launcher script's basename
+  # doesn't appear in the JVM's command line, but the mainclass does.
+  local mainclass
+  for mainclass in \
+      org.apache.texera.web.ComputingUnitMaster \
+      org.apache.texera.web.ComputingUnitWorker \
+      org.apache.texera.web.TexeraWebApplication \
+      org.apache.texera.service.ConfigService \
+      org.apache.texera.service.FileService \
+      org.apache.texera.service.AccessControlService \
+      org.apache.texera.service.ComputingUnitManagingService \
+      org.apache.texera.service.WorkflowCompilingService; do
+    pkill -f "$mainclass" 2>/dev/null || true
+  done
+
+  stop_lakefs
+  ok "stopped."
+}
+
+# ---- Dispatch ---------------------------------------------------------------
+usage() {
+  cat <<EOF
+Usage: texera <command> [args]
+
+Commands:
+  setup            One-time: toolchain check, sbt build, frontend+python deps, SQL DDLs.
+  build            Re-build staged backend binaries (run after backend code changes).
+  start [mode]     Start services. Without a mode, drops into an interactive menu.
+                   Modes:
+                     full       Postgres + LakeFS/MinIO + all backend services + agent + frontend
+                     backend    Infra + backend services + agent (no frontend)
+                     frontend   Frontend only (assumes backend running)
+                     infra      Postgres + LakeFS/MinIO only
+                     services   Backend services + agent + frontend (assumes infra running)
+  stop             Stop everything started by 'texera start'.
+  status           Show which services are reachable.
+  logs <service>   Tail one service's log (config|compile|file|managing|access|master|worker|web|agent|frontend).
+
+Logs land in: $LOG_DIR/
+EOF
+}
+
+case "${1:-}" in
+  setup)  shift; setup "$@" ;;
+  build)  shift; build_backend "$@" ;;
+  start)  shift; start "$@" ;;
+  stop)   shift; stop "$@" ;;
+  status) shift; status "$@" ;;
+  logs)   shift; logs "$@" ;;
+  ""|-h|--help|help) usage ;;
+  *) err "unknown command: $1"; usage; exit 1 ;;
+esac

--- a/bin/texera
+++ b/bin/texera
@@ -836,8 +836,34 @@ stop() {
     pkill -f "$mainclass" 2>/dev/null || true
   done
 
+  # Final safety net: sweep any process still bound to one of our ports.
+  # Catches orphans whose process group was lost — most commonly the
+  # frontend's y-websocket child (port 1234), which `concurrently` spawns
+  # under a transient parent and which can survive a pgid-targeted kill.
+  sweep_known_ports
+
   stop_lakefs
   ok "stopped."
+}
+
+# sweep_known_ports — for each well-known port, find the listening PID via
+# lsof and kill it (TERM then KILL). Logs each kill so a leaked grandchild
+# can never silently lock out the next `texera start`.
+sweep_known_ports() {
+  local port pids
+  for port in 1234 4200 3001 8080 8081 8082 8085 8888 9090 9092 9094 9096; do
+    pids=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)
+    [[ -z "$pids" ]] && continue
+    info "sweeping leaked listener on port $port (pid: $pids)"
+    # shellcheck disable=SC2086
+    kill -TERM $pids 2>/dev/null || true
+    sleep 0.3
+    pids=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null || true)
+    if [[ -n "$pids" ]]; then
+      # shellcheck disable=SC2086
+      kill -KILL $pids 2>/dev/null || true
+    fi
+  done
 }
 
 # ---- Dispatch ---------------------------------------------------------------

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -19,6 +19,8 @@
 
 import { Component } from "@angular/core";
 import { GuiConfigService } from "./common/service/gui-config.service";
+import { ThemeService } from "./common/service/theme/theme.service";
+import { MotionService } from "./common/service/motion/motion.service";
 import { UntilDestroy } from "@ngneat/until-destroy";
 
 @UntilDestroy()
@@ -40,7 +42,17 @@ import { UntilDestroy } from "@ngneat/until-destroy";
 export class AppComponent {
   configLoaded = false;
 
-  constructor(private config: GuiConfigService) {
+  constructor(
+    private config: GuiConfigService,
+    // Eager-instantiate ThemeService so it applies the persisted theme
+    // (and sets up the prefers-color-scheme fallback) before any view
+    // renders. Marked unused intentionally — the constructor side-effect
+    // is what we want.
+    private _theme: ThemeService,
+    // MotionService installs the global Konami listener and resolves
+    // motion/sound preferences. Same eager-load reasoning.
+    private _motion: MotionService
+  ) {
     // determine whether configuration was successfully loaded by APP_INITIALIZER
     try {
       // accessing env will throw if not loaded

--- a/frontend/src/app/common/service/motion/motion.service.ts
+++ b/frontend/src/app/common/service/motion/motion.service.ts
@@ -1,0 +1,314 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+import { UserConfigService } from "../user/config/user-config.service";
+import { UserService } from "../user/user.service";
+import { ThemeService } from "../theme/theme.service";
+import { BUILTIN_THEMES } from "../theme/themes";
+
+const MOTION_KEY = "ui.motion";
+const SOUND_KEY = "ui.sound";
+
+/**
+ * Owns the "delight layer" preferences (motion + sound) and the runtime
+ * primitives that depend on them: confetti, success/fail chimes, and the
+ * Konami easter egg.
+ *
+ * Defaults:
+ *   - motion: on (unless prefers-reduced-motion is set)
+ *   - sound:  off (don't startle people in a quiet office)
+ *
+ * Persistence mirrors ThemeService — user-config when logged in, otherwise
+ * localStorage. Errors are swallowed; preferences are non-critical.
+ */
+@Injectable({ providedIn: "root" })
+export class MotionService {
+  private readonly motion$ = new BehaviorSubject<boolean>(this.systemMotionDefault());
+  private readonly sound$ = new BehaviorSubject<boolean>(false);
+  private audioCtx: AudioContext | null = null;
+
+  constructor(
+    private readonly userConfig: UserConfigService,
+    private readonly userService: UserService,
+    private readonly themeService: ThemeService
+  ) {
+    this.loadPersisted();
+    this.userService.userChanged().subscribe(() => this.loadPersisted());
+    this.installKonamiListener();
+  }
+
+  motionEnabled(): Observable<boolean> { return this.motion$.asObservable(); }
+  soundEnabled(): Observable<boolean> { return this.sound$.asObservable(); }
+  isMotionEnabled(): boolean { return this.motion$.value; }
+  isSoundEnabled(): boolean { return this.sound$.value; }
+
+  setMotionEnabled(v: boolean): void {
+    if (v === this.motion$.value) return;
+    this.motion$.next(v);
+    this.persist(MOTION_KEY, v);
+  }
+
+  setSoundEnabled(v: boolean): void {
+    if (v === this.sound$.value) return;
+    this.sound$.next(v);
+    this.persist(SOUND_KEY, v);
+  }
+
+  /**
+   * Fire a quick confetti burst from the center of the viewport.
+   * Cheap canvas implementation — no library dep, no DOM thrash.
+   * No-op when motion is disabled.
+   */
+  confetti(opts?: { count?: number; durationMs?: number; origin?: { x: number; y: number } }): void {
+    if (!this.motion$.value || typeof document === "undefined") return;
+    const count = opts?.count ?? 120;
+    const duration = opts?.durationMs ?? 1800;
+    const origin = opts?.origin ?? { x: window.innerWidth / 2, y: window.innerHeight / 2 };
+
+    const canvas = document.createElement("canvas");
+    canvas.style.cssText =
+      "position:fixed;inset:0;pointer-events:none;z-index:99999;";
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+    document.body.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      canvas.remove();
+      return;
+    }
+
+    // Sample colors from the active theme so confetti matches.
+    const css = getComputedStyle(document.documentElement);
+    const palette = [
+      css.getPropertyValue("--tx-primary").trim() || "#1890ff",
+      css.getPropertyValue("--tx-success").trim() || "#52c41a",
+      css.getPropertyValue("--tx-warning").trim() || "#faad14",
+      css.getPropertyValue("--tx-info").trim() || "#13c2c2",
+      css.getPropertyValue("--tx-danger").trim() || "#ff4d4f",
+    ];
+
+    type Particle = {
+      x: number; y: number;
+      vx: number; vy: number;
+      rot: number; vrot: number;
+      size: number; color: string;
+      shape: 0 | 1; // 0 = rect, 1 = circle
+    };
+    const particles: Particle[] = [];
+    for (let i = 0; i < count; i++) {
+      const angle = Math.random() * Math.PI * 2;
+      const speed = 4 + Math.random() * 9;
+      particles.push({
+        x: origin.x,
+        y: origin.y,
+        vx: Math.cos(angle) * speed,
+        vy: Math.sin(angle) * speed - 4,
+        rot: Math.random() * Math.PI * 2,
+        vrot: (Math.random() - 0.5) * 0.4,
+        size: 5 + Math.random() * 7,
+        color: palette[Math.floor(Math.random() * palette.length)],
+        shape: Math.random() < 0.5 ? 0 : 1,
+      });
+    }
+
+    const start = performance.now();
+    const gravity = 0.22;
+    const drag = 0.992;
+    const step = (now: number) => {
+      const t = now - start;
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (const p of particles) {
+        p.vy += gravity;
+        p.vx *= drag;
+        p.vy *= drag;
+        p.x += p.vx;
+        p.y += p.vy;
+        p.rot += p.vrot;
+        const fade = Math.max(0, 1 - t / duration);
+        ctx.globalAlpha = fade;
+        ctx.save();
+        ctx.translate(p.x, p.y);
+        ctx.rotate(p.rot);
+        ctx.fillStyle = p.color;
+        if (p.shape === 0) {
+          ctx.fillRect(-p.size / 2, -p.size / 4, p.size, p.size / 2);
+        } else {
+          ctx.beginPath();
+          ctx.arc(0, 0, p.size / 2, 0, Math.PI * 2);
+          ctx.fill();
+        }
+        ctx.restore();
+      }
+      ctx.globalAlpha = 1;
+      if (t < duration) {
+        requestAnimationFrame(step);
+      } else {
+        canvas.remove();
+      }
+    };
+    requestAnimationFrame(step);
+  }
+
+  /**
+   * Play a short tonal chord. WebAudio-synthesized so no asset shipping.
+   * No-op when sound is disabled.
+   */
+  chime(kind: "success" | "fail"): void {
+    if (!this.sound$.value || typeof window === "undefined") return;
+    try {
+      const ctx = this.audioCtx ?? new (window.AudioContext || (window as any).webkitAudioContext)();
+      this.audioCtx = ctx;
+      // success = ascending C major triad. fail = descending tritone.
+      const notes = kind === "success" ? [523.25, 659.25, 783.99] : [466.16, 329.63];
+      const start = ctx.currentTime;
+      notes.forEach((freq, i) => {
+        const osc = ctx.createOscillator();
+        const gain = ctx.createGain();
+        osc.type = kind === "success" ? "triangle" : "sawtooth";
+        osc.frequency.value = freq;
+        gain.gain.setValueAtTime(0, start + i * 0.08);
+        gain.gain.linearRampToValueAtTime(0.16, start + i * 0.08 + 0.02);
+        gain.gain.exponentialRampToValueAtTime(0.0001, start + i * 0.08 + 0.55);
+        osc.connect(gain);
+        gain.connect(ctx.destination);
+        osc.start(start + i * 0.08);
+        osc.stop(start + i * 0.08 + 0.6);
+      });
+    } catch {
+      /* WebAudio unavailable; silently skip */
+    }
+  }
+
+  /**
+   * Briefly shake the viewport — used for execution failures. No-op when
+   * motion is off.
+   */
+  shake(): void {
+    if (!this.motion$.value || typeof document === "undefined") return;
+    const root = document.documentElement;
+    root.animate(
+      [
+        { transform: "translate(0,0)" },
+        { transform: "translate(-6px, 2px)" },
+        { transform: "translate(5px, -3px)" },
+        { transform: "translate(-3px, 1px)" },
+        { transform: "translate(0,0)" },
+      ],
+      { duration: 320, easing: "ease-in-out" }
+    );
+  }
+
+  /* ---- private ---------------------------------------------------------- */
+
+  private systemMotionDefault(): boolean {
+    if (typeof window === "undefined" || !window.matchMedia) return true;
+    return !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  private loadPersisted(): void {
+    const readLocal = (k: string): boolean | null => {
+      if (typeof localStorage === "undefined") return null;
+      const v = localStorage.getItem(k);
+      if (v === null) return null;
+      return v === "1" || v === "true";
+    };
+    const local = { m: readLocal(MOTION_KEY), s: readLocal(SOUND_KEY) };
+    if (local.m !== null) this.motion$.next(local.m);
+    if (local.s !== null) this.sound$.next(local.s);
+
+    if (this.userService.isLogin()) {
+      try {
+        this.userConfig.fetchKey(MOTION_KEY).subscribe({
+          next: v => {
+            if (v != null) this.motion$.next(v === "1" || v === "true");
+          },
+          error: () => {},
+        });
+        this.userConfig.fetchKey(SOUND_KEY).subscribe({
+          next: v => {
+            if (v != null) this.sound$.next(v === "1" || v === "true");
+          },
+          error: () => {},
+        });
+      } catch {
+        /* logged-out race — local fallback already applied */
+      }
+    }
+  }
+
+  private persist(key: string, value: boolean): void {
+    const str = value ? "1" : "0";
+    if (typeof localStorage !== "undefined") localStorage.setItem(key, str);
+    if (this.userService.isLogin()) {
+      try {
+        this.userConfig.set(key, str).subscribe({ error: () => {} });
+      } catch {
+        /* logged out by the time we got here; local already saved */
+      }
+    }
+  }
+
+  /* ---- Konami code easter egg ------------------------------------------- */
+  // ↑ ↑ ↓ ↓ ← → ← → B A — when matched, briefly forces Synthwave + a
+  // confetti volley + a chord. Reverts to the user's chosen theme after.
+  private readonly konami = [
+    "ArrowUp", "ArrowUp", "ArrowDown", "ArrowDown",
+    "ArrowLeft", "ArrowRight", "ArrowLeft", "ArrowRight",
+    "b", "a",
+  ];
+  private konamiIdx = 0;
+
+  private installKonamiListener(): void {
+    if (typeof window === "undefined") return;
+    window.addEventListener("keydown", e => {
+      const expected = this.konami[this.konamiIdx];
+      if (e.key.toLowerCase() === expected.toLowerCase()) {
+        this.konamiIdx++;
+        if (this.konamiIdx === this.konami.length) {
+          this.konamiIdx = 0;
+          this.partyMode();
+        }
+      } else {
+        this.konamiIdx = e.key === this.konami[0] ? 1 : 0;
+      }
+    });
+  }
+
+  private partyMode(): void {
+    const previous = this.themeService.getCurrent();
+    const synthwave = BUILTIN_THEMES.find(t => t.id === "synthwave");
+    if (synthwave) this.themeService.setTheme(synthwave);
+    // Two confetti volleys spaced apart for a sustained burst.
+    const oldMotion = this.motion$.value;
+    this.motion$.next(true); // override during easter egg
+    this.confetti({ count: 180 });
+    setTimeout(() => this.confetti({ count: 140 }), 600);
+    setTimeout(() => this.confetti({ count: 100 }), 1200);
+    setTimeout(() => {
+      this.themeService.setTheme(previous);
+      this.motion$.next(oldMotion);
+    }, 4500);
+    const oldSound = this.sound$.value;
+    this.sound$.next(true);
+    this.chime("success");
+    setTimeout(() => this.sound$.next(oldSound), 800);
+  }
+}

--- a/frontend/src/app/common/service/theme/theme.service.ts
+++ b/frontend/src/app/common/service/theme/theme.service.ts
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+import {
+  BUILTIN_THEMES,
+  DEFAULT_THEME,
+  Theme,
+  defaultThemeForSystem,
+  findTheme,
+} from "./themes";
+import { UserConfigService } from "../user/config/user-config.service";
+import { UserService } from "../user/user.service";
+
+/**
+ * Key under which the selected theme id is persisted in the user-config
+ * dictionary (see UserConfigResource on the backend).
+ */
+const THEME_CONFIG_KEY = "ui.theme";
+
+/**
+ * Key for the localStorage fallback used when the user isn't logged in.
+ * Same value as the user-config key for convenience.
+ */
+const THEME_LOCAL_KEY = "ui.theme";
+
+/**
+ * Applies the currently selected theme to the document, persists the
+ * selection, and exposes a stream of the active theme so components can
+ * react (e.g. to retheme third-party widgets like Monaco that don't read
+ * CSS variables).
+ *
+ * Lifecycle:
+ *   1. On construction, applies whatever the system-preference default is
+ *      (light or dark) so first paint isn't a flash of unstyled content.
+ *   2. Asynchronously loads the user's saved choice (from user-config when
+ *      logged in, localStorage otherwise) and re-applies if it differs.
+ *   3. setTheme() updates :root, persists, and emits.
+ */
+@Injectable({ providedIn: "root" })
+export class ThemeService {
+  /** Every built-in theme, in picker display order. */
+  public readonly themes: ReadonlyArray<Theme> = BUILTIN_THEMES;
+
+  private readonly current$ = new BehaviorSubject<Theme>(DEFAULT_THEME);
+
+  constructor(
+    private readonly userConfig: UserConfigService,
+    private readonly userService: UserService
+  ) {
+    // First paint: system-preference theme so dark-mode-OS users don't get
+    // a flash of light theme.
+    this.applyToDom(defaultThemeForSystem());
+
+    // Then resolve the persisted choice (if any) and apply it. Out-of-order
+    // updates are fine because applyToDom just sets CSS vars.
+    this.loadPersisted().then(theme => {
+      if (theme) {
+        this.applyToDom(theme);
+        this.current$.next(theme);
+      } else {
+        this.current$.next(defaultThemeForSystem());
+      }
+    });
+
+    // If the user logs in / out, re-resolve the persisted theme — a logged-in
+    // user's saved preference should win over a localStorage fallback.
+    this.userService.userChanged().subscribe(() => {
+      this.loadPersisted().then(theme => {
+        if (theme && theme.id !== this.current$.value.id) {
+          this.applyToDom(theme);
+          this.current$.next(theme);
+        }
+      });
+    });
+  }
+
+  /** The currently active theme. Use this for one-shot reads. */
+  public getCurrent(): Theme {
+    return this.current$.value;
+  }
+
+  /** Stream of theme changes. Use this in components that need to react. */
+  public current(): Observable<Theme> {
+    return this.current$.asObservable();
+  }
+
+  /**
+   * Switch to a theme by id (or full Theme object). Idempotent; no-ops if
+   * the id is already active.
+   */
+  public setTheme(theme: Theme | string): void {
+    const resolved = typeof theme === "string" ? findTheme(theme) : theme;
+    if (resolved.id === this.current$.value.id) return;
+    this.applyToDom(resolved);
+    this.persist(resolved.id);
+    this.current$.next(resolved);
+  }
+
+  /**
+   * Apply a Theme's tokens to :root and set color-scheme so the browser
+   * picks correct defaults for scrollbars, form controls, etc.
+   */
+  private applyToDom(theme: Theme): void {
+    if (typeof document === "undefined") return;
+    const root = document.documentElement;
+    for (const [key, value] of Object.entries(theme.tokens)) {
+      root.style.setProperty(`--${key}`, value);
+    }
+    root.style.colorScheme = theme.mode;
+    // Expose the active theme id as a data attribute so any non-token
+    // styling (e.g. SVG patterns) can branch on it via CSS selectors.
+    root.dataset["theme"] = theme.id;
+    // Monaco doesn't read CSS variables — but it does have a global
+    // setTheme() that retints every live editor. If monaco is loaded
+    // (Code Editor dialog is open or has been opened this session),
+    // sync it to the active theme. We swallow errors because monaco
+    // may not be on window yet on first paint, or may have been GC'd.
+    try {
+      const m = (window as unknown as { monaco?: { editor?: { setTheme?: (n: string) => void } } }).monaco;
+      const themeName = theme.mode === "dark" ? "vs-dark" : "vs";
+      m?.editor?.setTheme?.(themeName);
+    } catch {
+      /* monaco not loaded yet; will be retinted by its component on init */
+    }
+  }
+
+  /**
+   * Read the persisted theme id from user-config (preferred) or
+   * localStorage. Returns null if no choice has been recorded.
+   *
+   * Both paths swallow errors and treat them as "no preference recorded" —
+   * a missing key or a transient network failure should never prevent the
+   * app from rendering. The first-paint system-preference theme stays.
+   */
+  private async loadPersisted(): Promise<Theme | null> {
+    if (this.userService.isLogin()) {
+      try {
+        const id = await new Promise<string | null>(resolve => {
+          this.userConfig.fetchKey(THEME_CONFIG_KEY).subscribe({
+            next: v => resolve(v),
+            error: () => resolve(null),
+          });
+        });
+        if (id) return findTheme(id);
+      } catch {
+        // fetchKey throws synchronously when called while logged out — the
+        // isLogin() check above prevents that, but be defensive anyway.
+      }
+    }
+    if (typeof localStorage !== "undefined") {
+      const id = localStorage.getItem(THEME_LOCAL_KEY);
+      if (id) return findTheme(id);
+    }
+    return null;
+  }
+
+  /**
+   * Save the user's choice. Mirrors to localStorage so an unauthenticated
+   * page load still picks up the same theme.
+   */
+  private persist(themeId: string): void {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(THEME_LOCAL_KEY, themeId);
+    }
+    if (this.userService.isLogin()) {
+      try {
+        this.userConfig.set(THEME_CONFIG_KEY, themeId).subscribe({
+          error: () => {
+            // localStorage is still authoritative for next load; nothing more
+            // to do if the backend is unreachable.
+          },
+        });
+      } catch {
+        // userConfig.set throws synchronously when logged out (shouldn't
+        // happen given the isLogin() check, but be defensive).
+      }
+    }
+  }
+}

--- a/frontend/src/app/common/service/theme/themes.ts
+++ b/frontend/src/app/common/service/theme/themes.ts
@@ -1,0 +1,454 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A theme is a flat map from CSS custom property name (without the leading
+ * "--") to its value. Anything not specified inherits from the defaults in
+ * styles/_tokens.scss, so a theme can override as few or as many tokens as it
+ * likes.
+ */
+export type Theme = {
+  /** Stable identifier (used for persistence). Kebab-case. */
+  readonly id: string;
+  /** Human-readable name shown in the picker. */
+  readonly name: string;
+  /** One-line description shown in the picker. */
+  readonly description: string;
+  /** Either "light" or "dark" — used to set color-scheme on :root. */
+  readonly mode: "light" | "dark";
+  /** Token overrides. */
+  readonly tokens: Readonly<Record<string, string>>;
+};
+
+/* -- shared semantic palette helpers ------------------------------------- */
+// Most themes reuse the same green/orange/red triad; only the bg/text/accent
+// columns truly differ between themes. Defining these once keeps each theme
+// declaration tight.
+const STATUS_OK_LIGHT  = "#52c41a";
+const STATUS_WARN_LIGHT = "#faad14";
+const STATUS_BAD_LIGHT  = "#ff4d4f";
+
+const STATUS_OK_DARK  = "#73d13d";
+const STATUS_WARN_DARK = "#ffc53d";
+const STATUS_BAD_DARK  = "#ff7875";
+
+// ---- LIGHT (current Texera look, our default) ---------------------------
+const LIGHT: Theme = {
+  id: "light",
+  name: "Light",
+  description: "The classic Texera look.",
+  mode: "light",
+  tokens: {
+    "tx-bg-base":        "#ffffff",
+    "tx-bg-surface":     "#fafafa",
+    "tx-bg-elevated":    "#ffffff",
+    "tx-bg-canvas":      "#f5f7fa",
+    "tx-bg-hover":       "rgba(0, 0, 0, 0.04)",
+    "tx-bg-active":      "rgba(0, 0, 0, 0.08)",
+    "tx-bg-overlay":     "rgba(0, 0, 0, 0.45)",
+    "tx-text-primary":   "rgba(0, 0, 0, 0.88)",
+    "tx-text-secondary": "rgba(0, 0, 0, 0.65)",
+    "tx-text-tertiary":  "rgba(0, 0, 0, 0.45)",
+    "tx-text-disabled":  "rgba(0, 0, 0, 0.25)",
+    "tx-text-inverse":   "#ffffff",
+    "tx-border-subtle":  "#f0f0f0",
+    "tx-border-default": "#d9d9d9",
+    "tx-border-strong":  "#bfbfbf",
+    "tx-primary":        "#1890ff",
+    "tx-primary-hover":  "#40a9ff",
+    "tx-primary-active": "#096dd9",
+    "tx-primary-soft":   "rgba(24, 144, 255, 0.10)",
+    "tx-primary-fg":     "#ffffff",
+    "tx-success":        STATUS_OK_LIGHT,
+    "tx-success-soft":   "rgba(82, 196, 26, 0.12)",
+    "tx-warning":        STATUS_WARN_LIGHT,
+    "tx-warning-soft":   "rgba(250, 173, 20, 0.12)",
+    "tx-danger":         STATUS_BAD_LIGHT,
+    "tx-danger-soft":    "rgba(255, 77, 79, 0.12)",
+    "tx-info":           "#1890ff",
+    "tx-info-soft":      "rgba(24, 144, 255, 0.10)",
+    // workspace canvas
+    "tx-canvas-bg":      "#f6f6f6",
+    "tx-canvas-grid":    "rgba(0, 0, 0, 0.18)",
+    "tx-op-body-bg":     "#ffffff",
+    "tx-op-body-stroke": "#cfcfcf",
+    "tx-op-label":       "#595959",
+    "tx-op-sublabel":    "#888888",
+    "tx-op-port":        "#a0a0a0",
+    "tx-link-stroke":    "#919191",
+    "tx-link-handle":    "#919191",
+    "tx-minimap-border": "#797a79",
+    "tx-monaco-theme":   "vs",
+  },
+};
+
+// ---- DARK ---------------------------------------------------------------
+const DARK: Theme = {
+  id: "dark",
+  name: "Dark",
+  description: "Easy on the eyes after sundown.",
+  mode: "dark",
+  tokens: {
+    "tx-bg-base":        "#141414",
+    "tx-bg-surface":     "#1f1f1f",
+    "tx-bg-elevated":    "#262626",
+    "tx-bg-canvas":      "#181818",
+    "tx-bg-hover":       "rgba(255, 255, 255, 0.06)",
+    "tx-bg-active":      "rgba(255, 255, 255, 0.10)",
+    "tx-bg-overlay":     "rgba(0, 0, 0, 0.65)",
+    "tx-text-primary":   "rgba(255, 255, 255, 0.92)",
+    "tx-text-secondary": "rgba(255, 255, 255, 0.70)",
+    "tx-text-tertiary":  "rgba(255, 255, 255, 0.45)",
+    "tx-text-disabled":  "rgba(255, 255, 255, 0.25)",
+    "tx-text-inverse":   "#141414",
+    "tx-border-subtle":  "#303030",
+    "tx-border-default": "#434343",
+    "tx-border-strong":  "#595959",
+    "tx-primary":        "#1890ff",
+    "tx-primary-hover":  "#40a9ff",
+    "tx-primary-active": "#69c0ff",
+    "tx-primary-soft":   "rgba(24, 144, 255, 0.20)",
+    "tx-primary-fg":     "#ffffff",
+    "tx-success":        STATUS_OK_DARK,
+    "tx-success-soft":   "rgba(115, 209, 61, 0.18)",
+    "tx-warning":        STATUS_WARN_DARK,
+    "tx-warning-soft":   "rgba(255, 197, 61, 0.18)",
+    "tx-danger":         STATUS_BAD_DARK,
+    "tx-danger-soft":    "rgba(255, 120, 117, 0.18)",
+    "tx-info":           "#1890ff",
+    "tx-info-soft":      "rgba(24, 144, 255, 0.20)",
+    "tx-shadow-sm":      "0 1px 2px rgba(0, 0, 0, 0.4)",
+    "tx-shadow-md":      "0 2px 8px rgba(0, 0, 0, 0.5)",
+    "tx-shadow-lg":      "0 8px 24px rgba(0, 0, 0, 0.6)",
+    // workspace canvas
+    "tx-canvas-bg":      "#181818",
+    "tx-canvas-grid":    "rgba(255, 255, 255, 0.10)",
+    "tx-op-body-bg":     "#262626",
+    "tx-op-body-stroke": "#434343",
+    "tx-op-label":       "rgba(255, 255, 255, 0.92)",
+    "tx-op-sublabel":    "rgba(255, 255, 255, 0.55)",
+    "tx-op-port":        "#7a7a7a",
+    "tx-link-stroke":    "#a3a3a3",
+    "tx-link-handle":    "#a3a3a3",
+    "tx-minimap-border": "#888888",
+    "tx-monaco-theme":   "vs-dark",
+  },
+};
+
+// ---- SEPIA (warm, low-blue, paper-like) ---------------------------------
+const SEPIA: Theme = {
+  id: "sepia",
+  name: "Sepia",
+  description: "Warm, paper-feel. Low blue light.",
+  mode: "light",
+  tokens: {
+    "tx-bg-base":        "#f4ecd8",
+    "tx-bg-surface":     "#ebe1c9",
+    "tx-bg-elevated":    "#f8f2e2",
+    "tx-bg-canvas":      "#ede2c8",
+    "tx-bg-hover":       "rgba(99, 65, 35, 0.06)",
+    "tx-bg-active":      "rgba(99, 65, 35, 0.10)",
+    "tx-text-primary":   "#5b4636",
+    "tx-text-secondary": "rgba(91, 70, 54, 0.75)",
+    "tx-text-tertiary":  "rgba(91, 70, 54, 0.55)",
+    "tx-text-disabled":  "rgba(91, 70, 54, 0.35)",
+    "tx-text-inverse":   "#f4ecd8",
+    "tx-border-subtle":  "#d8cba8",
+    "tx-border-default": "#c5b58e",
+    "tx-border-strong":  "#a3936a",
+    "tx-primary":        "#a0522d",
+    "tx-primary-hover":  "#b86a3f",
+    "tx-primary-active": "#874523",
+    "tx-primary-soft":   "rgba(160, 82, 45, 0.15)",
+    // workspace canvas
+    "tx-canvas-bg":      "#ede2c8",
+    "tx-canvas-grid":    "rgba(91, 70, 54, 0.20)",
+    "tx-op-body-bg":     "#f8f2e2",
+    "tx-op-body-stroke": "#c5b58e",
+    "tx-op-label":       "#5b4636",
+    "tx-op-sublabel":    "rgba(91, 70, 54, 0.65)",
+    "tx-op-port":        "#a3936a",
+    "tx-link-stroke":    "#876b4a",
+    "tx-link-handle":    "#876b4a",
+    "tx-minimap-border": "#a3936a",
+    "tx-monaco-theme":   "vs",
+  },
+};
+
+// ---- SOLARIZED DARK (Ethan Schoonover's palette) ------------------------
+const SOLARIZED_DARK: Theme = {
+  id: "solarized-dark",
+  name: "Solarized Dark",
+  description: "The Ethan Schoonover classic.",
+  mode: "dark",
+  tokens: {
+    "tx-bg-base":        "#002b36", // base03
+    "tx-bg-surface":     "#073642", // base02
+    "tx-bg-elevated":    "#0a3b46",
+    "tx-bg-canvas":      "#00252e",
+    "tx-bg-hover":       "rgba(147, 161, 161, 0.08)",
+    "tx-bg-active":      "rgba(147, 161, 161, 0.14)",
+    "tx-text-primary":   "#93a1a1", // base1
+    "tx-text-secondary": "#839496", // base0
+    "tx-text-tertiary":  "#586e75", // base01
+    "tx-text-inverse":   "#002b36",
+    "tx-border-subtle":  "#073642",
+    "tx-border-default": "#586e75",
+    "tx-border-strong":  "#657b83",
+    "tx-primary":        "#268bd2", // blue
+    "tx-primary-hover":  "#3a9bd9",
+    "tx-primary-active": "#1e6fa8",
+    "tx-primary-soft":   "rgba(38, 139, 210, 0.20)",
+    "tx-success":        "#859900", // green
+    "tx-warning":        "#b58900", // yellow
+    "tx-danger":         "#dc322f", // red
+    "tx-info":           "#2aa198", // cyan
+    // workspace canvas
+    "tx-canvas-bg":      "#00252e",
+    "tx-canvas-grid":    "rgba(147, 161, 161, 0.18)",
+    "tx-op-body-bg":     "#073642",
+    "tx-op-body-stroke": "#586e75",
+    "tx-op-label":       "#93a1a1",
+    "tx-op-sublabel":    "#657b83",
+    "tx-op-port":        "#586e75",
+    "tx-link-stroke":    "#839496",
+    "tx-link-handle":    "#839496",
+    "tx-minimap-border": "#657b83",
+    "tx-monaco-theme":   "vs-dark",
+  },
+};
+
+// ---- GRUVBOX DARK (Pavel Pertsev's palette) -----------------------------
+const GRUVBOX: Theme = {
+  id: "gruvbox",
+  name: "Gruvbox",
+  description: "Retro warm dark. Heavy contrast.",
+  mode: "dark",
+  tokens: {
+    "tx-bg-base":        "#282828",
+    "tx-bg-surface":     "#3c3836",
+    "tx-bg-elevated":    "#504945",
+    "tx-bg-canvas":      "#1d2021",
+    "tx-bg-hover":       "rgba(235, 219, 178, 0.06)",
+    "tx-bg-active":      "rgba(235, 219, 178, 0.12)",
+    "tx-text-primary":   "#ebdbb2",
+    "tx-text-secondary": "#d5c4a1",
+    "tx-text-tertiary":  "#a89984",
+    "tx-text-inverse":   "#282828",
+    "tx-border-subtle":  "#3c3836",
+    "tx-border-default": "#665c54",
+    "tx-border-strong":  "#7c6f64",
+    "tx-primary":        "#fabd2f", // yellow
+    "tx-primary-hover":  "#fac440",
+    "tx-primary-active": "#d79921",
+    "tx-primary-soft":   "rgba(250, 189, 47, 0.18)",
+    "tx-primary-fg":     "#282828",
+    "tx-success":        "#b8bb26",
+    "tx-warning":        "#fe8019",
+    "tx-danger":         "#fb4934",
+    "tx-info":           "#83a598",
+    // workspace canvas
+    "tx-canvas-bg":      "#1d2021",
+    "tx-canvas-grid":    "rgba(235, 219, 178, 0.10)",
+    "tx-op-body-bg":     "#3c3836",
+    "tx-op-body-stroke": "#665c54",
+    "tx-op-label":       "#ebdbb2",
+    "tx-op-sublabel":    "#a89984",
+    "tx-op-port":        "#7c6f64",
+    "tx-link-stroke":    "#d5c4a1",
+    "tx-link-handle":    "#fabd2f",
+    "tx-minimap-border": "#a89984",
+    "tx-monaco-theme":   "vs-dark",
+  },
+};
+
+// ---- SYNTHWAVE (Outrun aesthetic — neon purple/pink on near-black) ------
+const SYNTHWAVE: Theme = {
+  id: "synthwave",
+  name: "Synthwave",
+  description: "Neon dreams. The 1984 future.",
+  mode: "dark",
+  tokens: {
+    "tx-bg-base":        "#1a1033",
+    "tx-bg-surface":     "#241447",
+    "tx-bg-elevated":    "#2d1b5e",
+    "tx-bg-canvas":      "#13092a",
+    "tx-bg-hover":       "rgba(255, 113, 206, 0.10)",
+    "tx-bg-active":      "rgba(255, 113, 206, 0.18)",
+    "tx-text-primary":   "#f8f8f2",
+    "tx-text-secondary": "#c5c1e8",
+    "tx-text-tertiary":  "#8b86c5",
+    "tx-text-inverse":   "#1a1033",
+    "tx-border-subtle":  "#352561",
+    "tx-border-default": "#5a3aa3",
+    "tx-border-strong":  "#7e57c2",
+    "tx-primary":        "#ff71ce", // hot pink
+    "tx-primary-hover":  "#ff8fd9",
+    "tx-primary-active": "#e055b2",
+    "tx-primary-soft":   "rgba(255, 113, 206, 0.20)",
+    "tx-primary-fg":     "#1a1033",
+    "tx-success":        "#05ffa1",
+    "tx-warning":        "#fffb96",
+    "tx-danger":         "#ff3864",
+    "tx-info":           "#01cdfe",
+    "tx-shadow-md":      "0 0 12px rgba(255, 113, 206, 0.18)",
+    "tx-shadow-lg":      "0 0 32px rgba(255, 113, 206, 0.30)",
+    // workspace canvas
+    "tx-canvas-bg":      "#13092a",
+    "tx-canvas-grid":    "rgba(255, 113, 206, 0.18)",
+    "tx-op-body-bg":     "#241447",
+    "tx-op-body-stroke": "#ff71ce",
+    "tx-op-label":       "#f8f8f2",
+    "tx-op-sublabel":    "#8b86c5",
+    "tx-op-port":        "#01cdfe",
+    "tx-link-stroke":    "#ff71ce",
+    "tx-link-handle":    "#01cdfe",
+    "tx-minimap-border": "#ff71ce",
+    "tx-monaco-theme":   "vs-dark",
+  },
+};
+
+// ---- FOREST (mossy greens, warm wood accents) ---------------------------
+const FOREST: Theme = {
+  id: "forest",
+  name: "Forest",
+  description: "Mossy greens, warm wood accents.",
+  mode: "dark",
+  tokens: {
+    "tx-bg-base":        "#1b2a1f",
+    "tx-bg-surface":     "#243a2a",
+    "tx-bg-elevated":    "#2d4a35",
+    "tx-bg-canvas":      "#152019",
+    "tx-bg-hover":       "rgba(184, 207, 168, 0.07)",
+    "tx-bg-active":      "rgba(184, 207, 168, 0.14)",
+    "tx-text-primary":   "#e8f0d8",
+    "tx-text-secondary": "#b8cfa8",
+    "tx-text-tertiary":  "#8aa67a",
+    "tx-text-inverse":   "#1b2a1f",
+    "tx-border-subtle":  "#2d4a35",
+    "tx-border-default": "#4a6b50",
+    "tx-border-strong":  "#6b8e6b",
+    "tx-primary":        "#a3c585", // moss
+    "tx-primary-hover":  "#b3d195",
+    "tx-primary-active": "#88a86b",
+    "tx-primary-soft":   "rgba(163, 197, 133, 0.18)",
+    "tx-primary-fg":     "#1b2a1f",
+    "tx-success":        "#7cb88c",
+    "tx-warning":        "#d4a574",
+    "tx-danger":         "#c97064",
+    "tx-info":           "#8bb8a8",
+    // workspace canvas
+    "tx-canvas-bg":      "#152019",
+    "tx-canvas-grid":    "rgba(184, 207, 168, 0.14)",
+    "tx-op-body-bg":     "#243a2a",
+    "tx-op-body-stroke": "#4a6b50",
+    "tx-op-label":       "#e8f0d8",
+    "tx-op-sublabel":    "#8aa67a",
+    "tx-op-port":        "#6b8e6b",
+    "tx-link-stroke":    "#b8cfa8",
+    "tx-link-handle":    "#a3c585",
+    "tx-minimap-border": "#6b8e6b",
+    "tx-monaco-theme":   "vs-dark",
+  },
+};
+
+// ---- CYBERPUNK (high-saturation neons on near-black) --------------------
+const CYBERPUNK: Theme = {
+  id: "cyberpunk",
+  name: "Cyberpunk",
+  description: "Yellow on cyan on black. Loud.",
+  mode: "dark",
+  tokens: {
+    "tx-bg-base":        "#0a0e1a",
+    "tx-bg-surface":     "#141a2e",
+    "tx-bg-elevated":    "#1c2440",
+    "tx-bg-canvas":      "#050810",
+    "tx-bg-hover":       "rgba(255, 233, 0, 0.08)",
+    "tx-bg-active":      "rgba(255, 233, 0, 0.16)",
+    "tx-text-primary":   "#fcee0a", // electric yellow
+    "tx-text-secondary": "#00f0ff", // cyan
+    "tx-text-tertiary":  "#7aaab0",
+    "tx-text-inverse":   "#0a0e1a",
+    "tx-border-subtle":  "#1c2440",
+    "tx-border-default": "#00f0ff",
+    "tx-border-strong":  "#fcee0a",
+    "tx-primary":        "#ff003c", // hot red
+    "tx-primary-hover":  "#ff2050",
+    "tx-primary-active": "#cc0030",
+    "tx-primary-soft":   "rgba(255, 0, 60, 0.18)",
+    "tx-primary-fg":     "#fcee0a",
+    "tx-success":        "#00ff9f",
+    "tx-warning":        "#ff9100",
+    "tx-danger":         "#ff003c",
+    "tx-info":           "#00f0ff",
+    "tx-shadow-md":      "0 0 14px rgba(0, 240, 255, 0.25)",
+    "tx-shadow-lg":      "0 0 36px rgba(252, 238, 10, 0.35)",
+    // workspace canvas
+    "tx-canvas-bg":      "#050810",
+    "tx-canvas-grid":    "rgba(0, 240, 255, 0.20)",
+    "tx-op-body-bg":     "#141a2e",
+    "tx-op-body-stroke": "#00f0ff",
+    "tx-op-label":       "#fcee0a",
+    "tx-op-sublabel":    "#00f0ff",
+    "tx-op-port":        "#ff003c",
+    "tx-link-stroke":    "#00f0ff",
+    "tx-link-handle":    "#fcee0a",
+    "tx-minimap-border": "#fcee0a",
+    "tx-monaco-theme":   "vs-dark",
+  },
+};
+
+/**
+ * All built-in themes, in the order they appear in the picker.
+ */
+export const BUILTIN_THEMES: ReadonlyArray<Theme> = [
+  LIGHT,
+  DARK,
+  SEPIA,
+  SOLARIZED_DARK,
+  GRUVBOX,
+  SYNTHWAVE,
+  FOREST,
+  CYBERPUNK,
+];
+
+/**
+ * Lookup by id with a sensible default.
+ */
+export function findTheme(id: string | null | undefined): Theme {
+  if (!id) return LIGHT;
+  return BUILTIN_THEMES.find(t => t.id === id) ?? LIGHT;
+}
+
+/**
+ * The theme to use the very first time a user visits, before they've made
+ * a choice. Mirrors the system color scheme when available.
+ */
+export function defaultThemeForSystem(): Theme {
+  if (
+    typeof window !== "undefined" &&
+    window.matchMedia &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+  ) {
+    return DARK;
+  }
+  return LIGHT;
+}
+
+export const DEFAULT_THEME: Theme = LIGHT;

--- a/frontend/src/app/dashboard/component/button-style.scss
+++ b/frontend/src/app/dashboard/component/button-style.scss
@@ -34,16 +34,16 @@
     padding: 0 20px;
     font-size: 16px;
     font-weight: 500;
-    background-color: #1a73e8;
-    color: white;
+    background-color: var(--tx-primary);
+    color: var(--tx-primary-fg);
     border: none;
     border-radius: 24px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--tx-shadow-sm);
     cursor: pointer;
 
     &:hover,
     &:focus {
-      background-color: #1558b0;
+      background-color: var(--tx-primary-hover);
     }
   }
 }

--- a/frontend/src/app/dashboard/component/dashboard.component.scss
+++ b/frontend/src/app/dashboard/component/dashboard.component.scss
@@ -22,7 +22,8 @@
   padding: 10px 15px;
   display: flex;
   align-items: center;
-  background-color: white;
+  background-color: var(--tx-bg-surface);
+  border-bottom: 1px solid var(--tx-border-subtle);
   justify-content: space-between;
 }
 
@@ -49,11 +50,11 @@ button {
 }
 
 .ant-layout-content {
-  background-color: white;
+  background-color: var(--tx-bg-base);
 }
 
 .page-content-layout {
-  border-left: 1px solid #f0f0f0;
+  border-left: 1px solid var(--tx-border-subtle);
 }
 
 .ant-layout-sider-has-trigger {
@@ -105,7 +106,7 @@ nz-content {
   left: 5px;
   bottom: 5px;
   font-size: 0.4em;
-  color: gray;
+  color: var(--tx-text-tertiary);
   z-index: 5;
   pointer-events: none;
 }

--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.scss
@@ -20,7 +20,8 @@
 .list-item-card {
   padding: 3px;
   width: 100%;
-  background-color: white;
+  background-color: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
   position: relative;
   min-height: 65px;
   height: auto;
@@ -30,7 +31,7 @@
   }
 
   &:hover {
-    background-color: #f0f0f0;
+    background-color: var(--tx-bg-hover);
 
     .edit-button {
       display: flex;
@@ -42,17 +43,17 @@
   }
 
   &.selected {
-    border-color: #1e90ff;
-    background-color: #e6f7ff;
+    border-color: var(--tx-primary);
+    background-color: var(--tx-primary-soft);
 
     .button-group,
     .button-group button {
-      background-color: #e6f7ff;
+      background-color: var(--tx-primary-soft);
     }
 
     .button-group button:hover,
     .edit-button button:hover {
-      background-color: #cceeff;
+      background-color: var(--tx-bg-active);
     }
   }
 }
@@ -76,12 +77,12 @@
 .resource-description {
   font-size: 12px;
   font-weight: 300;
-  color: grey;
+  color: var(--tx-text-secondary);
 }
 
 .resource-info {
   font-size: 13px;
-  color: grey;
+  color: var(--tx-text-secondary);
 }
 
 .large-checkbox {
@@ -110,13 +111,14 @@
   button {
     margin-right: 32px;
     transition: none;
-    background-color: #e0e0e0;
-    border: 1px solid #d0d0d0;
+    background-color: var(--tx-bg-elevated);
+    color: var(--tx-text-primary);
+    border: 1px solid var(--tx-border-default);
     border-radius: 8px;
   }
 
   button:hover {
-    background-color: #c7c7c7;
+    background-color: var(--tx-bg-hover);
   }
 }
 
@@ -138,14 +140,14 @@
 .resource-description {
   font-size: 14px;
   font-weight: 400;
-  color: #333333;
+  color: var(--tx-text-primary);
   transition: all 0.2s ease;
 }
 
 .list-item-card:hover .resource-description {
   font-size: 15px;
   font-weight: 500;
-  color: #1e90ff;
+  color: var(--tx-primary);
 }
 
 .resource-description-edit-textarea {
@@ -168,7 +170,7 @@
 
   &:hover {
     display: block;
-    background-color: #d9d9d9;
+    background-color: var(--tx-bg-hover);
   }
 
   button {

--- a/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.html
+++ b/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.html
@@ -30,6 +30,60 @@
 <nz-dropdown-menu #menu="nzDropdownMenu">
   <ul nz-menu>
     <li
+      nz-submenu
+      nzTitle="Theme"
+      nzIcon="bg-colors">
+      <ul>
+        <li
+          *ngFor="let theme of themes"
+          nz-menu-item
+          (click)="onSelectTheme(theme)">
+          <span
+            *ngIf="theme.id === currentThemeId"
+            nz-icon
+            nzType="check"
+            style="margin-right: 6px;"></span>
+          <span
+            *ngIf="theme.id !== currentThemeId"
+            style="display: inline-block; width: 20px;"></span>
+          {{ theme.name }}
+        </li>
+      </ul>
+    </li>
+    <li
+      nz-submenu
+      nzTitle="Preferences"
+      nzIcon="setting">
+      <ul>
+        <li
+          nz-menu-item
+          (click)="toggleMotion(); $event.stopPropagation()">
+          <span
+            *ngIf="motionOn"
+            nz-icon
+            nzType="check"
+            style="margin-right: 6px;"></span>
+          <span
+            *ngIf="!motionOn"
+            style="display: inline-block; width: 20px;"></span>
+          Animations
+        </li>
+        <li
+          nz-menu-item
+          (click)="toggleSound(); $event.stopPropagation()">
+          <span
+            *ngIf="soundOn"
+            nz-icon
+            nzType="check"
+            style="margin-right: 6px;"></span>
+          <span
+            *ngIf="!soundOn"
+            style="display: inline-block; width: 20px;"></span>
+          Sound effects
+        </li>
+      </ul>
+    </li>
+    <li
       (click)="onClickLogout()"
       nz-menu-item>
       Sign Out

--- a/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.ts
@@ -18,15 +18,20 @@
  */
 
 import { Component } from "@angular/core";
+import { CommonModule } from "@angular/common";
 import { UserService } from "../../../../common/service/user/user.service";
 import { User } from "../../../../common/type/user";
-import { UntilDestroy } from "@ngneat/until-destroy";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Router } from "@angular/router";
 import { DASHBOARD_ABOUT } from "../../../../app-routing.constant";
 import { UserAvatarComponent } from "../user-avatar/user-avatar.component";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
-import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
+import { NzMenuDirective, NzMenuItemComponent, NzSubMenuComponent } from "ng-zorro-antd/menu";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { ThemeService } from "../../../../common/service/theme/theme.service";
+import { Theme } from "../../../../common/service/theme/themes";
+import { MotionService } from "../../../../common/service/motion/motion.service";
 
 /**
  * UserIconComponent is used to control user system on the top right corner
@@ -39,22 +44,55 @@ import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
   templateUrl: "./user-icon.component.html",
   styleUrls: ["./user-icon.component.scss"],
   imports: [
+    CommonModule,
     UserAvatarComponent,
     ɵNzTransitionPatchDirective,
     NzDropdownDirective,
     NzDropdownMenuComponent,
     NzMenuDirective,
     NzMenuItemComponent,
+    NzSubMenuComponent,
+    NzIconDirective,
   ],
 })
 export class UserIconComponent {
   public user: User | undefined;
+  public themes: ReadonlyArray<Theme>;
+  public currentThemeId: string;
+  public motionOn: boolean;
+  public soundOn: boolean;
 
   constructor(
     private userService: UserService,
-    private router: Router
+    private router: Router,
+    private themeService: ThemeService,
+    private motionService: MotionService
   ) {
     this.user = this.userService.getCurrentUser();
+    this.themes = this.themeService.themes;
+    this.currentThemeId = this.themeService.getCurrent().id;
+    this.motionOn = this.motionService.isMotionEnabled();
+    this.soundOn = this.motionService.isSoundEnabled();
+    this.themeService
+      .current()
+      .pipe(untilDestroyed(this))
+      .subscribe(theme => (this.currentThemeId = theme.id));
+    this.motionService
+      .motionEnabled()
+      .pipe(untilDestroyed(this))
+      .subscribe(v => (this.motionOn = v));
+    this.motionService
+      .soundEnabled()
+      .pipe(untilDestroyed(this))
+      .subscribe(v => (this.soundOn = v));
+  }
+
+  public toggleMotion(): void {
+    this.motionService.setMotionEnabled(!this.motionOn);
+  }
+
+  public toggleSound(): void {
+    this.motionService.setSoundEnabled(!this.soundOn);
   }
 
   /**
@@ -64,5 +102,12 @@ export class UserIconComponent {
     this.userService.logout();
     document.cookie = "flarum_remember=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
     this.router.navigate([DASHBOARD_ABOUT]);
+  }
+
+  /**
+   * handle the event when user picks a theme from the dropdown
+   */
+  public onSelectTheme(theme: Theme): void {
+    this.themeService.setTheme(theme);
   }
 }

--- a/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -51,6 +51,7 @@ import { filter, switchMap } from "rxjs/operators";
 import { BreakpointConditionInputComponent } from "./breakpoint-condition-input/breakpoint-condition-input.component";
 import { CodeDebuggerComponent } from "./code-debugger.component";
 import { GuiConfigService } from "src/app/common/service/gui-config.service";
+import { ThemeService } from "src/app/common/service/theme/theme.service";
 import { CdkDrag, CdkDragHandle } from "@angular/cdk/drag-drop";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
@@ -139,7 +140,8 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     private workflowVersionService: WorkflowVersionService,
     public coeditorPresenceService: CoeditorPresenceService,
     private aiAssistantService: AIAssistantService,
-    private config: GuiConfigService
+    private config: GuiConfigService,
+    private themeService: ThemeService
   ) {
     this.currentOperatorId = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()[0];
     const operatorType = this.workflowActionService.getTexeraGraph().getOperator(this.currentOperatorId).operatorType;
@@ -246,7 +248,10 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           },
           userConfiguration: {
             json: JSON.stringify({
-              "workbench.colorTheme": "Default Dark Modern",
+              "workbench.colorTheme":
+                this.themeService.getCurrent().mode === "dark"
+                  ? "Default Dark Modern"
+                  : "Default Light Modern",
             }),
           },
         },
@@ -324,7 +329,10 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           },
           userConfiguration: {
             json: JSON.stringify({
-              "workbench.colorTheme": "Default Dark Modern",
+              "workbench.colorTheme":
+                this.themeService.getCurrent().mode === "dark"
+                  ? "Default Dark Modern"
+                  : "Default Light Modern",
             }),
           },
         },

--- a/frontend/src/app/workspace/component/left-panel/left-panel.component.scss
+++ b/frontend/src/app/workspace/component/left-panel/left-panel.component.scss
@@ -30,15 +30,17 @@
   top: calc(-100% + 80px);
   left: 0;
   z-index: 3;
-  background: white;
+  background: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
 }
 
 #title {
   padding: 5px 9px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--tx-border-subtle);
   position: absolute;
   top: 0;
-  background: white;
+  background: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
   width: calc(100% - 33px);
   z-index: 2;
 }
@@ -70,7 +72,8 @@
   padding-top: 32px;
   display: inline-block;
   overflow-y: auto;
-  border-left: 1px solid #f0f0f0;
+  border-left: 1px solid var(--tx-border-subtle);
+  background: var(--tx-bg-surface);
 }
 
 .divider {

--- a/frontend/src/app/workspace/component/property-editor/property-editor.component.scss
+++ b/frontend/src/app/workspace/component/property-editor/property-editor.component.scss
@@ -29,15 +29,17 @@
   position: fixed;
   top: 10vh;
   right: 0;
-  background: white;
+  background: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
 }
 
 #title {
   padding: 5px 9px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--tx-border-subtle);
   position: absolute;
   top: 0;
-  background: white;
+  background: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
   width: 100%;
   z-index: 2;
 }

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -33,12 +33,10 @@
   position: absolute;
   top: -300px;
   left: 0;
-  background: white;
+  background: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
   border-radius: 5px;
-  box-shadow:
-    0 3px 1px -2px #0003,
-    0 2px 2px #00000024,
-    0 1px 5px #0000001f;
+  box-shadow: var(--tx-shadow-md);
 }
 
 // make modal body scrollable and modal size fixed
@@ -110,10 +108,11 @@ $type-colors: (
 
 #title {
   padding: 5px 9px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--tx-border-subtle);
   position: absolute;
   top: 0;
-  background: white;
+  background: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
   width: 100%;
   z-index: 2;
 }

--- a/frontend/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.scss
+++ b/frontend/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.scss
@@ -60,7 +60,7 @@
 
 #mini-map-navigator {
   position: absolute;
-  border: 2px solid #797a79;
+  border: 2px solid var(--tx-minimap-border);
   cursor: move;
   z-index: 1;
 }

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -48,6 +48,8 @@ import { NzNoAnimationDirective } from "ng-zorro-antd/core/animation";
 import { ContextMenuComponent } from "./context-menu/context-menu/context-menu.component";
 import { NgIf } from "@angular/common";
 import { AgentInteractionComponent } from "../agent/agent-interaction/agent-interaction.component";
+import { ThemeService } from "../../../common/service/theme/theme.service";
+import { MotionService } from "../../../common/service/motion/motion.service";
 
 // jointjs interactive options for enabling and disabling interactivity
 // https://resources.jointjs.com/docs/jointjs/v3.2/joint.html#dia.Paper.prototype.options.interactive
@@ -128,7 +130,9 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     public nzContextMenu: NzContextMenuService,
     private elementRef: ElementRef,
     private config: GuiConfigService,
-    private agentService: AgentService
+    private agentService: AgentService,
+    private themeService: ThemeService,
+    private motionService: MotionService
   ) {
     this.wrapper = this.workflowActionService.getJointGraphWrapper();
   }
@@ -166,6 +170,11 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     this.editorWrapper = document.getElementById("workflow-editor-wrapper")!;
     document.addEventListener("keydown", this._handleKeyboardAction.bind(this));
     this.initializeJointPaper();
+    this.applyCanvasTheme();
+    this.themeService
+      .current()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.applyCanvasTheme());
     this.handleDisableJointPaperInteractiveness();
     this.handleOperatorValidation();
     this.handlePaperRestoreDefaultOffset();
@@ -205,6 +214,92 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     this.invokeResize();
     this.handleCenterEvent();
     this.handleOperatorChatButton();
+    this.handleMotionEffects();
+  }
+
+  /**
+   * Wire up the "delight" effects: confetti + chime on workflow success,
+   * shake + chime on failure, draw-in animation for newly-added links,
+   * settle scale for newly-added operators. Every hook is a no-op when
+   * the motion/sound preference is off, so we don't gate them here.
+   */
+  /** Tracks whether the workflow has finished loading, so we don't animate
+   * every operator and link of an opened-from-persistence workflow at once. */
+  private animationsArmed = false;
+
+  private handleMotionEffects(): void {
+    // Execution success / failure feedback.
+    this.executeWorkflowService
+      .getExecutionStateStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(({ previous, current }) => {
+        if (previous.state === current.state) return;
+        if (current.state === ExecutionState.Completed) {
+          this.motionService.confetti();
+          this.motionService.chime("success");
+        } else if (current.state === ExecutionState.Failed) {
+          this.motionService.shake();
+          this.motionService.chime("fail");
+        }
+      });
+
+    // Arm animations after the initial workflow-load burst settles.
+    // Anything added before this timer is presumed to be persistence-restored
+    // and shouldn't trigger an entrance animation.
+    setTimeout(() => { this.animationsArmed = true; }, 800);
+
+    // Link draw-in / element settle for newly-added cells.
+    const graph = this.wrapper.jointGraph;
+    graph.on("add", (cell: joint.dia.Cell) => {
+      if (!this.animationsArmed || !this.motionService.isMotionEnabled()) return;
+      if (cell.isLink()) {
+        requestAnimationFrame(() => this.animateLinkDrawIn(cell as joint.dia.Link));
+      } else if (cell.isElement()) {
+        requestAnimationFrame(() => this.animateElementSettle(cell as joint.dia.Element));
+      }
+    });
+  }
+
+  private animateLinkDrawIn(link: joint.dia.Link): void {
+    const view = this.paper.findViewByModel(link);
+    if (!view) return;
+    const path = view.el.querySelector("path.connection") as SVGPathElement | null;
+    if (!path) return;
+    const length = path.getTotalLength();
+    if (length === 0) return;
+    path.style.strokeDasharray = `${length}`;
+    path.style.strokeDashoffset = `${length}`;
+    path.style.transition = "stroke-dashoffset 380ms cubic-bezier(0.4, 0, 0.2, 1)";
+    // force reflow, then animate to 0
+    void path.getBoundingClientRect();
+    path.style.strokeDashoffset = "0";
+    // clean up so subsequent re-renders don't keep dasharray
+    setTimeout(() => {
+      path.style.transition = "";
+      path.style.strokeDasharray = "";
+      path.style.strokeDashoffset = "";
+    }, 450);
+  }
+
+  private animateElementSettle(element: joint.dia.Element): void {
+    const view = this.paper.findViewByModel(element);
+    if (!view) return;
+    const node = view.el as SVGGElement;
+    // JointJS positions elements via SVG transform="matrix(...)". We layer
+    // our scale on a CSS variable via `transform-origin` on the group,
+    // animating its `transform: scale()` ON TOP of the matrix. Since SVG
+    // <g> respects CSS transforms in modern browsers, this works without
+    // fighting JointJS's positioning.
+    node.style.transformBox = "fill-box";
+    node.style.transformOrigin = "center";
+    node.animate(
+      [
+        { transform: "scale(0.6)", opacity: 0 },
+        { transform: "scale(1.08)", opacity: 1, offset: 0.7 },
+        { transform: "scale(1)", opacity: 1 },
+      ],
+      { duration: 280, easing: "cubic-bezier(0.34, 1.56, 0.64, 1)" }
+    );
   }
 
   ngOnDestroy(): void {
@@ -237,6 +332,24 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
         }
         this._onProcessKeyboardActionObservable.complete();
       });
+  }
+
+  /**
+   * Sync the JointJS paper's background color and grid dots to the active
+   * theme. JointJS bakes both into inline styles / canvas-rendered images
+   * at construction, so a CSS variable alone can't retint them — we have
+   * to call drawBackground() and drawGrid() with the resolved token values.
+   */
+  private applyCanvasTheme(): void {
+    if (!this.paper) return;
+    const rootStyle = getComputedStyle(document.documentElement);
+    const bg = rootStyle.getPropertyValue("--tx-canvas-bg").trim() || "#f6f6f6";
+    const dot = rootStyle.getPropertyValue("--tx-canvas-grid").trim() || "rgba(0,0,0,0.18)";
+    this.paper.drawBackground({ color: bg });
+    this.paper.drawGrid({
+      name: "fixedDot",
+      args: { color: dot, scaleFactor: 8, thickness: 1.2 },
+    });
   }
 
   private initializeJointPaper(): void {

--- a/frontend/src/app/workspace/component/workspace.component.scss
+++ b/frontend/src/app/workspace/component/workspace.component.scss
@@ -28,7 +28,8 @@ texera-menu {
   left: 0;
   z-index: 1;
   width: 100%;
-  background-color: white;
+  background-color: var(--tx-bg-surface);
+  border-bottom: 1px solid var(--tx-border-subtle);
 }
 
 texera-mini-map {
@@ -44,7 +45,7 @@ texera-workflow-editor {
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: #f6f6f6;
+  background-color: var(--tx-canvas-bg);
 }
 
 .spinner-container {

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -19,6 +19,352 @@
 
 @import "@ali-hm/angular-tree-component/css/angular-tree-component.css";
 
+/* Theme token contract + transitions. */
+@import "./styles/tokens";
+
+/* -- App shell & ng-zorro retinting ---------------------------------------
+ *
+ * ng-zorro-antd ships as a pre-built minified stylesheet bundled in
+ * angular.json, so we can't customize its less variables through the
+ * supported channel without forking the build. Instead we override the
+ * high-visibility classes here using the token variables so the chrome
+ * (layouts, menus, modals, dropdowns, tables, cards, buttons, inputs)
+ * follows the active theme.
+ *
+ * Deeper ng-zorro components may still look ng-zorro-tinted; those land
+ * in phases 2 and 3.
+ * ------------------------------------------------------------------------ */
+
+html,
+body {
+  background-color: var(--tx-bg-base);
+  color: var(--tx-text-primary);
+  font-family: var(--tx-font-ui);
+  font-size: var(--tx-font-size-base);
+}
+
+/* Page-level layout containers — every dashboard/hub page lives inside one
+ * of these. */
+.ant-layout,
+.ant-layout-content,
+.ant-layout-footer {
+  background-color: var(--tx-bg-base);
+  color: var(--tx-text-primary);
+}
+
+.ant-layout-header,
+.ant-layout-sider {
+  background-color: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
+  border-color: var(--tx-border-subtle);
+}
+
+/* Menus (top nav, sidebar nav, context menus). */
+.ant-menu {
+  background-color: transparent;
+  color: var(--tx-text-primary);
+  border-color: var(--tx-border-subtle);
+}
+/* The sidebar uses nzTheme="light" which adds an .ant-menu-light class
+   that hardcodes white backgrounds on the menu itself AND on the inline
+   submenu panel (.ant-menu-sub) that opens beneath "Your Work" etc.
+   We need explicit overrides for both, plus the inline-submenu container,
+   otherwise the expanded items render on a white background regardless
+   of the active theme. */
+.ant-menu-light,
+.ant-menu-light .ant-menu-sub,
+.ant-menu.ant-menu-inline .ant-menu-sub.ant-menu-inline,
+.ant-menu-sub.ant-menu-inline {
+  background-color: var(--tx-bg-surface) !important;
+  color: var(--tx-text-primary);
+}
+.ant-menu-item,
+.ant-menu-submenu-title {
+  color: var(--tx-text-primary);
+}
+/* Submenu chevron and the small arrow on collapsed-submenu popouts. */
+.ant-menu-submenu-arrow,
+.ant-menu-submenu-arrow::before,
+.ant-menu-submenu-arrow::after {
+  color: var(--tx-text-secondary);
+  background: var(--tx-text-secondary);
+}
+.ant-menu-item:hover,
+.ant-menu-submenu-title:hover,
+.ant-menu-item-active {
+  background-color: var(--tx-bg-hover) !important;
+  color: var(--tx-primary) !important;
+}
+.ant-menu-item-selected,
+.ant-menu-light .ant-menu-item-selected {
+  background-color: var(--tx-primary-soft) !important;
+  color: var(--tx-primary) !important;
+}
+/* Sider trigger (the little collapse/expand chevron at the bottom edge). */
+.ant-layout-sider-trigger {
+  background-color: var(--tx-bg-elevated) !important;
+  color: var(--tx-text-secondary) !important;
+  border-top: 1px solid var(--tx-border-subtle);
+}
+
+/* Dropdowns (user menu, "more actions", picker popovers). */
+.ant-dropdown-menu,
+.ant-select-dropdown,
+.ant-picker-dropdown {
+  background-color: var(--tx-bg-elevated);
+  color: var(--tx-text-primary);
+  border: 1px solid var(--tx-border-subtle);
+  box-shadow: var(--tx-shadow-lg);
+}
+.ant-dropdown-menu-item {
+  color: var(--tx-text-primary);
+}
+.ant-dropdown-menu-item:hover,
+.ant-dropdown-menu-item-active {
+  background-color: var(--tx-bg-hover);
+  color: var(--tx-text-primary);
+}
+/* User-icon dropdown uses <ul nz-menu> inside <nz-dropdown-menu>, which
+   renders as .ant-dropdown > .ant-menu (NOT .ant-dropdown-menu). The
+   outer wrapper has its own white background that the menu sits on.
+   Retint the wrapper + every menu/submenu surface inside it. */
+.ant-dropdown,
+.ant-dropdown .ant-menu,
+.ant-dropdown .ant-menu-sub,
+.ant-dropdown .ant-menu.ant-menu-light,
+.ant-dropdown .ant-menu-submenu,
+.ant-dropdown .ant-menu-submenu .ant-menu-sub {
+  background-color: var(--tx-bg-elevated) !important;
+  color: var(--tx-text-primary);
+  box-shadow: var(--tx-shadow-lg);
+}
+.ant-dropdown .ant-menu-item,
+.ant-dropdown .ant-menu-submenu-title {
+  background-color: transparent !important;
+  color: var(--tx-text-primary) !important;
+}
+
+/* Submenu flyouts (the panel that opens when you hover "Theme" /
+   "Preferences") render in their own CDK overlay as .ant-menu-submenu-popup,
+   appended to <body> — they are NOT children of .ant-dropdown so the
+   selectors above don't reach them. Retint them directly. */
+.ant-menu-submenu-popup,
+.ant-menu-submenu-popup > .ant-menu,
+.ant-menu-submenu-popup .ant-menu,
+.ant-menu-submenu-popup .ant-menu-sub {
+  background-color: var(--tx-bg-elevated) !important;
+  color: var(--tx-text-primary);
+  box-shadow: var(--tx-shadow-lg);
+  border: 1px solid var(--tx-border-subtle);
+}
+.ant-menu-submenu-popup .ant-menu-item,
+.ant-menu-submenu-popup .ant-menu-submenu-title {
+  background-color: transparent !important;
+  color: var(--tx-text-primary) !important;
+}
+.ant-menu-submenu-popup .ant-menu-item:hover,
+.ant-menu-submenu-popup .ant-menu-submenu-title:hover {
+  background-color: var(--tx-bg-hover) !important;
+  color: var(--tx-primary) !important;
+}
+
+/* Modals. */
+.ant-modal-content,
+.ant-modal-header,
+.ant-modal-footer {
+  background-color: var(--tx-bg-elevated);
+  color: var(--tx-text-primary);
+  border-color: var(--tx-border-subtle);
+}
+.ant-modal-title {
+  color: var(--tx-text-primary);
+}
+.ant-modal-close,
+.ant-modal-close-x {
+  color: var(--tx-text-secondary);
+}
+.ant-modal-mask {
+  background-color: var(--tx-bg-overlay);
+}
+
+/* Cards (used everywhere on the dashboard/hub). */
+.ant-card {
+  background-color: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
+  border-color: var(--tx-border-subtle);
+}
+.ant-card-head {
+  background-color: transparent;
+  color: var(--tx-text-primary);
+  border-bottom-color: var(--tx-border-subtle);
+}
+
+/* Tables (admin pages, dataset listings, workflow versions). */
+.ant-table {
+  background-color: var(--tx-bg-surface);
+  color: var(--tx-text-primary);
+}
+.ant-table-thead > tr > th {
+  background-color: var(--tx-bg-base);
+  color: var(--tx-text-secondary);
+  border-bottom-color: var(--tx-border-subtle);
+}
+.ant-table-tbody > tr > td {
+  border-bottom-color: var(--tx-border-subtle);
+}
+.ant-table-tbody > tr:hover > td {
+  background-color: var(--tx-bg-hover) !important;
+}
+
+/* Inputs / selects / pickers. */
+.ant-input,
+.ant-input-number,
+.ant-input-affix-wrapper,
+.ant-select-selector,
+.ant-picker {
+  background-color: var(--tx-bg-base) !important;
+  color: var(--tx-text-primary) !important;
+  border-color: var(--tx-border-default) !important;
+}
+.ant-input:hover,
+.ant-input-affix-wrapper:hover,
+.ant-select-selector:hover {
+  border-color: var(--tx-primary-hover) !important;
+}
+.ant-input:focus,
+.ant-input-focused,
+.ant-select-focused .ant-select-selector,
+.ant-picker-focused {
+  border-color: var(--tx-primary) !important;
+  box-shadow: 0 0 0 2px var(--tx-primary-soft) !important;
+}
+
+/* Buttons. The primary button uses --tx-primary; default and ghost stay
+ * on surface tones. */
+.ant-btn {
+  background-color: var(--tx-bg-base);
+  color: var(--tx-text-primary);
+  border-color: var(--tx-border-default);
+}
+.ant-btn:hover {
+  color: var(--tx-primary);
+  border-color: var(--tx-primary);
+}
+.ant-btn-primary {
+  background-color: var(--tx-primary);
+  color: var(--tx-primary-fg);
+  border-color: var(--tx-primary);
+}
+.ant-btn-primary:hover {
+  background-color: var(--tx-primary-hover);
+  color: var(--tx-primary-fg);
+  border-color: var(--tx-primary-hover);
+}
+.ant-btn-link {
+  color: var(--tx-primary);
+}
+
+/* Disabled state. ng-zorro hardcodes a light-mode disabled palette
+   (#f5f5f5 bg / rgba(0,0,0,0.25) text / #d9d9d9 border) which becomes a
+   bright pale rectangle on any dark theme. Override with semantic tokens
+   so disabled buttons recede on every theme, regardless of variant. */
+.ant-btn[disabled],
+.ant-btn[disabled]:hover,
+.ant-btn[disabled]:focus,
+.ant-btn[disabled]:active,
+.ant-btn.ant-btn-disabled,
+.ant-btn-primary[disabled],
+.ant-btn-primary[disabled]:hover,
+.ant-btn-default[disabled],
+.ant-btn-default[disabled]:hover,
+.ant-btn-dashed[disabled],
+.ant-btn-dashed[disabled]:hover {
+  background-color: var(--tx-bg-active) !important;
+  color: var(--tx-text-disabled) !important;
+  border-color: var(--tx-border-default) !important;
+  text-shadow: none !important;
+  box-shadow: none !important;
+  cursor: not-allowed;
+}
+/* Link / text buttons disabled — keep them transparent so they don't paint
+   a filled rectangle into otherwise unfilled UI. */
+.ant-btn-link[disabled],
+.ant-btn-link[disabled]:hover,
+.ant-btn-text[disabled],
+.ant-btn-text[disabled]:hover {
+  background-color: transparent !important;
+  color: var(--tx-text-disabled) !important;
+  border-color: transparent !important;
+}
+/* Disabled form controls (inputs, selects, checkbox/radio labels, switches)
+   — share the same recede-into-the-surface treatment so the workspace
+   doesn't strobe between themed and un-themed regions. */
+.ant-input[disabled],
+.ant-input-affix-wrapper-disabled,
+.ant-input-number-disabled,
+.ant-input-number-disabled input,
+.ant-select-disabled .ant-select-selector,
+.ant-picker.ant-picker-disabled,
+.ant-checkbox-disabled + span,
+.ant-radio-disabled + span,
+textarea[disabled] {
+  background-color: var(--tx-bg-active) !important;
+  color: var(--tx-text-disabled) !important;
+  border-color: var(--tx-border-default) !important;
+}
+.ant-checkbox-disabled .ant-checkbox-inner,
+.ant-radio-disabled .ant-radio-inner {
+  background-color: var(--tx-bg-active) !important;
+  border-color: var(--tx-border-default) !important;
+}
+.ant-switch-disabled {
+  opacity: 0.5;
+}
+
+/* Tabs (used in property editor + dashboard sub-nav). */
+.ant-tabs {
+  color: var(--tx-text-primary);
+}
+.ant-tabs-tab {
+  color: var(--tx-text-secondary);
+}
+.ant-tabs-tab:hover {
+  color: var(--tx-primary);
+}
+.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--tx-primary) !important;
+}
+.ant-tabs-ink-bar {
+  background-color: var(--tx-primary) !important;
+}
+
+/* Tooltips. */
+.ant-tooltip-inner {
+  background-color: var(--tx-bg-elevated);
+  color: var(--tx-text-primary);
+  box-shadow: var(--tx-shadow-md);
+}
+.ant-tooltip-arrow-content {
+  background-color: var(--tx-bg-elevated);
+}
+
+/* Form labels. */
+.ant-form-item-label > label {
+  color: var(--tx-text-secondary);
+}
+
+/* Collapse (sidebars / accordions). */
+.ant-collapse {
+  background-color: transparent;
+  border-color: var(--tx-border-subtle);
+}
+.ant-collapse-item,
+.ant-collapse-content {
+  border-color: var(--tx-border-subtle);
+  background-color: transparent;
+  color: var(--tx-text-primary);
+}
+
 .ant-menu-item,
 .ant-menu-submenu-title,
 img {
@@ -60,22 +406,19 @@ img {
 }
 
 hr {
-  background-color: #d3d3d3;
+  background-color: var(--tx-border-default);
   height: 1px;
   border: 0;
 }
 
 // due to innerHTML, this rule has to be global
 .highlight-search-terms {
-  color: blue;
+  color: var(--tx-primary);
 }
 
 .box {
-  border-radius: 5px;
-  box-shadow:
-    0 3px 1px -2px #0003,
-    0 2px 2px #00000024,
-    0 1px 5px #0000001f;
+  border-radius: var(--tx-radius-lg);
+  box-shadow: var(--tx-shadow-md);
 }
 
 .ant-collapse-header {
@@ -91,7 +434,8 @@ hr {
 }
 
 .annotation-highlight {
-  background-color: #6a5acd;
+  background-color: var(--tx-primary-soft);
+  color: var(--tx-primary);
 }
 
 // makes avatar text centered in dropdown menu
@@ -412,4 +756,101 @@ hr {
       margin-top: 2px;
     }
   }
+}
+
+/* -- Workspace canvas overrides (phase 2) ----------------------------------
+ *
+ * JointJS renders the workflow editor's paper, operator boxes, links, and
+ * grid as inline SVG inside `<svg class="joint-paper"...>`. Each visual is
+ * configured via JointJS attrs that emit as SVG element attributes (eg.
+ * `fill="#FFFFFF"`). SVG attributes have lower CSS specificity than rules
+ * targeting the same element, so we can retint everything by selecting
+ * the generated DOM classes — no JointJS code changes needed.
+ *
+ * Important: do NOT add the universal transition to .joint-link paths —
+ * those are dragged and animating stroke turns into ghosting.
+ * ------------------------------------------------------------------------ */
+
+/* Paper background. JointJS draws a <rect> beneath everything when the
+ * paper is constructed with `background: { color: ... }`. The fill is
+ * an inline attribute — we override it. */
+.joint-paper-background {
+  fill: var(--tx-canvas-bg) !important;
+}
+
+/* Grid. JointJS renders the dot grid as an SVG <pattern> containing
+ * small <circle fill="black">. Targeting the pattern's children
+ * retints all dots. */
+.joint-paper-grid circle,
+.joint-paper-grid rect {
+  fill: var(--tx-canvas-grid) !important;
+}
+
+/* Operator box body (the main rounded rectangle of every operator).
+ * The default JointJS shape names the body element via `body` attr key,
+ * which becomes `class="body"` on the resulting <rect>. */
+.operator-element rect.body,
+.joint-element rect.body {
+  fill: var(--tx-op-body-bg);
+  stroke: var(--tx-op-body-stroke);
+}
+
+/* Operator port circles. */
+.operator-element circle.port-body,
+.joint-element circle.port-body,
+.joint-port-body {
+  fill: var(--tx-op-port);
+}
+
+/* Operator name (large title text). JointUIService binds it via the
+ * `text` attr selector — JointJS emits a <text> element with no extra
+ * class, so we target by tag-name within the element. The "name" label
+ * we set explicitly has the `data-attribute="text"` look — easier to
+ * match all <text> inside an operator and rely on token semantics. */
+.operator-element text,
+.joint-element text {
+  fill: var(--tx-op-label);
+}
+.operator-element text[font-size="12"],
+.operator-element text.operator-friendly-name,
+.joint-element text.operator-friendly-name {
+  fill: var(--tx-op-sublabel);
+}
+
+/* Links (the lines connecting operators). */
+.joint-link path.connection {
+  stroke: var(--tx-link-stroke);
+}
+.joint-link circle.marker-source,
+.joint-link circle.marker-target {
+  fill: var(--tx-link-handle);
+  stroke: var(--tx-link-handle);
+}
+
+/* Minimap surround (the small navigator in the bottom-right corner).
+ * Its outer rectangle is drawn with hardcoded `#797a79` — the SCSS for
+ * the component still owns that, but the rect background uses paper
+ * conventions same as main canvas. */
+texera-mini-map .joint-paper-background {
+  fill: var(--tx-canvas-bg) !important;
+}
+texera-mini-map svg {
+  border: 2px solid var(--tx-minimap-border);
+  background-color: var(--tx-bg-elevated);
+}
+
+/* Tab strips inside result panel / property editor — ng-zorro tabs. */
+.ant-tabs-tab {
+  color: var(--tx-text-secondary);
+}
+.ant-tabs-tab-active,
+.ant-tabs-tab-active .ant-tabs-tab-btn {
+  color: var(--tx-primary) !important;
+}
+.ant-tabs-ink-bar {
+  background: var(--tx-primary) !important;
+}
+.ant-tabs-nav::before,
+.ant-tabs-bar {
+  border-bottom-color: var(--tx-border-subtle) !important;
 }

--- a/frontend/src/styles/_tokens.scss
+++ b/frontend/src/styles/_tokens.scss
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * Theme tokens.
+ *
+ * Every color, radius, shadow, motion duration, and font family used in the
+ * frontend should ultimately resolve to one of the `--tx-*` variables below.
+ * The ThemeService overwrites these on `:root` at runtime; the defaults here
+ * are the Light theme so that uninitialized SSR / first-paint still works.
+ *
+ * Add new tokens here when you find a hardcoded value that needs to be
+ * theme-aware. Keep names semantic (`--tx-text-secondary`), not literal
+ * (`--tx-gray-500`) — that way themes can re-interpret them freely.
+ */
+
+:root {
+  /* ---- Surfaces (layered backgrounds, base -> elevated) ----------------- */
+  --tx-bg-base:        #ffffff;
+  --tx-bg-surface:     #fafafa;
+  --tx-bg-elevated:    #ffffff;
+  --tx-bg-canvas:      #f5f7fa;
+  --tx-bg-hover:       rgba(0, 0, 0, 0.04);
+  --tx-bg-active:      rgba(0, 0, 0, 0.08);
+  --tx-bg-overlay:     rgba(0, 0, 0, 0.45); /* modal scrim */
+
+  /* ---- Text ------------------------------------------------------------- */
+  --tx-text-primary:   rgba(0, 0, 0, 0.88);
+  --tx-text-secondary: rgba(0, 0, 0, 0.65);
+  --tx-text-tertiary:  rgba(0, 0, 0, 0.45);
+  --tx-text-disabled:  rgba(0, 0, 0, 0.25);
+  --tx-text-inverse:   #ffffff;
+
+  /* ---- Borders ---------------------------------------------------------- */
+  --tx-border-subtle:  #f0f0f0;
+  --tx-border-default: #d9d9d9;
+  --tx-border-strong:  #bfbfbf;
+
+  /* ---- Brand / primary action color ------------------------------------- */
+  --tx-primary:        #1890ff;
+  --tx-primary-hover:  #40a9ff;
+  --tx-primary-active: #096dd9;
+  --tx-primary-soft:   rgba(24, 144, 255, 0.10);
+  --tx-primary-fg:     #ffffff;
+
+  /* ---- Semantic --------------------------------------------------------- */
+  --tx-success:        #52c41a;
+  --tx-success-soft:   rgba(82, 196, 26, 0.12);
+  --tx-warning:        #faad14;
+  --tx-warning-soft:   rgba(250, 173, 20, 0.12);
+  --tx-danger:         #ff4d4f;
+  --tx-danger-soft:    rgba(255, 77, 79, 0.12);
+  --tx-info:           #1890ff;
+  --tx-info-soft:      rgba(24, 144, 255, 0.10);
+
+  /* ---- Shadows ---------------------------------------------------------- */
+  --tx-shadow-sm:      0 1px 2px rgba(0, 0, 0, 0.06);
+  --tx-shadow-md:      0 2px 8px rgba(0, 0, 0, 0.08);
+  --tx-shadow-lg:      0 8px 24px rgba(0, 0, 0, 0.12);
+
+  /* ---- Typography ------------------------------------------------------- */
+  --tx-font-ui:        -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                       "Helvetica Neue", Arial, sans-serif;
+  --tx-font-mono:      "JetBrains Mono", "Fira Code", "SF Mono", Monaco,
+                       Consolas, monospace;
+  --tx-font-size-base: 14px;
+
+  /* ---- Layout ----------------------------------------------------------- */
+  --tx-radius-sm:      2px;
+  --tx-radius-md:      4px;
+  --tx-radius-lg:      8px;
+
+  /* ---- Motion ----------------------------------------------------------- */
+  --tx-motion-fast:    100ms;
+  --tx-motion-default: 200ms;
+  --tx-motion-slow:    400ms;
+  --tx-motion-ease:    cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* ---- Workspace canvas (JointJS paper, grid, operator boxes, links) ---- */
+  --tx-canvas-bg:       #f6f6f6; /* paper background */
+  --tx-canvas-grid:     rgba(0, 0, 0, 0.18); /* grid dots */
+  --tx-op-body-bg:      #ffffff; /* operator box fill */
+  --tx-op-body-stroke:  #cfcfcf; /* operator box border (valid) */
+  --tx-op-label:        #595959; /* operator name */
+  --tx-op-sublabel:     #888888; /* operator friendly-name / subtitle */
+  --tx-op-port:         #a0a0a0; /* port circle fill */
+  --tx-link-stroke:     #919191; /* link line color */
+  --tx-link-handle:     #919191; /* source/target dot fill */
+  --tx-minimap-border:  #797a79; /* minimap viewport rectangle */
+
+  /* Monaco theme name (Monaco built-ins: "vs", "vs-dark", "hc-black"). */
+  --tx-monaco-theme:    "vs";
+}
+
+/*
+ * Theme transitions.
+ *
+ * When the user switches themes the CSS variables change instantly, but we
+ * want the visible color shift to crossfade. Animate the most common color-
+ * carrying properties on every element. Restricted to the listed properties
+ * so we don't trip layout animations.
+ */
+*,
+*::before,
+*::after {
+  transition:
+    background-color var(--tx-motion-default) var(--tx-motion-ease),
+    border-color     var(--tx-motion-default) var(--tx-motion-ease),
+    color            var(--tx-motion-default) var(--tx-motion-ease),
+    fill             var(--tx-motion-default) var(--tx-motion-ease),
+    stroke           var(--tx-motion-default) var(--tx-motion-ease),
+    box-shadow       var(--tx-motion-default) var(--tx-motion-ease);
+}
+
+/* Users who request reduced motion get instant theme switches. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION

## Why

Texera is a place people spend hours — building workflows, watching them run, iterating on UDFs. But it looks the same to every user, every session, every time of day. A grad student debugging a pipeline at 2 a.m. gets the same flat-white surface as someone demoing in a brightly lit lecture hall. There's no dark mode for dark-mode-OS users, no warm palette for long sessions, and nothing about the tool that feels like it's *yours*.

Submitted to the **dkNet-AI Apache Texera Agent Hackathon** under the brief "make using Texera enjoyable instead of it being just a tool." The goal isn't customization for its own sake — it's giving long-time users something that responds to them, and giving new users a moment of "oh, this is fun" the first time they finish a workflow run.

<img width="1920" height="1080" alt="Untitled design (2)" src="https://github.com/user-attachments/assets/64acb263-e630-420d-8b27-99b330b14d56" />


## What you get

**8 themes**, picked from a submenu under the user-icon avatar: Light, Dark, Sepia, Solarized Dark, Gruvbox, Synthwave, Forest, Cyberpunk. Every surface follows along — dashboard, sidebar, workspace canvas, operator boxes, links, modals, forms, and the Monaco code editor. Themes persist per-account; first-paint honors your OS's `prefers-color-scheme` so dark-mode users no longer get flashed with light.

<img width="555" height="333" alt="Screenshot 2026-05-15 at 6 05 16 PM" src="https://github.com/user-attachments/assets/6f4a574b-4a77-4b22-a5bd-75bc041e67ba" />


**Workflow run feedback.** When an execution completes, confetti bursts from the screen center in colors sampled from your active theme. When it fails, the viewport briefly shakes. Optional WebAudio chimes (off by default) play an ascending major triad on success and a descending tritone on failure. New operators scale in with a small overshoot when dropped; new links draw themselves in along their path.


https://github.com/user-attachments/assets/942cdee8-7d25-4557-82a5-2afeac242079


https://github.com/user-attachments/assets/9d3dcebe-0ea5-4648-8645-fef408c69637



**Easter egg.** Type `↑ ↑ ↓ ↓ ← → ← → B A` anywhere in the app. The Konami code locks the UI to Synthwave for ~4.5 seconds with three confetti volleys and the success chord, then quietly restores your previous theme.


https://github.com/user-attachments/assets/4afb23c6-a841-4d74-9dfe-53afb7109b35


**Preferences submenu.** Same user-icon dropdown, next to Theme — toggles for Animations and Sound effects. Both opt-in/out preferences persist per-account the same way the theme does. Users with `prefers-reduced-motion` get animations off by default.

## How to use it

1. Click your avatar in the top-right of the dashboard.
2. Hover **Theme** → pick any preset. Switches with a ~200ms crossfade.
3. Hover **Preferences** → toggle Animations / Sound to taste.
4. Run a workflow. (Or try the Konami code.)

That's it. Nothing else needs configuring; logged-in users have their choice synced across browsers via the existing `/api/user/config` endpoint, anonymous users get localStorage.

## Test plan

- [ ] First load in a fresh browser on a dark-mode OS comes up in Dark, not Light
- [ ] Switching themes flips the whole UI — dashboard chrome, list items, modals, workspace canvas, grid dots, operator boxes, link strokes, Monaco editor
- [ ] Animations toggle suppresses confetti + entrance animations but keeps the theme crossfade
- [ ] Sound toggle silences chimes
- [ ] Disabled buttons recede into the active theme on every preset (no pale-white rectangles)
- [ ] Konami code works from any page
- [ ] Theme persists across reload and across login/logout

## What's also in this PR (small)

`bin/texera stop` now sweeps known ports (1234/4200/3001/8080–9096) before exiting. Without it, an orphaned `y-websocket` from a prior run could survive `stop` and lock out the next `start` with `EADDRINUSE`. One-liner-fix-shaped, but it shows up the moment anyone runs the theme branch through the launcher.