### PR TITLE
fix(frontend): remove the Execution Settings hover popover next to the Run button

### DIFF
--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -391,11 +391,6 @@
         </button>
         <button
           (click)="onClickRunHandler()"
-          nz-popover
-          nzPopoverTitle="Execution Settings"
-          [nzPopoverTrigger]="'hover'"
-          [nzPopoverContent]="executionSettings"
-          nzPopoverPlacement="bottom"
           [disabled]="runDisable || (!workflowWebsocketService.isConnected && computingUnitStatus !== ComputingUnitState.NoComputingUnit) || displayParticularWorkflowVersion || selectedComputingUnit?.accessPrivilege !== Privilege.WRITE"
           id="run-button"
           nz-button
@@ -417,22 +412,6 @@
             nz-icon
             nzType="database"></i>
         </button>
-        <ng-template #executionSettings>
-          <div style="display: flex; flex-direction: column; gap: 10px">
-            <input
-              [(ngModel)]="currentExecutionName"
-              placeholder="Untitled Execution"
-              [disabled]="!isWorkflowModifiable" />
-            <div style="display: flex; align-items: center; gap: 10px">
-              <span>Email Notification</span>
-              <nz-switch
-                [(ngModel)]="this.config.env.workflowEmailNotificationEnabled"
-                nzCheckedChildren="On"
-                nzUnCheckedChildren="Off">
-              </nz-switch>
-            </div>
-          </div>
-        </ng-template>
         <div style="margin-left: 5px">
           <nz-badge
             nz-tooltip=""


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove the "Execution Settings" hover popover that appears next to the Run button in the workflow editor. The popover contained a custom-execution-name input and an email-notification toggle, but the same defaults work for ~all users and the hover trigger was felt to be unnecessary UX clutter.

- Drop the `nz-popover` directives and the `<ng-template #executionSettings>` block from `menu.component.html`.
- The `runWorkflow()` handler already falls back to `"Untitled Execution"` when `currentExecutionName` is empty, so behavior on click is unchanged.
- `currentExecutionName` (still declared as an unused `@Input`) and the email-notification toggle config flag remain in place for now; cleaning them up can be a follow-up if there's interest.

### Any related issues, documentation, discussions?

No linked issue — small UX cleanup.

### How was this PR tested?

Verified locally by applying the same edit to a running `ng serve` dev server: the hot-reloaded bundle no longer contains the `"Execution Settings"` string, and the Run button still triggers `runWorkflow()` with the default `"Untitled Execution"` name on click.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)
