### PR TITLE
[Hackathon] feat: AI workflow documentation tool with history, editing, and diff 

### DIFF
--- a/agent-service/src/agent/prompts.ts
+++ b/agent-service/src/agent/prompts.ts
@@ -320,9 +320,15 @@ List each sink operator and what it produces or where it writes, including outpu
 ## Caveats
 Note anything a reviewer should be aware of: unconfigured required properties, hardcoded file paths or credentials visible in properties, UDF operators whose correctness depends on user code, disabled operators that are excluded from execution, or columns referenced in one operator that do not appear in the upstream schema. Omit this section if there are no notable caveats.
 
+Operator references:
+- Whenever you mention a specific operator by name in any section, format the mention as a markdown link with the operator's display name as the link text and a special URI of the form \`texera:op:<OPERATOR_ID>\` as the link target. The OPERATOR_ID is the exact value shown after \`### Operator\` in the context (e.g., \`Filter-operator-abc123\`).
+- Example: if an operator has display name "Customer Filter" and ID \`Filter-operator-9f3a\`, write it as \`[Customer Filter](texera:op:Filter-operator-9f3a)\` — not as a plain name.
+- Use the link form everywhere the operator is named, including in the Inputs, Pipeline Stages, Outputs, and Caveats sections.
+- If you must group several operators together (e.g., "the three filter operators"), still emit each one as a link.
+
 Rules:
 - Write concise, precise technical prose. Prefer specific column names, file paths, and operator names over vague descriptions.
 - If you cannot infer something with reasonable confidence, say so briefly rather than guessing.
-- Do not reproduce raw property dictionaries or operator IDs in the output.
+- Do not reproduce raw property dictionaries in the output. Operator IDs may appear only inside \`texera:op:\` link targets, never as plain text.
 - If the workflow is empty or has no connected operators, state that it contains no connected pipeline.`;
 

--- a/agent-service/src/agent/prompts.ts
+++ b/agent-service/src/agent/prompts.ts
@@ -297,28 +297,32 @@ export function buildSystemPrompt(metadataStore: WorkflowSystemMetadata, allowed
 
 export const WORKFLOW_DOCUMENTATION_PROMPT = `You are a technical documentation assistant for Texera, a visual dataflow platform for collaborative data science.
 
-Given a Texera workflow represented as JSON, generate structured markdown documentation describing what the workflow does.
+You will be given a structured description of a Texera workflow containing:
+- Each operator's type, display name, human-readable description, configuration properties, and — for Python/R UDF operators — the full user-authored code
+- Output port schemas (column names and types) derived from static compilation, where available
+- Data flow links describing which operators connect to which
+- Author notes from comment boxes placed on the canvas
 
-Your output must use the following sections:
+Using this information, generate structured markdown documentation with the following sections:
 
 ## Purpose
-One to two sentences describing the overall goal of the workflow, inferred from operator types, names, properties, and connections.
+One to two sentences describing the overall goal of the workflow. Draw on operator descriptions, UDF code logic, property values, and author notes to state what the pipeline actually does, not just what kinds of operators it contains.
 
 ## Inputs
-List each source operator (e.g., CSV readers, database scanners) with its data source, file path, or query if visible in the properties.
+List each source operator with its data source — file path, table name, database query, or API endpoint — as found in the operator properties. Include column names from the output schema if available.
 
 ## Pipeline Stages
-Group the operators into logical processing stages (e.g., ingestion, filtering, transformation, aggregation, output). For each stage, describe what it does in one sentence.
+Group the operators into logical processing stages (e.g., ingestion, filtering, transformation, aggregation, output). For each stage, name the operators involved and describe in one sentence what transformation or analysis they perform. Use schema information to describe what columns are produced or consumed.
 
 ## Outputs
-List each sink operator and what it produces or where it writes.
+List each sink operator and what it produces or where it writes, including output column names where the schema is available.
 
 ## Caveats
-Note anything a reviewer should be aware of: unconfigured properties, hardcoded file paths or credentials, Python/R UDF operators whose behavior depends on user-supplied code, disabled operators, or potential schema mismatches. Omit this section if there are no notable caveats.
+Note anything a reviewer should be aware of: unconfigured required properties, hardcoded file paths or credentials visible in properties, UDF operators whose correctness depends on user code, disabled operators that are excluded from execution, or columns referenced in one operator that do not appear in the upstream schema. Omit this section if there are no notable caveats.
 
 Rules:
-- Write concise, precise technical prose. Avoid vague phrases like "processes data."
+- Write concise, precise technical prose. Prefer specific column names, file paths, and operator names over vague descriptions.
 - If you cannot infer something with reasonable confidence, say so briefly rather than guessing.
-- Do not include raw JSON, operator IDs, or code blocks unless essential for clarity.
+- Do not reproduce raw property dictionaries or operator IDs in the output.
 - If the workflow is empty or has no connected operators, state that it contains no connected pipeline.`;
 

--- a/agent-service/src/agent/prompts.ts
+++ b/agent-service/src/agent/prompts.ts
@@ -294,3 +294,31 @@ export function buildSystemPrompt(metadataStore: WorkflowSystemMetadata, allowed
   const base = SYSTEM_PROMPT_TEMPLATE.replace("{{OPERATOR_SCHEMA}}", operatorSchemas);
   return extraSections.length > 0 ? `${base}\n${extraSections.join("\n\n")}\n` : base;
 }
+
+export const WORKFLOW_DOCUMENTATION_PROMPT = `You are a technical documentation assistant for Texera, a visual dataflow platform for collaborative data science.
+
+Given a Texera workflow represented as JSON, generate structured markdown documentation describing what the workflow does.
+
+Your output must use the following sections:
+
+## Purpose
+One to two sentences describing the overall goal of the workflow, inferred from operator types, names, properties, and connections.
+
+## Inputs
+List each source operator (e.g., CSV readers, database scanners) with its data source, file path, or query if visible in the properties.
+
+## Pipeline Stages
+Group the operators into logical processing stages (e.g., ingestion, filtering, transformation, aggregation, output). For each stage, describe what it does in one sentence.
+
+## Outputs
+List each sink operator and what it produces or where it writes.
+
+## Caveats
+Note anything a reviewer should be aware of: unconfigured properties, hardcoded file paths or credentials, Python/R UDF operators whose behavior depends on user-supplied code, disabled operators, or potential schema mismatches. Omit this section if there are no notable caveats.
+
+Rules:
+- Write concise, precise technical prose. Avoid vague phrases like "processes data."
+- If you cannot infer something with reasonable confidence, say so briefly rather than guessing.
+- Do not include raw JSON, operator IDs, or code blocks unless essential for clarity.
+- If the workflow is empty or has no connected operators, state that it contains no connected pipeline.`;
+

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -937,11 +937,11 @@ export class TexeraAgent {
     }
 
     // Comment boxes (author notes)
-    const notes = (content.commentBoxes ?? []).filter(b => b.comments?.trim());
+    const notes = (content.commentBoxes ?? []).filter(b => typeof b.comments === "string" && b.comments.trim());
     if (notes.length > 0) {
       lines.push("## Author Notes\n");
       for (const box of notes) {
-        lines.push(`- ${box.comments.trim()}`);
+        lines.push(`- ${(box.comments as string).trim()}`);
       }
       lines.push("");
     }

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -31,7 +31,7 @@ import {
   OperatorResultSerializationMode,
   INITIAL_STEP_ID,
 } from "../types/agent";
-import { buildSystemPrompt } from "./prompts";
+import { buildSystemPrompt, WORKFLOW_DOCUMENTATION_PROMPT } from "./prompts";
 import {
   createAddOperatorTool,
   createModifyOperatorTool,
@@ -41,6 +41,7 @@ import {
   TOOL_NAME_DELETE_OPERATOR,
   type ToolContext,
 } from "./tools/workflow-crud-tools";
+import type { WorkflowContent } from "../types/workflow";
 import {
   createExecuteOperatorTool,
   executeOperatorAndFormat,
@@ -821,6 +822,16 @@ export class TexeraAgent {
     }
 
     return relevantSteps;
+  }
+
+  async documentWorkflow(workflowContent?: WorkflowContent): Promise<string> {
+    const content = workflowContent ?? this.workflowState.getWorkflowContent();
+    const { text } = await generateText({
+      model: this.model,
+      system: WORKFLOW_DOCUMENTATION_PROMPT,
+      prompt: JSON.stringify(content, null, 2),
+    });
+    return text;
   }
 
   destroy(): void {

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -41,7 +41,7 @@ import {
   TOOL_NAME_DELETE_OPERATOR,
   type ToolContext,
 } from "./tools/workflow-crud-tools";
-import type { WorkflowContent } from "../types/workflow";
+import type { WorkflowContent, LogicalPlan } from "../types/workflow";
 import {
   createExecuteOperatorTool,
   executeOperatorAndFormat,
@@ -826,12 +826,127 @@ export class TexeraAgent {
 
   async documentWorkflow(workflowContent?: WorkflowContent): Promise<string> {
     const content = workflowContent ?? this.workflowState.getWorkflowContent();
+    const context = await this.buildDocumentationContext(content);
     const { text } = await generateText({
       model: this.model,
       system: WORKFLOW_DOCUMENTATION_PROMPT,
-      prompt: JSON.stringify(content, null, 2),
+      prompt: context,
     });
     return text;
+  }
+
+  private async buildDocumentationContext(content: WorkflowContent): Promise<string> {
+    const UDF_CODE_KEYS = new Set(["code", "script"]);
+    const UDF_TYPES = new Set(["PythonUDFV2", "RUDF"]);
+
+    // Attempt compilation to get port schemas; fail gracefully.
+    let outputSchemas: Record<string, Record<string, readonly { attributeName: string; attributeType: string }[] | undefined>> = {};
+    const enabledOps = content.operators.filter(op => !op.isDisabled);
+    if (enabledOps.length > 0) {
+      try {
+        const logicalPlan: LogicalPlan = {
+          operators: enabledOps.map(op => ({
+            operatorID: op.operatorID,
+            operatorType: op.operatorType,
+            ...op.operatorProperties,
+            inputPorts: op.inputPorts,
+            outputPorts: op.outputPorts,
+          })),
+          links: content.links
+            .filter(l => enabledOps.some(o => o.operatorID === l.source.operatorID) &&
+                         enabledOps.some(o => o.operatorID === l.target.operatorID))
+            .map(l => ({
+              fromOpId: l.source.operatorID,
+              fromPortId: { id: parseInt(l.source.portID) || 0, internal: false },
+              toOpId: l.target.operatorID,
+              toPortId: { id: parseInt(l.target.portID) || 0, internal: false },
+            })),
+        };
+        const compiled = await compileWorkflowAsync(logicalPlan);
+        if (compiled) {
+          outputSchemas = compiled.operatorOutputSchemas as typeof outputSchemas;
+        }
+      } catch {
+        // schema enrichment is best-effort
+      }
+    }
+
+    const opDisplayName = (op: WorkflowContent["operators"][number]) =>
+      op.customDisplayName || op.operatorType;
+
+    const lines: string[] = [];
+
+    // Operators
+    lines.push("## Operators\n");
+    for (const op of content.operators) {
+      const label = opDisplayName(op);
+      const desc = this.metadataStore.getDescription(op.operatorType);
+      const disabled = op.isDisabled ? " [DISABLED — excluded from execution]" : "";
+
+      lines.push(`### "${label}" (${op.operatorType})${disabled}`);
+      if (desc) lines.push(`Description: ${desc}`);
+
+      const props = op.operatorProperties ?? {};
+      const isUDF = UDF_TYPES.has(op.operatorType);
+
+      if (isUDF) {
+        for (const key of UDF_CODE_KEYS) {
+          const code = props[key];
+          if (typeof code === "string" && code.trim()) {
+            lines.push(`${key}:\n\`\`\`python\n${code.trim()}\n\`\`\``);
+          }
+        }
+        const otherEntries = Object.entries(props).filter(([k, v]) => !UDF_CODE_KEYS.has(k) && v !== undefined && v !== null && v !== "");
+        if (otherEntries.length > 0) {
+          lines.push("Other properties: " + otherEntries.map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(", "));
+        }
+      } else {
+        const entries = Object.entries(props).filter(([, v]) => v !== undefined && v !== null && v !== "");
+        if (entries.length > 0) {
+          lines.push("Properties:");
+          for (const [k, v] of entries) {
+            lines.push(`  - ${k}: ${JSON.stringify(v)}`);
+          }
+        }
+      }
+
+      // Output schemas from compilation
+      const opSchemas = outputSchemas[op.operatorID];
+      if (opSchemas) {
+        for (const [portId, schema] of Object.entries(opSchemas)) {
+          if (schema && schema.length > 0) {
+            const cols = schema.map(a => `${a.attributeName}: ${a.attributeType}`).join(", ");
+            lines.push(`Output port ${portId} schema: [${cols}]`);
+          }
+        }
+      }
+
+      lines.push("");
+    }
+
+    // Links
+    if (content.links.length > 0) {
+      const opMap = new Map(content.operators.map(op => [op.operatorID, opDisplayName(op)]));
+      lines.push("## Data Flow\n");
+      for (const link of content.links) {
+        const from = opMap.get(link.source.operatorID) ?? link.source.operatorID;
+        const to = opMap.get(link.target.operatorID) ?? link.target.operatorID;
+        lines.push(`- "${from}" → "${to}"`);
+      }
+      lines.push("");
+    }
+
+    // Comment boxes (author notes)
+    const notes = (content.commentBoxes ?? []).filter(b => b.comments?.trim());
+    if (notes.length > 0) {
+      lines.push("## Author Notes\n");
+      for (const box of notes) {
+        lines.push(`- ${box.comments.trim()}`);
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n");
   }
 
   destroy(): void {

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -883,7 +883,7 @@ export class TexeraAgent {
       const desc = this.metadataStore.getDescription(op.operatorType);
       const disabled = op.isDisabled ? " [DISABLED — excluded from execution]" : "";
 
-      lines.push(`### "${label}" (${op.operatorType})${disabled}`);
+      lines.push(`### Operator \`${op.operatorID}\` — "${label}" (${op.operatorType})${disabled}`);
       if (desc) lines.push(`Description: ${desc}`);
 
       const props = op.operatorProperties ?? {};
@@ -929,9 +929,9 @@ export class TexeraAgent {
       const opMap = new Map(content.operators.map(op => [op.operatorID, opDisplayName(op)]));
       lines.push("## Data Flow\n");
       for (const link of content.links) {
-        const from = opMap.get(link.source.operatorID) ?? link.source.operatorID;
-        const to = opMap.get(link.target.operatorID) ?? link.target.operatorID;
-        lines.push(`- "${from}" → "${to}"`);
+        const fromName = opMap.get(link.source.operatorID) ?? link.source.operatorID;
+        const toName = opMap.get(link.target.operatorID) ?? link.target.operatorID;
+        lines.push(`- "${fromName}" \`${link.source.operatorID}\` → "${toName}" \`${link.target.operatorID}\``);
       }
       lines.push("");
     }

--- a/agent-service/src/server.test.ts
+++ b/agent-service/src/server.test.ts
@@ -200,6 +200,31 @@ describe("Agent control routes", () => {
   });
 });
 
+describe(`POST ${API}/agents/:id/document-workflow`, () => {
+  test("returns 404 for an unknown agent", async () => {
+    const res = await postJson(`${API}/agents/agent-does-not-exist/document-workflow`, {});
+    expect(res.status).toBe(404);
+    const body = await readJson<{ error: string }>(res);
+    expect(body.error).toBe("Agent not found");
+  });
+
+  test("accepts an empty body without schema error", async () => {
+    const created = await readJson<{ id: string }>(await postJson(`${API}/agents`, { modelType: "m" }));
+    const res = await postJson(`${API}/agents/${created.id}/document-workflow`, {});
+    // In the test environment the LLM call will fail (no real model backend).
+    // We accept any non-schema-validation failure (4xx/5xx) as long as it is not a 422.
+    expect(res.status).not.toBe(422);
+  });
+
+  test("accepts a workflowContent body without schema error", async () => {
+    const created = await readJson<{ id: string }>(await postJson(`${API}/agents`, { modelType: "m" }));
+    const res = await postJson(`${API}/agents/${created.id}/document-workflow`, {
+      workflowContent: { operators: [], links: [], operatorPositions: {}, commentBoxes: [], settings: { dataTransferBatchSize: 10 } },
+    });
+    expect(res.status).not.toBe(422);
+  });
+});
+
 describe(`PATCH ${API}/agents/:id/settings`, () => {
   test("updates settings and returns the new values", async () => {
     const created = await readJson<{ id: string }>(await postJson(`${API}/agents`, { modelType: "m" }));

--- a/agent-service/src/server.ts
+++ b/agent-service/src/server.ts
@@ -294,6 +294,23 @@ const agentsRouter = new Elysia({ prefix: "/agents" })
     return { status: "stopping" };
   })
 
+  .post(
+    "/:id/document-workflow",
+    async ({ params: { id }, body }) => {
+      const agent = getAgent(id);
+      const { workflowContent } = (body ?? {}) as { workflowContent?: any };
+      const markdown = await agent.documentWorkflow(workflowContent);
+      return { markdown };
+    },
+    {
+      body: t.Optional(
+        t.Object({
+          workflowContent: t.Optional(t.Any()),
+        })
+      ),
+    }
+  )
+
   .post("/:id/clear", ({ params: { id } }) => {
     const agent = getAgent(id);
     agent.clearHistory();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "concaveman": "2.0.0",
     "d3-shape": "2.1.0",
     "dagre": "0.8.5",
+    "diff": "^9.0.0",
     "file-saver": "2.0.5",
     "fuse.js": "6.5.3",
     "html2canvas": "1.4.1",

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -138,6 +138,7 @@ import { NzResizableModule } from "ng-zorro-antd/resizable";
 import { WorkflowRuntimeStatisticsComponent } from "./dashboard/component/user/user-workflow/ngbd-modal-workflow-executions/workflow-runtime-statistics/workflow-runtime-statistics.component";
 import { TimeTravelComponent } from "./workspace/component/left-panel/time-travel/time-travel.component";
 import { NzModalModule } from "ng-zorro-antd/modal";
+import { NzDrawerModule } from "ng-zorro-antd/drawer";
 import { NzDescriptionsModule } from "ng-zorro-antd/descriptions";
 import { OverlayModule } from "@angular/cdk/overlay";
 import { HighlightSearchTermsPipe } from "./dashboard/component/user/user-workflow/user-workflow-list-item/highlight-search-terms.pipe";
@@ -232,6 +233,7 @@ registerLocaleData(en);
     NzUploadModule,
     NgxJsonViewerModule,
     NzModalModule,
+    NzDrawerModule,
     NzDescriptionsModule,
     NzCardModule,
     NzTagModule,

--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -151,12 +151,12 @@
         </button>
         <button
           (click)="onClickDocumentWorkflow()"
-          [disabled]="isWorkflowEmpty || isGeneratingDoc"
+          [disabled]="isWorkflowEmpty"
           nz-button
           title="document workflow with AI">
           <i
             nz-icon
-            [nzType]="isGeneratingDoc ? 'loading' : 'file-text'"></i>
+            nzType="file-text"></i>
         </button>
       </nz-space-compact>
       <ng-template #utilities>

--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -149,6 +149,15 @@
             nz-icon
             nzType="info-circle"></i>
         </button>
+        <button
+          (click)="onClickDocumentWorkflow()"
+          [disabled]="isWorkflowEmpty || isGeneratingDoc"
+          nz-button
+          title="document workflow with AI">
+          <i
+            nz-icon
+            [nzType]="isGeneratingDoc ? 'loading' : 'file-text'"></i>
+        </button>
       </nz-space-compact>
       <ng-template #utilities>
         <nz-space-compact>

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -719,6 +719,7 @@ export class MenuComponent implements OnInit, OnDestroy {
         onUpdateEntry: (entry: DocEntry, newMarkdown: string) =>
           this.workflowDocService.updateHistoryEntry(wid, entry, newMarkdown),
         onCreateEntry: (markdown: string) => this.workflowDocService.createBlankEntry(wid, markdown),
+        onDuplicateEntry: (entry: DocEntry) => this.workflowDocService.duplicateEntry(wid, entry),
         editingState,
         onEditingChange: (state: DocEditingState | null) =>
           this.workflowDocService.setEditingState(wid, state),

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -132,7 +132,6 @@ export class MenuComponent implements OnInit, OnDestroy {
   public ComputingUnitState = ComputingUnitState; // make Angular HTML access enum definition
   public isWorkflowValid: boolean = true; // this will check whether the workflow error or not
   public isWorkflowEmpty: boolean = false;
-  public isGeneratingDoc: boolean = false;
   public isSaving: boolean = false;
   public isWorkflowModifiable: boolean = false;
   public workflowId?: number;
@@ -696,47 +695,17 @@ export class MenuComponent implements OnInit, OnDestroy {
 
   public onClickDocumentWorkflow(): void {
     const cached = this.workflowDocService.getCached(this.workflowId);
-    if (cached) {
-      this.openDocModal(cached.markdown, cached.generatedAt);
-      return;
-    }
-    this.runDocGeneration();
-  }
-
-  private openDocModal(markdown: string, generatedAt: Date): void {
     this.modalService.create({
       nzTitle: "Workflow Documentation",
       nzContent: WorkflowDocPanelComponent,
       nzData: {
-        markdown,
-        generatedAt,
-        onRegenerate: () => this.workflowDocService.generateDocumentation(),
+        cachedMarkdown: cached?.markdown,
+        cachedGeneratedAt: cached?.generatedAt,
+        onGenerate: () => this.workflowDocService.generateDocumentation(),
       },
       nzWidth: "800px",
       nzFooter: null,
     });
-  }
-
-  private runDocGeneration(): void {
-    this.isGeneratingDoc = true;
-    this.notificationService.blank("", "Generating workflow documentation…", { nzDuration: 0 });
-
-    this.workflowDocService
-      .generateDocumentation()
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: markdown => {
-          this.isGeneratingDoc = false;
-          this.notificationService.remove();
-          const entry = this.workflowDocService.getCached(this.workflowId);
-          this.openDocModal(markdown, entry?.generatedAt ?? new Date());
-        },
-        error: (err: unknown) => {
-          this.isGeneratingDoc = false;
-          this.notificationService.remove();
-          this.notificationService.error("Failed to generate documentation: " + (err as Error).message);
-        },
-      });
   }
 
   /**

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -703,7 +703,8 @@ export class MenuComponent implements OnInit, OnDestroy {
     const history = this.workflowDocService.getHistory(wid);
     const lastView = this.workflowDocService.getLastView(wid);
     const editingState = this.workflowDocService.getEditingState(wid);
-    const initialView = (editingState || lastView === "doc") && history.length > 0 ? "doc" : "intro";
+    const hasDraftOrViewable = !!editingState || (lastView === "doc" && history.length > 0);
+    const initialView = hasDraftOrViewable ? "doc" : "intro";
     this.docDrawerRef = this.drawerService.create({
       nzTitle: "Workflow Documentation",
       nzContent: WorkflowDocPanelComponent,
@@ -715,6 +716,7 @@ export class MenuComponent implements OnInit, OnDestroy {
         onDeleteEntry: (entry: DocEntry) => this.workflowDocService.deleteHistoryEntry(wid, entry),
         onUpdateEntry: (entry: DocEntry, newMarkdown: string) =>
           this.workflowDocService.updateHistoryEntry(wid, entry, newMarkdown),
+        onCreateEntry: (markdown: string) => this.workflowDocService.createBlankEntry(wid, markdown),
         editingState,
         onEditingChange: (state: DocEditingState | null) =>
           this.workflowDocService.setEditingState(wid, state),

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -695,6 +695,29 @@ export class MenuComponent implements OnInit, OnDestroy {
   }
 
   public onClickDocumentWorkflow(): void {
+    const cached = this.workflowDocService.getCached(this.workflowId);
+    if (cached) {
+      this.openDocModal(cached.markdown, cached.generatedAt);
+      return;
+    }
+    this.runDocGeneration();
+  }
+
+  private openDocModal(markdown: string, generatedAt: Date): void {
+    this.modalService.create({
+      nzTitle: "Workflow Documentation",
+      nzContent: WorkflowDocPanelComponent,
+      nzData: {
+        markdown,
+        generatedAt,
+        onRegenerate: () => this.workflowDocService.generateDocumentation(),
+      },
+      nzWidth: "800px",
+      nzFooter: null,
+    });
+  }
+
+  private runDocGeneration(): void {
     this.isGeneratingDoc = true;
     this.notificationService.blank("", "Generating workflow documentation…", { nzDuration: 0 });
 
@@ -705,13 +728,8 @@ export class MenuComponent implements OnInit, OnDestroy {
         next: markdown => {
           this.isGeneratingDoc = false;
           this.notificationService.remove();
-          this.modalService.create({
-            nzTitle: "Workflow Documentation",
-            nzContent: WorkflowDocPanelComponent,
-            nzData: { markdown },
-            nzWidth: "800px",
-            nzFooter: null,
-          });
+          const entry = this.workflowDocService.getCached(this.workflowId);
+          this.openDocModal(markdown, entry?.generatedAt ?? new Date());
         },
         error: (err: unknown) => {
           this.isGeneratingDoc = false;

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -46,6 +46,7 @@ import { CoeditorPresenceService } from "../../service/workflow-graph/model/coed
 import { firstValueFrom, of, Subscription, timer } from "rxjs";
 import { isDefined } from "../../../common/util/predicate";
 import { NzModalService } from "ng-zorro-antd/modal";
+import { NzDrawerService } from "ng-zorro-antd/drawer";
 import { ResultExportationComponent } from "../result-exportation/result-exportation.component";
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
@@ -187,6 +188,7 @@ export class MenuComponent implements OnInit, OnDestroy {
     public operatorMenu: OperatorMenuService,
     public coeditorPresenceService: CoeditorPresenceService,
     private modalService: NzModalService,
+    private drawerService: NzDrawerService,
     private reportGenerationService: ReportGenerationService,
     private panelService: PanelService,
     private computingUnitStatusService: ComputingUnitStatusService,
@@ -694,17 +696,24 @@ export class MenuComponent implements OnInit, OnDestroy {
   }
 
   public onClickDocumentWorkflow(): void {
-    const cached = this.workflowDocService.getCached(this.workflowId);
-    this.modalService.create({
+    const wid = this.workflowId;
+    const cached = this.workflowDocService.getCached(wid);
+    const lastView = this.workflowDocService.getLastView(wid);
+    const initialView = lastView === "doc" && cached ? "doc" : "intro";
+    this.drawerService.create({
       nzTitle: "Workflow Documentation",
       nzContent: WorkflowDocPanelComponent,
       nzData: {
         cachedMarkdown: cached?.markdown,
         cachedGeneratedAt: cached?.generatedAt,
+        initialView,
         onGenerate: () => this.workflowDocService.generateDocumentation(),
+        onViewChange: (view: "intro" | "doc") => this.workflowDocService.setLastView(wid, view),
       },
-      nzWidth: "800px",
-      nzFooter: null,
+      nzWidth: 520,
+      nzPlacement: "right",
+      nzMask: false,
+      nzClosable: true,
     });
   }
 

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -51,7 +51,7 @@ import { ResultExportationComponent } from "../result-exportation/result-exporta
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
 import { PanelService } from "../../service/panel/panel.service";
-import { DocEntry, WorkflowDocService } from "../../service/workflow-doc/workflow-doc.service";
+import { DocEditingState, DocEntry, WorkflowDocService } from "../../service/workflow-doc/workflow-doc.service";
 import { WorkflowDocPanelComponent } from "../workflow-doc-panel/workflow-doc-panel.component";
 import { DASHBOARD_USER_WORKFLOW } from "../../../app-routing.constant";
 import { ComputingUnitStatusService } from "../../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
@@ -702,7 +702,8 @@ export class MenuComponent implements OnInit, OnDestroy {
     const wid = this.workflowId;
     const history = this.workflowDocService.getHistory(wid);
     const lastView = this.workflowDocService.getLastView(wid);
-    const initialView = lastView === "doc" && history.length > 0 ? "doc" : "intro";
+    const editingState = this.workflowDocService.getEditingState(wid);
+    const initialView = (editingState || lastView === "doc") && history.length > 0 ? "doc" : "intro";
     this.docDrawerRef = this.drawerService.create({
       nzTitle: "Workflow Documentation",
       nzContent: WorkflowDocPanelComponent,
@@ -712,6 +713,11 @@ export class MenuComponent implements OnInit, OnDestroy {
         onGenerate: () => this.workflowDocService.generateDocumentation(),
         onViewChange: (view: "intro" | "doc") => this.workflowDocService.setLastView(wid, view),
         onDeleteEntry: (entry: DocEntry) => this.workflowDocService.deleteHistoryEntry(wid, entry),
+        onUpdateEntry: (entry: DocEntry, newMarkdown: string) =>
+          this.workflowDocService.updateHistoryEntry(wid, entry, newMarkdown),
+        editingState,
+        onEditingChange: (state: DocEditingState | null) =>
+          this.workflowDocService.setEditingState(wid, state),
       },
       nzWidth: 520,
       nzPlacement: "right",

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -261,6 +261,7 @@ export class MenuComponent implements OnInit, OnDestroy {
     this.workflowResultExportService.resetFlags();
     this.computingUnitStatusSubscription.unsubscribe();
     this.docDrawerRef?.close();
+    this.workflowDocService.setLastView(this.workflowId, "intro");
   }
 
   private subscribeToComputingUnitSelection(): void {

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -50,6 +50,8 @@ import { ResultExportationComponent } from "../result-exportation/result-exporta
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
 import { PanelService } from "../../service/panel/panel.service";
+import { WorkflowDocService } from "../../service/workflow-doc/workflow-doc.service";
+import { WorkflowDocPanelComponent } from "../workflow-doc-panel/workflow-doc-panel.component";
 import { DASHBOARD_USER_WORKFLOW } from "../../../app-routing.constant";
 import { ComputingUnitStatusService } from "../../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
 import { ComputingUnitState } from "../../../common/type/computing-unit-connection.interface";
@@ -130,6 +132,7 @@ export class MenuComponent implements OnInit, OnDestroy {
   public ComputingUnitState = ComputingUnitState; // make Angular HTML access enum definition
   public isWorkflowValid: boolean = true; // this will check whether the workflow error or not
   public isWorkflowEmpty: boolean = false;
+  public isGeneratingDoc: boolean = false;
   public isSaving: boolean = false;
   public isWorkflowModifiable: boolean = false;
   public workflowId?: number;
@@ -189,7 +192,8 @@ export class MenuComponent implements OnInit, OnDestroy {
     private panelService: PanelService,
     private computingUnitStatusService: ComputingUnitStatusService,
     protected config: GuiConfigService,
-    private router: Router
+    private router: Router,
+    private workflowDocService: WorkflowDocService
   ) {
     workflowWebsocketService
       .subscribeToEvent("ExecutionDurationUpdateEvent")
@@ -688,6 +692,33 @@ export class MenuComponent implements OnInit, OnDestroy {
 
       modalRef.close();
     });
+  }
+
+  public onClickDocumentWorkflow(): void {
+    this.isGeneratingDoc = true;
+    this.notificationService.blank("", "Generating workflow documentation…", { nzDuration: 0 });
+
+    this.workflowDocService
+      .generateDocumentation()
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: markdown => {
+          this.isGeneratingDoc = false;
+          this.notificationService.remove();
+          this.modalService.create({
+            nzTitle: "Workflow Documentation",
+            nzContent: WorkflowDocPanelComponent,
+            nzData: { markdown },
+            nzWidth: "800px",
+            nzFooter: null,
+          });
+        },
+        error: (err: unknown) => {
+          this.isGeneratingDoc = false;
+          this.notificationService.remove();
+          this.notificationService.error("Failed to generate documentation: " + (err as Error).message);
+        },
+      });
   }
 
   /**

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -51,7 +51,7 @@ import { ResultExportationComponent } from "../result-exportation/result-exporta
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
 import { PanelService } from "../../service/panel/panel.service";
-import { WorkflowDocService } from "../../service/workflow-doc/workflow-doc.service";
+import { DocEntry, WorkflowDocService } from "../../service/workflow-doc/workflow-doc.service";
 import { WorkflowDocPanelComponent } from "../workflow-doc-panel/workflow-doc-panel.component";
 import { DASHBOARD_USER_WORKFLOW } from "../../../app-routing.constant";
 import { ComputingUnitStatusService } from "../../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
@@ -708,6 +708,7 @@ export class MenuComponent implements OnInit, OnDestroy {
         initialView,
         onGenerate: () => this.workflowDocService.generateDocumentation(),
         onViewChange: (view: "intro" | "doc") => this.workflowDocService.setLastView(wid, view),
+        onDeleteEntry: (entry: DocEntry) => this.workflowDocService.deleteHistoryEntry(wid, entry),
       },
       nzWidth: 520,
       nzPlacement: "right",

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -46,7 +46,7 @@ import { CoeditorPresenceService } from "../../service/workflow-graph/model/coed
 import { firstValueFrom, of, Subscription, timer } from "rxjs";
 import { isDefined } from "../../../common/util/predicate";
 import { NzModalService } from "ng-zorro-antd/modal";
-import { NzDrawerService } from "ng-zorro-antd/drawer";
+import { NzDrawerRef, NzDrawerService } from "ng-zorro-antd/drawer";
 import { ResultExportationComponent } from "../result-exportation/result-exportation.component";
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
@@ -695,12 +695,15 @@ export class MenuComponent implements OnInit, OnDestroy {
     });
   }
 
+  private docDrawerRef: NzDrawerRef | null = null;
+
   public onClickDocumentWorkflow(): void {
+    if (this.docDrawerRef) return;
     const wid = this.workflowId;
     const history = this.workflowDocService.getHistory(wid);
     const lastView = this.workflowDocService.getLastView(wid);
     const initialView = lastView === "doc" && history.length > 0 ? "doc" : "intro";
-    this.drawerService.create({
+    this.docDrawerRef = this.drawerService.create({
       nzTitle: "Workflow Documentation",
       nzContent: WorkflowDocPanelComponent,
       nzData: {
@@ -714,6 +717,9 @@ export class MenuComponent implements OnInit, OnDestroy {
       nzPlacement: "right",
       nzMask: false,
       nzClosable: true,
+    });
+    this.docDrawerRef.afterClose.pipe(untilDestroyed(this)).subscribe(() => {
+      this.docDrawerRef = null;
     });
   }
 

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -720,6 +720,8 @@ export class MenuComponent implements OnInit, OnDestroy {
           this.workflowDocService.updateHistoryEntry(wid, entry, newMarkdown),
         onCreateEntry: (markdown: string) => this.workflowDocService.createBlankEntry(wid, markdown),
         onDuplicateEntry: (entry: DocEntry) => this.workflowDocService.duplicateEntry(wid, entry),
+        onRenameEntry: (entry: DocEntry, newTitle: string) =>
+          this.workflowDocService.renameEntry(wid, entry, newTitle),
         editingState,
         onEditingChange: (state: DocEditingState | null) =>
           this.workflowDocService.setEditingState(wid, state),

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -697,15 +697,14 @@ export class MenuComponent implements OnInit, OnDestroy {
 
   public onClickDocumentWorkflow(): void {
     const wid = this.workflowId;
-    const cached = this.workflowDocService.getCached(wid);
+    const history = this.workflowDocService.getHistory(wid);
     const lastView = this.workflowDocService.getLastView(wid);
-    const initialView = lastView === "doc" && cached ? "doc" : "intro";
+    const initialView = lastView === "doc" && history.length > 0 ? "doc" : "intro";
     this.drawerService.create({
       nzTitle: "Workflow Documentation",
       nzContent: WorkflowDocPanelComponent,
       nzData: {
-        cachedMarkdown: cached?.markdown,
-        cachedGeneratedAt: cached?.generatedAt,
+        history,
         initialView,
         onGenerate: () => this.workflowDocService.generateDocumentation(),
         onViewChange: (view: "intro" | "doc") => this.workflowDocService.setLastView(wid, view),

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -260,6 +260,7 @@ export class MenuComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.workflowResultExportService.resetFlags();
     this.computingUnitStatusSubscription.unsubscribe();
+    this.docDrawerRef?.close();
   }
 
   private subscribeToComputingUnitSelection(): void {

--- a/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.html
@@ -1,0 +1,77 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="doc-diff">
+  <div class="doc-diff-summary">
+    <span
+      *ngIf="base"
+      class="doc-diff-side doc-diff-side-left">
+      <strong>Base</strong>
+      <span class="doc-diff-time">{{ base.generatedAt | date: "short" }}</span>
+    </span>
+    <span class="doc-diff-arrow">→</span>
+    <span
+      *ngIf="head"
+      class="doc-diff-side doc-diff-side-right">
+      <strong>Head</strong>
+      <span class="doc-diff-time">{{ head.generatedAt | date: "short" }}</span>
+    </span>
+    <span class="doc-diff-stats">
+      <span class="doc-diff-stat-removed">−{{ removedCount }}</span>
+      <span class="doc-diff-stat-added">+{{ addedCount }}</span>
+    </span>
+  </div>
+  <div class="doc-diff-table">
+    <div
+      *ngFor="let row of rows"
+      class="doc-diff-row">
+      <div
+        class="doc-diff-cell doc-diff-cell-left"
+        [class.doc-diff-cell-del]="row.leftType === 'del'"
+        [class.doc-diff-cell-pad]="row.leftType === 'pad'">
+        <span
+          class="doc-diff-marker"
+          *ngIf="row.leftType === 'del'">−</span>
+        <pre
+          *ngIf="row.leftSegments"
+          class="doc-diff-line"><span
+            *ngFor="let seg of row.leftSegments"
+            [class.doc-diff-word-del]="seg.changed">{{ seg.text }}</span></pre>
+      </div>
+      <div
+        class="doc-diff-cell doc-diff-cell-right"
+        [class.doc-diff-cell-add]="row.rightType === 'add'"
+        [class.doc-diff-cell-pad]="row.rightType === 'pad'">
+        <span
+          class="doc-diff-marker"
+          *ngIf="row.rightType === 'add'">+</span>
+        <pre
+          *ngIf="row.rightSegments"
+          class="doc-diff-line"><span
+            *ngFor="let seg of row.rightSegments"
+            [class.doc-diff-word-add]="seg.changed">{{ seg.text }}</span></pre>
+      </div>
+    </div>
+    <div
+      *ngIf="rows.length === 0"
+      class="doc-diff-empty">
+      No changes between these two reports.
+    </div>
+  </div>
+</div>

--- a/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.html
@@ -22,14 +22,14 @@
     <span
       *ngIf="base"
       class="doc-diff-side doc-diff-side-left">
-      <strong>Base</strong>
+      <strong>{{ base.title || "Base" }}</strong>
       <span class="doc-diff-time">{{ base.generatedAt | date: "short" }}</span>
     </span>
     <span class="doc-diff-arrow">→</span>
     <span
       *ngIf="head"
       class="doc-diff-side doc-diff-side-right">
-      <strong>Head</strong>
+      <strong>{{ head.title || "Head" }}</strong>
       <span class="doc-diff-time">{{ head.generatedAt | date: "short" }}</span>
     </span>
     <span class="doc-diff-stats">

--- a/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.scss
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.doc-diff {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.doc-diff-summary {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+  color: #595959;
+  padding: 8px 12px;
+  background-color: #fafafa;
+  border-radius: 4px;
+}
+
+.doc-diff-side {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.doc-diff-time {
+  font-variant-numeric: tabular-nums;
+  color: #8c8c8c;
+  font-size: 12px;
+}
+
+.doc-diff-arrow {
+  color: #bfbfbf;
+}
+
+.doc-diff-stats {
+  margin-left: auto;
+  display: inline-flex;
+  gap: 8px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+.doc-diff-stat-removed {
+  color: #cf1322;
+}
+
+.doc-diff-stat-added {
+  color: #389e0d;
+}
+
+.doc-diff-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #f0f0f0;
+  border-radius: 4px;
+  overflow: auto;
+  max-height: 70vh;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.doc-diff-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  border-bottom: 1px solid #fafafa;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.doc-diff-cell {
+  position: relative;
+  padding: 2px 8px 2px 22px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-right: 1px solid #f0f0f0;
+  min-height: 18px;
+
+  &:last-child {
+    border-right: none;
+  }
+}
+
+.doc-diff-cell-del {
+  background-color: #fff1f0;
+}
+
+.doc-diff-cell-add {
+  background-color: #f6ffed;
+}
+
+.doc-diff-cell-pad {
+  background-color: #fafafa;
+}
+
+.doc-diff-marker {
+  position: absolute;
+  left: 8px;
+  font-weight: 700;
+  user-select: none;
+}
+
+.doc-diff-cell-del .doc-diff-marker {
+  color: #cf1322;
+}
+
+.doc-diff-cell-add .doc-diff-marker {
+  color: #389e0d;
+}
+
+.doc-diff-line {
+  margin: 0;
+  font-family: inherit;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.doc-diff-word-del {
+  background-color: #ffccc7;
+  border-radius: 2px;
+}
+
+.doc-diff-word-add {
+  background-color: #b7eb8f;
+  border-radius: 2px;
+}
+
+.doc-diff-empty {
+  padding: 40px 0;
+  text-align: center;
+  color: #8c8c8c;
+  font-style: italic;
+}

--- a/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-diff/workflow-doc-diff.component.ts
@@ -1,0 +1,165 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject, OnInit } from "@angular/core";
+import { DatePipe, NgFor, NgIf } from "@angular/common";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { diffLines, diffWordsWithSpace } from "diff";
+import { DocEntry } from "../../service/workflow-doc/workflow-doc.service";
+
+interface DiffSegment {
+  text: string;
+  changed: boolean;
+}
+
+interface DiffRow {
+  leftSegments: DiffSegment[] | null;
+  rightSegments: DiffSegment[] | null;
+  leftType: "eq" | "del" | "pad";
+  rightType: "eq" | "add" | "pad";
+}
+
+@Component({
+  selector: "texera-workflow-doc-diff",
+  templateUrl: "./workflow-doc-diff.component.html",
+  styleUrls: ["./workflow-doc-diff.component.scss"],
+  imports: [NgFor, NgIf, DatePipe],
+})
+export class WorkflowDocDiffComponent implements OnInit {
+  private modalData = inject(NZ_MODAL_DATA, { optional: true }) as {
+    base: DocEntry;
+    head: DocEntry;
+  } | null;
+
+  base: DocEntry | null = null;
+  head: DocEntry | null = null;
+  rows: DiffRow[] = [];
+  addedCount = 0;
+  removedCount = 0;
+
+  ngOnInit(): void {
+    if (!this.modalData) return;
+    this.base = this.modalData.base;
+    this.head = this.modalData.head;
+    this.computeDiff();
+  }
+
+  private computeDiff(): void {
+    if (!this.base || !this.head) return;
+    const parts = diffLines(this.base.markdown, this.head.markdown);
+    const rows: DiffRow[] = [];
+    let added = 0;
+    let removed = 0;
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      const lines = part.value.replace(/\n$/, "").split("\n");
+      if (part.added) {
+        for (const line of lines) {
+          rows.push({
+            leftSegments: null,
+            rightSegments: [{ text: line, changed: true }],
+            leftType: "pad",
+            rightType: "add",
+          });
+          added++;
+        }
+      } else if (part.removed) {
+        const next = parts[i + 1];
+        if (next?.added) {
+          const nextLines = next.value.replace(/\n$/, "").split("\n");
+          const pairCount = Math.min(lines.length, nextLines.length);
+          for (let j = 0; j < pairCount; j++) {
+            const { left, right } = this.diffLinePair(lines[j], nextLines[j]);
+            rows.push({
+              leftSegments: left,
+              rightSegments: right,
+              leftType: "del",
+              rightType: "add",
+            });
+            removed++;
+            added++;
+          }
+          for (let j = pairCount; j < lines.length; j++) {
+            rows.push({
+              leftSegments: [{ text: lines[j], changed: true }],
+              rightSegments: null,
+              leftType: "del",
+              rightType: "pad",
+            });
+            removed++;
+          }
+          for (let j = pairCount; j < nextLines.length; j++) {
+            rows.push({
+              leftSegments: null,
+              rightSegments: [{ text: nextLines[j], changed: true }],
+              leftType: "pad",
+              rightType: "add",
+            });
+            added++;
+          }
+          i++;
+        } else {
+          for (const line of lines) {
+            rows.push({
+              leftSegments: [{ text: line, changed: true }],
+              rightSegments: null,
+              leftType: "del",
+              rightType: "pad",
+            });
+            removed++;
+          }
+        }
+      } else {
+        for (const line of lines) {
+          rows.push({
+            leftSegments: [{ text: line, changed: false }],
+            rightSegments: [{ text: line, changed: false }],
+            leftType: "eq",
+            rightType: "eq",
+          });
+        }
+      }
+    }
+
+    this.rows = rows;
+    this.addedCount = added;
+    this.removedCount = removed;
+  }
+
+  private diffLinePair(leftLine: string, rightLine: string): {
+    left: DiffSegment[];
+    right: DiffSegment[];
+  } {
+    const wordParts = diffWordsWithSpace(leftLine, rightLine);
+    const left: DiffSegment[] = [];
+    const right: DiffSegment[] = [];
+    for (const wp of wordParts) {
+      if (wp.added) {
+        right.push({ text: wp.value, changed: true });
+      } else if (wp.removed) {
+        left.push({ text: wp.value, changed: true });
+      } else {
+        left.push({ text: wp.value, changed: false });
+        right.push({ text: wp.value, changed: false });
+      }
+    }
+    return { left, right };
+  }
+}

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -57,6 +57,16 @@
           nzType="thunderbolt"></i>
         {{ hasHistory ? "Generate New" : "Generate Documentation" }}
       </button>
+      <button
+        nz-button
+        nzType="default"
+        nzSize="large"
+        (click)="startBlank()">
+        <i
+          nz-icon
+          nzType="edit"></i>
+        Write Your Own
+      </button>
     </div>
     <div
       *ngIf="hasHistory"
@@ -172,13 +182,16 @@
           nz-icon
           nzType="clock-circle"
           nzTheme="outline"></i>
-        <span>{{ currentEntry?.edited ? "Updated" : "Generated" }} {{ generatedAt | date: "short" }}</span>
+        <span>{{ currentEntry?.written ? "Written" : currentEntry?.edited ? "Updated" : "Generated" }} {{ generatedAt | date: "short" }}</span>
         <span
-          *ngIf="currentEntry?.edited"
+          *ngIf="currentEntry?.written"
+          class="doc-written-badge">written</span>
+        <span
+          *ngIf="!currentEntry?.written && currentEntry?.edited"
           class="doc-edited-badge">edited</span>
       </div>
       <div
-        *ngIf="rawMarkdown"
+        *ngIf="rawMarkdown || editMode"
         class="doc-actions">
         <ng-container *ngIf="!editMode">
           <button

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -39,6 +39,13 @@
       <li><strong>Outputs</strong> — sink operators and the schemas they produce</li>
       <li><strong>Caveats</strong> — unconfigured properties, hardcoded paths, or schema mismatches</li>
     </ul>
+    <p class="doc-intro-tip">
+      <i
+        nz-icon
+        nzType="bulb"
+        nzTheme="twotone"></i>
+      Operator names in the report are clickable — click one to jump to and highlight that operator on the canvas.
+    </p>
     <p
       *ngIf="hasCached"
       class="doc-intro-cached">
@@ -137,6 +144,7 @@
     <div
       *ngIf="renderedMarkdown && !isGenerating"
       class="doc-content md-rendered"
+      (click)="onContentClick($event)"
       [innerHTML]="renderedMarkdown"></div>
     <div
       *ngIf="!renderedMarkdown && !isGenerating"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -172,24 +172,64 @@
           nz-icon
           nzType="clock-circle"
           nzTheme="outline"></i>
-        <span>Generated {{ generatedAt | date: "short" }}</span>
+        <span>{{ currentEntry?.edited ? "Updated" : "Generated" }} {{ generatedAt | date: "short" }}</span>
+        <span
+          *ngIf="currentEntry?.edited"
+          class="doc-edited-badge">edited</span>
       </div>
       <div
         *ngIf="rawMarkdown"
         class="doc-actions">
-        <button
-          nz-button
-          nzType="default"
-          nzSize="small"
-          class="doc-action-copy"
-          [disabled]="isGenerating"
-          [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
-          (click)="copyToClipboard()">
-          <i
-            nz-icon
-            [nzType]="copied ? 'check' : 'copy'"></i>
-          {{ copied ? "Copied" : "Copy Markdown" }}
-        </button>
+        <ng-container *ngIf="!editMode">
+          <button
+            nz-button
+            nzType="default"
+            nzSize="small"
+            class="doc-action-edit"
+            [disabled]="isGenerating"
+            [nz-tooltip]="'Edit this report'"
+            (click)="enterEditMode()">
+            <i
+              nz-icon
+              nzType="edit"></i>
+            Edit
+          </button>
+          <button
+            nz-button
+            nzType="default"
+            nzSize="small"
+            class="doc-action-copy"
+            [disabled]="isGenerating"
+            [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
+            (click)="copyToClipboard()">
+            <i
+              nz-icon
+              [nzType]="copied ? 'check' : 'copy'"></i>
+            {{ copied ? "Copied" : "Copy Markdown" }}
+          </button>
+        </ng-container>
+        <ng-container *ngIf="editMode">
+          <button
+            nz-button
+            nzType="default"
+            nzSize="small"
+            (click)="cancelEdit()">
+            <i
+              nz-icon
+              nzType="close"></i>
+            Cancel
+          </button>
+          <button
+            nz-button
+            nzType="primary"
+            nzSize="small"
+            (click)="saveEdit()">
+            <i
+              nz-icon
+              nzType="save"></i>
+            Save
+          </button>
+        </ng-container>
       </div>
     </div>
     <div
@@ -212,13 +252,19 @@
         Cancel
       </button>
     </div>
+    <textarea
+      *ngIf="editMode && !isGenerating"
+      class="doc-editor"
+      [ngModel]="editorContent"
+      (ngModelChange)="onEditorContentChange($event)"
+      spellcheck="false"></textarea>
     <div
-      *ngIf="renderedMarkdown && !isGenerating"
+      *ngIf="!editMode && renderedMarkdown && !isGenerating"
       class="doc-content md-rendered"
       (click)="onContentClick($event)"
       [innerHTML]="renderedMarkdown"></div>
     <div
-      *ngIf="!renderedMarkdown && !isGenerating"
+      *ngIf="!editMode && !renderedMarkdown && !isGenerating"
       class="doc-empty">
       No documentation available.
     </div>

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -46,26 +46,7 @@
         nzTheme="twotone"></i>
       Operator names in the report are clickable — click one to jump to and highlight that operator on the canvas.
     </p>
-    <p
-      *ngIf="hasCached"
-      class="doc-intro-cached">
-      <i
-        nz-icon
-        nzType="clock-circle"></i>
-      A previous version was generated {{ generatedAt | date: "short" }}.
-    </p>
     <div class="doc-intro-actions">
-      <button
-        *ngIf="hasCached"
-        nz-button
-        nzType="default"
-        nzSize="large"
-        (click)="viewLatest()">
-        <i
-          nz-icon
-          nzType="eye"></i>
-        View Latest
-      </button>
       <button
         nz-button
         nzType="primary"
@@ -74,8 +55,35 @@
         <i
           nz-icon
           nzType="thunderbolt"></i>
-        {{ hasCached ? "Generate New" : "Generate Documentation" }}
+        {{ hasHistory ? "Generate New" : "Generate Documentation" }}
       </button>
+    </div>
+    <div
+      *ngIf="hasHistory"
+      class="doc-history">
+      <h4 class="doc-history-title">
+        Previous reports
+        <span class="doc-history-count">{{ history.length }}</span>
+      </h4>
+      <ul class="doc-history-list">
+        <li
+          *ngFor="let entry of history; let i = index"
+          class="doc-history-item"
+          (click)="viewEntry(entry)">
+          <i
+            nz-icon
+            nzType="file-text"
+            class="doc-history-icon"></i>
+          <span class="doc-history-time">{{ entry.generatedAt | date: "short" }}</span>
+          <span
+            *ngIf="i === 0"
+            class="doc-history-latest">Latest</span>
+          <i
+            nz-icon
+            nzType="right"
+            class="doc-history-chevron"></i>
+        </li>
+      </ul>
     </div>
   </div>
 

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -113,8 +113,10 @@
           <i
             *ngIf="!compareMode"
             nz-icon
-            nzType="file-text"
-            class="doc-history-icon"></i>
+            [nzType]="entry.written ? 'edit' : 'thunderbolt'"
+            class="doc-history-icon"
+            [class.doc-history-icon-written]="entry.written"
+            [nz-tooltip]="entry.written ? 'Written by you' : 'AI-generated'"></i>
           <span class="doc-history-time">{{ entry.generatedAt | date: "short" }}</span>
           <span
             *ngIf="i === 0"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -117,10 +117,34 @@
             class="doc-history-icon"
             [class.doc-history-icon-written]="entry.written"
             [nz-tooltip]="entry.written ? 'Written by you' : 'AI-generated'"></i>
-          <span class="doc-history-time">{{ entry.generatedAt | date: "short" }}</span>
-          <span
-            *ngIf="i === 0"
-            class="doc-history-latest">Latest</span>
+          <ng-container *ngIf="!isRenaming(entry)">
+            <span class="doc-history-time">{{ entry.title || (entry.generatedAt | date: "short") }}</span>
+            <span
+              *ngIf="i === 0"
+              class="doc-history-latest">Latest</span>
+          </ng-container>
+          <input
+            *ngIf="isRenaming(entry)"
+            class="doc-history-rename-input"
+            [(ngModel)]="renameDraft"
+            (keydown.enter)="commitRename(); $event.stopPropagation()"
+            (keydown.escape)="cancelRename(); $event.stopPropagation()"
+            (blur)="commitRename()"
+            (click)="$event.stopPropagation()"
+            placeholder="Untitled report"
+            autofocus />
+          <button
+            *ngIf="!compareMode && !isRenaming(entry)"
+            nz-button
+            nzType="text"
+            nzSize="small"
+            class="doc-history-rename"
+            (click)="startRename(entry); $event.stopPropagation()"
+            [nz-tooltip]="'Rename'">
+            <i
+              nz-icon
+              nzType="edit"></i>
+          </button>
           <button
             *ngIf="!compareMode"
             nz-button
@@ -190,18 +214,49 @@
         Back
       </button>
       <div
-        *ngIf="generatedAt && !isGenerating"
-        class="doc-timestamp"
-        [class.doc-timestamp-written]="currentEntry?.written"
-        [class.doc-timestamp-generated]="!currentEntry?.written">
-        <i
-          nz-icon
-          nzType="clock-circle"
-          nzTheme="outline"></i>
-        <span>{{ currentEntry?.written ? "Written" : currentEntry?.edited ? "Updated" : "Generated" }} {{ generatedAt | date: "short" }}</span>
-        <span
-          *ngIf="!currentEntry?.written && currentEntry?.edited"
-          class="doc-edited-badge">edited</span>
+        *ngIf="!isGenerating"
+        class="doc-header-info">
+        <div
+          *ngIf="currentEntry"
+          class="doc-title-row">
+          <ng-container *ngIf="!isRenaming(currentEntry)">
+            <span class="doc-title">{{ currentEntry.title || "Untitled report" }}</span>
+            <button
+              nz-button
+              nzType="text"
+              nzSize="small"
+              class="doc-title-rename"
+              (click)="startRename(currentEntry)"
+              [nz-tooltip]="'Rename'">
+              <i
+                nz-icon
+                nzType="edit"></i>
+            </button>
+          </ng-container>
+          <input
+            *ngIf="isRenaming(currentEntry)"
+            class="doc-title-rename-input"
+            [(ngModel)]="renameDraft"
+            (keydown.enter)="commitRename()"
+            (keydown.escape)="cancelRename()"
+            (blur)="commitRename()"
+            placeholder="Untitled report"
+            autofocus />
+        </div>
+        <div
+          *ngIf="generatedAt"
+          class="doc-timestamp"
+          [class.doc-timestamp-written]="currentEntry?.written"
+          [class.doc-timestamp-generated]="!currentEntry?.written">
+          <i
+            nz-icon
+            nzType="clock-circle"
+            nzTheme="outline"></i>
+          <span>{{ currentEntry?.written ? "Written" : currentEntry?.edited ? "Updated" : "Generated" }} {{ generatedAt | date: "short" }}</span>
+          <span
+            *ngIf="!currentEntry?.written && currentEntry?.edited"
+            class="doc-edited-badge">edited</span>
+        </div>
       </div>
       <div
         *ngIf="rawMarkdown || editMode"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -142,6 +142,7 @@
         nz-icon
         nzType="loading"></i>
       <span>Generating documentation…</span>
+      <span class="doc-loading-elapsed">{{ elapsedDisplay }}</span>
     </div>
     <div
       *ngIf="renderedMarkdown && !isGenerating"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -179,15 +179,14 @@
       </button>
       <div
         *ngIf="generatedAt && !isGenerating"
-        class="doc-timestamp">
+        class="doc-timestamp"
+        [class.doc-timestamp-written]="currentEntry?.written"
+        [class.doc-timestamp-generated]="!currentEntry?.written">
         <i
           nz-icon
           nzType="clock-circle"
           nzTheme="outline"></i>
         <span>{{ currentEntry?.written ? "Written" : currentEntry?.edited ? "Updated" : "Generated" }} {{ generatedAt | date: "short" }}</span>
-        <span
-          *ngIf="currentEntry?.written"
-          class="doc-written-badge">written</span>
         <span
           *ngIf="!currentEntry?.written && currentEntry?.edited"
           class="doc-edited-badge">edited</span>

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -78,6 +78,23 @@
           <span
             *ngIf="i === 0"
             class="doc-history-latest">Latest</span>
+          <button
+            nz-button
+            nzType="text"
+            nzSize="small"
+            class="doc-history-delete"
+            nz-popconfirm
+            nzPopconfirmTitle="Delete this report?"
+            nzPopconfirmPlacement="left"
+            nzOkText="Delete"
+            nzOkDanger="true"
+            (nzOnConfirm)="deleteEntry(entry)"
+            (click)="$event.stopPropagation()"
+            [nz-tooltip]="'Delete this report'">
+            <i
+              nz-icon
+              nzType="delete"></i>
+          </button>
           <i
             nz-icon
             nzType="right"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -126,6 +126,18 @@
             nz-button
             nzType="text"
             nzSize="small"
+            class="doc-history-duplicate"
+            (click)="duplicateEntry(entry); $event.stopPropagation()"
+            [nz-tooltip]="'Duplicate this report'">
+            <i
+              nz-icon
+              nzType="copy"></i>
+          </button>
+          <button
+            *ngIf="!compareMode"
+            nz-button
+            nzType="text"
+            nzSize="small"
             class="doc-history-delete"
             nz-popconfirm
             nzPopconfirmTitle="Delete this report?"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -136,6 +136,17 @@
         nzType="loading"></i>
       <span>Generating documentation…</span>
       <span class="doc-loading-elapsed">{{ elapsedDisplay }}</span>
+      <button
+        nz-button
+        nzType="default"
+        nzSize="small"
+        class="doc-loading-cancel"
+        (click)="cancel()">
+        <i
+          nz-icon
+          nzType="close"></i>
+        Cancel
+      </button>
     </div>
     <div
       *ngIf="renderedMarkdown && !isGenerating"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -1,0 +1,43 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="doc-panel">
+  <div class="doc-actions">
+    <button
+      nz-button
+      nzType="text"
+      nzSize="small"
+      [nz-tooltip]="copied ? 'Copied!' : 'Copy as Markdown'"
+      (click)="copyToClipboard()">
+      <i
+        nz-icon
+        [nzType]="copied ? 'check' : 'copy'"></i>
+      {{ copied ? "Copied" : "Copy Markdown" }}
+    </button>
+  </div>
+  <div
+    *ngIf="renderedMarkdown"
+    class="doc-content md-rendered"
+    [innerHTML]="renderedMarkdown"></div>
+  <div
+    *ngIf="!renderedMarkdown"
+    class="doc-empty">
+    No documentation available.
+  </div>
+</div>

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -285,12 +285,12 @@
             nzSize="small"
             class="doc-action-copy"
             [disabled]="isGenerating"
-            [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
-            (click)="copyToClipboard()">
+            [nz-tooltip]="'Download as Markdown file'"
+            (click)="downloadMarkdown()">
             <i
               nz-icon
-              [nzType]="copied ? 'check' : 'copy'"></i>
-            {{ copied ? "Copied" : "Copy Markdown" }}
+              nzType="download"></i>
+            Download
           </button>
         </ng-container>
         <ng-container *ngIf="editMode">

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -102,13 +102,15 @@
           nzTheme="outline"></i>
         <span>Generated {{ generatedAt | date: "short" }}</span>
       </div>
-      <div class="doc-actions">
+      <div
+        *ngIf="rawMarkdown"
+        class="doc-actions">
         <button
           nz-button
           nzType="default"
           nzSize="small"
           class="doc-action-copy"
-          [disabled]="!rawMarkdown || isGenerating"
+          [disabled]="isGenerating"
           [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
           (click)="copyToClipboard()">
           <i

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -17,7 +17,9 @@
  under the License.
 -->
 
-<div class="doc-panel">
+<div
+  class="doc-panel"
+  [@slideView]="view">
   <div
     *ngIf="view === 'intro'"
     class="doc-intro">
@@ -199,7 +201,9 @@
     </div>
   </div>
 
-  <ng-container *ngIf="view === 'doc'">
+  <div
+    *ngIf="view === 'doc'"
+    class="doc-view-container">
     <div class="doc-header">
       <button
         nz-button
@@ -349,5 +353,5 @@
       class="doc-empty">
       No documentation available.
     </div>
-  </ng-container>
+  </div>
 </div>

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -18,34 +18,45 @@
 -->
 
 <div class="doc-panel">
-  <div class="doc-actions">
-    <span
+  <div class="doc-header">
+    <div
       *ngIf="generatedAt"
       class="doc-timestamp">
-      Generated {{ generatedAt | date: "short" }}
-    </span>
-    <button
-      nz-button
-      nzType="text"
-      nzSize="small"
-      [disabled]="isRegenerating"
-      (click)="regenerate()">
       <i
         nz-icon
-        [nzType]="isRegenerating ? 'loading' : 'sync'"></i>
-      {{ isRegenerating ? "Regenerating…" : "Re-generate" }}
-    </button>
-    <button
-      nz-button
-      nzType="text"
-      nzSize="small"
-      [nz-tooltip]="copied ? 'Copied!' : 'Copy as Markdown'"
-      (click)="copyToClipboard()">
-      <i
-        nz-icon
-        [nzType]="copied ? 'check' : 'copy'"></i>
-      {{ copied ? "Copied" : "Copy Markdown" }}
-    </button>
+        nzType="clock-circle"
+        nzTheme="outline"></i>
+      <span>Generated {{ generatedAt | date: "short" }}</span>
+    </div>
+    <div class="doc-actions">
+      <button
+        nz-button
+        nzType="default"
+        nzSize="small"
+        class="doc-action-copy"
+        [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
+        (click)="copyToClipboard()">
+        <i
+          nz-icon
+          [nzType]="copied ? 'check' : 'copy'"></i>
+        {{ copied ? "Copied" : "Copy Markdown" }}
+      </button>
+      <button
+        nz-button
+        nzType="primary"
+        nzSize="small"
+        class="doc-action-regenerate"
+        [nzLoading]="isRegenerating"
+        [disabled]="isRegenerating"
+        [nz-tooltip]="'Run the LLM again to produce a fresh report'"
+        (click)="regenerate()">
+        <i
+          *ngIf="!isRegenerating"
+          nz-icon
+          nzType="sync"></i>
+        {{ isRegenerating ? "Regenerating…" : "Re-generate" }}
+      </button>
+    </div>
   </div>
   <div
     *ngIf="renderedMarkdown"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -19,6 +19,22 @@
 
 <div class="doc-panel">
   <div class="doc-actions">
+    <span
+      *ngIf="generatedAt"
+      class="doc-timestamp">
+      Generated {{ generatedAt | date: "short" }}
+    </span>
+    <button
+      nz-button
+      nzType="text"
+      nzSize="small"
+      [disabled]="isRegenerating"
+      (click)="regenerate()">
+      <i
+        nz-icon
+        [nzType]="isRegenerating ? 'loading' : 'sync'"></i>
+      {{ isRegenerating ? "Regenerating…" : "Re-generate" }}
+    </button>
     <button
       nz-button
       nzType="text"

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -126,21 +126,6 @@
             [nzType]="copied ? 'check' : 'copy'"></i>
           {{ copied ? "Copied" : "Copy Markdown" }}
         </button>
-        <button
-          nz-button
-          nzType="primary"
-          nzSize="small"
-          class="doc-action-regenerate"
-          [nzLoading]="isGenerating"
-          [disabled]="isGenerating"
-          [nz-tooltip]="'Run the LLM again to produce a fresh report'"
-          (click)="generate()">
-          <i
-            *ngIf="!isGenerating"
-            nz-icon
-            nzType="sync"></i>
-          {{ isGenerating ? "Regenerating…" : "Re-generate" }}
-        </button>
       </div>
     </div>
     <div

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -61,16 +61,47 @@
     <div
       *ngIf="hasHistory"
       class="doc-history">
-      <h4 class="doc-history-title">
-        Previous reports
-        <span class="doc-history-count">{{ history.length }}</span>
-      </h4>
+      <div class="doc-history-header">
+        <h4 class="doc-history-title">
+          Previous reports
+          <span class="doc-history-count">{{ history.length }}</span>
+        </h4>
+        <button
+          *ngIf="history.length >= 2"
+          nz-button
+          nzType="text"
+          nzSize="small"
+          class="doc-history-compare-toggle"
+          [class.doc-history-compare-toggle-active]="compareMode"
+          (click)="toggleCompareMode()">
+          <i
+            nz-icon
+            [nzType]="compareMode ? 'close' : 'diff'"></i>
+          {{ compareMode ? "Cancel" : "Compare" }}
+        </button>
+      </div>
+      <div
+        *ngIf="compareMode"
+        class="doc-history-compare-hint">
+        Select {{ 2 - selectedEntries.size }} more
+        report{{ selectedEntries.size === 1 ? "" : "s" }}
+        to compare.
+      </div>
       <ul class="doc-history-list">
         <li
           *ngFor="let entry of history; let i = index"
           class="doc-history-item"
+          [class.doc-history-item-selected]="compareMode && isSelected(entry)"
           (click)="viewEntry(entry)">
+          <label
+            *ngIf="compareMode"
+            nz-checkbox
+            class="doc-history-checkbox"
+            [ngModel]="isSelected(entry)"
+            (ngModelChange)="toggleEntrySelection(entry)"
+            (click)="$event.stopPropagation()"></label>
           <i
+            *ngIf="!compareMode"
             nz-icon
             nzType="file-text"
             class="doc-history-icon"></i>
@@ -79,6 +110,7 @@
             *ngIf="i === 0"
             class="doc-history-latest">Latest</span>
           <button
+            *ngIf="!compareMode"
             nz-button
             nzType="text"
             nzSize="small"
@@ -96,11 +128,26 @@
               nzType="delete"></i>
           </button>
           <i
+            *ngIf="!compareMode"
             nz-icon
             nzType="right"
             class="doc-history-chevron"></i>
         </li>
       </ul>
+      <div
+        *ngIf="compareMode"
+        class="doc-history-compare-action">
+        <button
+          nz-button
+          nzType="primary"
+          [disabled]="!canCompare"
+          (click)="openDiff()">
+          <i
+            nz-icon
+            nzType="diff"></i>
+          Compare selected
+        </button>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.html
@@ -18,53 +18,130 @@
 -->
 
 <div class="doc-panel">
-  <div class="doc-header">
-    <div
-      *ngIf="generatedAt"
-      class="doc-timestamp">
+  <div
+    *ngIf="view === 'intro'"
+    class="doc-intro">
+    <div class="doc-intro-icon">
       <i
         nz-icon
-        nzType="clock-circle"
-        nzTheme="outline"></i>
-      <span>Generated {{ generatedAt | date: "short" }}</span>
+        nzType="file-text"
+        nzTheme="twotone"></i>
     </div>
-    <div class="doc-actions">
+    <h3 class="doc-intro-title">AI-Generated Workflow Documentation</h3>
+    <p class="doc-intro-description">
+      Send the current workflow to an AI model and get back structured markdown documentation.
+      The report covers:
+    </p>
+    <ul class="doc-intro-features">
+      <li><strong>Purpose</strong> — what the pipeline actually does</li>
+      <li><strong>Inputs</strong> — source operators with file paths, tables, and columns</li>
+      <li><strong>Pipeline Stages</strong> — logical processing stages and the transformations they perform</li>
+      <li><strong>Outputs</strong> — sink operators and the schemas they produce</li>
+      <li><strong>Caveats</strong> — unconfigured properties, hardcoded paths, or schema mismatches</li>
+    </ul>
+    <p
+      *ngIf="hasCached"
+      class="doc-intro-cached">
+      <i
+        nz-icon
+        nzType="clock-circle"></i>
+      A previous version was generated {{ generatedAt | date: "short" }}.
+    </p>
+    <div class="doc-intro-actions">
       <button
+        *ngIf="hasCached"
         nz-button
         nzType="default"
-        nzSize="small"
-        class="doc-action-copy"
-        [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
-        (click)="copyToClipboard()">
+        nzSize="large"
+        (click)="viewLatest()">
         <i
           nz-icon
-          [nzType]="copied ? 'check' : 'copy'"></i>
-        {{ copied ? "Copied" : "Copy Markdown" }}
+          nzType="eye"></i>
+        View Latest
       </button>
       <button
         nz-button
         nzType="primary"
-        nzSize="small"
-        class="doc-action-regenerate"
-        [nzLoading]="isRegenerating"
-        [disabled]="isRegenerating"
-        [nz-tooltip]="'Run the LLM again to produce a fresh report'"
-        (click)="regenerate()">
+        nzSize="large"
+        (click)="generate()">
         <i
-          *ngIf="!isRegenerating"
           nz-icon
-          nzType="sync"></i>
-        {{ isRegenerating ? "Regenerating…" : "Re-generate" }}
+          nzType="thunderbolt"></i>
+        {{ hasCached ? "Generate New" : "Generate Documentation" }}
       </button>
     </div>
   </div>
-  <div
-    *ngIf="renderedMarkdown"
-    class="doc-content md-rendered"
-    [innerHTML]="renderedMarkdown"></div>
-  <div
-    *ngIf="!renderedMarkdown"
-    class="doc-empty">
-    No documentation available.
-  </div>
+
+  <ng-container *ngIf="view === 'doc'">
+    <div class="doc-header">
+      <button
+        nz-button
+        nzType="text"
+        nzSize="small"
+        class="doc-back-button"
+        [disabled]="isGenerating"
+        (click)="backToIntro()">
+        <i
+          nz-icon
+          nzType="arrow-left"></i>
+        Back
+      </button>
+      <div
+        *ngIf="generatedAt && !isGenerating"
+        class="doc-timestamp">
+        <i
+          nz-icon
+          nzType="clock-circle"
+          nzTheme="outline"></i>
+        <span>Generated {{ generatedAt | date: "short" }}</span>
+      </div>
+      <div class="doc-actions">
+        <button
+          nz-button
+          nzType="default"
+          nzSize="small"
+          class="doc-action-copy"
+          [disabled]="!rawMarkdown || isGenerating"
+          [nz-tooltip]="copied ? 'Copied to clipboard!' : 'Copy as Markdown'"
+          (click)="copyToClipboard()">
+          <i
+            nz-icon
+            [nzType]="copied ? 'check' : 'copy'"></i>
+          {{ copied ? "Copied" : "Copy Markdown" }}
+        </button>
+        <button
+          nz-button
+          nzType="primary"
+          nzSize="small"
+          class="doc-action-regenerate"
+          [nzLoading]="isGenerating"
+          [disabled]="isGenerating"
+          [nz-tooltip]="'Run the LLM again to produce a fresh report'"
+          (click)="generate()">
+          <i
+            *ngIf="!isGenerating"
+            nz-icon
+            nzType="sync"></i>
+          {{ isGenerating ? "Regenerating…" : "Re-generate" }}
+        </button>
+      </div>
+    </div>
+    <div
+      *ngIf="isGenerating"
+      class="doc-loading">
+      <i
+        nz-icon
+        nzType="loading"></i>
+      <span>Generating documentation…</span>
+    </div>
+    <div
+      *ngIf="renderedMarkdown && !isGenerating"
+      class="doc-content md-rendered"
+      [innerHTML]="renderedMarkdown"></div>
+    <div
+      *ngIf="!renderedMarkdown && !isGenerating"
+      class="doc-empty">
+      No documentation available.
+    </div>
+  </ng-container>
 </div>

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -174,6 +174,23 @@
   font-size: 12px;
 }
 
+.doc-history-delete {
+  color: #bfbfbf;
+  padding: 0 4px;
+  height: 22px;
+  line-height: 22px;
+  transition: color 0.15s ease;
+
+  i {
+    font-size: 14px;
+  }
+
+  &:hover {
+    color: #ff4d4f;
+    background-color: transparent;
+  }
+}
+
 .doc-header {
   display: flex;
   align-items: center;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.doc-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 4px 0;
+}
+
+.doc-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.doc-content {
+  line-height: 1.6;
+  overflow-y: auto;
+  max-height: 60vh;
+
+  h2 {
+    font-size: 15px;
+    font-weight: 600;
+    margin-top: 16px;
+    margin-bottom: 6px;
+    border-bottom: 1px solid #f0f0f0;
+    padding-bottom: 4px;
+  }
+
+  p,
+  li {
+    font-size: 13px;
+    color: #333;
+  }
+
+  ul {
+    padding-left: 20px;
+  }
+}
+
+.doc-empty {
+  color: #999;
+  font-style: italic;
+}

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -197,6 +197,10 @@
   font-size: 16px;
 }
 
+.doc-history-icon-written {
+  color: #722ed1;
+}
+
 .doc-history-time {
   flex: 1;
   font-size: 13px;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -287,6 +287,18 @@
   letter-spacing: 0.5px;
 }
 
+.doc-written-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: #722ed1;
+  background-color: rgba(114, 46, 209, 0.12);
+  padding: 1px 6px;
+  border-radius: 8px;
+  margin-left: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
 .doc-editor {
   flex: 1;
   min-height: 0;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -68,17 +68,6 @@
   }
 }
 
-.doc-intro-cached {
-  font-size: 12px;
-  color: #8c8c8c;
-  margin: 0 0 16px;
-  font-style: italic;
-
-  i {
-    margin-right: 4px;
-  }
-}
-
 .doc-intro-tip {
   font-size: 12px;
   color: #595959;
@@ -101,6 +90,88 @@
   i {
     margin-right: 6px;
   }
+}
+
+.doc-history {
+  width: 100%;
+  max-width: 520px;
+  margin-top: 28px;
+}
+
+.doc-history-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: #595959;
+  text-align: left;
+  margin: 0 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.doc-history-count {
+  font-size: 11px;
+  font-weight: 500;
+  color: #8c8c8c;
+  background-color: #f0f0f0;
+  padding: 1px 8px;
+  border-radius: 10px;
+}
+
+.doc-history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  border: 1px solid #f0f0f0;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.doc-history-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid #f5f5f5;
+  transition: background-color 0.15s ease;
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  &:hover {
+    background-color: rgba(24, 144, 255, 0.06);
+  }
+}
+
+.doc-history-icon {
+  color: #1890ff;
+  font-size: 16px;
+}
+
+.doc-history-time {
+  flex: 1;
+  font-size: 13px;
+  color: #262626;
+  font-variant-numeric: tabular-nums;
+}
+
+.doc-history-latest {
+  font-size: 10px;
+  font-weight: 600;
+  color: #1890ff;
+  background-color: rgba(24, 144, 255, 0.1);
+  padding: 2px 8px;
+  border-radius: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.doc-history-chevron {
+  color: #bfbfbf;
+  font-size: 12px;
 }
 
 .doc-header {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -78,6 +78,20 @@
   }
 }
 
+.doc-intro-tip {
+  font-size: 12px;
+  color: #595959;
+  margin: 0 0 16px;
+  padding: 8px 12px;
+  background-color: rgba(24, 144, 255, 0.06);
+  border-radius: 4px;
+  max-width: 520px;
+
+  i {
+    margin-right: 6px;
+  }
+}
+
 .doc-intro-actions {
   display: flex;
   gap: 12px;
@@ -171,6 +185,30 @@
 
   ul {
     padding-left: 20px;
+  }
+
+  a[href^="texera:op:"] {
+    color: #1890ff;
+    font-weight: 500;
+    text-decoration: none;
+    padding: 1px 6px;
+    border-radius: 3px;
+    background-color: rgba(24, 144, 255, 0.08);
+    border: 1px solid rgba(24, 144, 255, 0.2);
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    &::before {
+      content: "↪ ";
+      font-size: 11px;
+      opacity: 0.7;
+    }
+
+    &:hover {
+      background-color: rgba(24, 144, 255, 0.16);
+      border-color: rgba(24, 144, 255, 0.4);
+      text-decoration: none;
+    }
   }
 }
 

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -24,13 +24,85 @@
   padding: 4px 0;
 }
 
+.doc-intro {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 16px 24px 8px;
+}
+
+.doc-intro-icon {
+  font-size: 48px;
+  color: #1890ff;
+  margin-bottom: 12px;
+  line-height: 1;
+}
+
+.doc-intro-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0 0 10px;
+  color: #262626;
+}
+
+.doc-intro-description {
+  font-size: 14px;
+  color: #595959;
+  margin: 0 0 12px;
+  max-width: 560px;
+}
+
+.doc-intro-features {
+  text-align: left;
+  font-size: 13px;
+  color: #595959;
+  max-width: 520px;
+  margin: 0 0 16px;
+  padding-left: 20px;
+  line-height: 1.7;
+
+  strong {
+    color: #262626;
+  }
+}
+
+.doc-intro-cached {
+  font-size: 12px;
+  color: #8c8c8c;
+  margin: 0 0 16px;
+  font-style: italic;
+
+  i {
+    margin-right: 4px;
+  }
+}
+
+.doc-intro-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 4px;
+
+  i {
+    margin-right: 6px;
+  }
+}
+
 .doc-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 12px;
   padding-bottom: 12px;
   border-bottom: 1px solid #f0f0f0;
+}
+
+.doc-back-button {
+  padding-left: 4px;
+  padding-right: 8px;
+
+  i {
+    margin-right: 4px;
+  }
 }
 
 .doc-timestamp {
@@ -61,6 +133,22 @@
   margin-right: 4px;
 }
 
+.doc-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+  gap: 12px;
+  font-size: 14px;
+  color: #8c8c8c;
+
+  i {
+    font-size: 32px;
+    color: #1890ff;
+  }
+}
+
 .doc-content {
   line-height: 1.6;
   overflow-y: auto;
@@ -89,4 +177,6 @@
 .doc-empty {
   color: #999;
   font-style: italic;
+  text-align: center;
+  padding: 40px 0;
 }

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -20,13 +20,45 @@
 .doc-panel {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
   padding: 4px 0;
+}
+
+.doc-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.doc-timestamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #8c8c8c;
+  font-size: 12px;
+  font-style: italic;
 }
 
 .doc-actions {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.doc-action-regenerate {
+  font-weight: 500;
+
+  i {
+    margin-right: 4px;
+  }
+}
+
+.doc-action-copy i {
+  margin-right: 4px;
 }
 
 .doc-content {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -164,6 +164,16 @@
   }
 }
 
+.doc-loading-elapsed {
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+  color: #595959;
+  background-color: #f5f5f5;
+  padding: 2px 10px;
+  border-radius: 10px;
+  letter-spacing: 0.5px;
+}
+
 .doc-content {
   line-height: 1.6;
   overflow-y: auto;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -241,6 +241,23 @@
   }
 }
 
+.doc-history-duplicate {
+  color: #bfbfbf;
+  padding: 0 4px;
+  height: 22px;
+  line-height: 22px;
+  transition: color 0.15s ease;
+
+  i {
+    font-size: 14px;
+  }
+
+  &:hover {
+    color: #1890ff;
+    background-color: transparent;
+  }
+}
+
 .doc-header {
   display: flex;
   align-items: center;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -98,15 +98,49 @@
   margin-top: 28px;
 }
 
+.doc-history-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 0 8px;
+}
+
 .doc-history-title {
   font-size: 13px;
   font-weight: 600;
   color: #595959;
   text-align: left;
-  margin: 0 0 8px;
+  margin: 0;
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.doc-history-compare-toggle {
+  i {
+    margin-right: 4px;
+  }
+}
+
+.doc-history-compare-toggle-active {
+  color: #cf1322;
+}
+
+.doc-history-compare-hint {
+  font-size: 12px;
+  color: #8c8c8c;
+  margin: 0 0 8px;
+  text-align: left;
+}
+
+.doc-history-compare-action {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+
+  i {
+    margin-right: 4px;
+  }
 }
 
 .doc-history-count {
@@ -144,6 +178,18 @@
   &:hover {
     background-color: rgba(24, 144, 255, 0.06);
   }
+}
+
+.doc-history-item-selected {
+  background-color: rgba(24, 144, 255, 0.12);
+
+  &:hover {
+    background-color: rgba(24, 144, 255, 0.18);
+  }
+}
+
+.doc-history-checkbox {
+  margin: 0;
 }
 
 .doc-history-icon {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -25,6 +25,14 @@
   min-height: 0;
 }
 
+.doc-view-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+  min-height: 0;
+}
+
 .doc-intro {
   display: flex;
   flex-direction: column;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -291,16 +291,12 @@
   letter-spacing: 0.5px;
 }
 
-.doc-written-badge {
-  font-size: 10px;
-  font-weight: 600;
+.doc-timestamp-written {
   color: #722ed1;
-  background-color: rgba(114, 46, 209, 0.12);
-  padding: 1px 6px;
-  border-radius: 8px;
-  margin-left: 4px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
+}
+
+.doc-timestamp-generated {
+  color: #1890ff;
 }
 
 .doc-editor {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -221,7 +221,7 @@
   font-size: 14px;
   color: #8c8c8c;
 
-  i {
+  > i {
     font-size: 32px;
     color: #1890ff;
   }
@@ -235,6 +235,14 @@
   padding: 2px 10px;
   border-radius: 10px;
   letter-spacing: 0.5px;
+}
+
+.doc-loading-cancel {
+  margin-top: 4px;
+
+  i {
+    margin-right: 4px;
+  }
 }
 
 .doc-content {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -21,7 +21,8 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  padding: 4px 0;
+  height: 100%;
+  min-height: 0;
 }
 
 .doc-intro {
@@ -166,7 +167,8 @@
 .doc-content {
   line-height: 1.6;
   overflow-y: auto;
-  max-height: 60vh;
+  flex: 1;
+  min-height: 0;
 
   h2 {
     font-size: 15px;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -270,8 +270,43 @@
   margin-left: auto;
 }
 
-.doc-action-copy i {
+.doc-action-copy i,
+.doc-action-edit i {
   margin-right: 4px;
+}
+
+.doc-edited-badge {
+  font-size: 10px;
+  font-weight: 600;
+  color: #fa8c16;
+  background-color: rgba(250, 140, 22, 0.12);
+  padding: 1px 6px;
+  border-radius: 8px;
+  margin-left: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.doc-editor {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  resize: none;
+  border: 1px solid #d9d9d9;
+  border-radius: 4px;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #262626;
+  background-color: #fafafa;
+
+  &:focus {
+    outline: none;
+    border-color: #1890ff;
+    box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.15);
+    background-color: #ffffff;
+  }
 }
 
 .doc-loading {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -206,6 +206,37 @@
   font-size: 13px;
   color: #262626;
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.doc-history-rename {
+  color: #bfbfbf;
+  padding: 0 4px;
+  height: 22px;
+  line-height: 22px;
+  transition: color 0.15s ease;
+
+  i {
+    font-size: 14px;
+  }
+
+  &:hover {
+    color: #1890ff;
+    background-color: transparent;
+  }
+}
+
+.doc-history-rename-input {
+  flex: 1;
+  font-size: 13px;
+  border: 1px solid #1890ff;
+  border-radius: 3px;
+  padding: 2px 6px;
+  outline: none;
+  min-width: 0;
 }
 
 .doc-history-latest {
@@ -264,6 +295,61 @@
   gap: 12px;
   padding-bottom: 12px;
   border-bottom: 1px solid #f0f0f0;
+}
+
+.doc-header-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  flex: 1;
+}
+
+.doc-title-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+
+.doc-title {
+  font-size: 14px;
+  font-weight: 600;
+  color: #262626;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.doc-title-rename {
+  color: #bfbfbf;
+  padding: 0 4px;
+  height: 22px;
+  line-height: 22px;
+  flex-shrink: 0;
+
+  i {
+    font-size: 13px;
+  }
+
+  &:hover {
+    color: #1890ff;
+    background-color: transparent;
+  }
+}
+
+.doc-title-rename-input {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;
+  color: #262626;
+  border: 1px solid #1890ff;
+  border-radius: 3px;
+  padding: 2px 6px;
+  outline: none;
+  background-color: #fff;
+  min-width: 0;
 }
 
 .doc-back-button {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -207,14 +207,6 @@
   margin-left: auto;
 }
 
-.doc-action-regenerate {
-  font-weight: 500;
-
-  i {
-    margin-right: 4px;
-  }
-}
-
 .doc-action-copy i {
   margin-right: 4px;
 }

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.scss
@@ -31,6 +31,9 @@
   align-items: center;
   text-align: center;
   padding: 16px 24px 8px;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
 }
 
 .doc-intro-icon {
@@ -96,6 +99,10 @@
   width: 100%;
   max-width: 520px;
   margin-top: 28px;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .doc-history-header {
@@ -157,9 +164,11 @@
   padding: 0;
   margin: 0;
   text-align: left;
-  border: 1px solid #f0f0f0;
+  border: 1px solid #bfbfbf;
   border-radius: 4px;
-  overflow: hidden;
+  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
 }
 
 .doc-history-item {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-import { Component, inject, OnDestroy, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, inject, OnDestroy, OnInit } from "@angular/core";
 import { DatePipe, NgIf } from "@angular/common";
-import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { NZ_DRAWER_DATA } from "ng-zorro-antd/drawer";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
@@ -47,7 +47,7 @@ type DocPanelView = "intro" | "doc";
   ],
 })
 export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
-  private modalData = inject(NZ_MODAL_DATA, { optional: true });
+  private modalData = inject(NZ_DRAWER_DATA, { optional: true });
 
   view: DocPanelView = "intro";
   renderedMarkdown = "";
@@ -60,7 +60,8 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   constructor(
     private markdownService: MarkdownService,
     private notificationService: NotificationService,
-    private workflowActionService: WorkflowActionService
+    private workflowActionService: WorkflowActionService,
+    private cdr: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
@@ -68,6 +69,10 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.generatedAt = this.modalData?.cachedGeneratedAt ?? null;
     if (this.rawMarkdown) {
       this.renderMarkdown(this.rawMarkdown);
+    }
+    const requestedView: DocPanelView | undefined = this.modalData?.initialView;
+    if (requestedView === "doc" && this.rawMarkdown) {
+      this.view = "doc";
     }
   }
 
@@ -81,33 +86,35 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
 
   viewLatest(): void {
     if (this.hasCached) {
-      this.view = "doc";
+      this.setView("doc");
     }
   }
 
   backToIntro(): void {
     if (this.isGenerating) return;
-    this.view = "intro";
+    this.setView("intro");
   }
 
   generate(): void {
     const onGenerate: (() => Observable<string>) | undefined = this.modalData?.onGenerate;
     if (!onGenerate || this.isGenerating) return;
     this.isGenerating = true;
-    this.view = "doc";
+    this.setView("doc");
     this.generateSub = onGenerate().subscribe({
       next: markdown => {
         this.rawMarkdown = markdown;
         this.generatedAt = new Date();
-        this.renderMarkdown(markdown);
         this.isGenerating = false;
+        this.renderMarkdown(markdown);
+        this.cdr.detectChanges();
       },
       error: (err: unknown) => {
         this.isGenerating = false;
         this.notificationService.error("Failed to generate documentation: " + (err as Error).message);
         if (!this.hasCached) {
-          this.view = "intro";
+          this.setView("intro");
         }
+        this.cdr.detectChanges();
       },
     });
   }
@@ -134,10 +141,18 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     });
   }
 
+  private setView(next: DocPanelView): void {
+    if (this.view === next) return;
+    this.view = next;
+    const onViewChange: ((view: DocPanelView) => void) | undefined = this.modalData?.onViewChange;
+    onViewChange?.(next);
+  }
+
   private renderMarkdown(md: string): void {
     if (md) {
       Promise.resolve(this.markdownService.parse(md)).then(html => {
         this.renderedMarkdown = html;
+        this.cdr.detectChanges();
       });
     } else {
       this.renderedMarkdown = "";

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -32,6 +32,7 @@ import { NzCheckboxComponent } from "ng-zorro-antd/checkbox";
 import { FormsModule } from "@angular/forms";
 import { MarkdownService } from "ngx-markdown";
 import { interval, Observable, Subscription } from "rxjs";
+import { saveAs } from "file-saver";
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { DocEditingState, DocEntry } from "../../service/workflow-doc/workflow-doc.service";
@@ -90,7 +91,6 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   generatedAt: Date | null = null;
   history: DocEntry[] = [];
   isGenerating = false;
-  copied = false;
   elapsedSeconds = 0;
   compareMode = false;
   selectedEntries = new Set<DocEntry>();
@@ -362,11 +362,17 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.workflowActionService.getTexeraGraph().triggerCenterOnOperatorEvent(operatorID);
   }
 
-  copyToClipboard(): void {
-    navigator.clipboard.writeText(this.rawMarkdown).then(() => {
-      this.copied = true;
-      setTimeout(() => (this.copied = false), 2000);
-    });
+  downloadMarkdown(): void {
+    if (!this.rawMarkdown) return;
+    const workflowName = this.workflowActionService.getWorkflow()?.name?.trim() || "Untitled Workflow";
+    const reportPart =
+      this.currentEntry?.title?.trim() ||
+      `workflow-doc-${new Date().toISOString().replace(/[:.]/g, "-")}`;
+    const safeName = `${workflowName} - ${reportPart}`
+      .replace(/[<>:"/\\|?*\x00-\x1f]/g, "_")
+      .slice(0, 160);
+    const blob = new Blob([this.rawMarkdown], { type: "text/markdown;charset=utf-8" });
+    saveAs(blob, `${safeName}.md`);
   }
 
   isViewingEntry(entry: DocEntry): boolean {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -454,9 +454,11 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     const onUpdateEntry: ((entry: DocEntry, newMarkdown: string) => Date | void) | undefined =
       this.modalData?.onUpdateEntry;
     const newTimestamp = onUpdateEntry?.(this.currentEntry, content) ?? new Date();
-    this.currentEntry.markdown = content;
-    this.currentEntry.generatedAt = newTimestamp;
-    this.currentEntry.edited = true;
+    const updated = this.currentEntry;
+    updated.markdown = content;
+    updated.generatedAt = newTimestamp;
+    updated.edited = true;
+    this.history = [updated, ...this.history.filter(e => e !== updated)];
     this.rawMarkdown = content;
     this.generatedAt = newTimestamp;
     this.renderMarkdown(content);

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -18,6 +18,7 @@
  */
 
 import { ChangeDetectorRef, Component, inject, OnDestroy, OnInit } from "@angular/core";
+import { animate, query, style, transition, trigger } from "@angular/animations";
 import { DatePipe, NgFor, NgIf } from "@angular/common";
 import { NZ_DRAWER_DATA } from "ng-zorro-antd/drawer";
 import { NzButtonComponent } from "ng-zorro-antd/button";
@@ -54,6 +55,30 @@ type DocPanelView = "intro" | "doc";
     NzCheckboxComponent,
     FormsModule,
     NzWaveDirective,
+  ],
+  animations: [
+    trigger("slideView", [
+      transition("intro => doc", [
+        query(
+          ":enter",
+          [
+            style({ opacity: 0, transform: "translateX(30px)" }),
+            animate("250ms ease-out", style({ opacity: 1, transform: "translateX(0)" })),
+          ],
+          { optional: true }
+        ),
+      ]),
+      transition("doc => intro", [
+        query(
+          ":enter",
+          [
+            style({ opacity: 0, transform: "translateX(-30px)" }),
+            animate("250ms ease-out", style({ opacity: 1, transform: "translateX(0)" })),
+          ],
+          { optional: true }
+        ),
+      ]),
+    ]),
   ],
 })
 export class WorkflowDocPanelComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject, OnInit } from "@angular/core";
+import { NgIf } from "@angular/common";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
+import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
+import { NzWaveDirective } from "ng-zorro-antd/core/wave";
+import { MarkdownService } from "ngx-markdown";
+
+@Component({
+  selector: "texera-workflow-doc-panel",
+  templateUrl: "./workflow-doc-panel.component.html",
+  styleUrls: ["./workflow-doc-panel.component.scss"],
+  imports: [
+    NgIf,
+    NzButtonComponent,
+    ɵNzTransitionPatchDirective,
+    NzIconDirective,
+    NzTooltipDirective,
+    NzWaveDirective,
+  ],
+})
+export class WorkflowDocPanelComponent implements OnInit {
+  private modalData = inject(NZ_MODAL_DATA, { optional: true });
+
+  renderedMarkdown = "";
+  copied = false;
+  rawMarkdown = "";
+
+  constructor(private markdownService: MarkdownService) {}
+
+  ngOnInit(): void {
+    this.rawMarkdown = this.modalData?.markdown ?? "";
+    if (this.rawMarkdown) {
+      Promise.resolve(this.markdownService.parse(this.rawMarkdown)).then(html => {
+        this.renderedMarkdown = html;
+      });
+    }
+  }
+
+  copyToClipboard(): void {
+    navigator.clipboard.writeText(this.rawMarkdown).then(() => {
+      this.copied = true;
+      setTimeout(() => (this.copied = false), 2000);
+    });
+  }
+}

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -61,6 +61,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   isGenerating = false;
   copied = false;
   elapsedSeconds = 0;
+  private elapsedStartedAtMs = 0;
   private generateSub?: Subscription;
   private elapsedTimerSub?: Subscription;
 
@@ -171,9 +172,10 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
 
   private startElapsedTimer(): void {
     this.elapsedTimerSub?.unsubscribe();
+    this.elapsedStartedAtMs = Date.now();
     this.elapsedSeconds = 0;
     this.elapsedTimerSub = interval(1000).subscribe(() => {
-      this.elapsedSeconds += 1;
+      this.elapsedSeconds = Math.floor((Date.now() - this.elapsedStartedAtMs) / 1000);
       this.cdr.detectChanges();
     });
   }
@@ -181,6 +183,9 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   private stopElapsedTimer(): void {
     this.elapsedTimerSub?.unsubscribe();
     this.elapsedTimerSub = undefined;
+    if (this.elapsedStartedAtMs) {
+      this.elapsedSeconds = Math.floor((Date.now() - this.elapsedStartedAtMs) / 1000);
+    }
   }
 
   onContentClick(event: MouseEvent): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -215,6 +215,16 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     });
   }
 
+  duplicateEntry(entry: DocEntry): void {
+    const onDuplicateEntry: ((entry: DocEntry) => DocEntry) | undefined =
+      this.modalData?.onDuplicateEntry;
+    if (!onDuplicateEntry) return;
+    const copy = onDuplicateEntry(entry);
+    this.history = [copy, ...this.history];
+    this.notificationService.success("Report duplicated.");
+    this.cdr.detectChanges();
+  }
+
   deleteEntry(entry: DocEntry): void {
     const wasViewing = this.isViewingEntry(entry);
     this.history = this.history.filter(e => e !== entry);

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -26,7 +26,7 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { MarkdownService } from "ngx-markdown";
-import { Observable, Subscription } from "rxjs";
+import { interval, Observable, Subscription } from "rxjs";
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 
@@ -55,7 +55,9 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   generatedAt: Date | null = null;
   isGenerating = false;
   copied = false;
+  elapsedSeconds = 0;
   private generateSub?: Subscription;
+  private elapsedTimerSub?: Subscription;
 
   constructor(
     private markdownService: MarkdownService,
@@ -78,6 +80,13 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.generateSub?.unsubscribe();
+    this.elapsedTimerSub?.unsubscribe();
+  }
+
+  get elapsedDisplay(): string {
+    const m = Math.floor(this.elapsedSeconds / 60);
+    const s = this.elapsedSeconds % 60;
+    return `${m}:${s.toString().padStart(2, "0")}`;
   }
 
   get hasCached(): boolean {
@@ -100,16 +109,19 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     if (!onGenerate || this.isGenerating) return;
     this.isGenerating = true;
     this.setView("doc");
+    this.startElapsedTimer();
     this.generateSub = onGenerate().subscribe({
       next: markdown => {
         this.rawMarkdown = markdown;
         this.generatedAt = new Date();
         this.isGenerating = false;
+        this.stopElapsedTimer();
         this.renderMarkdown(markdown);
         this.cdr.detectChanges();
       },
       error: (err: unknown) => {
         this.isGenerating = false;
+        this.stopElapsedTimer();
         this.notificationService.error("Failed to generate documentation: " + (err as Error).message);
         if (!this.hasCached) {
           this.setView("intro");
@@ -117,6 +129,20 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       },
     });
+  }
+
+  private startElapsedTimer(): void {
+    this.elapsedTimerSub?.unsubscribe();
+    this.elapsedSeconds = 0;
+    this.elapsedTimerSub = interval(1000).subscribe(() => {
+      this.elapsedSeconds += 1;
+      this.cdr.detectChanges();
+    });
+  }
+
+  private stopElapsedTimer(): void {
+    this.elapsedTimerSub?.unsubscribe();
+    this.elapsedTimerSub = undefined;
   }
 
   onContentClick(event: MouseEvent): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -23,6 +23,7 @@ import { NZ_DRAWER_DATA } from "ng-zorro-antd/drawer";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
+import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { MarkdownService } from "ngx-markdown";
@@ -45,6 +46,7 @@ type DocPanelView = "intro" | "doc";
     ɵNzTransitionPatchDirective,
     NzIconDirective,
     NzTooltipDirective,
+    NzPopconfirmDirective,
     NzWaveDirective,
   ],
 })
@@ -104,7 +106,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   }
 
   generate(): void {
-    const onGenerate: (() => Observable<string>) | undefined = this.modalData?.onGenerate;
+    const onGenerate: (() => Observable<DocEntry>) | undefined = this.modalData?.onGenerate;
     if (!onGenerate || this.isGenerating) return;
     this.isGenerating = true;
     this.rawMarkdown = "";
@@ -113,8 +115,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.setView("doc");
     this.startElapsedTimer();
     this.generateSub = onGenerate().subscribe({
-      next: markdown => {
-        const entry: DocEntry = { markdown, generatedAt: new Date() };
+      next: entry => {
         this.history = [entry, ...this.history];
         this.isGenerating = false;
         this.stopElapsedTimer();
@@ -133,6 +134,24 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       },
     });
+  }
+
+  deleteEntry(entry: DocEntry): void {
+    const wasViewing = this.isViewingEntry(entry);
+    this.history = this.history.filter(e => e !== entry);
+    const onDeleteEntry: ((entry: DocEntry) => void) | undefined = this.modalData?.onDeleteEntry;
+    onDeleteEntry?.(entry);
+    if (wasViewing) {
+      if (this.hasHistory) {
+        this.loadEntry(this.history[0]);
+      } else {
+        this.rawMarkdown = "";
+        this.renderedMarkdown = "";
+        this.generatedAt = null;
+        this.setView("intro");
+      }
+    }
+    this.cdr.detectChanges();
   }
 
   cancel(): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -88,18 +88,24 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.history = [...(this.modalData?.history ?? [])];
     const requestedView: DocPanelView | undefined = this.modalData?.initialView;
     const editingState: DocEditingState | undefined = this.modalData?.editingState;
-    if (editingState && editingState.entry === null) {
+    if (editingState && editingState.entryId === null) {
       this.currentEntry = null;
       this.rawMarkdown = "";
       this.generatedAt = null;
       this.editorContent = editingState.content;
       this.editMode = true;
       this.view = "doc";
-    } else if (editingState && editingState.entry && this.history.includes(editingState.entry)) {
-      this.loadEntry(editingState.entry);
-      this.view = "doc";
-      this.editorContent = editingState.content;
-      this.editMode = true;
+    } else if (editingState && editingState.entryId) {
+      const found = this.history.find(e => e.id === editingState.entryId);
+      if (found) {
+        this.loadEntry(found);
+        this.view = "doc";
+        this.editorContent = editingState.content;
+        this.editMode = true;
+      } else if (requestedView === "doc" && this.history.length > 0) {
+        this.loadEntry(this.history[0]);
+        this.view = "doc";
+      }
     } else if (requestedView === "doc" && this.history.length > 0) {
       this.loadEntry(this.history[0]);
       this.view = "doc";
@@ -286,7 +292,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   }
 
   isViewingEntry(entry: DocEntry): boolean {
-    return this.generatedAt === entry.generatedAt;
+    return this.currentEntry?.id === entry.id;
   }
 
   private loadEntry(entry: DocEntry): void {
@@ -361,7 +367,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
       this.modalData?.onEditingChange;
     if (!onEditingChange) return;
     if (this.editMode) {
-      onEditingChange({ entry: this.currentEntry, content: this.editorContent });
+      onEditingChange({ entryId: this.currentEntry?.id ?? null, content: this.editorContent });
     } else {
       onEditingChange(null);
     }
@@ -376,7 +382,8 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
         return;
       }
       const onCreateEntry: ((markdown: string) => DocEntry) | undefined = this.modalData?.onCreateEntry;
-      const created = onCreateEntry?.(content) ?? { markdown: content, generatedAt: new Date(), written: true };
+      if (!onCreateEntry) return;
+      const created = onCreateEntry(content);
       this.history = [created, ...this.history];
       this.loadEntry(created);
       this.editMode = false;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -135,6 +135,21 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     });
   }
 
+  cancel(): void {
+    if (!this.isGenerating) return;
+    this.generateSub?.unsubscribe();
+    this.generateSub = undefined;
+    this.stopElapsedTimer();
+    this.isGenerating = false;
+    this.notificationService.info("Documentation generation cancelled.");
+    if (this.hasHistory) {
+      this.loadEntry(this.history[0]);
+    } else {
+      this.setView("intro");
+    }
+    this.cdr.detectChanges();
+  }
+
   private startElapsedTimer(): void {
     this.elapsedTimerSub?.unsubscribe();
     this.elapsedSeconds = 0;

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -26,11 +26,15 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { NzCheckboxComponent } from "ng-zorro-antd/checkbox";
+import { FormsModule } from "@angular/forms";
 import { MarkdownService } from "ngx-markdown";
 import { interval, Observable, Subscription } from "rxjs";
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { DocEntry } from "../../service/workflow-doc/workflow-doc.service";
+import { WorkflowDocDiffComponent } from "../workflow-doc-diff/workflow-doc-diff.component";
 
 type DocPanelView = "intro" | "doc";
 
@@ -47,6 +51,8 @@ type DocPanelView = "intro" | "doc";
     NzIconDirective,
     NzTooltipDirective,
     NzPopconfirmDirective,
+    NzCheckboxComponent,
+    FormsModule,
     NzWaveDirective,
   ],
 })
@@ -61,6 +67,8 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   isGenerating = false;
   copied = false;
   elapsedSeconds = 0;
+  compareMode = false;
+  selectedEntries = new Set<DocEntry>();
   private elapsedStartedAtMs = 0;
   private generateSub?: Subscription;
   private elapsedTimerSub?: Subscription;
@@ -69,6 +77,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     private markdownService: MarkdownService,
     private notificationService: NotificationService,
     private workflowActionService: WorkflowActionService,
+    private modalService: NzModalService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -97,8 +106,49 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   }
 
   viewEntry(entry: DocEntry): void {
+    if (this.compareMode) {
+      this.toggleEntrySelection(entry);
+      return;
+    }
     this.loadEntry(entry);
     this.setView("doc");
+  }
+
+  toggleCompareMode(): void {
+    this.compareMode = !this.compareMode;
+    this.selectedEntries.clear();
+  }
+
+  toggleEntrySelection(entry: DocEntry): void {
+    if (this.selectedEntries.has(entry)) {
+      this.selectedEntries.delete(entry);
+    } else if (this.selectedEntries.size < 2) {
+      this.selectedEntries.add(entry);
+    }
+  }
+
+  isSelected(entry: DocEntry): boolean {
+    return this.selectedEntries.has(entry);
+  }
+
+  get canCompare(): boolean {
+    return this.selectedEntries.size === 2;
+  }
+
+  openDiff(): void {
+    if (!this.canCompare) return;
+    const picked = Array.from(this.selectedEntries).sort(
+      (a, b) => a.generatedAt.getTime() - b.generatedAt.getTime()
+    );
+    const [base, head] = picked;
+    this.modalService.create({
+      nzTitle: "Compare reports",
+      nzContent: WorkflowDocDiffComponent,
+      nzData: { base, head },
+      nzWidth: "min(1100px, 92vw)",
+      nzFooter: null,
+      nzCentered: true,
+    });
   }
 
   backToIntro(): void {
@@ -140,6 +190,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   deleteEntry(entry: DocEntry): void {
     const wasViewing = this.isViewingEntry(entry);
     this.history = this.history.filter(e => e !== entry);
+    this.selectedEntries.delete(entry);
     const onDeleteEntry: ((entry: DocEntry) => void) | undefined = this.modalData?.onDeleteEntry;
     onDeleteEntry?.(entry);
     if (wasViewing) {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -33,7 +33,7 @@ import { MarkdownService } from "ngx-markdown";
 import { interval, Observable, Subscription } from "rxjs";
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
-import { DocEntry } from "../../service/workflow-doc/workflow-doc.service";
+import { DocEditingState, DocEntry } from "../../service/workflow-doc/workflow-doc.service";
 import { WorkflowDocDiffComponent } from "../workflow-doc-diff/workflow-doc-diff.component";
 
 type DocPanelView = "intro" | "doc";
@@ -69,6 +69,9 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   elapsedSeconds = 0;
   compareMode = false;
   selectedEntries = new Set<DocEntry>();
+  editMode = false;
+  editorContent = "";
+  currentEntry: DocEntry | null = null;
   private elapsedStartedAtMs = 0;
   private generateSub?: Subscription;
   private elapsedTimerSub?: Subscription;
@@ -84,7 +87,14 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.history = [...(this.modalData?.history ?? [])];
     const requestedView: DocPanelView | undefined = this.modalData?.initialView;
-    if (requestedView === "doc" && this.history.length > 0) {
+    const editingState: DocEditingState | undefined = this.modalData?.editingState;
+    const editingEntry = editingState ? this.history.find(e => e === editingState.entry) : undefined;
+    if (editingEntry && editingState) {
+      this.loadEntry(editingEntry);
+      this.view = "doc";
+      this.editorContent = editingState.content;
+      this.editMode = true;
+    } else if (requestedView === "doc" && this.history.length > 0) {
       this.loadEntry(this.history[0]);
       this.view = "doc";
     }
@@ -110,8 +120,11 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
       this.toggleEntrySelection(entry);
       return;
     }
-    this.loadEntry(entry);
-    this.setView("doc");
+    this.confirmDiscardOrProceed(() => {
+      this.cancelEdit();
+      this.loadEntry(entry);
+      this.setView("doc");
+    });
   }
 
   toggleCompareMode(): void {
@@ -153,7 +166,10 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
 
   backToIntro(): void {
     if (this.isGenerating) return;
-    this.setView("intro");
+    this.confirmDiscardOrProceed(() => {
+      this.cancelEdit();
+      this.setView("intro");
+    });
   }
 
   generate(): void {
@@ -194,9 +210,11 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     const onDeleteEntry: ((entry: DocEntry) => void) | undefined = this.modalData?.onDeleteEntry;
     onDeleteEntry?.(entry);
     if (wasViewing) {
+      this.cancelEdit();
       if (this.hasHistory) {
         this.loadEntry(this.history[0]);
       } else {
+        this.currentEntry = null;
         this.rawMarkdown = "";
         this.renderedMarkdown = "";
         this.generatedAt = null;
@@ -266,9 +284,85 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   }
 
   private loadEntry(entry: DocEntry): void {
+    this.currentEntry = entry;
     this.rawMarkdown = entry.markdown;
     this.generatedAt = entry.generatedAt;
     this.renderMarkdown(entry.markdown);
+  }
+
+  get hasUnsavedChanges(): boolean {
+    return this.editMode && this.editorContent !== this.rawMarkdown;
+  }
+
+  private confirmDiscardOrProceed(action: () => void): void {
+    if (!this.hasUnsavedChanges) {
+      action();
+      return;
+    }
+    this.modalService.confirm({
+      nzTitle: "Discard unsaved changes?",
+      nzContent: "Your edits to this report will be lost.",
+      nzOkText: "Discard",
+      nzOkDanger: true,
+      nzCancelText: "Keep editing",
+      nzOnOk: () => {
+        action();
+        this.cdr.detectChanges();
+      },
+    });
+  }
+
+  enterEditMode(): void {
+    if (!this.currentEntry || this.isGenerating) return;
+    this.editorContent = this.rawMarkdown;
+    this.editMode = true;
+    this.persistEditingState();
+  }
+
+  cancelEdit(): void {
+    if (!this.editMode) return;
+    this.editMode = false;
+    this.editorContent = "";
+    this.persistEditingState();
+  }
+
+  onEditorContentChange(content: string): void {
+    this.editorContent = content;
+    this.persistEditingState();
+  }
+
+  private persistEditingState(): void {
+    const onEditingChange: ((state: DocEditingState | null) => void) | undefined =
+      this.modalData?.onEditingChange;
+    if (!onEditingChange) return;
+    if (this.editMode && this.currentEntry) {
+      onEditingChange({ entry: this.currentEntry, content: this.editorContent });
+    } else {
+      onEditingChange(null);
+    }
+  }
+
+  saveEdit(): void {
+    if (!this.editMode || !this.currentEntry) return;
+    const trimmed = this.editorContent;
+    if (trimmed === this.rawMarkdown) {
+      this.editMode = false;
+      return;
+    }
+    const onUpdateEntry: ((entry: DocEntry, newMarkdown: string) => Date | void) | undefined =
+      this.modalData?.onUpdateEntry;
+    const newTimestamp = onUpdateEntry?.(this.currentEntry, trimmed) ?? new Date();
+    this.currentEntry.markdown = trimmed;
+    this.currentEntry.generatedAt = newTimestamp;
+    this.currentEntry.edited = true;
+    this.rawMarkdown = trimmed;
+    this.generatedAt = newTimestamp;
+    this.renderMarkdown(trimmed);
+    this.editMode = false;
+    this.editorContent = "";
+    this.persistEditingState();
+    this.notificationService.success("Documentation updated.");
+    this.cdr.detectChanges();
   }
 
   private setView(next: DocPanelView): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -18,7 +18,7 @@
  */
 
 import { ChangeDetectorRef, Component, inject, OnDestroy, OnInit } from "@angular/core";
-import { DatePipe, NgIf } from "@angular/common";
+import { DatePipe, NgFor, NgIf } from "@angular/common";
 import { NZ_DRAWER_DATA } from "ng-zorro-antd/drawer";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzIconDirective } from "ng-zorro-antd/icon";
@@ -29,6 +29,7 @@ import { MarkdownService } from "ngx-markdown";
 import { interval, Observable, Subscription } from "rxjs";
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { DocEntry } from "../../service/workflow-doc/workflow-doc.service";
 
 type DocPanelView = "intro" | "doc";
 
@@ -38,6 +39,7 @@ type DocPanelView = "intro" | "doc";
   styleUrls: ["./workflow-doc-panel.component.scss"],
   imports: [
     NgIf,
+    NgFor,
     DatePipe,
     NzButtonComponent,
     ɵNzTransitionPatchDirective,
@@ -53,6 +55,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   renderedMarkdown = "";
   rawMarkdown = "";
   generatedAt: Date | null = null;
+  history: DocEntry[] = [];
   isGenerating = false;
   copied = false;
   elapsedSeconds = 0;
@@ -67,13 +70,10 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
-    this.rawMarkdown = this.modalData?.cachedMarkdown ?? "";
-    this.generatedAt = this.modalData?.cachedGeneratedAt ?? null;
-    if (this.rawMarkdown) {
-      this.renderMarkdown(this.rawMarkdown);
-    }
+    this.history = [...(this.modalData?.history ?? [])];
     const requestedView: DocPanelView | undefined = this.modalData?.initialView;
-    if (requestedView === "doc" && this.rawMarkdown) {
+    if (requestedView === "doc" && this.history.length > 0) {
+      this.loadEntry(this.history[0]);
       this.view = "doc";
     }
   }
@@ -89,14 +89,13 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     return `${m}:${s.toString().padStart(2, "0")}`;
   }
 
-  get hasCached(): boolean {
-    return this.rawMarkdown.length > 0;
+  get hasHistory(): boolean {
+    return this.history.length > 0;
   }
 
-  viewLatest(): void {
-    if (this.hasCached) {
-      this.setView("doc");
-    }
+  viewEntry(entry: DocEntry): void {
+    this.loadEntry(entry);
+    this.setView("doc");
   }
 
   backToIntro(): void {
@@ -108,23 +107,28 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     const onGenerate: (() => Observable<string>) | undefined = this.modalData?.onGenerate;
     if (!onGenerate || this.isGenerating) return;
     this.isGenerating = true;
+    this.rawMarkdown = "";
+    this.renderedMarkdown = "";
+    this.generatedAt = null;
     this.setView("doc");
     this.startElapsedTimer();
     this.generateSub = onGenerate().subscribe({
       next: markdown => {
-        this.rawMarkdown = markdown;
-        this.generatedAt = new Date();
+        const entry: DocEntry = { markdown, generatedAt: new Date() };
+        this.history = [entry, ...this.history];
         this.isGenerating = false;
         this.stopElapsedTimer();
-        this.renderMarkdown(markdown);
+        this.loadEntry(entry);
         this.cdr.detectChanges();
       },
       error: (err: unknown) => {
         this.isGenerating = false;
         this.stopElapsedTimer();
         this.notificationService.error("Failed to generate documentation: " + (err as Error).message);
-        if (!this.hasCached) {
+        if (!this.hasHistory) {
           this.setView("intro");
+        } else {
+          this.loadEntry(this.history[0]);
         }
         this.cdr.detectChanges();
       },
@@ -165,6 +169,16 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
       this.copied = true;
       setTimeout(() => (this.copied = false), 2000);
     });
+  }
+
+  isViewingEntry(entry: DocEntry): boolean {
+    return this.generatedAt === entry.generatedAt;
+  }
+
+  private loadEntry(entry: DocEntry): void {
+    this.rawMarkdown = entry.markdown;
+    this.generatedAt = entry.generatedAt;
+    this.renderMarkdown(entry.markdown);
   }
 
   private setView(next: DocPanelView): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -88,9 +88,15 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.history = [...(this.modalData?.history ?? [])];
     const requestedView: DocPanelView | undefined = this.modalData?.initialView;
     const editingState: DocEditingState | undefined = this.modalData?.editingState;
-    const editingEntry = editingState ? this.history.find(e => e === editingState.entry) : undefined;
-    if (editingEntry && editingState) {
-      this.loadEntry(editingEntry);
+    if (editingState && editingState.entry === null) {
+      this.currentEntry = null;
+      this.rawMarkdown = "";
+      this.generatedAt = null;
+      this.editorContent = editingState.content;
+      this.editMode = true;
+      this.view = "doc";
+    } else if (editingState && editingState.entry && this.history.includes(editingState.entry)) {
+      this.loadEntry(editingState.entry);
       this.view = "doc";
       this.editorContent = editingState.content;
       this.editMode = true;
@@ -319,11 +325,30 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.persistEditingState();
   }
 
+  startBlank(): void {
+    if (this.isGenerating) return;
+    this.currentEntry = null;
+    this.rawMarkdown = "";
+    this.renderedMarkdown = "";
+    this.generatedAt = null;
+    this.editorContent = "";
+    this.editMode = true;
+    this.setView("doc");
+    this.persistEditingState();
+  }
+
   cancelEdit(): void {
     if (!this.editMode) return;
+    const wasDrafting = this.currentEntry === null;
     this.editMode = false;
     this.editorContent = "";
     this.persistEditingState();
+    if (wasDrafting) {
+      this.rawMarkdown = "";
+      this.renderedMarkdown = "";
+      this.generatedAt = null;
+      this.setView("intro");
+    }
   }
 
   onEditorContentChange(content: string): void {
@@ -335,7 +360,7 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     const onEditingChange: ((state: DocEditingState | null) => void) | undefined =
       this.modalData?.onEditingChange;
     if (!onEditingChange) return;
-    if (this.editMode && this.currentEntry) {
+    if (this.editMode) {
       onEditingChange({ entry: this.currentEntry, content: this.editorContent });
     } else {
       onEditingChange(null);
@@ -343,21 +368,38 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   }
 
   saveEdit(): void {
-    if (!this.editMode || !this.currentEntry) return;
-    const trimmed = this.editorContent;
-    if (trimmed === this.rawMarkdown) {
+    if (!this.editMode) return;
+    const content = this.editorContent;
+    if (this.currentEntry === null) {
+      if (!content.trim()) {
+        this.notificationService.error("Write some content before saving.");
+        return;
+      }
+      const onCreateEntry: ((markdown: string) => DocEntry) | undefined = this.modalData?.onCreateEntry;
+      const created = onCreateEntry?.(content) ?? { markdown: content, generatedAt: new Date(), written: true };
+      this.history = [created, ...this.history];
+      this.loadEntry(created);
       this.editMode = false;
+      this.editorContent = "";
+      this.persistEditingState();
+      this.notificationService.success("Documentation saved.");
+      this.cdr.detectChanges();
+      return;
+    }
+    if (content === this.rawMarkdown) {
+      this.editMode = false;
+      this.persistEditingState();
       return;
     }
     const onUpdateEntry: ((entry: DocEntry, newMarkdown: string) => Date | void) | undefined =
       this.modalData?.onUpdateEntry;
-    const newTimestamp = onUpdateEntry?.(this.currentEntry, trimmed) ?? new Date();
-    this.currentEntry.markdown = trimmed;
+    const newTimestamp = onUpdateEntry?.(this.currentEntry, content) ?? new Date();
+    this.currentEntry.markdown = content;
     this.currentEntry.generatedAt = newTimestamp;
     this.currentEntry.edited = true;
-    this.rawMarkdown = trimmed;
+    this.rawMarkdown = content;
     this.generatedAt = newTimestamp;
-    this.renderMarkdown(trimmed);
+    this.renderMarkdown(content);
     this.editMode = false;
     this.editorContent = "";
     this.persistEditingState();

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -72,6 +72,8 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   editMode = false;
   editorContent = "";
   currentEntry: DocEntry | null = null;
+  renamingEntryId: string | null = null;
+  renameDraft = "";
   private elapsedStartedAtMs = 0;
   private generateSub?: Subscription;
   private elapsedTimerSub?: Subscription;
@@ -213,6 +215,47 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       },
     });
+  }
+
+  startRename(entry: DocEntry): void {
+    this.commitRename();
+    this.renamingEntryId = entry.id;
+    this.renameDraft = entry.title ?? "";
+  }
+
+  commitRename(): void {
+    if (!this.renamingEntryId) return;
+    const target = this.history.find(e => e.id === this.renamingEntryId);
+    if (!target) {
+      this.cancelRename();
+      return;
+    }
+    const trimmed = this.renameDraft.trim();
+    const onRenameEntry: ((entry: DocEntry, title: string) => void) | undefined =
+      this.modalData?.onRenameEntry;
+    if (onRenameEntry) {
+      onRenameEntry(target, trimmed);
+    } else if (trimmed) {
+      target.title = trimmed;
+    } else {
+      delete target.title;
+    }
+    this.renamingEntryId = null;
+    this.renameDraft = "";
+    this.cdr.detectChanges();
+  }
+
+  cancelRename(): void {
+    this.renamingEntryId = null;
+    this.renameDraft = "";
+  }
+
+  isRenaming(entry: DocEntry): boolean {
+    return this.renamingEntryId === entry.id;
+  }
+
+  displayTitle(entry: DocEntry): string {
+    return entry.title ?? "";
   }
 
   duplicateEntry(entry: DocEntry): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -27,6 +27,9 @@ import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patc
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { MarkdownService } from "ngx-markdown";
 import { Observable, Subscription } from "rxjs";
+import { NotificationService } from "../../../common/service/notification/notification.service";
+
+type DocPanelView = "intro" | "doc";
 
 @Component({
   selector: "texera-workflow-doc-panel",
@@ -45,23 +48,73 @@ import { Observable, Subscription } from "rxjs";
 export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   private modalData = inject(NZ_MODAL_DATA, { optional: true });
 
+  view: DocPanelView = "intro";
   renderedMarkdown = "";
-  copied = false;
   rawMarkdown = "";
   generatedAt: Date | null = null;
-  isRegenerating = false;
-  private regenerateSub?: Subscription;
+  isGenerating = false;
+  copied = false;
+  private generateSub?: Subscription;
 
-  constructor(private markdownService: MarkdownService) {}
+  constructor(
+    private markdownService: MarkdownService,
+    private notificationService: NotificationService
+  ) {}
 
   ngOnInit(): void {
-    this.rawMarkdown = this.modalData?.markdown ?? "";
-    this.generatedAt = this.modalData?.generatedAt ?? null;
-    this.renderMarkdown(this.rawMarkdown);
+    this.rawMarkdown = this.modalData?.cachedMarkdown ?? "";
+    this.generatedAt = this.modalData?.cachedGeneratedAt ?? null;
+    if (this.rawMarkdown) {
+      this.renderMarkdown(this.rawMarkdown);
+    }
   }
 
   ngOnDestroy(): void {
-    this.regenerateSub?.unsubscribe();
+    this.generateSub?.unsubscribe();
+  }
+
+  get hasCached(): boolean {
+    return this.rawMarkdown.length > 0;
+  }
+
+  viewLatest(): void {
+    if (this.hasCached) {
+      this.view = "doc";
+    }
+  }
+
+  backToIntro(): void {
+    if (this.isGenerating) return;
+    this.view = "intro";
+  }
+
+  generate(): void {
+    const onGenerate: (() => Observable<string>) | undefined = this.modalData?.onGenerate;
+    if (!onGenerate || this.isGenerating) return;
+    this.isGenerating = true;
+    this.view = "doc";
+    this.generateSub = onGenerate().subscribe({
+      next: markdown => {
+        this.rawMarkdown = markdown;
+        this.generatedAt = new Date();
+        this.renderMarkdown(markdown);
+        this.isGenerating = false;
+      },
+      error: (err: unknown) => {
+        this.isGenerating = false;
+        this.notificationService.error("Failed to generate documentation: " + (err as Error).message);
+        if (!this.hasCached) {
+          this.view = "intro";
+        }
+      },
+    });
+  }
+
+  copyToClipboard(): void {
+    navigator.clipboard.writeText(this.rawMarkdown).then(() => {
+      this.copied = true;
+      setTimeout(() => (this.copied = false), 2000);
+    });
   }
 
   private renderMarkdown(md: string): void {
@@ -72,29 +125,5 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     } else {
       this.renderedMarkdown = "";
     }
-  }
-
-  regenerate(): void {
-    const onRegenerate: (() => Observable<string>) | undefined = this.modalData?.onRegenerate;
-    if (!onRegenerate || this.isRegenerating) return;
-    this.isRegenerating = true;
-    this.regenerateSub = onRegenerate().subscribe({
-      next: markdown => {
-        this.rawMarkdown = markdown;
-        this.generatedAt = new Date();
-        this.renderMarkdown(markdown);
-        this.isRegenerating = false;
-      },
-      error: () => {
-        this.isRegenerating = false;
-      },
-    });
-  }
-
-  copyToClipboard(): void {
-    navigator.clipboard.writeText(this.rawMarkdown).then(() => {
-      this.copied = true;
-      setTimeout(() => (this.copied = false), 2000);
-    });
   }
 }

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-import { Component, inject, OnInit } from "@angular/core";
-import { NgIf } from "@angular/common";
+import { Component, inject, OnDestroy, OnInit } from "@angular/core";
+import { DatePipe, NgIf } from "@angular/common";
 import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzIconDirective } from "ng-zorro-antd/icon";
@@ -26,6 +26,7 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { MarkdownService } from "ngx-markdown";
+import { Observable, Subscription } from "rxjs";
 
 @Component({
   selector: "texera-workflow-doc-panel",
@@ -33,6 +34,7 @@ import { MarkdownService } from "ngx-markdown";
   styleUrls: ["./workflow-doc-panel.component.scss"],
   imports: [
     NgIf,
+    DatePipe,
     NzButtonComponent,
     ɵNzTransitionPatchDirective,
     NzIconDirective,
@@ -40,22 +42,53 @@ import { MarkdownService } from "ngx-markdown";
     NzWaveDirective,
   ],
 })
-export class WorkflowDocPanelComponent implements OnInit {
+export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
   private modalData = inject(NZ_MODAL_DATA, { optional: true });
 
   renderedMarkdown = "";
   copied = false;
   rawMarkdown = "";
+  generatedAt: Date | null = null;
+  isRegenerating = false;
+  private regenerateSub?: Subscription;
 
   constructor(private markdownService: MarkdownService) {}
 
   ngOnInit(): void {
     this.rawMarkdown = this.modalData?.markdown ?? "";
-    if (this.rawMarkdown) {
-      Promise.resolve(this.markdownService.parse(this.rawMarkdown)).then(html => {
+    this.generatedAt = this.modalData?.generatedAt ?? null;
+    this.renderMarkdown(this.rawMarkdown);
+  }
+
+  ngOnDestroy(): void {
+    this.regenerateSub?.unsubscribe();
+  }
+
+  private renderMarkdown(md: string): void {
+    if (md) {
+      Promise.resolve(this.markdownService.parse(md)).then(html => {
         this.renderedMarkdown = html;
       });
+    } else {
+      this.renderedMarkdown = "";
     }
+  }
+
+  regenerate(): void {
+    const onRegenerate: (() => Observable<string>) | undefined = this.modalData?.onRegenerate;
+    if (!onRegenerate || this.isRegenerating) return;
+    this.isRegenerating = true;
+    this.regenerateSub = onRegenerate().subscribe({
+      next: markdown => {
+        this.rawMarkdown = markdown;
+        this.generatedAt = new Date();
+        this.renderMarkdown(markdown);
+        this.isRegenerating = false;
+      },
+      error: () => {
+        this.isRegenerating = false;
+      },
+    });
   }
 
   copyToClipboard(): void {

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -243,11 +243,11 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
     this.stopElapsedTimer();
     this.isGenerating = false;
     this.notificationService.info("Documentation generation cancelled.");
-    if (this.hasHistory) {
-      this.loadEntry(this.history[0]);
-    } else {
-      this.setView("intro");
-    }
+    this.currentEntry = null;
+    this.rawMarkdown = "";
+    this.renderedMarkdown = "";
+    this.generatedAt = null;
+    this.setView("intro");
     this.cdr.detectChanges();
   }
 

--- a/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
+++ b/frontend/src/app/workspace/component/workflow-doc-panel/workflow-doc-panel.component.ts
@@ -28,6 +28,7 @@ import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { MarkdownService } from "ngx-markdown";
 import { Observable, Subscription } from "rxjs";
 import { NotificationService } from "../../../common/service/notification/notification.service";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 
 type DocPanelView = "intro" | "doc";
 
@@ -58,7 +59,8 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
 
   constructor(
     private markdownService: MarkdownService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private workflowActionService: WorkflowActionService
   ) {}
 
   ngOnInit(): void {
@@ -108,6 +110,21 @@ export class WorkflowDocPanelComponent implements OnInit, OnDestroy {
         }
       },
     });
+  }
+
+  onContentClick(event: MouseEvent): void {
+    const anchor = (event.target as HTMLElement | null)?.closest("a") as HTMLAnchorElement | null;
+    if (!anchor) return;
+    const href = anchor.getAttribute("href") ?? "";
+    const opRefPrefix = "texera:op:";
+    if (!href.startsWith(opRefPrefix)) return;
+    event.preventDefault();
+    const operatorID = href.slice(opRefPrefix.length);
+    if (!this.workflowActionService.getTexeraGraph().hasOperator(operatorID)) {
+      this.notificationService.error(`Operator "${operatorID}" is not on the canvas (it may have been deleted or renamed since this report was generated)`);
+      return;
+    }
+    this.workflowActionService.getTexeraGraph().triggerCenterOnOperatorEvent(operatorID);
   }
 
   copyToClipboard(): void {

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -204,6 +204,7 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     this.handleURLFragment();
     this.invokeResize();
     this.handleCenterEvent();
+    this.handleCenterOnOperatorEvent();
     this.handleOperatorChatButton();
   }
 
@@ -1443,6 +1444,31 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
         };
 
         this.paper.translate(-targetCoord.x, -targetCoord.y);
+      });
+  }
+
+  /**
+   * Centers the canvas on a single operator and highlights it.
+   * Triggered when the user clicks an operator reference in the AI-generated workflow doc.
+   */
+  private handleCenterOnOperatorEvent(): void {
+    this.workflowActionService
+      .getTexeraGraph()
+      .getCenterOnOperatorEventStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(operatorID => {
+        if (!this.workflowActionService.getTexeraGraph().hasOperator(operatorID)) return;
+        const view = this.paper.findViewByModel(operatorID);
+        if (!view) return;
+        const bbox = view.model.getBBox();
+        const scale = this.paper.scale().sx || 1;
+        const viewportWidth = this.editor.offsetWidth;
+        const viewportHeight = this.editor.offsetHeight;
+        const opCenterX = (bbox.x + bbox.width / 2) * scale;
+        const opCenterY = (bbox.y + bbox.height / 2) * scale;
+        this.paper.translate(viewportWidth / 2 - opCenterX, viewportHeight / 2 - opCenterY);
+        this.wrapper.unhighlightElements(this.wrapper.getCurrentHighlights());
+        this.wrapper.highlightOperators(operatorID);
       });
   }
 

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -29,6 +29,7 @@ export interface DocEntry {
   generatedAt: Date;
   edited?: boolean;
   written?: boolean;
+  title?: string;
 }
 
 export type DocPanelView = "intro" | "doc";
@@ -107,6 +108,20 @@ export class WorkflowDocService {
     return entry;
   }
 
+  renameEntry(wid: number | undefined, entry: DocEntry, newTitle: string): void {
+    const list = this.history.get(wid) ?? [];
+    const target = list.find(e => e === entry);
+    if (target) {
+      const trimmed = newTitle.trim();
+      if (trimmed) {
+        target.title = trimmed;
+      } else {
+        delete target.title;
+      }
+      this.writeAll();
+    }
+  }
+
   duplicateEntry(wid: number | undefined, source: DocEntry): DocEntry {
     const entry: DocEntry = {
       id: this.generateId(),
@@ -114,6 +129,7 @@ export class WorkflowDocService {
       generatedAt: new Date(),
       edited: source.edited,
       written: source.written,
+      title: source.title ? `${source.title} (copy)` : undefined,
     };
     const list = [entry, ...(this.history.get(wid) ?? [])];
     this.history.set(wid, list);

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -107,6 +107,20 @@ export class WorkflowDocService {
     return entry;
   }
 
+  duplicateEntry(wid: number | undefined, source: DocEntry): DocEntry {
+    const entry: DocEntry = {
+      id: this.generateId(),
+      markdown: source.markdown,
+      generatedAt: new Date(),
+      edited: source.edited,
+      written: source.written,
+    };
+    const list = [entry, ...(this.history.get(wid) ?? [])];
+    this.history.set(wid, list);
+    this.writeAll();
+    return entry;
+  }
+
   updateHistoryEntry(wid: number | undefined, entry: DocEntry, newMarkdown: string): Date {
     const list = this.history.get(wid) ?? [];
     const target = list.find(e => e === entry);

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -28,12 +28,15 @@ export interface DocEntry {
   generatedAt: Date;
 }
 
+export type DocPanelView = "intro" | "doc";
+
 @Injectable({
   providedIn: "root",
 })
 export class WorkflowDocService {
   private readonly AGENT_API_BASE = "/api";
   private cache = new Map<number | undefined, DocEntry>();
+  private lastViews = new Map<number | undefined, DocPanelView>();
 
   constructor(
     private http: HttpClient,
@@ -43,6 +46,14 @@ export class WorkflowDocService {
 
   getCached(wid: number | undefined): DocEntry | null {
     return this.cache.get(wid) ?? null;
+  }
+
+  getLastView(wid: number | undefined): DocPanelView | null {
+    return this.lastViews.get(wid) ?? null;
+  }
+
+  setLastView(wid: number | undefined, view: DocPanelView): void {
+    this.lastViews.set(wid, view);
   }
 
   generateDocumentation(): Observable<string> {

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -27,12 +27,13 @@ export interface DocEntry {
   markdown: string;
   generatedAt: Date;
   edited?: boolean;
+  written?: boolean;
 }
 
 export type DocPanelView = "intro" | "doc";
 
 export interface DocEditingState {
-  entry: DocEntry;
+  entry: DocEntry | null;
   content: string;
 }
 
@@ -82,6 +83,13 @@ export class WorkflowDocService {
     if (editing && editing.entry === entry) {
       this.editingStates.delete(wid);
     }
+  }
+
+  createBlankEntry(wid: number | undefined, markdown: string): DocEntry {
+    const entry: DocEntry = { markdown, generatedAt: new Date(), written: true };
+    const list = [entry, ...(this.history.get(wid) ?? [])];
+    this.history.set(wid, list);
+    return entry;
   }
 
   updateHistoryEntry(wid: number | undefined, entry: DocEntry, newMarkdown: string): Date {

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -23,11 +23,17 @@ import { Observable, switchMap, map, finalize, throwError } from "rxjs";
 import { AgentService } from "../agent/agent.service";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 
+export interface DocEntry {
+  markdown: string;
+  generatedAt: Date;
+}
+
 @Injectable({
   providedIn: "root",
 })
 export class WorkflowDocService {
   private readonly AGENT_API_BASE = "/api";
+  private cache = new Map<number | undefined, DocEntry>();
 
   constructor(
     private http: HttpClient,
@@ -35,7 +41,12 @@ export class WorkflowDocService {
     private workflowActionService: WorkflowActionService
   ) {}
 
+  getCached(wid: number | undefined): DocEntry | null {
+    return this.cache.get(wid) ?? null;
+  }
+
   generateDocumentation(): Observable<string> {
+    const wid = this.workflowActionService.getWorkflow()?.wid;
     const workflowContent = this.workflowActionService.getWorkflowContent();
     let tempAgentId: string | null = null;
 
@@ -53,7 +64,10 @@ export class WorkflowDocService {
             workflowContent,
           })
           .pipe(
-            map(response => response.markdown),
+            map(response => {
+              this.cache.set(wid, { markdown: response.markdown, generatedAt: new Date() });
+              return response.markdown;
+            }),
             finalize(() => {
               if (tempAgentId) {
                 this.agentService.deleteAgent(tempAgentId).subscribe();

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -56,7 +56,12 @@ export class WorkflowDocService {
     this.lastViews.set(wid, view);
   }
 
-  generateDocumentation(): Observable<string> {
+  deleteHistoryEntry(wid: number | undefined, entry: DocEntry): void {
+    const list = this.history.get(wid) ?? [];
+    this.history.set(wid, list.filter(e => e !== entry));
+  }
+
+  generateDocumentation(): Observable<DocEntry> {
     const wid = this.workflowActionService.getWorkflow()?.wid;
     const workflowContent = this.workflowActionService.getWorkflowContent();
     let tempAgentId: string | null = null;
@@ -80,7 +85,7 @@ export class WorkflowDocService {
               const list = [...(this.history.get(wid) ?? [])];
               list.unshift(entry);
               this.history.set(wid, list);
-              return response.markdown;
+              return entry;
             }),
             finalize(() => {
               if (tempAgentId) {

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -24,6 +24,7 @@ import { AgentService } from "../agent/agent.service";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 
 export interface DocEntry {
+  id: string;
   markdown: string;
   generatedAt: Date;
   edited?: boolean;
@@ -33,9 +34,17 @@ export interface DocEntry {
 export type DocPanelView = "intro" | "doc";
 
 export interface DocEditingState {
-  entry: DocEntry | null;
+  entryId: string | null;
   content: string;
 }
+
+interface PersistedShape {
+  history: Record<string, DocEntry[]>;
+  lastView: Record<string, DocPanelView>;
+  editing: Record<string, DocEditingState>;
+}
+
+const STORAGE_KEY = "texera.workflowDoc.v1";
 
 @Injectable({
   providedIn: "root",
@@ -50,7 +59,9 @@ export class WorkflowDocService {
     private http: HttpClient,
     private agentService: AgentService,
     private workflowActionService: WorkflowActionService
-  ) {}
+  ) {
+    this.loadFromStorage();
+  }
 
   getHistory(wid: number | undefined): readonly DocEntry[] {
     return this.history.get(wid) ?? [];
@@ -62,6 +73,7 @@ export class WorkflowDocService {
 
   setLastView(wid: number | undefined, view: DocPanelView): void {
     this.lastViews.set(wid, view);
+    this.writeAll();
   }
 
   getEditingState(wid: number | undefined): DocEditingState | null {
@@ -74,21 +86,24 @@ export class WorkflowDocService {
     } else {
       this.editingStates.delete(wid);
     }
+    this.writeAll();
   }
 
   deleteHistoryEntry(wid: number | undefined, entry: DocEntry): void {
     const list = this.history.get(wid) ?? [];
     this.history.set(wid, list.filter(e => e !== entry));
     const editing = this.editingStates.get(wid);
-    if (editing && editing.entry === entry) {
+    if (editing && editing.entryId === entry.id) {
       this.editingStates.delete(wid);
     }
+    this.writeAll();
   }
 
   createBlankEntry(wid: number | undefined, markdown: string): DocEntry {
-    const entry: DocEntry = { markdown, generatedAt: new Date(), written: true };
+    const entry: DocEntry = { id: this.generateId(), markdown, generatedAt: new Date(), written: true };
     const list = [entry, ...(this.history.get(wid) ?? [])];
     this.history.set(wid, list);
+    this.writeAll();
     return entry;
   }
 
@@ -101,6 +116,7 @@ export class WorkflowDocService {
       target.generatedAt = newTimestamp;
       target.edited = true;
     }
+    this.writeAll();
     return newTimestamp;
   }
 
@@ -124,10 +140,15 @@ export class WorkflowDocService {
           })
           .pipe(
             map(response => {
-              const entry: DocEntry = { markdown: response.markdown, generatedAt: new Date() };
+              const entry: DocEntry = {
+                id: this.generateId(),
+                markdown: response.markdown,
+                generatedAt: new Date(),
+              };
               const list = [...(this.history.get(wid) ?? [])];
               list.unshift(entry);
               this.history.set(wid, list);
+              this.writeAll();
               return entry;
             }),
             finalize(() => {
@@ -139,5 +160,73 @@ export class WorkflowDocService {
           );
       })
     );
+  }
+
+  private generateId(): string {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+      return crypto.randomUUID();
+    }
+    return `doc-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+
+  private widFromKey(key: string): number | undefined {
+    return key === "undefined" ? undefined : Number(key);
+  }
+
+  private widToKey(wid: number | undefined): string {
+    return wid === undefined ? "undefined" : String(wid);
+  }
+
+  private loadFromStorage(): void {
+    if (typeof localStorage === "undefined") return;
+    let raw: string | null;
+    try {
+      raw = localStorage.getItem(STORAGE_KEY);
+    } catch {
+      return;
+    }
+    if (!raw) return;
+    let parsed: PersistedShape;
+    try {
+      parsed = JSON.parse(raw) as PersistedShape;
+    } catch {
+      return;
+    }
+    if (parsed.history) {
+      for (const [key, entries] of Object.entries(parsed.history)) {
+        const wid = this.widFromKey(key);
+        const revived = entries.map(e => ({ ...e, generatedAt: new Date(e.generatedAt) }));
+        this.history.set(wid, revived);
+      }
+    }
+    if (parsed.lastView) {
+      for (const [key, view] of Object.entries(parsed.lastView)) {
+        this.lastViews.set(this.widFromKey(key), view);
+      }
+    }
+    if (parsed.editing) {
+      for (const [key, state] of Object.entries(parsed.editing)) {
+        this.editingStates.set(this.widFromKey(key), state);
+      }
+    }
+  }
+
+  private writeAll(): void {
+    if (typeof localStorage === "undefined") return;
+    const payload: PersistedShape = { history: {}, lastView: {}, editing: {} };
+    this.history.forEach((entries, wid) => {
+      payload.history[this.widToKey(wid)] = entries;
+    });
+    this.lastViews.forEach((view, wid) => {
+      payload.lastView[this.widToKey(wid)] = view;
+    });
+    this.editingStates.forEach((state, wid) => {
+      payload.editing[this.widToKey(wid)] = state;
+    });
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    } catch {
+      // Quota exceeded or storage unavailable — degrade silently to in-memory.
+    }
   }
 }

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -35,7 +35,7 @@ export type DocPanelView = "intro" | "doc";
 })
 export class WorkflowDocService {
   private readonly AGENT_API_BASE = "/api";
-  private cache = new Map<number | undefined, DocEntry>();
+  private history = new Map<number | undefined, DocEntry[]>();
   private lastViews = new Map<number | undefined, DocPanelView>();
 
   constructor(
@@ -44,8 +44,8 @@ export class WorkflowDocService {
     private workflowActionService: WorkflowActionService
   ) {}
 
-  getCached(wid: number | undefined): DocEntry | null {
-    return this.cache.get(wid) ?? null;
+  getHistory(wid: number | undefined): readonly DocEntry[] {
+    return this.history.get(wid) ?? [];
   }
 
   getLastView(wid: number | undefined): DocPanelView | null {
@@ -76,7 +76,10 @@ export class WorkflowDocService {
           })
           .pipe(
             map(response => {
-              this.cache.set(wid, { markdown: response.markdown, generatedAt: new Date() });
+              const entry: DocEntry = { markdown: response.markdown, generatedAt: new Date() };
+              const list = [...(this.history.get(wid) ?? [])];
+              list.unshift(entry);
+              this.history.set(wid, list);
               return response.markdown;
             }),
             finalize(() => {

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -145,6 +145,8 @@ export class WorkflowDocService {
       target.markdown = newMarkdown;
       target.generatedAt = newTimestamp;
       target.edited = true;
+      const reordered = [target, ...list.filter(e => e !== target)];
+      this.history.set(wid, reordered);
     }
     this.writeAll();
     return newTimestamp;

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -26,9 +26,15 @@ import { WorkflowActionService } from "../workflow-graph/model/workflow-action.s
 export interface DocEntry {
   markdown: string;
   generatedAt: Date;
+  edited?: boolean;
 }
 
 export type DocPanelView = "intro" | "doc";
+
+export interface DocEditingState {
+  entry: DocEntry;
+  content: string;
+}
 
 @Injectable({
   providedIn: "root",
@@ -37,6 +43,7 @@ export class WorkflowDocService {
   private readonly AGENT_API_BASE = "/api";
   private history = new Map<number | undefined, DocEntry[]>();
   private lastViews = new Map<number | undefined, DocPanelView>();
+  private editingStates = new Map<number | undefined, DocEditingState>();
 
   constructor(
     private http: HttpClient,
@@ -56,9 +63,37 @@ export class WorkflowDocService {
     this.lastViews.set(wid, view);
   }
 
+  getEditingState(wid: number | undefined): DocEditingState | null {
+    return this.editingStates.get(wid) ?? null;
+  }
+
+  setEditingState(wid: number | undefined, state: DocEditingState | null): void {
+    if (state) {
+      this.editingStates.set(wid, state);
+    } else {
+      this.editingStates.delete(wid);
+    }
+  }
+
   deleteHistoryEntry(wid: number | undefined, entry: DocEntry): void {
     const list = this.history.get(wid) ?? [];
     this.history.set(wid, list.filter(e => e !== entry));
+    const editing = this.editingStates.get(wid);
+    if (editing && editing.entry === entry) {
+      this.editingStates.delete(wid);
+    }
+  }
+
+  updateHistoryEntry(wid: number | undefined, entry: DocEntry, newMarkdown: string): Date {
+    const list = this.history.get(wid) ?? [];
+    const target = list.find(e => e === entry);
+    const newTimestamp = new Date();
+    if (target) {
+      target.markdown = newMarkdown;
+      target.generatedAt = newTimestamp;
+      target.edited = true;
+    }
+    return newTimestamp;
   }
 
   generateDocumentation(): Observable<DocEntry> {

--- a/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
+++ b/frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable, switchMap, map, finalize, throwError } from "rxjs";
+import { AgentService } from "../agent/agent.service";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class WorkflowDocService {
+  private readonly AGENT_API_BASE = "/api";
+
+  constructor(
+    private http: HttpClient,
+    private agentService: AgentService,
+    private workflowActionService: WorkflowActionService
+  ) {}
+
+  generateDocumentation(): Observable<string> {
+    const workflowContent = this.workflowActionService.getWorkflowContent();
+    let tempAgentId: string | null = null;
+
+    return this.agentService.fetchModelTypes().pipe(
+      switchMap(modelTypes => {
+        if (modelTypes.length === 0) {
+          return throwError(() => new Error("No AI models are available. Please contact your administrator."));
+        }
+        return this.agentService.createAgent(modelTypes[0].id, "doc-agent");
+      }),
+      switchMap(agent => {
+        tempAgentId = agent.id;
+        return this.http
+          .post<{ markdown: string }>(`${this.AGENT_API_BASE}/agents/${agent.id}/document-workflow`, {
+            workflowContent,
+          })
+          .pipe(
+            map(response => response.markdown),
+            finalize(() => {
+              if (tempAgentId) {
+                this.agentService.deleteAgent(tempAgentId).subscribe();
+                tempAgentId = null;
+              }
+            })
+          );
+      })
+    );
+  }
+}

--- a/frontend/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -97,6 +97,7 @@ export class WorkflowGraph {
   public sharedModel!: SharedModel;
   public newYDocLoadedSubject = new Subject();
   private readonly centerEventSubject = new Subject<void>();
+  private readonly centerOnOperatorEventSubject = new Subject<string>();
 
   public readonly operatorAddSubject = new Subject<OperatorPredicate>();
 
@@ -1012,6 +1013,14 @@ export class WorkflowGraph {
 
   public triggerCenterEvent(): void {
     this.centerEventSubject.next();
+  }
+
+  public getCenterOnOperatorEventStream(): Observable<string> {
+    return this.centerOnOperatorEventSubject.asObservable();
+  }
+
+  public triggerCenterOnOperatorEvent(operatorID: string): void {
+    this.centerOnOperatorEventSubject.next(operatorID);
   }
 
   /**


### PR DESCRIPTION
## Demo Video
https://drive.google.com/file/d/1PcP_N_hucajoNYRuUK9bxhqcg7jfvic9/view?usp=sharing

## What changes were proposed in this PR?
Adds a new AI Workflow Documentation tool to the workspace, accessible from the existing menu bar via the document-text icon. The tool lives in a right-side nz-drawer that doesn't block the canvas, and supports three main flows: generating documentation with an LLM, writing it manually, and managing a per-workflow history of reports.

### Generating a report
  - Click Generate Documentation on the intro page. The backend agent-service calls the LLM with a structured context of the current workflow (operator IDs, display names, types, descriptions, properties, UDF source code, compiled output schemas, link graph, and author comment-box notes) and a prompt instructing the model to produce sections for Purpose / Inputs / Pipeline Stages / Outputs / Caveats.
  - The prompt requires the LLM to format every operator mention as a markdown link of the form [Display Name](texera:op:OPERATOR_ID). Clicking one of these links in the rendered doc pans the canvas to center the operator and highlights it.
  - A centered spinner and stopwatch gives feedback during the wait. A Cancel button unsubscribes the request and cleans up the temp agent via the service's finalize handler.

### Writing your own
  - Write Your Own opens the doc view in edit mode with a blank text area. Saving creates a new history entry tagged `written: true`.
  - An Edit button on any existing entry swaps the rendered markdown for a text area pre-filled with the current content. Saving updates the entry in place, marks it `edited: true`, refreshes its timestamp, and moves it to the top of the history. Source labels in the timestamp adjust accordingly ("Generated" → blue, "Updated" → blue + orange edited pill, "Written" → purple).
  - Both the editor and any in-progress draft are persisted, so closing the drawer mid-edit and reopening it lands the user back in the editor with their unsaved text intact. Navigating away from the entry (Back, viewing another report) pops a "Discard unsaved changes?" confirm.

### Per-workflow history
  - Every generated/written/edited entry is recorded in a list on the intro page. Rows show the title (or timestamp fallback), a "Latest" badge on the newest, plus icons that mirror the report's origin (blue thunderbolt for AI, purple edit pencil for hand-written).
  - Each row supports Rename (inline editable title field, with the rename also exposed inside the doc view's header), Duplicate (carries title with a (copy) suffix), and Delete (with popconfirm). The list scrolls internally so long histories don't blow out the drawer.
  - A Compare mode lets the user pick any two entries and opens a side-by-side diff. The diff is line-level via diff.diffLines, but each (removed, added) pair runs through diffWordsWithSpace so only the actually-changed words light up — entirely rewritten lines are still uniformly colored. The compare modal shows entry titles (or "Base"/"Head") plus −N / +M totals.

### Persistence
  - History, last-viewed-page-per-workflow, and the in-progress editing state are all serialized to localStorage under a single versioned key (texera.workflowDoc.v1). The constructor revives Date fields on load; every mutation writes back. DocEntry gets a stable id (crypto.randomUUID() with a timestamp fallback) so the editing-state restore can match entries across JSON round-trips. Quota / availability failures degrade silently to the previous in-memory behavior.

### Files
  - New: 
      - `frontend/src/app/workspace/service/workflow-doc/workflow-doc.service.ts`
      - `frontend/src/app/workspace/component/workflow-doc-panel/`
      - `frontend/src/app/workspace/component/workflow-doc-diff/`
      - `agent-service` documentation prompt + endpoint.
  - Modified: 
      - `agent-service/src/agent/texera-agent.ts`
      - `agent-service/src/server.ts`
      - `frontend/src/app/workspace/component/menu/{menu.component.ts,menu.component.html}`
      - `frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts`
      - `frontend/src/app/workspace/service/workflow-graph/model/workflow-graph.ts`
      - `frontend/src/app/app.module.ts` (registers NzDrawerModule)
      - `frontend/package.json` (adds diff and file-saver types where needed).

## Any related issues, documentation, discussions?
See Discussion #5059 

## Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Anthropic Claude Opus 4.7)

## Future Work
  - Bidirectional report ↔ workflow editing — keep the report and the canvas in sync as both sides change. Editing an operator's description in the report could propagate back to the operator's properties on the canvas; adding or renaming an operator on the canvas could update the corresponding section in the latest report.
  - Include runtime information in the doc — augment the LLM context with execution metadata (per-operator runtime stats, row counts, errors, last execution time) so generated reports describe not just what the pipeline does structurally but how it actually behaves on the current data.
  - Richer compare view — collapse unchanged sections with git-style "show N unchanged lines" expanders; make texera:op: links clickable inside the diff to reuse the canvas pan/highlight flow; add per-section change summaries ("Inputs: unchanged, Pipeline Stages: 3 lines changed"); offer a unified-vs-side-by-side toggle and an "ignore whitespace" mode.
  - Floating, draggable, resizable panel — replace the right-side drawer with a movable, resizable window, so the tool no longer obscures operator details, the run button, or other right-side UI.