### PR TITLE
[Hackathon] feat: Multi-Source Data Import — URL, Local File, SQLite, REST API

### DIFF
--- a/.run/AccessControlService.run.xml
+++ b/.run/AccessControlService.run.xml
@@ -1,25 +1,7 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="AccessControlService" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.service.AccessControlService" />
-    <module name="texera.access-control-service" />
+    <module name="texera.access-control-service.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
       <pattern>

--- a/.run/ComputingUnitManagingService.run.xml
+++ b/.run/ComputingUnitManagingService.run.xml
@@ -1,25 +1,7 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ComputingUnitManagingService" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.service.ComputingUnitManagingService" />
-    <module name="texera.computing-unit-managing-service" />
+    <module name="texera.computing-unit-managing-service.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
       <pattern>

--- a/.run/ComputingUnitMaster.run.xml
+++ b/.run/ComputingUnitMaster.run.xml
@@ -1,27 +1,9 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ComputingUnitMaster" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.web.ComputingUnitMaster" />
-    <option name="VM_PARAMETERS" value="@$PROJECT_DIR$/.jvmopts" />
-    <module name="texera.amber" />
+    <module name="texera.amber.main" />
     <shortenClasspath name="ARGS_FILE" />
+    <option name="VM_PARAMETERS" value="@$PROJECT_DIR$/.jvmopts" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.texera.web.*" />

--- a/.run/ComputingUnitWorker.run.xml
+++ b/.run/ComputingUnitWorker.run.xml
@@ -1,27 +1,9 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ComputingUnitWorker" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.web.ComputingUnitWorker" />
-    <option name="VM_PARAMETERS" value="@$PROJECT_DIR$/.jvmopts" />
-    <module name="texera.amber" />
+    <module name="texera.amber.main" />
     <shortenClasspath name="ARGS_FILE" />
+    <option name="VM_PARAMETERS" value="@$PROJECT_DIR$/.jvmopts" />
     <extension name="coverage">
       <pattern>
         <option name="PATTERN" value="org.apache.texera.web.*" />

--- a/.run/ConfigService.run.xml
+++ b/.run/ConfigService.run.xml
@@ -1,25 +1,7 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ConfigService" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.service.ConfigService" />
-    <module name="texera.config-service" />
+    <module name="texera.config-service.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
       <pattern>

--- a/.run/FileService.run.xml
+++ b/.run/FileService.run.xml
@@ -1,25 +1,7 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="FileService" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.service.FileService" />
-    <module name="texera.file-service" />
+    <module name="texera.file-service.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
       <pattern>

--- a/.run/TexeraWebApplication.run.xml
+++ b/.run/TexeraWebApplication.run.xml
@@ -1,25 +1,7 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="TexeraWebApplication" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.web.TexeraWebApplication" />
-    <module name="texera.amber" />
+    <module name="texera.amber.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
       <pattern>

--- a/.run/WorkflowCompilingService.run.xml
+++ b/.run/WorkflowCompilingService.run.xml
@@ -1,25 +1,7 @@
-<!--
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements. See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership. The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied. See the License for the
-specific language governing permissions and limitations
-under the License.
--->
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="WorkflowCompilingService" type="Application" factoryName="Application">
     <option name="MAIN_CLASS_NAME" value="org.apache.texera.service.WorkflowCompilingService" />
-    <module name="texera.workflow-compiling-service" />
+    <module name="texera.workflow-compiling-service.main" />
     <shortenClasspath name="ARGS_FILE" />
     <extension name="coverage">
       <pattern>

--- a/agent-service/src/agent/prompts.ts
+++ b/agent-service/src/agent/prompts.ts
@@ -281,7 +281,219 @@ function buildAllowedOperatorSchemas(
   return schemas.length > 0 ? schemas.join("\n\n") : "No operators available.";
 }
 
-export function buildSystemPrompt(metadataStore: WorkflowSystemMetadata, allowedOperatorTypes: string[] = []): string {
+/**
+ * Subset of the Texera custom-agent config that influences the system prompt.
+ * Keep this loose — extra fields from the frontend are ignored.
+ */
+export interface CustomAgentConfig {
+  name?: string;
+  description?: string;
+  icon?: string;
+  domain?: string;
+  methodology?: string;
+  taskType?: string;
+  guardrails?: {
+    requireTrainTestSplit?: boolean;
+    requireEvaluation?: boolean;
+    preventDataLeakage?: boolean;
+    handleMissingValues?: boolean;
+    featureScalingCheck?: boolean;
+  };
+  customRules?: string;
+  preferredOperators?: string[];
+  knowledgeFiles?: Array<{ name: string; mimeType?: string; contentBase64?: string }>;
+  exampleWorkflowIds?: number[];
+  outputPreferences?: {
+    includeVisualization?: boolean;
+    exportToCsv?: boolean;
+    generateSummaryStats?: boolean;
+    includeDataProfiling?: boolean;
+    defaultFormat?: string;
+  };
+}
+
+const DOMAIN_LABELS: Record<string, string> = {
+  biomedical: "Biomedical",
+  nlp: "NLP / Text Analysis",
+  finance: "Finance",
+  social_science: "Social Science",
+  cv: "Computer Vision",
+  general: "General",
+};
+
+const METHODOLOGY_GUIDANCE: Record<string, string> = {
+  crisp_dm:
+    "CRISP-DM: structure the workflow as Business Understanding → Data Understanding → Data Preparation → Modeling → Evaluation → Deployment.",
+  semma: "SEMMA: structure the workflow as Sample → Explore → Modify → Model → Assess.",
+  kdd: "KDD: structure the workflow as Selection → Preprocessing → Transformation → Data Mining → Interpretation/Evaluation.",
+  none: "No specific framework is required.",
+};
+
+const TASK_LABELS: Record<string, string> = {
+  classification: "Classification",
+  regression: "Regression",
+  clustering: "Clustering",
+  eda: "Exploratory Data Analysis",
+  cleaning: "Data Cleaning",
+  custom: "Custom",
+};
+
+const OUTPUT_FORMAT_LABELS: Record<string, string> = {
+  dashboard: "Dashboard",
+  csv_export: "CSV Export",
+  report: "Report",
+  none: "No specific output format required",
+};
+
+function decodeBase64Text(b64: string, mimeType?: string): string | undefined {
+  // Only attempt for text-like content; skip binary like PDF.
+  const isTextLike =
+    !mimeType ||
+    mimeType.startsWith("text/") ||
+    mimeType === "application/json" ||
+    mimeType === "application/x-yaml";
+  if (!isTextLike) return undefined;
+  try {
+    const buf = Buffer.from(b64, "base64");
+    return buf.toString("utf-8");
+  } catch {
+    return undefined;
+  }
+}
+
+function buildOperatorCatalog(metadataStore: WorkflowSystemMetadata): string {
+  const entries = Object.entries(metadataStore.getAllOperatorTypes())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([type, desc]) => `- ${type}: ${desc || "(no description)"}`);
+  return entries.join("\n");
+}
+
+export function buildCustomAgentSection(
+  config: CustomAgentConfig,
+  metadataStore?: WorkflowSystemMetadata
+): string {
+  const sections: string[] = ["\n\n# Custom Agent Specialization"];
+
+  sections.push("## Action-First Policy");
+  sections.push(
+    "IMPORTANT: When the user asks you to create a workflow, DO NOT ask clarifying questions. " +
+      "Use reasonable defaults and start building immediately. You can always modify later.\n\n" +
+      "Default assumptions when not specified:\n" +
+      "- Missing values: mean imputation for numeric, mode for categorical\n" +
+      "- Train/test split: 80/20 with random seed 42\n" +
+      "- Evaluation metrics: accuracy, F1, AUC-ROC, confusion matrix\n" +
+      "- Always proceed with action, explain what you chose and why AFTER building."
+  );
+
+  if (metadataStore && metadataStore.getOperatorCount() > 0) {
+    sections.push("## Available Texera Operators (use these instead of Python UDFs when possible)");
+    sections.push(
+      "**ALWAYS prefer built-in Texera operators over Python UDFs.** Only use PythonUDFV2 " +
+        "(or other UDF operators) when no built-in operator exists for the task."
+    );
+    sections.push(buildOperatorCatalog(metadataStore));
+  }
+
+  if (config.name || config.description) {
+    sections.push("## Your Identity");
+    if (config.name) sections.push(`Name: ${config.icon ? config.icon + " " : ""}${config.name}`);
+    if (config.domain && DOMAIN_LABELS[config.domain]) sections.push(`Domain: ${DOMAIN_LABELS[config.domain]}`);
+    if (config.taskType && TASK_LABELS[config.taskType]) sections.push(`Primary Task: ${TASK_LABELS[config.taskType]}`);
+    if (config.description) sections.push(`Specialty: ${config.description}`);
+  }
+
+  if (config.methodology && METHODOLOGY_GUIDANCE[config.methodology]) {
+    sections.push("## Methodology");
+    sections.push(METHODOLOGY_GUIDANCE[config.methodology]);
+  }
+
+  const guardrailLines: string[] = [];
+  if (config.guardrails?.requireTrainTestSplit) {
+    guardrailLines.push("- You MUST include a train/test split operator before any model training operator.");
+  }
+  if (config.guardrails?.requireEvaluation) {
+    guardrailLines.push("- You MUST include an evaluation operator after every model operator.");
+  }
+  if (config.guardrails?.preventDataLeakage) {
+    guardrailLines.push(
+      "- You MUST NOT place feature engineering or fitting operators after the train/test split in a way that leaks test data into training."
+    );
+  }
+  if (config.guardrails?.handleMissingValues) {
+    guardrailLines.push("- You MUST handle missing values explicitly (impute or filter) before modeling.");
+  }
+  if (config.guardrails?.featureScalingCheck) {
+    guardrailLines.push("- You MUST consider feature scaling for distance-based or gradient-based models.");
+  }
+  if (guardrailLines.length > 0) {
+    sections.push("## Guardrails — enforce these strictly");
+    sections.push(guardrailLines.join("\n"));
+  }
+
+  const customRules = (config.customRules || "")
+    .split(/\r?\n/)
+    .map(r => r.trim())
+    .filter(Boolean);
+  if (customRules.length > 0) {
+    sections.push("## Custom Rules — follow these");
+    sections.push(customRules.map((r, i) => `${i + 1}. ${r}`).join("\n"));
+  }
+
+  if (config.preferredOperators && config.preferredOperators.length > 0) {
+    sections.push("## Preferred Operators");
+    sections.push(
+      `When multiple operators could satisfy a step, prefer: ${config.preferredOperators.join(", ")}.`
+    );
+  }
+
+  const outputLines: string[] = [];
+  const out = config.outputPreferences;
+  if (out?.includeVisualization) outputLines.push("- Include visualization operators (scatter plots, bar charts).");
+  if (out?.exportToCsv) outputLines.push("- Export results to CSV at the end of the workflow.");
+  if (out?.generateSummaryStats) outputLines.push("- Generate summary statistics for the data.");
+  if (out?.includeDataProfiling) outputLines.push("- Include a data profiling step early in the workflow.");
+  if (out?.defaultFormat && OUTPUT_FORMAT_LABELS[out.defaultFormat] && out.defaultFormat !== "none") {
+    outputLines.push(`- Target output format: ${OUTPUT_FORMAT_LABELS[out.defaultFormat]}.`);
+  }
+  if (outputLines.length > 0) {
+    sections.push("## Output Preferences");
+    sections.push(outputLines.join("\n"));
+  }
+
+  if (config.knowledgeFiles && config.knowledgeFiles.length > 0) {
+    sections.push("## Knowledge Base");
+    sections.push("The user has provided the following reference files. Treat them as authoritative context.");
+    for (const file of config.knowledgeFiles) {
+      const decoded = file.contentBase64 ? decodeBase64Text(file.contentBase64, file.mimeType) : undefined;
+      if (decoded !== undefined) {
+        const truncated = decoded.length > 4000 ? decoded.slice(0, 4000) + "\n... [truncated]" : decoded;
+        sections.push(`### File: ${file.name}\n\`\`\`\n${truncated}\n\`\`\``);
+      } else {
+        sections.push(`### File: ${file.name}\n(Binary or unreadable content — name available only.)`);
+      }
+    }
+  }
+
+  if (config.exampleWorkflowIds && config.exampleWorkflowIds.length > 0) {
+    sections.push("## Example Workflows");
+    sections.push(
+      `The user has marked workflow ids ${config.exampleWorkflowIds.join(", ")} as templates. ` +
+        "Follow similar operator structures and link patterns when relevant."
+    );
+  }
+
+  sections.push(
+    "## Behavior\nWhen generating workflows, briefly state why each operator was chosen (one short sentence) before adding it via the add_operator tool."
+  );
+
+  return sections.join("\n\n");
+}
+
+export function buildSystemPrompt(
+  metadataStore: WorkflowSystemMetadata,
+  allowedOperatorTypes: string[] = [],
+  customAgent?: CustomAgentConfig
+): string {
   const operatorSchemas = buildAllowedOperatorSchemas(metadataStore, allowedOperatorTypes);
   const allowsAll = allowedOperatorTypes.length === 0;
   const pythonAllowed = allowsAll || allowedOperatorTypes.some(t => PYTHON_UDF_OPERATOR_TYPES.includes(t));
@@ -292,5 +504,9 @@ export function buildSystemPrompt(metadataStore: WorkflowSystemMetadata, allowed
   if (rAllowed) extraSections.push(R_UDF_INSTRUCTIONS);
 
   const base = SYSTEM_PROMPT_TEMPLATE.replace("{{OPERATOR_SCHEMA}}", operatorSchemas);
-  return extraSections.length > 0 ? `${base}\n${extraSections.join("\n\n")}\n` : base;
+  let result = extraSections.length > 0 ? `${base}\n${extraSections.join("\n\n")}\n` : base;
+  if (customAgent) {
+    result += buildCustomAgentSection(customAgent, metadataStore);
+  }
+  return result;
 }

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -51,6 +51,7 @@ import {
   createWorkflowHistoryTool,
   TOOL_NAME_WORKFLOW_HISTORY,
 } from "./tools/workflow-history-tool";
+import { createFetchApiDataTool, TOOL_NAME_FETCH_API_DATA } from "./tools/data-source-tools";
 import { assembleContext } from "./util/context-utils";
 import { compileWorkflowAsync, type WorkflowCompilationResponse } from "../api/compile-api";
 import { createLogger } from "../logger";
@@ -244,6 +245,16 @@ export class TexeraAgent {
         };
       });
     }
+
+    tools[TOOL_NAME_FETCH_API_DATA] = createFetchApiDataTool(() => this.delegateConfig?.userToken);
+
+    this.log.info(
+      {
+        toolNames: Object.keys(tools),
+        hasDelegate: !!this.delegateConfig,
+      },
+      "tools registered for agent"
+    );
 
     return tools;
   }
@@ -547,12 +558,23 @@ export class TexeraAgent {
       // Pass only the current user turn; prepareStep rebuilds full context each step
       // (historical interactions + DAG + this message).
       const currentUserMessage: ModelMessage[] = [{ role: "user", content: userMessage }];
+      this.log.info(
+        {
+          toolNames: Object.keys(this.tools),
+          modelType: this.modelType,
+          messagePreview: userMessage.substring(0, 120),
+        },
+        "sendMessage starting — tools available to the model"
+      );
+      // No `temperature` here: many reasoning models (o1/o3/etc.) reject the parameter
+      // entirely and the SDK logs a noisy warning for every step. Leave it unset so the
+      // provider picks the model's default; non-reasoning models default to ~1.0 which
+      // is fine for our short-turn tool-calling workflow.
       const result = await generateText({
         model: this.model,
         system: this.systemPrompt,
         messages: currentUserMessage,
         tools: this.tools,
-        temperature: 0.2,
         stopWhen: stepCountIs(this.settings.maxSteps),
         prepareStep: async ({ stepNumber, messages: currentMessages }) => {
           let compilationResult: WorkflowCompilationResponse | null = null;

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -31,7 +31,7 @@ import {
   OperatorResultSerializationMode,
   INITIAL_STEP_ID,
 } from "../types/agent";
-import { buildSystemPrompt } from "./prompts";
+import { buildSystemPrompt, CustomAgentConfig } from "./prompts";
 import {
   createAddOperatorTool,
   createModifyOperatorTool,
@@ -47,6 +47,10 @@ import {
   TOOL_NAME_EXECUTE_OPERATOR,
   type ExecutionConfig,
 } from "./tools/workflow-execution-tools";
+import {
+  createWorkflowHistoryTool,
+  TOOL_NAME_WORKFLOW_HISTORY,
+} from "./tools/workflow-history-tool";
 import { assembleContext } from "./util/context-utils";
 import { compileWorkflowAsync, type WorkflowCompilationResponse } from "../api/compile-api";
 import { createLogger } from "../logger";
@@ -60,6 +64,7 @@ export interface TexeraAgentConfig {
   agentId: string;
   agentName?: string;
   systemPrompt?: string;
+  customAgent?: CustomAgentConfig;
 }
 
 export interface AgentMessageResult {
@@ -100,6 +105,7 @@ export class TexeraAgent {
   private model: LanguageModel;
   private systemPrompt: string;
   private settings: AgentSettings;
+  private customAgent?: CustomAgentConfig;
 
   private reActStepsByMessageId: Map<string, ReActStep[]> = new Map();
 
@@ -132,6 +138,7 @@ export class TexeraAgent {
     this.createdAt = new Date();
     this.model = config.model;
     this.systemPrompt = config.systemPrompt || "";
+    this.customAgent = config.customAgent;
     this.log = createLogger("TexeraAgent", { agentId: this.agentId });
 
     this.workflowState = new WorkflowState();
@@ -175,7 +182,7 @@ export class TexeraAgent {
   }
 
   private rebuildSystemPrompt(): void {
-    this.systemPrompt = buildSystemPrompt(this.metadataStore, this.settings.allowedOperatorTypes);
+    this.systemPrompt = buildSystemPrompt(this.metadataStore, this.settings.allowedOperatorTypes, this.customAgent);
     this.settings.systemPrompt = this.systemPrompt;
   }
 
@@ -226,6 +233,16 @@ export class TexeraAgent {
           this.workflowResultState.set(opId, this.head, operatorInfo);
         }
       );
+    }
+
+    if (this.delegateConfig) {
+      tools[TOOL_NAME_WORKFLOW_HISTORY] = createWorkflowHistoryTool(() => {
+        if (!this.delegateConfig) return undefined;
+        return {
+          userToken: this.delegateConfig.userToken,
+          workflowId: this.delegateConfig.workflowId,
+        };
+      });
     }
 
     return tools;

--- a/agent-service/src/agent/tools/data-source-tools.ts
+++ b/agent-service/src/agent/tools/data-source-tools.ts
@@ -1,0 +1,195 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { z } from "zod";
+import { tool } from "ai";
+import { importCsvAsDataset } from "../../data-source/dataset-import";
+import { env } from "../../config/env";
+import { createLogger } from "../../logger";
+
+const log = createLogger("FetchApiDataTool");
+
+export const TOOL_NAME_FETCH_API_DATA = "fetch_api_data";
+
+interface FetchUrlResponse {
+  url: string;
+  contentType: string;
+  format: "json" | "csv";
+  byteLength: number;
+  filename: string;
+  rows: number;
+  columns: string[];
+  preview: any[];
+  csv: string;
+}
+
+/**
+ * Resolve the URL of the local /api/data-source/fetch-url endpoint. The tool
+ * runs inside the same agent-service process, so we hit ourselves via loopback
+ * rather than going through any external proxy.
+ */
+function internalFetchUrlEndpoint(): string {
+  return `http://127.0.0.1:${env.PORT}${env.API_PREFIX}/data-source/fetch-url`;
+}
+
+/**
+ * Pull a URL via the same /api/data-source/fetch-url endpoint the Datasets page
+ * uses (loopback, no proxy), convert JSON/CSV to a tabular format, and save it
+ * as a private Texera dataset.
+ *
+ * Why call the internal endpoint instead of fetching the URL directly? It
+ * keeps the format-detection + JSON-flattening + CSV-preview logic in one
+ * place, and it isolates the tool from any host networking quirks the agent
+ * runtime may have — the endpoint is already verified to work via curl, so if
+ * fetch_api_data used to fail while curl succeeded, this routing is the fix.
+ *
+ * Requires a user token in `getDelegateUserToken()` — without it, the tool can
+ * fetch the URL but cannot create the dataset, so it returns the preview only.
+ */
+export function createFetchApiDataTool(getDelegateUserToken: () => string | undefined) {
+  return tool({
+    description: `Fetch data from a REST API URL and add it as a private dataset in Texera.
+
+Use this for: "fetch data from <URL>", "load this API into the workflow", "pull patient data from <URL>".
+The result includes a "filePath" (e.g. "imported-data/data.csv") that you should pass to a CSVFileScan
+operator's "fileName" property in a follow-up addOperator call.
+
+Input: { url: string, method?: 'GET'|'POST', headers?: {...}, format?: 'json'|'csv'|'auto' }
+Output: { datasetName, filePath, rows, columns, preview }`,
+    inputSchema: z.object({
+      url: z.string().min(1).describe("HTTP(S) URL to fetch."),
+      method: z.enum(["GET", "POST"]).optional().describe("HTTP method (default GET)."),
+      headers: z
+        .record(z.string())
+        .optional()
+        .describe("Optional request headers (e.g. Authorization). Sent verbatim to the upstream URL."),
+      format: z
+        .enum(["json", "csv", "auto"])
+        .optional()
+        .describe("Format of the response body. 'auto' detects from Content-Type and sniffs the body."),
+      datasetName: z
+        .string()
+        .optional()
+        .describe(
+          "Optional dataset name. Will be sanitized (lowercase, hyphens). If omitted, a name is derived from the URL path."
+        ),
+    }),
+    execute: async (args: {
+      url: string;
+      method?: "GET" | "POST";
+      headers?: Record<string, string>;
+      format?: "json" | "csv" | "auto";
+      datasetName?: string;
+    }) => {
+      try {
+        // Call our own /api/data-source/fetch-url. It already does
+        // server-side fetch, format detection, JSON→CSV flattening, and CSV preview.
+        const endpoint = internalFetchUrlEndpoint();
+        log.info({ endpoint, url: args.url }, "fetch_api_data calling internal endpoint");
+        const internalResponse = await fetch(endpoint, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            url: args.url,
+            method: args.method || "GET",
+            headers: args.headers || {},
+            format: args.format || "auto",
+          }),
+        });
+        if (!internalResponse.ok) {
+          let detail = "";
+          try {
+            const errBody = (await internalResponse.json()) as { error?: string };
+            detail = errBody?.error || "";
+          } catch {
+            detail = await internalResponse.text();
+          }
+          return {
+            error: `/api/data-source/fetch-url returned ${internalResponse.status}: ${detail || internalResponse.statusText}`,
+          };
+        }
+        const fetched = (await internalResponse.json()) as FetchUrlResponse;
+        const { csv, columns, preview, rows, format: detectedFormat, byteLength } = fetched;
+
+        const baseName = deriveBaseName(args.datasetName || urlBasename(args.url));
+        const ts = new Date().toISOString().replace(/[-:T.Z]/g, "").slice(0, 14);
+        const datasetName = `${baseName}-${ts}`;
+        const csvFileName = fetched.filename || `${baseName}.csv`;
+
+        const userToken = getDelegateUserToken();
+        if (!userToken) {
+          // No user context; return the preview so the model has something useful.
+          return {
+            warning:
+              "Fetched the URL but no user token is available in this agent — dataset was NOT created. Returning preview only.",
+            url: args.url,
+            format: detectedFormat,
+            byteLength,
+            rows,
+            columns,
+            preview,
+          };
+        }
+
+        const created = await importCsvAsDataset({
+          userToken,
+          datasetName,
+          description: `Fetched from ${args.url}`,
+          fileName: csvFileName,
+          csv,
+        });
+
+        return {
+          datasetName: created.datasetName,
+          did: created.did,
+          filePath: created.filePath,
+          format: detectedFormat,
+          rows,
+          columns,
+          preview,
+          message: `Fetched ${rows} rows, ${columns.length} columns from ${args.url} and saved as dataset "${created.datasetName}". Use this filePath in CSVFileScan.fileName to load it: ${created.filePath}`,
+        };
+      } catch (err: any) {
+        log.error({ err: err?.message || err }, "fetch_api_data tool failed");
+        return { error: err?.message || String(err) };
+      }
+    },
+  });
+}
+
+function urlBasename(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length > 0) return segments[segments.length - 1];
+    return parsed.hostname;
+  } catch {
+    return "api-data";
+  }
+}
+
+function deriveBaseName(value: string): string {
+  const stripped = value.replace(/\.[^.]+$/, "");
+  const slug = stripped
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "api-data";
+}

--- a/agent-service/src/agent/tools/index.ts
+++ b/agent-service/src/agent/tools/index.ts
@@ -20,3 +20,4 @@
 export * from "./tools-utility";
 export * from "./workflow-crud-tools";
 export * from "./workflow-execution-tools";
+export * from "./workflow-history-tool";

--- a/agent-service/src/agent/tools/index.ts
+++ b/agent-service/src/agent/tools/index.ts
@@ -21,3 +21,4 @@ export * from "./tools-utility";
 export * from "./workflow-crud-tools";
 export * from "./workflow-execution-tools";
 export * from "./workflow-history-tool";
+export * from "./data-source-tools";

--- a/agent-service/src/agent/tools/workflow-history-tool.ts
+++ b/agent-service/src/agent/tools/workflow-history-tool.ts
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { z } from "zod";
+import { tool } from "ai";
+import { getBackendConfig } from "../../api/backend-api";
+import { createAuthHeaders } from "../../api/auth-api";
+import { createToolResult, createErrorResult } from "./tools-utility";
+
+export const TOOL_NAME_WORKFLOW_HISTORY = "workflowHistory";
+
+interface WorkflowHistoryConfig {
+  userToken: string;
+  workflowId: number;
+}
+
+interface SnapshotEntry {
+  sid: number;
+  wid: number;
+  version: number;
+  changeType: string;
+  changeSummary: string;
+  changedOperators: string[];
+  source: "user" | "agent";
+  creationTime: string;
+}
+
+/**
+ * Build the workflowHistory tool for the agent. The tool talks to the amber
+ * `/api/time-machine/...` endpoints — it doesn't touch the audit rules
+ * or the agent chat UI, so this file is independent of those features.
+ *
+ * Actions:
+ *   - list:     return recent snapshots (default limit 20)
+ *   - revert:   revert the workflow to a specific snapshot by version number
+ *               (the agent should typically pick a version from `list` first)
+ *   - snapshot: explicitly save a checkpoint tagged as agent-sourced. Call
+ *               this after generating or modifying the workflow so the user
+ *               sees a 🤖 entry in the Time Machine timeline.
+ */
+export function createWorkflowHistoryTool(getConfig: () => WorkflowHistoryConfig | undefined) {
+  return tool({
+    description:
+      "Browse and manipulate the version history of the current workflow. " +
+      "Use `list` to see recent changes (with timestamps, who made them, " +
+      "what changed), `revert` to roll the workflow back to a specific " +
+      "version, and `snapshot` to record an agent-tagged checkpoint after " +
+      "you have generated or modified the workflow. " +
+      "Useful when the user says things like 'undo the last change' or " +
+      "'go back to before you added that operator'. Always call `snapshot` " +
+      "with a short summary after a multi-step workflow change so the user " +
+      "can revert to that point.",
+    inputSchema: z.object({
+      action: z
+        .enum(["list", "revert", "snapshot"])
+        .describe("'list' returns the timeline; 'revert' rolls back; 'snapshot' saves a checkpoint."),
+      version: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Snapshot version number (required for revert). Get this from the `list` action first."),
+      limit: z.number().int().min(1).max(50).optional().describe("Cap for the list action. Default 20."),
+      summary: z
+        .string()
+        .optional()
+        .describe(
+          "Short summary for the `snapshot` action, e.g. 'Generated ML pipeline' or 'Added Random Forest'. <= 80 chars."
+        ),
+      changedOperators: z
+        .array(z.string())
+        .optional()
+        .describe("Optional operator IDs that were added/modified, for the `snapshot` action."),
+    }),
+    execute: async (args: {
+      action: "list" | "revert" | "snapshot";
+      version?: number;
+      limit?: number;
+      summary?: string;
+      changedOperators?: string[];
+    }) => {
+      const cfg = getConfig();
+      if (!cfg) {
+        return createErrorResult("workflowHistory tool requires a workflow context (token + workflow id).");
+      }
+      const base = `${getBackendConfig().apiEndpoint}/api/time-machine/${cfg.workflowId}`;
+      const headers = createAuthHeaders(cfg.userToken);
+      try {
+        if (args.action === "snapshot") {
+          // Fetch current workflow content from amber, then POST a snapshot.
+          // We can't compose the snapshot content from the agent side without
+          // the workflow JSON, so we read it back from the workflow endpoint.
+          const workflowResp = await fetch(
+            `${getBackendConfig().apiEndpoint}/api/workflow/${cfg.workflowId}`,
+            { method: "GET", headers }
+          );
+          if (!workflowResp.ok) {
+            const text = await workflowResp.text();
+            return createErrorResult(`could not fetch current workflow content: ${workflowResp.status} ${text}`);
+          }
+          const wf = (await workflowResp.json()) as { content: unknown };
+          const content = typeof wf.content === "string" ? wf.content : JSON.stringify(wf.content);
+          const postResp = await fetch(`${base}/snapshots`, {
+            method: "POST",
+            headers: { ...headers, "Content-Type": "application/json" },
+            body: JSON.stringify({
+              content,
+              changeType: "agent_generated",
+              changeSummary: args.summary?.slice(0, 200) ?? "Agent-generated workflow change",
+              changedOperators: args.changedOperators ?? [],
+              source: "agent",
+            }),
+          });
+          if (!postResp.ok) {
+            const text = await postResp.text();
+            return createErrorResult(`snapshot save failed: ${postResp.status} ${text}`);
+          }
+          const saved = (await postResp.json()) as { version: number; sid: number };
+          return createToolResult(`Saved snapshot v${saved.version} (sid=${saved.sid}) tagged as agent-sourced.`);
+        }
+        if (args.action === "list") {
+          const response = await fetch(`${base}/snapshots`, { method: "GET", headers });
+          if (!response.ok) {
+            const text = await response.text();
+            return createErrorResult(`list snapshots failed: ${response.status} ${text}`);
+          }
+          const all = (await response.json()) as SnapshotEntry[];
+          const limit = args.limit ?? 20;
+          const items = all.slice(0, limit);
+          const lines = items.map(
+            e =>
+              `v${e.version}  ${e.creationTime}  [${e.source}]  ${e.changeType}: ${e.changeSummary}` +
+              (e.changedOperators?.length ? `  (ops: ${e.changedOperators.join(",")})` : "")
+          );
+          const summary =
+            items.length === 0
+              ? "No snapshots recorded yet."
+              : `Showing ${items.length} of ${all.length} snapshots:\n${lines.join("\n")}`;
+          return createToolResult(summary);
+        }
+
+        // revert
+        if (args.version === undefined) {
+          return createErrorResult("revert requires `version` (an integer from the `list` action).");
+        }
+        const listResp = await fetch(`${base}/snapshots`, { method: "GET", headers });
+        if (!listResp.ok) {
+          const text = await listResp.text();
+          return createErrorResult(`could not look up version: ${listResp.status} ${text}`);
+        }
+        const all = (await listResp.json()) as SnapshotEntry[];
+        const target = all.find(s => s.version === args.version);
+        if (!target) {
+          return createErrorResult(
+            `no snapshot with version ${args.version}. Available: ${all.map(s => `v${s.version}`).join(", ") || "(none)"}.`
+          );
+        }
+        const revertResp = await fetch(`${base}/snapshots/${target.sid}/revert`, {
+          method: "POST",
+          headers,
+        });
+        if (!revertResp.ok) {
+          const text = await revertResp.text();
+          return createErrorResult(`revert failed: ${revertResp.status} ${text}`);
+        }
+        return createToolResult(
+          `Reverted workflow to v${target.version} ("${target.changeSummary}"). ` +
+            "The user should reload their canvas to see the change."
+        );
+      } catch (err: any) {
+        return createErrorResult(`workflowHistory failed: ${err?.message ?? String(err)}`);
+      }
+    },
+  });
+}

--- a/agent-service/src/data-source/data-source-router.ts
+++ b/agent-service/src/data-source/data-source-router.ts
@@ -25,11 +25,41 @@ import {
   parseCsvPreview,
   type FetchedData,
 } from "./format-utils";
+import { listSqliteTables, exportSqliteTableAsCsv } from "./sqlite-utils";
 
 const log = createLogger("DataSource");
 
 const FETCH_TIMEOUT_MS = 30_000;
 const MAX_RESPONSE_BYTES = 100 * 1024 * 1024; // 100 MB safety cap
+
+/**
+ * In-memory cache of uploaded SQLite files. Two-step flow:
+ *  1. POST /sqlite-tables uploads the bytes once and returns a fileHandle + table list
+ *  2. POST /sqlite-export references the handle to export a table without re-uploading
+ *
+ * Entries auto-expire to prevent leaking memory if the user navigates away.
+ */
+interface SqliteCacheEntry {
+  bytes: Uint8Array;
+  filename: string;
+  createdAt: number;
+}
+const SQLITE_CACHE_TTL_MS = 30 * 60 * 1000;
+const SQLITE_MAX_BYTES = 500 * 1024 * 1024;
+const sqliteCache = new Map<string, SqliteCacheEntry>();
+
+function pruneSqliteCache(): void {
+  const now = Date.now();
+  for (const [handle, entry] of sqliteCache) {
+    if (now - entry.createdAt > SQLITE_CACHE_TTL_MS) {
+      sqliteCache.delete(handle);
+    }
+  }
+}
+
+function generateHandle(): string {
+  return `sqlite-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
 
 function suggestFilename(url: string, contentType: string): string {
   let pathSegment = "data";
@@ -157,6 +187,80 @@ export const dataSourceRouter = new Elysia({ prefix: "/data-source" })
         method: t.Optional(t.Union([t.Literal("GET"), t.Literal("POST")])),
         headers: t.Optional(t.Record(t.String(), t.String())),
         format: t.Optional(t.Union([t.Literal("json"), t.Literal("csv"), t.Literal("auto")])),
+      }),
+    }
+  )
+
+  /**
+   * Accept an uploaded .sqlite/.db file and return its table list. The bytes
+   * are cached server-side under a fileHandle so /sqlite-export can read them
+   * without forcing the browser to re-upload.
+   */
+  .post(
+    "/sqlite-tables",
+    async ({ body, set }) => {
+      pruneSqliteCache();
+      const form = body as { file: File };
+      const file = form.file;
+      if (!file) {
+        set.status = 400;
+        return { error: "file is required" };
+      }
+      if (file.size > SQLITE_MAX_BYTES) {
+        set.status = 413;
+        return { error: `SQLite file too large (${file.size} bytes, limit ${SQLITE_MAX_BYTES})` };
+      }
+      const arrayBuffer = await file.arrayBuffer();
+      const bytes = new Uint8Array(arrayBuffer);
+
+      log.info({ filename: file.name, size: bytes.byteLength }, "received sqlite upload");
+
+      const tables = await listSqliteTables(bytes);
+      const handle = generateHandle();
+      sqliteCache.set(handle, { bytes, filename: file.name, createdAt: Date.now() });
+
+      return {
+        fileHandle: handle,
+        filename: file.name,
+        tables,
+      };
+    },
+    {
+      body: t.Object({
+        file: t.File(),
+      }),
+    }
+  )
+
+  /**
+   * Export a single table from a previously uploaded SQLite file (by fileHandle) as CSV.
+   */
+  .post(
+    "/sqlite-export",
+    async ({ body, set }) => {
+      pruneSqliteCache();
+      const { fileHandle, tableName, limit } = body as {
+        fileHandle: string;
+        tableName: string;
+        limit?: number;
+      };
+
+      const entry = sqliteCache.get(fileHandle);
+      if (!entry) {
+        set.status = 404;
+        return { error: "Unknown or expired fileHandle. Please re-upload the SQLite file." };
+      }
+
+      log.info({ fileHandle, tableName, limit }, "exporting sqlite table");
+
+      const exported = await exportSqliteTableAsCsv(entry.bytes, tableName, limit ?? 100_000);
+      return exported;
+    },
+    {
+      body: t.Object({
+        fileHandle: t.String({ minLength: 1 }),
+        tableName: t.String({ minLength: 1 }),
+        limit: t.Optional(t.Number()),
       }),
     }
   );

--- a/agent-service/src/data-source/data-source-router.ts
+++ b/agent-service/src/data-source/data-source-router.ts
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Elysia, t } from "elysia";
+import { createLogger } from "../logger";
+import {
+  detectFormatFromContentType,
+  jsonToCsv,
+  parseCsvPreview,
+  type FetchedData,
+} from "./format-utils";
+
+const log = createLogger("DataSource");
+
+const FETCH_TIMEOUT_MS = 30_000;
+const MAX_RESPONSE_BYTES = 100 * 1024 * 1024; // 100 MB safety cap
+
+function suggestFilename(url: string, contentType: string): string {
+  let pathSegment = "data";
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length > 0) {
+      pathSegment = segments[segments.length - 1];
+    }
+  } catch {}
+
+  // Strip query/hash if any leaked through
+  pathSegment = pathSegment.split("?")[0].split("#")[0];
+
+  if (pathSegment.includes(".")) {
+    return pathSegment;
+  }
+
+  const lc = contentType.toLowerCase();
+  if (lc.includes("json")) return `${pathSegment}.json`;
+  if (lc.includes("csv")) return `${pathSegment}.csv`;
+  return `${pathSegment}.txt`;
+}
+
+async function fetchUrlWithTimeout(
+  url: string,
+  method: string,
+  headers: Record<string, string>
+): Promise<FetchedData> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      signal: controller.signal,
+      redirect: "follow",
+    });
+    if (!response.ok) {
+      throw new Error(`Upstream returned ${response.status} ${response.statusText}`);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    const buf = await response.arrayBuffer();
+    if (buf.byteLength > MAX_RESPONSE_BYTES) {
+      throw new Error(`Response too large (${buf.byteLength} bytes, limit ${MAX_RESPONSE_BYTES})`);
+    }
+    const text = new TextDecoder("utf-8").decode(buf);
+    return { contentType, text, byteLength: buf.byteLength };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export const dataSourceRouter = new Elysia({ prefix: "/data-source" })
+  .onError(({ error, set }) => {
+    log.error({ err: error }, "data-source request error");
+    const message = error instanceof Error ? error.message : String(error);
+    set.status = 500;
+    return { error: message };
+  })
+
+  /**
+   * Fetch a URL server-side (bypasses browser CORS) and return the body as text
+   * along with metadata. The caller (frontend or agent tool) decides how to use it.
+   */
+  .post(
+    "/fetch-url",
+    async ({ body }) => {
+      const { url, method = "GET", headers = {}, format = "auto" } = body as {
+        url: string;
+        method?: "GET" | "POST";
+        headers?: Record<string, string>;
+        format?: "json" | "csv" | "auto";
+      };
+
+      log.info({ url, method, format }, "fetching url");
+
+      const fetched = await fetchUrlWithTimeout(url, method, headers);
+      const detectedFormat =
+        format === "auto" ? detectFormatFromContentType(fetched.contentType, fetched.text) : format;
+
+      const filename = suggestFilename(url, fetched.contentType);
+
+      let csvText: string;
+      let columns: string[];
+      let preview: any[];
+      let rowCount: number;
+
+      if (detectedFormat === "json") {
+        const conversion = jsonToCsv(fetched.text);
+        csvText = conversion.csv;
+        columns = conversion.columns;
+        preview = conversion.preview;
+        rowCount = conversion.rowCount;
+      } else {
+        // Treat as CSV (or whatever text it is — pass through)
+        csvText = fetched.text;
+        const parsed = parseCsvPreview(fetched.text);
+        columns = parsed.columns;
+        preview = parsed.preview;
+        rowCount = parsed.rowCount;
+      }
+
+      // Always export a normalized .csv name when we converted JSON,
+      // otherwise keep the suggested filename.
+      const exportFilename =
+        detectedFormat === "json" ? filename.replace(/\.json$/i, ".csv") : filename;
+
+      return {
+        url,
+        contentType: fetched.contentType,
+        format: detectedFormat,
+        byteLength: fetched.byteLength,
+        filename: exportFilename,
+        rows: rowCount,
+        columns,
+        preview,
+        csv: csvText,
+      };
+    },
+    {
+      body: t.Object({
+        url: t.String({ minLength: 1 }),
+        method: t.Optional(t.Union([t.Literal("GET"), t.Literal("POST")])),
+        headers: t.Optional(t.Record(t.String(), t.String())),
+        format: t.Optional(t.Union([t.Literal("json"), t.Literal("csv"), t.Literal("auto")])),
+      }),
+    }
+  );

--- a/agent-service/src/data-source/dataset-import.ts
+++ b/agent-service/src/data-source/dataset-import.ts
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { getBackendConfig } from "../api/backend-api";
+import { createAuthHeaders } from "../api/auth-api";
+
+export interface CreatedDataset {
+  did: number;
+  datasetName: string;
+  ownerEmail: string;
+  filePath: string;
+}
+
+interface DashboardDataset {
+  isOwner: boolean;
+  ownerEmail: string;
+  dataset: {
+    did?: number;
+    name: string;
+    description: string;
+  };
+}
+
+/**
+ * Push a CSV string into Texera as a new private dataset and commit an initial
+ * version. Used by the `fetch_api_data` agent tool so it can hand the result
+ * back to the workflow as a real, addressable dataset file.
+ *
+ * Returns the dataset name + filePath that a CSVFileScan / TableFileScan
+ * operator can reference.
+ */
+export async function importCsvAsDataset(opts: {
+  userToken: string;
+  datasetName: string;
+  description: string;
+  fileName: string;
+  csv: string;
+}): Promise<CreatedDataset> {
+  const { userToken, datasetName, description, fileName, csv } = opts;
+  const config = getBackendConfig();
+  const baseUrl = `${config.apiEndpoint}/api/dataset`;
+  const authHeaders = createAuthHeaders(userToken);
+
+  // 1. Create the dataset record
+  const createRes = await fetch(`${baseUrl}/create`, {
+    method: "POST",
+    headers: {
+      ...authHeaders,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      datasetName,
+      datasetDescription: description,
+      isDatasetPublic: false,
+      isDatasetDownloadable: false,
+    }),
+  });
+  if (!createRes.ok) {
+    const text = await createRes.text();
+    throw new Error(`Failed to create dataset: ${createRes.status} ${text}`);
+  }
+  const dashboard = (await createRes.json()) as DashboardDataset;
+  const did = dashboard.dataset.did;
+  if (!did) {
+    throw new Error("Dataset created but missing did in response.");
+  }
+
+  // 2. Multipart upload — for the modest CSV sizes the URL fetcher returns,
+  //    a single part is plenty.
+  const bytes = new TextEncoder().encode(csv);
+  const fileSize = bytes.byteLength;
+  const partSize = Math.max(1, fileSize); // single part covers the whole file
+
+  const initParams = new URLSearchParams({
+    type: "init",
+    ownerEmail: dashboard.ownerEmail,
+    datasetName,
+    filePath: encodeURIComponent(fileName),
+    fileSizeBytes: String(fileSize),
+    partSizeBytes: String(partSize),
+    restart: "false",
+  });
+  const initRes = await fetch(`${baseUrl}/multipart-upload?${initParams.toString()}`, {
+    method: "POST",
+    headers: authHeaders,
+  });
+  if (!initRes.ok) {
+    const text = await initRes.text();
+    throw new Error(`Failed to init upload: ${initRes.status} ${text}`);
+  }
+  const initBody = (await initRes.json()) as { missingParts: number[] };
+  const missingParts = initBody?.missingParts ?? [1];
+
+  for (const partNumber of missingParts) {
+    const partParams = new URLSearchParams({
+      ownerEmail: dashboard.ownerEmail,
+      datasetName,
+      filePath: encodeURIComponent(fileName),
+      partNumber: String(partNumber),
+    });
+    const partRes = await fetch(`${baseUrl}/multipart-upload/part?${partParams.toString()}`, {
+      method: "POST",
+      headers: {
+        ...authHeaders,
+        "Content-Type": "application/octet-stream",
+      },
+      body: bytes,
+    });
+    if (!partRes.ok) {
+      const text = await partRes.text();
+      throw new Error(`Failed to upload part ${partNumber}: ${partRes.status} ${text}`);
+    }
+  }
+
+  const finishParams = new URLSearchParams({
+    type: "finish",
+    ownerEmail: dashboard.ownerEmail,
+    datasetName,
+    filePath: encodeURIComponent(fileName),
+  });
+  const finishRes = await fetch(`${baseUrl}/multipart-upload?${finishParams.toString()}`, {
+    method: "POST",
+    headers: authHeaders,
+  });
+  if (!finishRes.ok) {
+    const text = await finishRes.text();
+    throw new Error(`Failed to finish upload: ${finishRes.status} ${text}`);
+  }
+
+  // 3. Commit an initial version so the dataset is readable
+  const versionRes = await fetch(`${baseUrl}/${did}/version/create`, {
+    method: "POST",
+    headers: {
+      ...authHeaders,
+      "Content-Type": "text/plain",
+    },
+    body: "Imported via fetch_api_data",
+  });
+  if (!versionRes.ok) {
+    const text = await versionRes.text();
+    throw new Error(`Failed to create version: ${versionRes.status} ${text}`);
+  }
+
+  return {
+    did,
+    datasetName,
+    ownerEmail: dashboard.ownerEmail,
+    filePath: `${datasetName}/${fileName}`,
+  };
+}

--- a/agent-service/src/data-source/format-utils.ts
+++ b/agent-service/src/data-source/format-utils.ts
@@ -1,0 +1,232 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface FetchedData {
+  contentType: string;
+  text: string;
+  byteLength: number;
+}
+
+export interface CsvConversion {
+  csv: string;
+  columns: string[];
+  preview: any[];
+  rowCount: number;
+}
+
+export function detectFormatFromContentType(contentType: string, body: string): "json" | "csv" {
+  const lc = contentType.toLowerCase();
+  if (lc.includes("json")) return "json";
+  if (lc.includes("csv")) return "csv";
+
+  // Sniff: if it parses as JSON, it's JSON.
+  const trimmed = body.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    try {
+      JSON.parse(body);
+      return "json";
+    } catch {}
+  }
+  return "csv";
+}
+
+/**
+ * Flatten a nested object using dot-notation. Arrays become JSON strings so they
+ * fit in a single CSV cell. We don't try to expand arrays into rows.
+ */
+function flatten(obj: any, prefix: string = "", out: Record<string, any> = {}): Record<string, any> {
+  if (obj === null || obj === undefined) {
+    if (prefix) out[prefix] = "";
+    return out;
+  }
+  if (Array.isArray(obj)) {
+    out[prefix || "value"] = JSON.stringify(obj);
+    return out;
+  }
+  if (typeof obj === "object") {
+    for (const [key, value] of Object.entries(obj)) {
+      const nextKey = prefix ? `${prefix}.${key}` : key;
+      if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+        flatten(value, nextKey, out);
+      } else if (Array.isArray(value)) {
+        out[nextKey] = JSON.stringify(value);
+      } else {
+        out[nextKey] = value;
+      }
+    }
+    return out;
+  }
+  out[prefix || "value"] = obj;
+  return out;
+}
+
+function csvEscape(value: any): string {
+  if (value === null || value === undefined) return "";
+  let s = typeof value === "string" ? value : String(value);
+  if (s.includes(",") || s.includes("\n") || s.includes("\r") || s.includes('"')) {
+    s = `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Convert JSON text to CSV. Supports:
+ *  - top-level array of objects: each element is a row
+ *  - top-level object with an array field (e.g. {data: [...], meta: ...}): use that array
+ *  - top-level scalar/object: single-row CSV
+ */
+export function jsonToCsv(jsonText: string): CsvConversion {
+  let parsed: any;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (e) {
+    throw new Error(`Response did not parse as JSON: ${(e as Error).message}`);
+  }
+
+  let rows: any[];
+  if (Array.isArray(parsed)) {
+    rows = parsed;
+  } else if (parsed && typeof parsed === "object") {
+    // Find the first array field that looks like records
+    const arrayField = Object.values(parsed).find(v => Array.isArray(v) && v.length > 0);
+    if (arrayField) {
+      rows = arrayField as any[];
+    } else {
+      rows = [parsed];
+    }
+  } else {
+    rows = [{ value: parsed }];
+  }
+
+  if (rows.length === 0) {
+    return { csv: "", columns: [], preview: [], rowCount: 0 };
+  }
+
+  const flatRows = rows.map(row => {
+    if (row === null || row === undefined) return {};
+    if (typeof row !== "object") return { value: row };
+    return flatten(row);
+  });
+
+  // Collect column names in first-seen order
+  const colSet = new Set<string>();
+  const columns: string[] = [];
+  for (const row of flatRows) {
+    for (const key of Object.keys(row)) {
+      if (!colSet.has(key)) {
+        colSet.add(key);
+        columns.push(key);
+      }
+    }
+  }
+
+  const lines: string[] = [];
+  lines.push(columns.map(csvEscape).join(","));
+  for (const row of flatRows) {
+    lines.push(columns.map(c => csvEscape(row[c])).join(","));
+  }
+
+  return {
+    csv: lines.join("\n"),
+    columns,
+    preview: flatRows.slice(0, 5),
+    rowCount: flatRows.length,
+  };
+}
+
+/**
+ * Lightweight CSV preview. Handles quoted fields with embedded commas/newlines.
+ * Returns the columns (header), first 5 data rows as objects, and total row count.
+ */
+export function parseCsvPreview(csvText: string): {
+  columns: string[];
+  preview: any[];
+  rowCount: number;
+} {
+  const records = parseCsv(csvText);
+  if (records.length === 0) {
+    return { columns: [], preview: [], rowCount: 0 };
+  }
+  const header = records[0];
+  const dataRows = records.slice(1);
+  const preview = dataRows.slice(0, 5).map(row => {
+    const obj: Record<string, any> = {};
+    header.forEach((col, i) => {
+      obj[col] = row[i] ?? "";
+    });
+    return obj;
+  });
+  return {
+    columns: header,
+    preview,
+    rowCount: dataRows.length,
+  };
+}
+
+function parseCsv(text: string): string[][] {
+  const records: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let inQuotes = false;
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 2;
+          continue;
+        }
+        inQuotes = false;
+        i++;
+        continue;
+      }
+      field += ch;
+      i++;
+    } else {
+      if (ch === '"') {
+        inQuotes = true;
+        i++;
+      } else if (ch === ",") {
+        row.push(field);
+        field = "";
+        i++;
+      } else if (ch === "\r") {
+        // swallow; \r\n handled by \n branch
+        i++;
+      } else if (ch === "\n") {
+        row.push(field);
+        records.push(row);
+        row = [];
+        field = "";
+        i++;
+      } else {
+        field += ch;
+        i++;
+      }
+    }
+  }
+  // Trailing field/row if no newline at end
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    records.push(row);
+  }
+  return records;
+}

--- a/agent-service/src/data-source/sqlite-utils.ts
+++ b/agent-service/src/data-source/sqlite-utils.ts
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { mkdtemp, writeFile, unlink, rmdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+export interface SqliteTableSummary {
+  name: string;
+  rowCount: number;
+  columns: string[];
+}
+
+export interface SqliteExportResult {
+  csv: string;
+  rows: number;
+  columns: string[];
+}
+
+const SQL_TABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/**
+ * Open a SQLite database from raw bytes via Bun's built-in `bun:sqlite`.
+ * We write the buffer to a temp file because bun:sqlite needs a path. The
+ * caller is responsible for deferring cleanup until export completes too —
+ * if you need both list+export, write once and reuse the path.
+ */
+async function withSqlite<T>(bytes: Uint8Array, fn: (db: any, tempPath: string) => Promise<T>): Promise<T> {
+  // Lazy import so non-Bun runtimes don't crash at module load.
+  const { Database } = (await import("bun:sqlite")) as typeof import("bun:sqlite");
+  const dir = await mkdtemp(join(tmpdir(), "texera-sqlite-"));
+  const path = join(dir, "input.sqlite");
+  await writeFile(path, bytes);
+  let db: any;
+  try {
+    db = new Database(path, { readonly: true });
+    return await fn(db, path);
+  } finally {
+    try {
+      if (db) db.close();
+    } catch {}
+    try {
+      await unlink(path);
+    } catch {}
+    try {
+      await rmdir(dir);
+    } catch {}
+  }
+}
+
+export async function listSqliteTables(bytes: Uint8Array): Promise<SqliteTableSummary[]> {
+  return withSqlite(bytes, async db => {
+    const tableRows = db
+      .query("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+      .all() as { name: string }[];
+
+    const summaries: SqliteTableSummary[] = [];
+    for (const { name } of tableRows) {
+      if (!SQL_TABLE_NAME.test(name)) {
+        // Skip non-standard table names rather than risk an injection; users will see
+        // it missing and can rename in their tool of choice.
+        continue;
+      }
+      const countRow = db.query(`SELECT COUNT(*) AS c FROM "${name}"`).get() as { c: number };
+      const columnRows = db.query(`PRAGMA table_info("${name}")`).all() as { name: string }[];
+      summaries.push({
+        name,
+        rowCount: countRow?.c ?? 0,
+        columns: columnRows.map(c => c.name),
+      });
+    }
+    return summaries;
+  });
+}
+
+export async function exportSqliteTableAsCsv(
+  bytes: Uint8Array,
+  tableName: string,
+  limit: number = 100_000
+): Promise<SqliteExportResult> {
+  if (!SQL_TABLE_NAME.test(tableName)) {
+    throw new Error(`Invalid table name: ${tableName}`);
+  }
+  return withSqlite(bytes, async db => {
+    const columnRows = db.query(`PRAGMA table_info("${tableName}")`).all() as { name: string }[];
+    if (columnRows.length === 0) {
+      throw new Error(`Table "${tableName}" not found or has no columns.`);
+    }
+    const columns = columnRows.map(c => c.name);
+    const rows = db.query(`SELECT * FROM "${tableName}" LIMIT ${Math.max(0, Math.floor(limit))}`).all() as Record<
+      string,
+      any
+    >[];
+
+    const lines: string[] = [];
+    lines.push(columns.map(csvEscape).join(","));
+    for (const row of rows) {
+      lines.push(columns.map(c => csvEscape(row[c])).join(","));
+    }
+    return {
+      csv: lines.join("\n"),
+      rows: rows.length,
+      columns,
+    };
+  });
+}
+
+function csvEscape(value: any): string {
+  if (value === null || value === undefined) return "";
+  let s: string;
+  if (value instanceof Uint8Array) {
+    // Encode blobs as base64 strings so the CSV stays printable.
+    s = Buffer.from(value).toString("base64");
+  } else if (typeof value === "object") {
+    s = JSON.stringify(value);
+  } else {
+    s = String(value);
+  }
+  if (s.includes(",") || s.includes("\n") || s.includes("\r") || s.includes('"')) {
+    s = `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}

--- a/agent-service/src/server.ts
+++ b/agent-service/src/server.ts
@@ -46,7 +46,8 @@ let agentCounter = 0;
 async function createAgentInstance(
   modelType: string,
   customName?: string,
-  delegateConfig?: AgentDelegateConfig
+  delegateConfig?: AgentDelegateConfig,
+  customAgent?: any
 ): Promise<{ agentId: string; agent: TexeraAgent }> {
   const agentId = `agent-${++agentCounter}`;
   const config = getBackendConfig();
@@ -63,6 +64,7 @@ async function createAgentInstance(
     modelType,
     agentId,
     agentName: customName || "Bob",
+    customAgent,
   });
 
   await agent.initialize();
@@ -167,7 +169,8 @@ const agentsRouter = new Elysia({ prefix: "/agents" })
   .post(
     "/",
     async ({ body }) => {
-      const { modelType, name, userToken, workflowId, computingUnitId, settings } = body as CreateAgentRequest;
+      const { modelType, name, userToken, workflowId, computingUnitId, settings, customAgent } =
+        body as CreateAgentRequest & { customAgent?: any };
 
       if (!modelType) {
         throw new Error("modelType is required");
@@ -188,7 +191,7 @@ const agentsRouter = new Elysia({ prefix: "/agents" })
         };
       }
 
-      const { agentId, agent } = await createAgentInstance(modelType, name, delegateConfig);
+      const { agentId, agent } = await createAgentInstance(modelType, name, delegateConfig, customAgent);
 
       if (settings) {
         log.info(
@@ -234,6 +237,8 @@ const agentsRouter = new Elysia({ prefix: "/agents" })
             allowedOperatorTypes: t.Optional(t.Array(t.String())),
           })
         ),
+        // Loose schema — frontend may include additional fields; backend treats it as opaque.
+        customAgent: t.Optional(t.Any()),
       }),
     }
   )

--- a/agent-service/src/server.ts
+++ b/agent-service/src/server.ts
@@ -27,6 +27,7 @@ import { retrieveWorkflow } from "./api/workflow-api";
 import { WorkflowSystemMetadata } from "./agent/util/workflow-system-metadata";
 import { env } from "./config/env";
 import { createLogger } from "./logger";
+import { dataSourceRouter } from "./data-source/data-source-router";
 
 const log = createLogger("Server");
 const wsLog = createLogger("WS");
@@ -489,6 +490,7 @@ export function buildApp() {
           timestamp: new Date().toISOString(),
         }))
         .use(agentsRouter)
+        .use(dataSourceRouter)
     )
     .ws(`${env.API_PREFIX}/agents/:id/react`, {
       open(ws) {

--- a/amber/src/main/scala/org/apache/texera/web/TexeraWebApplication.scala
+++ b/amber/src/main/scala/org/apache/texera/web/TexeraWebApplication.scala
@@ -50,6 +50,7 @@ import org.apache.texera.web.resource.dashboard.user.workflow.{
   WorkflowAccessResource,
   WorkflowExecutionsResource,
   WorkflowResource,
+  WorkflowSnapshotResource,
   WorkflowVersionResource
 }
 import org.eclipse.jetty.server.session.SessionHandler
@@ -151,6 +152,7 @@ class TexeraWebApplication
     environment.jersey.register(classOf[HubResource])
     environment.jersey.register(classOf[UserResource])
     environment.jersey.register(classOf[WorkflowVersionResource])
+    environment.jersey.register(classOf[WorkflowSnapshotResource])
     environment.jersey.register(classOf[ProjectResource])
     environment.jersey.register(classOf[ProjectAccessResource])
     environment.jersey.register(classOf[WorkflowExecutionsResource])

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
@@ -128,12 +128,15 @@ object DatasetSearchQueryBuilder extends SearchQueryBuilder with LazyLogging {
       size = LakeFSStorageClient.retrieveRepositorySize(dataset.getRepositoryName)
     } catch {
       case e: io.lakefs.clients.sdk.ApiException =>
-        // Treat all LakeFS ApiException as mismatch (repository not found, being deleted, or any fatal error)
-        logger.error(
-          s"LakeFS ApiException for dataset repository '${dataset.getRepositoryName}': ${e.getMessage}",
+        // LakeFS can transiently fail to report a repo's size for newly created datasets
+        // (commit not yet visible, repo metadata still propagating, etc.). Previously we
+        // dropped the entry entirely, which made just-imported datasets disappear from the
+        // dashboard. Fall back to size=0 and still return the entry so the user can see it.
+        logger.warn(
+          s"LakeFS ApiException for dataset repository '${dataset.getRepositoryName}': ${e.getMessage}. Returning entry with size=0.",
           e
         )
-        return null
+        size = 0L
     }
 
     val dd = DashboardDataset(

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowSnapshotResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowSnapshotResource.scala
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.resource.dashboard.user.workflow
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.dropwizard.auth.Auth
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.apache.texera.auth.SessionUser
+import org.apache.texera.dao.SqlServer
+import org.apache.texera.dao.jooq.generated.tables.daos.WorkflowDao
+import org.jooq.{DSLContext, Field, Record}
+import org.jooq.impl.DSL
+
+import java.sql.Timestamp
+import javax.annotation.security.RolesAllowed
+import javax.ws.rs._
+import javax.ws.rs.core.MediaType
+import scala.jdk.CollectionConverters._
+
+/**
+  * Time Machine — full-snapshot version history for workflows.
+  *
+  * This is a parallel mechanism to WorkflowVersionResource, which stores JSON
+  * diffs on persist. Snapshots here are full content captures tagged with the
+  * discrete event that produced them (operator added, link removed, etc.).
+  *
+  * Reads/writes go through plain DSL because the generated jOOQ bindings for
+  * workflow_snapshot aren't part of this branch — regenerating jOOQ would be a
+  * heavier change than this hackathon scope warrants.
+  */
+object WorkflowSnapshotResource {
+
+  // raw table / field references (no generated jOOQ bindings for this table)
+  private val T = DSL.table(DSL.name("workflow_snapshot"))
+  private val SID: Field[Integer] = DSL.field(DSL.name("sid"), classOf[Integer])
+  private val WID: Field[Integer] = DSL.field(DSL.name("wid"), classOf[Integer])
+  private val UID: Field[Integer] = DSL.field(DSL.name("uid"), classOf[Integer])
+  private val SNAPSHOT_VERSION: Field[Integer] =
+    DSL.field(DSL.name("snapshot_version"), classOf[Integer])
+  private val CONTENT: Field[String] = DSL.field(DSL.name("content"), classOf[String])
+  private val CHANGE_TYPE: Field[String] = DSL.field(DSL.name("change_type"), classOf[String])
+  private val CHANGE_SUMMARY: Field[String] = DSL.field(DSL.name("change_summary"), classOf[String])
+  private val CHANGED_OPERATORS: Field[String] =
+    DSL.field(DSL.name("changed_operators"), classOf[String])
+  private val SOURCE: Field[String] = DSL.field(DSL.name("source"), classOf[String])
+  private val CREATION_TIME: Field[Timestamp] =
+    DSL.field(DSL.name("creation_time"), classOf[Timestamp])
+
+  private def context: DSLContext = SqlServer.getInstance().createDSLContext()
+
+  /** Public DTO returned by list endpoint. Lightweight — no full content. */
+  case class SnapshotEntry(
+      sid: Int,
+      wid: Int,
+      version: Int,
+      changeType: String,
+      changeSummary: String,
+      changedOperators: List[String],
+      source: String,
+      uid: Option[Int],
+      creationTime: Timestamp
+  )
+
+  /** Full snapshot including content. Returned by get-one and revert. */
+  case class SnapshotFull(
+      sid: Int,
+      wid: Int,
+      version: Int,
+      changeType: String,
+      changeSummary: String,
+      changedOperators: List[String],
+      source: String,
+      uid: Option[Int],
+      creationTime: Timestamp,
+      content: String
+  )
+
+  /** Request body for POST /snapshots. */
+  case class SnapshotCreateRequest(
+      content: String,
+      changeType: String,
+      changeSummary: String,
+      changedOperators: java.util.List[String],
+      source: String
+  ) {
+    def changedOpsList: List[String] =
+      Option(changedOperators).map(_.asScala.toList).getOrElse(Nil)
+  }
+
+  /**
+    * A single operator in a diff. `displayName` is pre-resolved on the
+    * server side from `customDisplayName` → `operatorType` → `operatorID`,
+    * so the frontend can render it directly without re-parsing the snapshot
+    * or relying on Option-field serialization. `operatorType` is also
+    * returned separately so the UI can prefer a friendlier schema label
+    * (via OperatorMetadataService.userFriendlyName) when one is available.
+    */
+  case class OperatorDiffEntry(
+      operatorID: String,
+      operatorType: String,
+      customDisplayName: String,
+      displayName: String
+  )
+
+  case class DiffResult(
+      v1: Int,
+      v2: Int,
+      operatorsAdded: List[OperatorDiffEntry],
+      operatorsRemoved: List[OperatorDiffEntry],
+      operatorsModified: List[OperatorDiffEntry],
+      linksAdded: Int,
+      linksRemoved: Int
+  )
+
+  private def nextVersion(ctx: DSLContext, wid: Integer): Int = {
+    val max = ctx
+      .select(DSL.max(SNAPSHOT_VERSION))
+      .from(T)
+      .where(WID.eq(wid))
+      .fetchOne()
+    if (max == null || max.value1() == null) 1 else max.value1().intValue() + 1
+  }
+
+  private def toEntry(r: Record): SnapshotEntry =
+    SnapshotEntry(
+      sid = r.get(SID).intValue(),
+      wid = r.get(WID).intValue(),
+      version = r.get(SNAPSHOT_VERSION).intValue(),
+      changeType = r.get(CHANGE_TYPE),
+      changeSummary = r.get(CHANGE_SUMMARY),
+      changedOperators = parseStringList(r.get(CHANGED_OPERATORS)),
+      source = r.get(SOURCE),
+      uid = Option(r.get(UID)).map(_.intValue()),
+      creationTime = r.get(CREATION_TIME)
+    )
+
+  private def toFull(r: Record): SnapshotFull = {
+    val e = toEntry(r)
+    SnapshotFull(
+      sid = e.sid,
+      wid = e.wid,
+      version = e.version,
+      changeType = e.changeType,
+      changeSummary = e.changeSummary,
+      changedOperators = e.changedOperators,
+      source = e.source,
+      uid = e.uid,
+      creationTime = e.creationTime,
+      content = r.get(CONTENT)
+    )
+  }
+
+  private def parseStringList(raw: String): List[String] = {
+    if (raw == null || raw.isEmpty) return Nil
+    try {
+      val node = objectMapper.readTree(raw)
+      if (node.isArray) node.elements().asScala.map(_.asText()).toList else Nil
+    } catch {
+      case _: Throwable => Nil
+    }
+  }
+
+  /** Extract operator IDs from a workflow content JSON string. */
+  private def extractOperatorIds(content: String): Set[String] = {
+    if (content == null || content.isEmpty) return Set.empty
+    try {
+      val root = objectMapper.readTree(content)
+      val ops = root.path("operators")
+      if (!ops.isArray) return Set.empty
+      ops.elements().asScala.map(_.path("operatorID").asText("")).filter(_.nonEmpty).toSet
+    } catch {
+      case _: Throwable => Set.empty
+    }
+  }
+
+  /** Build a `id -> JSON node` map of operators inside a workflow content. */
+  private def operatorMap(content: String): Map[String, JsonNode] = {
+    if (content == null || content.isEmpty) return Map.empty
+    try {
+      val ops = objectMapper.readTree(content).path("operators")
+      if (!ops.isArray) return Map.empty
+      ops.elements().asScala.toList.flatMap { op =>
+        val id = op.path("operatorID").asText("")
+        if (id.isEmpty) None else Some(id -> op)
+      }.toMap
+    } catch {
+      case _: Throwable => Map.empty
+    }
+  }
+
+  /** Extract a stable id for each link (source op + port -> target op + port). */
+  private def linkIds(content: String): Set[String] = {
+    if (content == null || content.isEmpty) return Set.empty
+    try {
+      val links = objectMapper.readTree(content).path("links")
+      if (!links.isArray) return Set.empty
+      links.elements().asScala.map { l =>
+        val src = l.path("source")
+        val tgt = l.path("target")
+        s"${src.path("operatorID").asText()}:${src.path("portID").asText()}->" +
+          s"${tgt.path("operatorID").asText()}:${tgt.path("portID").asText()}"
+      }.toSet
+    } catch {
+      case _: Throwable => Set.empty
+    }
+  }
+
+  private def toDiffEntry(id: String, node: JsonNode): OperatorDiffEntry = {
+    val opType = node.path("operatorType").asText("")
+    val custom = node.path("customDisplayName").asText("")
+    val resolved =
+      if (custom.nonEmpty) custom
+      else if (opType.nonEmpty) opType
+      else id
+    OperatorDiffEntry(
+      operatorID = id,
+      operatorType = opType,
+      customDisplayName = custom,
+      displayName = resolved
+    )
+  }
+
+  private def computeDiff(v1Content: String, v2Content: String, v1: Int, v2: Int): DiffResult = {
+    val ops1 = operatorMap(v1Content)
+    val ops2 = operatorMap(v2Content)
+    val ids1 = ops1.keySet
+    val ids2 = ops2.keySet
+    // For added/modified, pull metadata from v2 (the "after" side).
+    // For removed, pull from v1 since the operator no longer exists in v2.
+    val added = (ids2 -- ids1).toList.sorted.map(id => toDiffEntry(id, ops2(id)))
+    val removed = (ids1 -- ids2).toList.sorted.map(id => toDiffEntry(id, ops1(id)))
+    val modified = (ids1 intersect ids2).toList
+      .filter(id => ops1(id) != ops2(id))
+      .sorted
+      .map(id => toDiffEntry(id, ops2(id)))
+    val l1 = linkIds(v1Content)
+    val l2 = linkIds(v2Content)
+    DiffResult(
+      v1 = v1,
+      v2 = v2,
+      operatorsAdded = added,
+      operatorsRemoved = removed,
+      operatorsModified = modified,
+      linksAdded = (l2 -- l1).size,
+      linksRemoved = (l1 -- l2).size
+    )
+  }
+
+  private def hasReadAccess(wid: Integer, user: SessionUser): Boolean =
+    WorkflowAccessResource.hasReadAccess(wid, user.getUser.getUid)
+
+  private def hasWriteAccess(wid: Integer, user: SessionUser): Boolean =
+    WorkflowAccessResource.hasWriteAccess(wid, user.getUser.getUid)
+}
+
+@Path("/time-machine")
+@Produces(Array(MediaType.APPLICATION_JSON))
+@Consumes(Array(MediaType.APPLICATION_JSON))
+class WorkflowSnapshotResource {
+  import WorkflowSnapshotResource._
+
+  /** List snapshots, newest first. Lightweight (no content). */
+  @GET
+  @Path("/{wid}/snapshots")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def listSnapshots(
+      @PathParam("wid") wid: Integer,
+      @Auth sessionUser: SessionUser
+  ): java.util.List[SnapshotEntry] = {
+    if (!hasReadAccess(wid, sessionUser)) {
+      throw new ForbiddenException("No sufficient access privilege.")
+    }
+    val ctx = context
+    ctx
+      .select(
+        SID,
+        WID,
+        UID,
+        SNAPSHOT_VERSION,
+        CHANGE_TYPE,
+        CHANGE_SUMMARY,
+        CHANGED_OPERATORS,
+        SOURCE,
+        CREATION_TIME
+      )
+      .from(T)
+      .where(WID.eq(wid))
+      .orderBy(SNAPSHOT_VERSION.desc())
+      .fetch()
+      .asScala
+      .map(toEntry)
+      .toList
+      .asJava
+  }
+
+  /** Get one snapshot including full content. Used for preview and revert. */
+  @GET
+  @Path("/{wid}/snapshots/{sid}")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def getSnapshot(
+      @PathParam("wid") wid: Integer,
+      @PathParam("sid") sid: Integer,
+      @Auth sessionUser: SessionUser
+  ): SnapshotFull = {
+    if (!hasReadAccess(wid, sessionUser)) {
+      throw new ForbiddenException("No sufficient access privilege.")
+    }
+    val rec = context
+      .select(
+        SID,
+        WID,
+        UID,
+        SNAPSHOT_VERSION,
+        CHANGE_TYPE,
+        CHANGE_SUMMARY,
+        CHANGED_OPERATORS,
+        SOURCE,
+        CREATION_TIME,
+        CONTENT
+      )
+      .from(T)
+      .where(WID.eq(wid).and(SID.eq(sid)))
+      .fetchOne()
+    if (rec == null) throw new NotFoundException(s"Snapshot $sid not found for workflow $wid")
+    toFull(rec)
+  }
+
+  /** Create a new snapshot for this workflow. */
+  @POST
+  @Path("/{wid}/snapshots")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def createSnapshot(
+      @PathParam("wid") wid: Integer,
+      req: SnapshotCreateRequest,
+      @Auth sessionUser: SessionUser
+  ): SnapshotEntry = {
+    if (!hasWriteAccess(wid, sessionUser)) {
+      throw new ForbiddenException("No sufficient access privilege.")
+    }
+    if (req == null || req.content == null || req.content.isEmpty) {
+      throw new BadRequestException("Snapshot content is required.")
+    }
+    val ctx = context
+    val v = nextVersion(ctx, wid)
+    val changedOpsJson =
+      objectMapper.writeValueAsString(req.changedOpsList.asJava)
+    val source = Option(req.source).filter(Set("user", "agent").contains).getOrElse("user")
+    val uid: Integer = sessionUser.getUser.getUid
+
+    val sid: Integer = ctx
+      .insertInto(T)
+      .columns(
+        WID,
+        UID,
+        SNAPSHOT_VERSION,
+        CONTENT,
+        CHANGE_TYPE,
+        CHANGE_SUMMARY,
+        CHANGED_OPERATORS,
+        SOURCE
+      )
+      .values(
+        wid,
+        uid,
+        Integer.valueOf(v),
+        req.content,
+        Option(req.changeType).getOrElse("manual_save"),
+        Option(req.changeSummary).getOrElse(""),
+        changedOpsJson,
+        source
+      )
+      .returning(SID)
+      .fetchOne()
+      .get(SID)
+
+    val rec = ctx
+      .select(
+        SID,
+        WID,
+        UID,
+        SNAPSHOT_VERSION,
+        CHANGE_TYPE,
+        CHANGE_SUMMARY,
+        CHANGED_OPERATORS,
+        SOURCE,
+        CREATION_TIME
+      )
+      .from(T)
+      .where(SID.eq(sid))
+      .fetchOne()
+    toEntry(rec)
+  }
+
+  /**
+    * Revert the workflow content to the snapshot. Writes the snapshot's content
+    * back into the workflow row and records a new snapshot describing the revert.
+    */
+  @POST
+  @Path("/{wid}/snapshots/{sid}/revert")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def revertSnapshot(
+      @PathParam("wid") wid: Integer,
+      @PathParam("sid") sid: Integer,
+      @Auth sessionUser: SessionUser
+  ): SnapshotFull = {
+    if (!hasWriteAccess(wid, sessionUser)) {
+      throw new ForbiddenException("No sufficient access privilege.")
+    }
+    val ctx = context
+    val target = getSnapshot(wid, sid, sessionUser)
+
+    // overwrite workflow content with the snapshot
+    val workflowDao = new WorkflowDao(ctx.configuration)
+    val workflow = workflowDao.fetchOneByWid(wid)
+    if (workflow == null) throw new NotFoundException(s"Workflow $wid not found")
+    workflow.setContent(target.content)
+    workflow.setLastModifiedTime(new Timestamp(System.currentTimeMillis()))
+    workflowDao.update(workflow)
+
+    // record the revert as its own snapshot entry, pointing at the same content
+    val v = nextVersion(ctx, wid)
+    val uid: Integer = sessionUser.getUser.getUid
+    val emptyOps = objectMapper.writeValueAsString(List.empty[String].asJava)
+    ctx
+      .insertInto(T)
+      .columns(
+        WID,
+        UID,
+        SNAPSHOT_VERSION,
+        CONTENT,
+        CHANGE_TYPE,
+        CHANGE_SUMMARY,
+        CHANGED_OPERATORS,
+        SOURCE
+      )
+      .values(
+        wid,
+        uid,
+        Integer.valueOf(v),
+        target.content,
+        "revert",
+        s"Reverted to version ${target.version}",
+        emptyOps,
+        "user"
+      )
+      .execute()
+
+    target
+  }
+
+  /** Diff between two snapshots of the same workflow. */
+  @GET
+  @Path("/{wid}/diff")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def diffSnapshots(
+      @PathParam("wid") wid: Integer,
+      @QueryParam("v1") sid1: Integer,
+      @QueryParam("v2") sid2: Integer,
+      @Auth sessionUser: SessionUser
+  ): DiffResult = {
+    if (!hasReadAccess(wid, sessionUser)) {
+      throw new ForbiddenException("No sufficient access privilege.")
+    }
+    if (sid1 == null || sid2 == null) {
+      throw new BadRequestException("Both v1 and v2 query params (snapshot sids) are required.")
+    }
+    val a = getSnapshot(wid, sid1, sessionUser)
+    val b = getSnapshot(wid, sid2, sessionUser)
+    computeDiff(a.content, b.content, a.version, b.version)
+  }
+}

--- a/bin/litellm-config.yaml
+++ b/bin/litellm-config.yaml
@@ -29,6 +29,10 @@ model_list:
     litellm_params:
       model: claude-haiku-4-5-20251001
       api_key: "os.environ/ANTHROPIC_API_KEY"
+  - model_name: claude-opus-4.7
+    litellm_params:
+      model: claude-opus-4-7
+      api_key: "os.environ/ANTHROPIC_API_KEY"
   - model_name: gpt-5-mini
     litellm_params:
       model: gpt-5-mini-2025-08-07

--- a/common/config/src/main/resources/gui.conf
+++ b/common/config/src/main/resources/gui.conf
@@ -109,7 +109,7 @@ gui {
     active-time-in-minutes = ${?GUI_WORKFLOW_WORKSPACE_ACTIVE_TIME_IN_MINUTES}
 
     # whether AI copilot feature is enabled
-    copilot-enabled = false
+    copilot-enabled = true
     copilot-enabled = ${?GUI_WORKFLOW_WORKSPACE_COPILOT_ENABLED}
 
     # the limit of columns to be displayed in the result table

--- a/frontend/proxy.config.json
+++ b/frontend/proxy.config.json
@@ -10,6 +10,11 @@
     "secure": false,
     "changeOrigin": true
   },
+  "/api/data-source": {
+    "target": "http://localhost:3001",
+    "secure": false,
+    "changeOrigin": true
+  },
 "/api/models": {
     "target": "http://localhost:9096",
     "secure": false,

--- a/frontend/src/app/app-routing.constant.ts
+++ b/frontend/src/app/app-routing.constant.ts
@@ -37,6 +37,7 @@ export const DASHBOARD_USER_DATASET = `${DASHBOARD_USER}/dataset`;
 export const DASHBOARD_USER_DATASET_CREATE = `${DASHBOARD_USER_DATASET}/create`;
 export const DASHBOARD_USER_COMPUTING_UNIT = `${DASHBOARD_USER}/compute`;
 export const DASHBOARD_USER_QUOTA = `${DASHBOARD_USER}/quota`;
+export const DASHBOARD_USER_AGENT = `${DASHBOARD_USER}/agent`;
 export const DASHBOARD_USER_DISCUSSION = `${DASHBOARD_USER}/discussion`;
 
 export const DASHBOARD_ADMIN = `${DASHBOARD}/admin`;

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -36,6 +36,7 @@ import { FlarumComponent } from "./dashboard/component/user/flarum/flarum.compon
 import { AdminGmailComponent } from "./dashboard/component/admin/gmail/admin-gmail.component";
 import { DatasetDetailComponent } from "./dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component";
 import { UserDatasetComponent } from "./dashboard/component/user/user-dataset/user-dataset.component";
+import { UserAgentComponent } from "./dashboard/component/user/user-agent/user-agent.component";
 import { HubWorkflowDetailComponent } from "./hub/component/workflow/detail/hub-workflow-detail.component";
 import { LandingPageComponent } from "./hub/component/landing-page/landing-page.component";
 import { DASHBOARD_ABOUT, DASHBOARD_USER_WORKFLOW } from "./app-routing.constant";
@@ -138,6 +139,10 @@ routes.push({
         {
           path: "quota",
           component: UserQuotaComponent,
+        },
+        {
+          path: "agent",
+          component: UserAgentComponent,
         },
         {
           path: "discussion",

--- a/frontend/src/app/dashboard/component/dashboard.component.html
+++ b/frontend/src/app/dashboard/component/dashboard.component.html
@@ -98,6 +98,17 @@
             <span>Datasets</span>
           </li>
           <li
+            nz-menu-item
+            nz-tooltip="Manage your custom AI agents"
+            nzMatchRouter="true"
+            nzTooltipPlacement="right"
+            [routerLink]="DASHBOARD_USER_AGENT">
+            <span
+              nz-icon
+              nzType="robot"></span>
+            <span>Agents</span>
+          </li>
+          <li
             *ngIf="sidebarTabs.compute_enabled"
             nz-menu-item
             nz-tooltip="Manage computing units"

--- a/frontend/src/app/dashboard/component/dashboard.component.ts
+++ b/frontend/src/app/dashboard/component/dashboard.component.ts
@@ -40,6 +40,7 @@ import {
   DASHBOARD_USER_PROJECT,
   DASHBOARD_USER_QUOTA,
   DASHBOARD_USER_WORKFLOW,
+  DASHBOARD_USER_AGENT,
 } from "../../app-routing.constant";
 import { Version } from "../../../environments/version";
 import { SidebarTabs } from "../../common/type/gui-config";
@@ -111,6 +112,7 @@ export class DashboardComponent implements OnInit {
   protected readonly DASHBOARD_USER_COMPUTING_UNIT = DASHBOARD_USER_COMPUTING_UNIT;
   protected readonly DASHBOARD_USER_QUOTA = DASHBOARD_USER_QUOTA;
   protected readonly DASHBOARD_USER_DISCUSSION = DASHBOARD_USER_DISCUSSION;
+  protected readonly DASHBOARD_USER_AGENT = DASHBOARD_USER_AGENT;
   protected readonly DASHBOARD_ADMIN_USER = DASHBOARD_ADMIN_USER;
   protected readonly DASHBOARD_ADMIN_GMAIL = DASHBOARD_ADMIN_GMAIL;
   protected readonly DASHBOARD_ADMIN_EXECUTION = DASHBOARD_ADMIN_EXECUTION;

--- a/frontend/src/app/dashboard/component/user/user-agent/user-agent-editor.component.html
+++ b/frontend/src/app/dashboard/component/user/user-agent/user-agent-editor.component.html
@@ -1,0 +1,130 @@
+<div class="agent-editor">
+  <!-- Basic info: icon + name on one row, then description, then model. -->
+  <div class="basic-row">
+    <div class="icon-tile">
+      <input nz-input class="icon-tile-input" maxlength="4" [(ngModel)]="draft.icon" />
+      <span class="icon-tile-badge" nz-icon nzType="edit" nzTheme="outline"></span>
+    </div>
+    <input nz-input class="name-input" [(ngModel)]="draft.name" placeholder="Agent name" />
+  </div>
+  <textarea
+    nz-input
+    class="description-input"
+    rows="2"
+    [(ngModel)]="draft.description"
+    placeholder="What does this agent specialize in?"></textarea>
+  <div class="model-row">
+    <nz-select [(ngModel)]="draft.model" class="full-width">
+      <nz-option *ngFor="let opt of MODELS" [nzValue]="opt.value" [nzLabel]="opt.label"></nz-option>
+    </nz-select>
+    <p class="hint">Opus: best for complex workflows. Haiku: fast &amp; simple tasks.</p>
+  </div>
+
+  <nz-divider nzText="Configuration" nzOrientation="left"></nz-divider>
+  <div class="form-row-grid">
+    <div>
+      <label>Domain</label>
+      <nz-select [(ngModel)]="draft.domain" class="full-width">
+        <nz-option *ngFor="let opt of DOMAINS" [nzValue]="opt.value" [nzLabel]="opt.label"></nz-option>
+      </nz-select>
+    </div>
+    <div>
+      <label>Methodology</label>
+      <nz-select [(ngModel)]="draft.methodology" class="full-width">
+        <nz-option *ngFor="let opt of METHODOLOGIES" [nzValue]="opt.value" [nzLabel]="opt.label"></nz-option>
+      </nz-select>
+    </div>
+    <div>
+      <label>Task Type</label>
+      <nz-select [(ngModel)]="draft.taskType" class="full-width">
+        <nz-option *ngFor="let opt of TASK_TYPES" [nzValue]="opt.value" [nzLabel]="opt.label"></nz-option>
+      </nz-select>
+    </div>
+  </div>
+
+  <nz-divider nzText="Guardrails" nzOrientation="left"></nz-divider>
+  <div class="guardrails-grid">
+    <label
+      nz-checkbox
+      class="guardrail-chip"
+      [class.is-checked]="draft.guardrails.requireTrainTestSplit"
+      [(ngModel)]="draft.guardrails.requireTrainTestSplit">
+      Require train/test split
+    </label>
+    <label
+      nz-checkbox
+      class="guardrail-chip"
+      [class.is-checked]="draft.guardrails.requireEvaluation"
+      [(ngModel)]="draft.guardrails.requireEvaluation">
+      Require evaluation metrics
+    </label>
+    <label
+      nz-checkbox
+      class="guardrail-chip"
+      [class.is-checked]="draft.guardrails.preventDataLeakage"
+      [(ngModel)]="draft.guardrails.preventDataLeakage">
+      Prevent data leakage
+    </label>
+    <label
+      nz-checkbox
+      class="guardrail-chip"
+      [class.is-checked]="draft.guardrails.handleMissingValues"
+      [(ngModel)]="draft.guardrails.handleMissingValues">
+      Handle missing values
+    </label>
+    <label
+      nz-checkbox
+      class="guardrail-chip"
+      [class.is-checked]="draft.guardrails.featureScalingCheck"
+      [(ngModel)]="draft.guardrails.featureScalingCheck">
+      Feature scaling check
+    </label>
+  </div>
+
+  <nz-divider nzText="Example Workflows" nzOrientation="left"></nz-divider>
+  <p class="section-hint">Select workflows as templates. Your agent will follow similar patterns.</p>
+  <nz-select
+    nzMode="multiple"
+    class="full-width"
+    [(ngModel)]="draft.exampleWorkflowIds"
+    nzPlaceHolder="Pick from your saved workflows"
+    nzAllowClear>
+    <nz-option *ngFor="let wf of workflowOptions" [nzValue]="wf.value" [nzLabel]="wf.label"></nz-option>
+  </nz-select>
+  <p class="hint" *ngIf="workflowOptions.length === 0">No saved workflows found.</p>
+
+  <nz-divider nzText="Reference Files" nzOrientation="left"></nz-divider>
+  <p class="section-hint">Upload data dictionaries, methodology docs, or paper excerpts.</p>
+  <div
+    class="dropzone"
+    [class.is-dragging]="dragging"
+    (dragover)="onDragOver($event)"
+    (dragleave)="onDragLeave($event)"
+    (drop)="onDrop($event)">
+    <span nz-icon nzType="inbox"></span>
+    <p>
+      Drag &amp; drop files here, or
+      <label class="browse-link">
+        browse
+        <input type="file" multiple [accept]="KNOWLEDGE_ACCEPT" (change)="onFileInput($event)" />
+      </label>
+    </p>
+    <p class="hint">CSV, PDF, TXT, MD, JSON — max 1 MB each</p>
+  </div>
+  <ul class="file-list" *ngIf="draft.knowledgeFiles?.length">
+    <li *ngFor="let file of draft.knowledgeFiles">
+      <span nz-icon nzType="file" class="file-icon"></span>
+      <span class="file-name">{{ file.name }}</span>
+      <span class="file-meta">{{ formatSize(file.size) }}</span>
+      <button nz-button nzType="text" nzSize="small" nzDanger (click)="removeKnowledgeFile(file.id)">
+        <span nz-icon nzType="close"></span>
+      </button>
+    </li>
+  </ul>
+
+  <nz-divider></nz-divider>
+  <div class="footer">
+    <button nz-button (click)="cancel()">Cancel</button>
+    <button nz-button nzType="primary" (click)="save()" [disabled]="!draft.name?.trim()">Save</button>
+  </div>
+</div>

--- a/frontend/src/app/dashboard/component/user/user-agent/user-agent-editor.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-agent/user-agent-editor.component.scss
@@ -1,0 +1,187 @@
+.agent-editor {
+  display: flex;
+  flex-direction: column;
+
+  label {
+    display: block;
+    font-weight: 500;
+    margin-bottom: 4px;
+    .required { color: #f5222d; }
+  }
+
+  .full-width {
+    width: 100%;
+  }
+
+  // ----- Basic info row: 48px icon tile + name input ---------------------
+  .basic-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+  }
+
+  .icon-tile {
+    position: relative;
+    width: 48px;
+    height: 48px;
+    flex-shrink: 0;
+
+    .icon-tile-input {
+      width: 48px;
+      height: 48px;
+      padding: 0;
+      text-align: center;
+      font-size: 26px;
+      line-height: 48px;
+      border-radius: 8px;
+      background: #fafafa;
+    }
+
+    .icon-tile-badge {
+      position: absolute;
+      right: -4px;
+      bottom: -4px;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: #1890ff;
+      color: #fff;
+      font-size: 9px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      pointer-events: none;
+      box-shadow: 0 0 0 2px #fff;
+    }
+  }
+
+  .name-input {
+    flex: 1;
+  }
+
+  .description-input {
+    margin-bottom: 8px;
+  }
+
+  .model-row {
+    margin-bottom: 4px;
+  }
+
+  // ----- Configuration: 3-column grid ------------------------------------
+  .form-row-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+  }
+
+  // ----- Guardrails: 2-column chip grid ----------------------------------
+  .guardrails-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+  }
+
+  // Each chip is an nz-checkbox label styled as a pill. ng-zorro renders the
+  // checkbox glyph inside a `.ant-checkbox` span; this rule colors the
+  // surrounding label, not the glyph.
+  .guardrail-chip {
+    display: flex;
+    align-items: center;
+    margin: 0;
+    padding: 8px 12px;
+    border-radius: 6px;
+    background: #f5f5f5;
+    transition: background 0.15s, color 0.15s;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 400;
+
+    &.is-checked {
+      background: #e6f4ff;
+      color: #003a8c;
+    }
+
+    &:hover {
+      background: #ebebeb;
+    }
+
+    &.is-checked:hover {
+      background: #d6ebff;
+    }
+  }
+
+  // ----- Sections ---------------------------------------------------------
+  .footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .section-hint {
+    color: rgba(0, 0, 0, 0.55);
+    margin: 0 0 8px;
+    font-size: 13px;
+  }
+
+  .hint {
+    color: rgba(0, 0, 0, 0.45);
+    font-size: 12px;
+    margin: 4px 0 0;
+  }
+
+  // ----- Reference files (dropzone) --------------------------------------
+  .dropzone {
+    border: 1px dashed #d9d9d9;
+    border-radius: 6px;
+    padding: 16px;
+    text-align: center;
+    background: #fafafa;
+    transition: border-color 0.15s, background 0.15s;
+
+    &.is-dragging {
+      border-color: #1890ff;
+      background: #e6f7ff;
+    }
+
+    span[nz-icon] {
+      font-size: 24px;
+      color: #1890ff;
+    }
+
+    p {
+      margin: 4px 0 0;
+    }
+
+    .browse-link {
+      color: #1890ff;
+      cursor: pointer;
+      text-decoration: underline;
+
+      input[type="file"] {
+        display: none;
+      }
+    }
+  }
+
+  .file-list {
+    list-style: none;
+    padding: 0;
+    margin: 8px 0 0;
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border: 1px solid #f0f0f0;
+      border-radius: 4px;
+      margin-bottom: 4px;
+      background: #fff;
+
+      .file-icon { color: rgba(0, 0, 0, 0.45); }
+      .file-name { flex: 1; }
+      .file-meta { color: rgba(0, 0, 0, 0.45); font-size: 12px; }
+    }
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-agent/user-agent-editor.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-agent/user-agent-editor.component.ts
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject, OnInit } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { CommonModule } from "@angular/common";
+import { NzModalRef, NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { NzInputModule } from "ng-zorro-antd/input";
+import { NzSelectModule } from "ng-zorro-antd/select";
+import { NzCheckboxModule } from "ng-zorro-antd/checkbox";
+import { NzButtonModule } from "ng-zorro-antd/button";
+import { NzFormModule } from "ng-zorro-antd/form";
+import { NzDividerModule } from "ng-zorro-antd/divider";
+import { NzIconModule } from "ng-zorro-antd/icon";
+import { NzMessageService } from "ng-zorro-antd/message";
+import {
+  CustomAgent,
+  AGENT_DOMAIN_OPTIONS,
+  AGENT_METHODOLOGY_OPTIONS,
+  AGENT_MODEL_OPTIONS,
+  AGENT_TASK_TYPE_OPTIONS,
+  AGENT_OUTPUT_FORMAT_OPTIONS,
+  KnowledgeFile,
+  KNOWLEDGE_FILE_MAX_BYTES,
+  KNOWLEDGE_FILE_ACCEPT,
+} from "../../../type/custom-agent.interface";
+import { OperatorMetadataService } from "../../../../workspace/service/operator-metadata/operator-metadata.service";
+import { WorkflowPersistService } from "../../../../common/service/workflow-persist/workflow-persist.service";
+
+interface OperatorOption {
+  value: string;
+  label: string;
+}
+
+interface WorkflowOption {
+  value: number;
+  label: string;
+}
+
+@Component({
+  selector: "texera-user-agent-editor",
+  templateUrl: "./user-agent-editor.component.html",
+  styleUrls: ["./user-agent-editor.component.scss"],
+  imports: [
+    CommonModule,
+    FormsModule,
+    NzInputModule,
+    NzSelectModule,
+    NzCheckboxModule,
+    NzButtonModule,
+    NzFormModule,
+    NzDividerModule,
+    NzIconModule,
+  ],
+})
+export class UserAgentEditorComponent implements OnInit {
+  protected readonly DOMAINS = AGENT_DOMAIN_OPTIONS;
+  protected readonly METHODOLOGIES = AGENT_METHODOLOGY_OPTIONS;
+  protected readonly MODELS = AGENT_MODEL_OPTIONS;
+  protected readonly TASK_TYPES = AGENT_TASK_TYPE_OPTIONS;
+  protected readonly OUTPUT_FORMATS = AGENT_OUTPUT_FORMAT_OPTIONS;
+  protected readonly KNOWLEDGE_ACCEPT = KNOWLEDGE_FILE_ACCEPT;
+
+  public draft!: Omit<CustomAgent, "id" | "createdAt" | "updatedAt"> & Partial<Pick<CustomAgent, "id">>;
+  public operatorOptions: OperatorOption[] = [];
+  public workflowOptions: WorkflowOption[] = [];
+  public dragging = false;
+
+  private readonly modalRef = inject(NzModalRef);
+  private readonly modalData = inject<{
+    initial: Omit<CustomAgent, "id" | "createdAt" | "updatedAt"> & Partial<Pick<CustomAgent, "id">>;
+    title: string;
+  }>(NZ_MODAL_DATA);
+
+  constructor(
+    private operatorMetadataService: OperatorMetadataService,
+    private workflowPersistService: WorkflowPersistService,
+    private message: NzMessageService
+  ) {}
+
+  ngOnInit(): void {
+    this.draft = { ...this.modalData.initial };
+
+    this.operatorMetadataService.getOperatorMetadata().subscribe(meta => {
+      this.operatorOptions = (meta?.operators ?? [])
+        .map(op => ({
+          value: op.operatorType,
+          label: op.additionalMetadata?.userFriendlyName
+            ? `${op.additionalMetadata.userFriendlyName} (${op.operatorType})`
+            : op.operatorType,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+    });
+
+    this.workflowPersistService.retrieveWorkflowsBySessionUser().subscribe({
+      next: workflows => {
+        this.workflowOptions = workflows
+          .filter(w => w.workflow.wid !== undefined)
+          .map(w => ({ value: w.workflow.wid as number, label: w.workflow.name }))
+          .sort((a, b) => a.label.localeCompare(b.label));
+      },
+      error: () => {
+        // Not logged in or backend unavailable — leave list empty.
+      },
+    });
+  }
+
+  public save(): void {
+    if (!this.draft.name.trim()) return;
+    this.modalRef.close(this.draft);
+  }
+
+  public cancel(): void {
+    this.modalRef.close(null);
+  }
+
+  public onFileInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files) return;
+    this.ingestFiles(Array.from(input.files));
+    input.value = "";
+  }
+
+  public onDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.dragging = false;
+    const files = event.dataTransfer?.files;
+    if (files) this.ingestFiles(Array.from(files));
+  }
+
+  public onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.dragging = true;
+  }
+
+  public onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    this.dragging = false;
+  }
+
+  public removeKnowledgeFile(id: string): void {
+    this.draft.knowledgeFiles = this.draft.knowledgeFiles.filter(f => f.id !== id);
+  }
+
+  private ingestFiles(files: File[]): void {
+    files.forEach(file => {
+      if (file.size > KNOWLEDGE_FILE_MAX_BYTES) {
+        this.message.warning(`"${file.name}" is too large (max 1 MB).`);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = reader.result;
+        if (typeof result !== "string") return;
+        const commaIdx = result.indexOf(",");
+        const base64 = commaIdx >= 0 ? result.slice(commaIdx + 1) : result;
+        const entry: KnowledgeFile = {
+          id: `kf-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+          name: file.name,
+          mimeType: file.type || "application/octet-stream",
+          size: file.size,
+          contentBase64: base64,
+        };
+        this.draft.knowledgeFiles = [...this.draft.knowledgeFiles, entry];
+      };
+      reader.readAsDataURL(file);
+    });
+  }
+
+  public formatSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-agent/user-agent.component.html
+++ b/frontend/src/app/dashboard/component/user/user-agent/user-agent.component.html
@@ -1,0 +1,46 @@
+<div class="agent-library">
+  <div class="header">
+    <div class="title-block">
+      <h2>My Agents</h2>
+      <p class="subtitle">Specialized AI agents for your Texera workflows.</p>
+    </div>
+    <button nz-button nzType="primary" nzSize="large" (click)="openCreate()">
+      <span nz-icon nzType="plus"></span>
+      Create Agent
+    </button>
+  </div>
+
+  <nz-empty *ngIf="agents.length === 0" nzNotFoundContent="No agents yet. Click 'Create Agent' to build your first one."></nz-empty>
+
+  <div class="cards-grid" *ngIf="agents.length > 0">
+    <nz-card *ngFor="let agent of agents" class="agent-card">
+      <div class="card-head">
+        <span class="icon">{{ agent.icon }}</span>
+        <div class="name-block">
+          <div class="name">{{ agent.name }}</div>
+          <div class="badges">
+            <nz-tag nzColor="blue">{{ domainLabel(agent.domain) }}</nz-tag>
+            <nz-tag *ngIf="agent.methodology !== 'none'" nzColor="purple">{{ methodologyLabel(agent.methodology) }}</nz-tag>
+            <nz-tag *ngIf="agent.isPublic" nzColor="green">Public</nz-tag>
+          </div>
+        </div>
+      </div>
+      <div class="description">{{ agent.description || '—' }}</div>
+      <div class="card-meta">Created {{ agent.createdAt | date:'short' }}</div>
+      <div class="card-actions">
+        <button nz-button nzSize="small" (click)="openEdit(agent)">
+          <span nz-icon nzType="edit"></span> Edit
+        </button>
+        <button nz-button nzSize="small" (click)="duplicate(agent)">
+          <span nz-icon nzType="copy"></span> Duplicate
+        </button>
+        <button nz-button nzSize="small" nzDanger
+          nz-popconfirm
+          nzPopconfirmTitle="Delete this agent?"
+          (nzOnConfirm)="delete(agent)">
+          <span nz-icon nzType="delete"></span> Delete
+        </button>
+      </div>
+    </nz-card>
+  </div>
+</div>

--- a/frontend/src/app/dashboard/component/user/user-agent/user-agent.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-agent/user-agent.component.scss
@@ -1,0 +1,65 @@
+.agent-library {
+  padding: 24px;
+  max-width: 1400px;
+  margin: 0 auto;
+
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 24px;
+
+    .title-block h2 {
+      margin: 0 0 4px;
+      font-size: 24px;
+    }
+    .subtitle {
+      color: rgba(0,0,0,0.55);
+      margin: 0;
+    }
+  }
+
+  .cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+  }
+
+  .agent-card {
+    .card-head {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 8px;
+    }
+    .icon {
+      font-size: 36px;
+      line-height: 1;
+    }
+    .name {
+      font-size: 16px;
+      font-weight: 600;
+      margin-bottom: 4px;
+    }
+    .badges {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+    }
+    .description {
+      color: rgba(0,0,0,0.65);
+      min-height: 40px;
+      margin-bottom: 12px;
+      white-space: pre-wrap;
+    }
+    .card-meta {
+      color: rgba(0,0,0,0.45);
+      font-size: 12px;
+      margin-bottom: 12px;
+    }
+    .card-actions {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+    }
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-agent/user-agent.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-agent/user-agent.component.ts
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { NzButtonModule } from "ng-zorro-antd/button";
+import { NzIconModule } from "ng-zorro-antd/icon";
+import { NzCardModule } from "ng-zorro-antd/card";
+import { NzTagModule } from "ng-zorro-antd/tag";
+import { NzEmptyModule } from "ng-zorro-antd/empty";
+import { NzPopconfirmModule } from "ng-zorro-antd/popconfirm";
+import { NzTooltipModule } from "ng-zorro-antd/tooltip";
+import { CustomAgentService } from "../../../service/user/custom-agent/custom-agent.service";
+import { UserService } from "../../../../common/service/user/user.service";
+import { UserAgentEditorComponent } from "./user-agent-editor.component";
+import {
+  AGENT_DOMAIN_OPTIONS,
+  AGENT_METHODOLOGY_OPTIONS,
+  CustomAgent,
+} from "../../../type/custom-agent.interface";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-user-agent",
+  templateUrl: "./user-agent.component.html",
+  styleUrls: ["./user-agent.component.scss"],
+  imports: [
+    CommonModule,
+    NzButtonModule,
+    NzIconModule,
+    NzCardModule,
+    NzTagModule,
+    NzEmptyModule,
+    NzPopconfirmModule,
+    NzTooltipModule,
+  ],
+})
+export class UserAgentComponent implements OnInit {
+  public agents: CustomAgent[] = [];
+
+  private readonly domainLabels = new Map(AGENT_DOMAIN_OPTIONS.map(o => [o.value, o.label]));
+  private readonly methodologyLabels = new Map(AGENT_METHODOLOGY_OPTIONS.map(o => [o.value, o.label]));
+
+  constructor(
+    private customAgentService: CustomAgentService,
+    private modalService: NzModalService,
+    private userService: UserService
+  ) {}
+
+  ngOnInit(): void {
+    this.customAgentService
+      .list$()
+      .pipe(untilDestroyed(this))
+      .subscribe(agents => (this.agents = agents));
+  }
+
+  public domainLabel(value: string): string {
+    return this.domainLabels.get(value as any) ?? value;
+  }
+
+  public methodologyLabel(value: string): string {
+    return this.methodologyLabels.get(value as any) ?? value;
+  }
+
+  public openCreate(): void {
+    const creator = this.currentUserName();
+    const draft = this.customAgentService.emptyDraft(creator);
+    this.openEditor("Create agent", draft, saved => {
+      this.customAgentService.create(saved);
+    });
+  }
+
+  public openEdit(agent: CustomAgent): void {
+    const { id, createdAt, updatedAt, ...editable } = agent;
+    this.openEditor("Edit agent", { ...editable, id }, saved => {
+      const { id: savedId, ...patch } = saved as CustomAgent;
+      this.customAgentService.update(agent.id, patch);
+    });
+  }
+
+  public duplicate(agent: CustomAgent): void {
+    this.customAgentService.duplicate(agent.id);
+  }
+
+  public delete(agent: CustomAgent): void {
+    this.customAgentService.delete(agent.id);
+  }
+
+  private currentUserName(): string {
+    const user = this.userService.getCurrentUser();
+    return user?.name ?? "anonymous";
+  }
+
+  private openEditor(
+    title: string,
+    initial: Omit<CustomAgent, "id" | "createdAt" | "updatedAt"> & Partial<Pick<CustomAgent, "id">>,
+    onSave: (saved: any) => void
+  ): void {
+    const ref = this.modalService.create({
+      nzTitle: title,
+      nzContent: UserAgentEditorComponent,
+      nzData: { initial, title },
+      nzFooter: null,
+      nzWidth: 720,
+    });
+    ref.afterClose.subscribe(result => {
+      if (result) onSave(result);
+    });
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
@@ -36,6 +36,69 @@
     </div>
   </nz-card>
 
+  <nz-card
+    *ngIf="isLogin"
+    class="import-sources-card"
+    [nzBordered]="false">
+    <div class="import-sources-row">
+      <div class="import-source-block">
+        <div class="import-source-title">
+          <i
+            nz-icon
+            nzType="link"
+            nzTheme="outline"></i>
+          <span>Import from URL</span>
+        </div>
+        <div class="url-import-controls">
+          <input
+            type="text"
+            placeholder="https://example.com/data.csv"
+            [(ngModel)]="urlImportInput"
+            [disabled]="isImporting"
+            (keyup.enter)="onClickImportFromUrl()" />
+          <button
+            nz-button
+            nzType="primary"
+            [nzLoading]="isImporting"
+            [disabled]="!urlImportInput || isImporting"
+            (click)="onClickImportFromUrl()">
+            Import
+          </button>
+        </div>
+        <div class="import-source-hint">Paste any URL pointing to a CSV or JSON file.</div>
+      </div>
+
+      <div class="import-source-block">
+        <div class="import-source-title">
+          <i
+            nz-icon
+            nzType="inbox"
+            nzTheme="outline"></i>
+          <span>Import Local File</span>
+        </div>
+        <div
+          class="drop-zone"
+          [class.dragging]="isDragging"
+          (click)="fileInput.click()"
+          (dragenter)="onDragEnter($event)"
+          (dragover)="onDragOver($event)"
+          (dragleave)="onDragLeave($event)"
+          (drop)="onDrop($event)">
+          <div class="drop-zone-primary">
+            Drag & drop .sqlite, .csv, .json, or .xlsx here
+          </div>
+          <div class="drop-zone-secondary">or click to browse</div>
+        </div>
+        <input
+          #fileInput
+          type="file"
+          hidden
+          accept=".sqlite,.db,.csv,.json,.xlsx"
+          (change)="onFileSelected($event)" />
+      </div>
+    </div>
+  </nz-card>
+
   <div class="section-search-bar">
     <texera-filters-instructions></texera-filters-instructions>
     <nz-select

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
@@ -84,9 +84,7 @@
           (dragover)="onDragOver($event)"
           (dragleave)="onDragLeave($event)"
           (drop)="onDrop($event)">
-          <div class="drop-zone-primary">
-            Drag & drop .sqlite, .csv, .json, or .xlsx here
-          </div>
+          <div class="drop-zone-primary">Drag & drop .sqlite, .csv, .json, or .xlsx here</div>
           <div class="drop-zone-secondary">or click to browse</div>
         </div>
         <input

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
@@ -25,3 +25,84 @@
   height: 55px;
   overflow-y: hidden;
 }
+
+.import-sources-card {
+  margin-bottom: 8px;
+
+  .import-sources-row {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+
+  .import-source-block {
+    flex: 1 1 320px;
+    border: 1px solid #e8e8e8;
+    border-radius: 6px;
+    padding: 10px 12px;
+    background: #fafafa;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    .import-source-title {
+      font-weight: 600;
+      font-size: 13px;
+      color: #262626;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .import-source-hint {
+      color: #8c8c8c;
+      font-size: 11px;
+      line-height: 1.4;
+    }
+  }
+
+  .url-import-controls {
+    display: flex;
+    gap: 6px;
+
+    input {
+      flex: 1;
+      padding: 4px 10px;
+      border: 1px solid #d9d9d9;
+      border-radius: 4px;
+      font-size: 13px;
+      outline: none;
+
+      &:focus {
+        border-color: #1890ff;
+      }
+    }
+  }
+
+  .drop-zone {
+    border: 1.5px dashed #bfbfbf;
+    border-radius: 6px;
+    padding: 14px;
+    text-align: center;
+    color: #595959;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s;
+    font-size: 12px;
+
+    &.dragging {
+      border-color: #1890ff;
+      background: #e6f7ff;
+      color: #096dd9;
+    }
+
+    .drop-zone-primary {
+      font-weight: 500;
+    }
+
+    .drop-zone-secondary {
+      font-size: 11px;
+      color: #8c8c8c;
+      margin-top: 2px;
+    }
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -27,7 +27,7 @@ import { SortMethod } from "../../../type/sort-method";
 import { DashboardEntry } from "../../../type/dashboard-entry";
 import { SearchResultsComponent } from "../search-results/search-results.component";
 import { FiltersComponent } from "../filters/filters.component";
-import { firstValueFrom } from "rxjs";
+import { firstValueFrom, lastValueFrom } from "rxjs";
 import { DASHBOARD_USER_DATASET } from "../../../../app-routing.constant";
 import { NzModalService } from "ng-zorro-antd/modal";
 import { UserDatasetVersionCreatorComponent } from "./user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component";
@@ -43,6 +43,8 @@ import { NzIconDirective } from "ng-zorro-antd/icon";
 import { FiltersInstructionsComponent } from "../filters-instructions/filters-instructions.component";
 import { NzSelectComponent } from "ng-zorro-antd/select";
 import { FormsModule } from "@angular/forms";
+import { CommonModule } from "@angular/common";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
 
 @UntilDestroy()
 @Component({
@@ -50,6 +52,7 @@ import { FormsModule } from "@angular/forms";
   templateUrl: "user-dataset.component.html",
   styleUrls: ["user-dataset.component.scss"],
   imports: [
+    CommonModule,
     NzCardComponent,
     NzSpaceCompactItemDirective,
     NzButtonComponent,
@@ -69,6 +72,11 @@ export class UserDatasetComponent implements AfterViewInit {
   public isLogin = this.userService.isLogin();
   public currentUid = this.userService.getCurrentUser()?.uid;
   public hasMismatch = false; // Display warning when there are mismatched datasets
+
+  // URL import state
+  public urlImportInput = "";
+  public isImporting = false;
+  public isDragging = false;
 
   private _searchResultsComponent?: SearchResultsComponent;
   @ViewChild(SearchResultsComponent) get searchResultsComponent(): SearchResultsComponent {
@@ -102,7 +110,8 @@ export class UserDatasetComponent implements AfterViewInit {
     private router: Router,
     private searchService: SearchService,
     private datasetService: DatasetService,
-    private message: NzMessageService
+    private message: NzMessageService,
+    private notificationService: NotificationService
   ) {
     this.userService
       .userChanged()
@@ -219,5 +228,338 @@ export class UserDatasetComponent implements AfterViewInit {
           datasetEntry => datasetEntry.dataset.dataset.did !== entry.dataset.dataset.did
         );
       });
+  }
+
+  // ============================================================
+  // Import-from-URL flow
+  // ============================================================
+
+  public async onClickImportFromUrl(): Promise<void> {
+    const rawUrl = (this.urlImportInput || "").trim();
+    if (!rawUrl || this.isImporting) return;
+
+    let parsed: URL;
+    try {
+      parsed = new URL(rawUrl);
+    } catch {
+      this.notificationService.error("Please enter a valid URL.");
+      return;
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      this.notificationService.error("Only http:// and https:// URLs are supported.");
+      return;
+    }
+
+    this.isImporting = true;
+    const messageId = this.message.loading("Importing from URL…", { nzDuration: 0 }).messageId;
+
+    try {
+      const fetched = await firstValueFrom(this.datasetService.fetchUrlAsCsv(rawUrl));
+      const blob = new Blob([fetched.csv], { type: "text/csv" });
+      const file = new File([blob], fetched.filename, { type: "text/csv" });
+
+      const datasetName = this.deriveDatasetName(fetched.filename);
+      await this.createDatasetFromFile(datasetName, "Imported from " + rawUrl, file);
+
+      this.message.remove(messageId);
+      this.notificationService.success(
+        `Imported "${fetched.filename}" (${fetched.rows} rows, ${fetched.columns.length} columns).`
+      );
+      this.urlImportInput = "";
+      this.refreshAfterImport();
+    } catch (err: any) {
+      this.message.remove(messageId);
+      const errMsg = err?.error?.error || err?.error?.message || err?.message || "Unknown error";
+      this.notificationService.error(`Import failed: ${errMsg}`);
+    } finally {
+      this.isImporting = false;
+    }
+  }
+
+  // ============================================================
+  // Local file drop flow (CSV / JSON / XLSX direct; SQLite stub)
+  // ============================================================
+
+  public onDragEnter(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = true;
+  }
+
+  public onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = true;
+  }
+
+  public onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = false;
+  }
+
+  public onDrop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.isDragging = false;
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this.handleLocalFile(files[0]);
+    }
+  }
+
+  public onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.handleLocalFile(input.files[0]);
+    }
+    // reset so re-selecting the same file fires change again
+    input.value = "";
+  }
+
+  private async handleLocalFile(file: File): Promise<void> {
+    const lower = file.name.toLowerCase();
+    if (lower.endsWith(".sqlite") || lower.endsWith(".db")) {
+      // SQLite path requires the user to pick a table; route to backend importer.
+      await this.importSqliteFile(file);
+      return;
+    }
+    if (
+      lower.endsWith(".csv") ||
+      lower.endsWith(".json") ||
+      lower.endsWith(".xlsx") ||
+      lower.endsWith(".tsv") ||
+      lower.endsWith(".txt")
+    ) {
+      await this.importTabularFile(file);
+      return;
+    }
+    this.notificationService.warning(
+      "Unsupported file type. Use .sqlite, .db, .csv, .json, .xlsx, .tsv, or .txt."
+    );
+  }
+
+  private async importTabularFile(file: File): Promise<void> {
+    if (this.isImporting) return;
+    this.isImporting = true;
+    const messageId = this.message.loading(`Uploading ${file.name}…`, { nzDuration: 0 }).messageId;
+    try {
+      const datasetName = this.deriveDatasetName(file.name);
+      await this.createDatasetFromFile(datasetName, `Imported from local file ${file.name}`, file);
+      this.message.remove(messageId);
+      this.notificationService.success(`Imported "${file.name}".`);
+      this.refreshAfterImport();
+    } catch (err: any) {
+      this.message.remove(messageId);
+      const errMsg = err?.error?.error || err?.error?.message || err?.message || "Unknown error";
+      this.notificationService.error(`Upload failed: ${errMsg}`);
+    } finally {
+      this.isImporting = false;
+    }
+  }
+
+  private async importSqliteFile(file: File): Promise<void> {
+    if (this.isImporting) return;
+    this.isImporting = true;
+    const messageId = this.message.loading(`Reading ${file.name}…`, { nzDuration: 0 }).messageId;
+    try {
+      const tables = await firstValueFrom(this.datasetService.listSqliteTables(file));
+      this.message.remove(messageId);
+      if (!tables.tables || tables.tables.length === 0) {
+        this.notificationService.warning(`${file.name} contains no readable tables.`);
+        return;
+      }
+
+      // Minimal UX: prompt for which table(s) to import. Single-table files import directly.
+      let chosenTables: string[];
+      if (tables.tables.length === 1) {
+        chosenTables = [tables.tables[0].name];
+      } else {
+        const summary = tables.tables
+          .map((t, i) => `${i + 1}. ${t.name} (${t.rowCount} rows, ${t.columns.length} cols)`)
+          .join("\n");
+        const answer = window.prompt(
+          `Found ${tables.tables.length} tables in ${file.name}:\n\n${summary}\n\nEnter table names to import (comma-separated), or leave empty for all:`,
+          ""
+        );
+        if (answer === null) {
+          this.notificationService.info("Import cancelled.");
+          return;
+        }
+        const trimmed = answer.trim();
+        if (trimmed.length === 0) {
+          chosenTables = tables.tables.map(t => t.name);
+        } else {
+          const wanted = new Set(trimmed.split(",").map(s => s.trim()).filter(Boolean));
+          chosenTables = tables.tables.filter(t => wanted.has(t.name)).map(t => t.name);
+          if (chosenTables.length === 0) {
+            this.notificationService.warning("None of those table names were found.");
+            return;
+          }
+        }
+      }
+
+      const baseDatasetName = this.deriveDatasetName(file.name);
+      for (const tableName of chosenTables) {
+        const exportId = this.message.loading(`Exporting "${tableName}"…`, { nzDuration: 0 }).messageId;
+        try {
+          const exported = await firstValueFrom(
+            this.datasetService.exportSqliteTable(tables.fileHandle, tableName)
+          );
+          const blob = new Blob([exported.csv], { type: "text/csv" });
+          const csvFile = new File([blob], `${tableName}.csv`, { type: "text/csv" });
+          const dsName =
+            chosenTables.length === 1 ? baseDatasetName : `${baseDatasetName}-${this.slug(tableName)}`;
+          await this.createDatasetFromFile(
+            dsName,
+            `Imported from SQLite ${file.name} (table ${tableName})`,
+            csvFile
+          );
+          this.message.remove(exportId);
+          this.notificationService.success(
+            `Imported "${tableName}" (${exported.rows} rows, ${exported.columns.length} columns).`
+          );
+        } catch (e: any) {
+          this.message.remove(exportId);
+          const errMsg = e?.error?.error || e?.error?.message || e?.message || "Unknown error";
+          this.notificationService.error(`Failed to import table "${tableName}": ${errMsg}`);
+        }
+      }
+      this.refreshAfterImport();
+    } catch (err: any) {
+      this.message.remove(messageId);
+      const errMsg = err?.error?.error || err?.error?.message || err?.message || "Unknown error";
+      this.notificationService.error(`Failed to read SQLite: ${errMsg}`);
+    } finally {
+      this.isImporting = false;
+    }
+  }
+
+  // ============================================================
+  // Helpers
+  // ============================================================
+
+  /**
+   * Reload the page after a successful import. The brief delay lets the success
+   * toast finish rendering before the page swap. Paired with the
+   * DatasetSearchQueryBuilder.scala fix that no longer drops entries on LakeFS
+   * ApiException, the new dataset will appear in the list after the reload.
+   */
+  private refreshAfterImport(): void {
+    this.lastCreatedDid = null;
+    setTimeout(() => window.location.reload(), 800);
+  }
+
+  /**
+   * Derive a dataset name from the source filename: drop the extension, slug it,
+   * and append a short hh:mm:ss-style suffix to avoid the "name already exists"
+   * error if the same file is imported twice in a session.
+   */
+  private deriveDatasetName(filename: string): string {
+    const base = filename.replace(/\.[^.]+$/, "");
+    const baseSlug = this.slug(base) || "imported";
+    const d = new Date();
+    const hhmmss =
+      String(d.getHours()).padStart(2, "0") +
+      String(d.getMinutes()).padStart(2, "0") +
+      String(d.getSeconds()).padStart(2, "0");
+    return `${baseSlug}-${hhmmss}`;
+  }
+
+  private slug(value: string): string {
+    return value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+  }
+
+  /** Tracks the most recently created dataset so we can route to its detail page after import. */
+  private lastCreatedDid: number | null = null;
+
+  /**
+   * Create a new dataset, push the file via multipart upload, and commit an initial version.
+   * Shared by URL, SQLite, and direct-file import paths.
+   *
+   * Three sequential backend calls, each logged so a Network-tab/console trace
+   * pinpoints which one failed if the dataset doesn't show up.
+   */
+  private async createDatasetFromFile(datasetName: string, description: string, file: File): Promise<void> {
+    console.log("[dataset-import] step 1/3 createDataset", { datasetName, fileSize: file.size });
+    let dashboardDataset: DashboardDataset;
+    try {
+      dashboardDataset = await firstValueFrom(
+        this.datasetService.createDataset({
+          name: datasetName,
+          description,
+          isPublic: false,
+          isDownloadable: false,
+          did: undefined,
+          ownerUid: undefined,
+          storagePath: undefined,
+          creationTime: undefined,
+          coverImage: undefined,
+        })
+      );
+    } catch (e) {
+      console.error("[dataset-import] createDataset FAILED", e);
+      throw e;
+    }
+
+    const ownerEmail = dashboardDataset.ownerEmail;
+    const did = dashboardDataset.dataset.did;
+    console.log("[dataset-import] step 1/3 OK", { did, ownerEmail });
+    if (!did) {
+      throw new Error("Dataset created but missing did.");
+    }
+    this.lastCreatedDid = did;
+
+    console.log("[dataset-import] step 2/3 multipartUpload", { filePath: file.name });
+    const partSize = 8 * 1024 * 1024;
+    const concurrency = 4;
+    try {
+      await lastValueFrom(
+        this.datasetService.multipartUpload(
+          ownerEmail,
+          datasetName,
+          file.name,
+          file,
+          partSize,
+          concurrency,
+          false
+        )
+      );
+    } catch (e) {
+      console.error("[dataset-import] multipartUpload FAILED", e);
+      throw e;
+    }
+    console.log("[dataset-import] step 2/3 OK");
+
+    console.log("[dataset-import] step 3/3 createDatasetVersion");
+    try {
+      await firstValueFrom(this.datasetService.createDatasetVersion(did, "Initial import"));
+    } catch (e) {
+      console.error("[dataset-import] createDatasetVersion FAILED", e);
+      throw e;
+    }
+    console.log("[dataset-import] step 3/3 OK — dataset is ready", { datasetName, did });
+
+    // Verify the dataset is actually queryable. /api/dataset/list reads from DB
+    // (no LakeFS check); the search listing in the UI uses /api/dashboard/search
+    // which calls LakeFSStorageClient.retrieveRepositorySize and silently drops
+    // any dataset whose LakeFS repo throws — that's the most common reason a
+    // just-created dataset is missing from the list.
+    try {
+      const accessible = await firstValueFrom(this.datasetService.retrieveAccessibleDatasets());
+      const found = accessible.find(d => d.dataset.did === did);
+      console.log("[dataset-import] verify via /api/dataset/list:", found ? "FOUND" : "NOT FOUND in DB", {
+        did,
+        datasetName,
+        totalAccessible: accessible.length,
+        match: found,
+      });
+    } catch (e) {
+      console.warn("[dataset-import] verification list call failed (non-fatal)", e);
+    }
   }
 }

--- a/frontend/src/app/dashboard/service/user/custom-agent/custom-agent.service.ts
+++ b/frontend/src/app/dashboard/service/user/custom-agent/custom-agent.service.ts
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+import {
+  CustomAgent,
+  DEFAULT_AGENT_MODEL,
+  DEFAULT_GUARDRAILS,
+  DEFAULT_OUTPUT_PREFERENCES,
+} from "../../../type/custom-agent.interface";
+
+const STORAGE_KEY = "texera.customAgents.v1";
+
+@Injectable({
+  providedIn: "root",
+})
+export class CustomAgentService {
+  private readonly agentsSubject = new BehaviorSubject<CustomAgent[]>(this.readAll());
+
+  public list$(): Observable<CustomAgent[]> {
+    return this.agentsSubject.asObservable();
+  }
+
+  public list(): CustomAgent[] {
+    return this.agentsSubject.value;
+  }
+
+  public get(id: string): CustomAgent | undefined {
+    return this.agentsSubject.value.find(a => a.id === id);
+  }
+
+  public create(input: Omit<CustomAgent, "id" | "createdAt" | "updatedAt">): CustomAgent {
+    const now = new Date().toISOString();
+    const agent: CustomAgent = {
+      ...input,
+      id: this.generateId(),
+      createdAt: now,
+      updatedAt: now,
+    };
+    const next = [...this.agentsSubject.value, agent];
+    this.persist(next);
+    return agent;
+  }
+
+  public update(id: string, patch: Partial<Omit<CustomAgent, "id" | "createdAt">>): CustomAgent | undefined {
+    const idx = this.agentsSubject.value.findIndex(a => a.id === id);
+    if (idx === -1) return undefined;
+    const updated: CustomAgent = {
+      ...this.agentsSubject.value[idx],
+      ...patch,
+      id,
+      createdAt: this.agentsSubject.value[idx].createdAt,
+      updatedAt: new Date().toISOString(),
+    };
+    const next = [...this.agentsSubject.value];
+    next[idx] = updated;
+    this.persist(next);
+    return updated;
+  }
+
+  public delete(id: string): void {
+    const next = this.agentsSubject.value.filter(a => a.id !== id);
+    this.persist(next);
+  }
+
+  public duplicate(id: string): CustomAgent | undefined {
+    const source = this.get(id);
+    if (!source) return undefined;
+    const { id: _ignored, createdAt: _c, updatedAt: _u, ...rest } = source;
+    return this.create({ ...rest, name: `${source.name} (Copy)` });
+  }
+
+  public emptyDraft(creator: string): Omit<CustomAgent, "id" | "createdAt" | "updatedAt"> {
+    return {
+      name: "",
+      description: "",
+      icon: "🤖",
+      creator,
+      model: DEFAULT_AGENT_MODEL,
+      domain: "general",
+      methodology: "crisp_dm",
+      taskType: "classification",
+      guardrails: { ...DEFAULT_GUARDRAILS },
+      customRules: "",
+      knowledgeFiles: [],
+      exampleWorkflowIds: [],
+      outputPreferences: { ...DEFAULT_OUTPUT_PREFERENCES },
+      preferredOperators: [],
+      isPublic: false,
+    };
+  }
+
+  private readAll(): CustomAgent[] {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return (parsed as CustomAgent[]).map(a => ({
+        ...a,
+        model: a.model ?? DEFAULT_AGENT_MODEL,
+        knowledgeFiles: a.knowledgeFiles ?? [],
+        exampleWorkflowIds: a.exampleWorkflowIds ?? [],
+        outputPreferences: a.outputPreferences ?? { ...DEFAULT_OUTPUT_PREFERENCES },
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  private persist(agents: CustomAgent[]): void {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(agents));
+    this.agentsSubject.next(agents);
+  }
+
+  private generateId(): string {
+    return `agent-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+}

--- a/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -560,8 +560,7 @@ export class DatasetService {
 
   /**
    * Calls the agent-service data-source proxy to fetch a remote URL server-side
-   * (avoids browser CORS) and convert the response to CSV. Returns the CSV text
-   * plus metadata that the caller can use to upload it as a dataset.
+   * (bypasses browser CORS) and convert the response to CSV.
    */
   public fetchUrlAsCsv(url: string): Observable<{
     filename: string;
@@ -579,5 +578,36 @@ export class DatasetService {
       preview: any[];
       format: "json" | "csv";
     }>(`/api/data-source/fetch-url`, { url });
+  }
+
+  /**
+   * Upload a .sqlite file to the agent-service and list its tables. The response
+   * includes a `fileHandle` token that {@link exportSqliteTable} uses to read a
+   * specific table from the cached upload without re-sending the bytes.
+   */
+  public listSqliteTables(file: File): Observable<{
+    fileHandle: string;
+    tables: { name: string; rowCount: number; columns: string[] }[];
+  }> {
+    const form = new FormData();
+    form.append("file", file, file.name);
+    return this.http.post<{
+      fileHandle: string;
+      tables: { name: string; rowCount: number; columns: string[] }[];
+    }>(`/api/data-source/sqlite-tables`, form);
+  }
+
+  /**
+   * Export a single table from a previously-uploaded SQLite file (identified by
+   * the `fileHandle` from {@link listSqliteTables}) as CSV.
+   */
+  public exportSqliteTable(
+    fileHandle: string,
+    tableName: string
+  ): Observable<{ csv: string; rows: number; columns: string[] }> {
+    return this.http.post<{ csv: string; rows: number; columns: string[] }>(`/api/data-source/sqlite-export`, {
+      fileHandle,
+      tableName,
+    });
   }
 }

--- a/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -557,4 +557,27 @@ export class DatasetService {
       coverImage: coverImage,
     });
   }
+
+  /**
+   * Calls the agent-service data-source proxy to fetch a remote URL server-side
+   * (avoids browser CORS) and convert the response to CSV. Returns the CSV text
+   * plus metadata that the caller can use to upload it as a dataset.
+   */
+  public fetchUrlAsCsv(url: string): Observable<{
+    filename: string;
+    csv: string;
+    rows: number;
+    columns: string[];
+    preview: any[];
+    format: "json" | "csv";
+  }> {
+    return this.http.post<{
+      filename: string;
+      csv: string;
+      rows: number;
+      columns: string[];
+      preview: any[];
+      format: "json" | "csv";
+    }>(`/api/data-source/fetch-url`, { url });
+  }
 }

--- a/frontend/src/app/dashboard/type/custom-agent.interface.ts
+++ b/frontend/src/app/dashboard/type/custom-agent.interface.ts
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * LiteLLM `model_name` values registered in `bin/litellm-config.yaml`. Keep
+ * this union in sync with that file — picking a value not registered there
+ * will cause LiteLLM to return 404 on chat completion.
+ */
+export type AgentModel = "claude-opus-4.7" | "claude-haiku-4.5";
+
+export const DEFAULT_AGENT_MODEL: AgentModel = "claude-haiku-4.5";
+
+export const AGENT_MODEL_OPTIONS: { value: AgentModel; label: string }[] = [
+  { value: "claude-opus-4.7", label: "claude-opus-4.7 (most capable, slower)" },
+  { value: "claude-haiku-4.5", label: "claude-haiku-4.5 (fastest, cheapest)" },
+];
+
+export type AgentDomain = "biomedical" | "nlp" | "finance" | "social_science" | "cv" | "general";
+
+export type AgentMethodology = "crisp_dm" | "semma" | "kdd" | "none";
+
+export type AgentTaskType = "classification" | "regression" | "clustering" | "eda" | "cleaning" | "custom";
+
+export interface AgentGuardrails {
+  requireTrainTestSplit: boolean;
+  requireEvaluation: boolean;
+  preventDataLeakage: boolean;
+  handleMissingValues: boolean;
+  featureScalingCheck: boolean;
+}
+
+export type AgentOutputFormat = "dashboard" | "csv_export" | "report" | "none";
+
+export interface AgentOutputPreferences {
+  includeVisualization: boolean;
+  exportToCsv: boolean;
+  generateSummaryStats: boolean;
+  includeDataProfiling: boolean;
+  defaultFormat: AgentOutputFormat;
+}
+
+export interface KnowledgeFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  size: number;
+  /** Base64-encoded contents (no data: prefix). For hackathon storage; size-capped. */
+  contentBase64: string;
+}
+
+export interface CustomAgent {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  creator: string;
+  /** LiteLLM model_name to use for this agent's LLM calls. */
+  model: AgentModel;
+  domain: AgentDomain;
+  methodology: AgentMethodology;
+  taskType: AgentTaskType;
+  guardrails: AgentGuardrails;
+  customRules: string;
+  /** Reference files (data dictionaries, methodology docs, papers). */
+  knowledgeFiles: KnowledgeFile[];
+  /** wids of user workflows used as templates. */
+  exampleWorkflowIds: number[];
+  outputPreferences: AgentOutputPreferences;
+  preferredOperators: string[];
+  isPublic: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const DEFAULT_GUARDRAILS: AgentGuardrails = {
+  requireTrainTestSplit: true,
+  requireEvaluation: true,
+  preventDataLeakage: true,
+  handleMissingValues: true,
+  featureScalingCheck: true,
+};
+
+export const AGENT_DOMAIN_OPTIONS: { value: AgentDomain; label: string }[] = [
+  { value: "biomedical", label: "Biomedical" },
+  { value: "nlp", label: "NLP / Text Analysis" },
+  { value: "finance", label: "Finance" },
+  { value: "social_science", label: "Social Science" },
+  { value: "cv", label: "Computer Vision" },
+  { value: "general", label: "General" },
+];
+
+export const AGENT_METHODOLOGY_OPTIONS: { value: AgentMethodology; label: string }[] = [
+  { value: "crisp_dm", label: "CRISP-DM" },
+  { value: "semma", label: "SEMMA" },
+  { value: "kdd", label: "KDD" },
+  { value: "none", label: "None" },
+];
+
+export const AGENT_TASK_TYPE_OPTIONS: { value: AgentTaskType; label: string }[] = [
+  { value: "classification", label: "Classification" },
+  { value: "regression", label: "Regression" },
+  { value: "clustering", label: "Clustering" },
+  { value: "eda", label: "EDA" },
+  { value: "cleaning", label: "Data Cleaning" },
+  { value: "custom", label: "Custom" },
+];
+
+export const AGENT_OUTPUT_FORMAT_OPTIONS: { value: AgentOutputFormat; label: string }[] = [
+  { value: "dashboard", label: "Dashboard" },
+  { value: "csv_export", label: "CSV Export" },
+  { value: "report", label: "Report" },
+  { value: "none", label: "None" },
+];
+
+export const DEFAULT_OUTPUT_PREFERENCES: AgentOutputPreferences = {
+  includeVisualization: false,
+  exportToCsv: false,
+  generateSummaryStats: false,
+  includeDataProfiling: false,
+  defaultFormat: "none",
+};
+
+/** Knowledge file size cap (per file) to keep localStorage usable. */
+export const KNOWLEDGE_FILE_MAX_BYTES = 1_000_000; // 1 MB
+export const KNOWLEDGE_FILE_ACCEPT = ".csv,.pdf,.txt,.md,.json";

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.html
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.html
@@ -181,8 +181,42 @@
         </div>
       </div>
 
+      <!-- Attachment chips -->
+      <div class="attachment-chips" *ngIf="attachments.length > 0">
+        <div class="attachment-chip" *ngFor="let att of attachments; let i = index">
+          <i nz-icon nzType="paper-clip"></i>
+          <div class="chip-text">
+            <div class="chip-name">{{ att.name }}</div>
+            <div class="chip-summary">{{ att.summary }}</div>
+          </div>
+          <button nz-button nzType="text" nzSize="small" (click)="removeAttachment(i)">
+            <i nz-icon nzType="close"></i>
+          </button>
+        </div>
+      </div>
+
+      <!-- Hidden file input, triggered by the paperclip button below -->
+      <input
+        #fileInput
+        type="file"
+        multiple
+        class="hidden-file-input"
+        [accept]="attachmentAccept"
+        (change)="onAttachmentSelected($event)" />
+
       <!-- Input Area -->
       <div class="input-area">
+        <button
+          nz-button
+          nzType="text"
+          nzSize="default"
+          class="attach-button"
+          [disabled]="!canSendMessage()"
+          (click)="fileInput.click()"
+          nz-tooltip
+          nzTooltipTitle="Attach a file (CSV / TXT / MD / JSON)">
+          <i nz-icon nzType="paper-clip" nzTheme="outline"></i>
+        </button>
         <textarea
           #messageInput
           nz-input
@@ -194,7 +228,7 @@
         <button
           nz-button
           nzType="primary"
-          [disabled]="!currentMessage.trim() || !canSendMessage()"
+          [disabled]="(!currentMessage.trim() && attachments.length === 0) || !canSendMessage()"
           (click)="sendMessage()">
           <i
             nz-icon

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.scss
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.scss
@@ -204,20 +204,99 @@
   }
 }
 
+// Truly hidden file picker — positioned off-screen rather than display:none so
+// it remains focusable/clickable from script. The paperclip button click()s it.
+.hidden-file-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
 .input-area {
   display: flex;
   gap: 8px;
   padding: 8px 12px;
   border-top: 1px solid #f0f0f0;
   background: #ffffff;
-  align-items: center;
+  align-items: flex-end;
 
   textarea {
-    flex: 1;
+    flex: 1 1 auto;
+    min-width: 0;
   }
 
-  button {
-    align-self: flex-end;
+  > button {
+    flex-shrink: 0;
+  }
+
+  .attach-button {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    padding: 0 !important;
+    border-radius: 6px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: rgba(0, 0, 0, 0.55);
+    transition: background 0.15s, color 0.15s;
+
+    &:hover {
+      color: #1890ff;
+    }
+
+    i[nz-icon] {
+      font-size: 18px;
+    }
+  }
+}
+
+.attachment-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 6px 12px 0;
+  background: #ffffff;
+
+  .attachment-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 8px;
+    border: 1px solid #d9d9d9;
+    border-radius: 4px;
+    background: #fafafa;
+    max-width: 100%;
+
+    i[nz-icon] {
+      color: #1890ff;
+    }
+
+    .chip-text {
+      display: flex;
+      flex-direction: column;
+      max-width: 220px;
+
+      .chip-name {
+        font-size: 12px;
+        font-weight: 500;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .chip-summary {
+        font-size: 11px;
+        color: rgba(0, 0, 0, 0.45);
+      }
+    }
   }
 }
 

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.ts
@@ -60,6 +60,20 @@ import { NzInputNumberComponent } from "ng-zorro-antd/input-number";
 import { NzTagComponent } from "ng-zorro-antd/tag";
 import { NzSwitchComponent } from "ng-zorro-antd/switch";
 
+/**
+ * In-memory attachment carried into the next outgoing message.
+ * preview holds the inlineable content (CSV sample, full text for small text
+ * files, etc); empty for unsupported types like PDF.
+ */
+export interface ChatAttachment {
+  name: string;
+  size: number;
+  summary: string;
+  preview: string;
+  fence?: string;
+  note?: string;
+}
+
 @UntilDestroy()
 @Component({
   selector: "texera-agent-chat",
@@ -102,6 +116,12 @@ export class AgentChatComponent implements OnInit, AfterViewChecked, OnDestroy, 
   /** Steps on the HEAD path only (for chat rendering) */
   public visibleSteps: ReActStep[] = [];
   public currentMessage = "";
+  /** Files attached to the next outgoing message. Cleared on send. */
+  public attachments: ChatAttachment[] = [];
+  /** File types accepted by the attachment input. */
+  public readonly attachmentAccept = ".csv,.txt,.md,.json,.pdf,.tsv";
+  /** Maximum per-file size to read inline. Larger files are noted but their content is omitted. */
+  private readonly MAX_INLINE_BYTES = 200_000;
   private shouldScrollToBottom = false;
   public isDetailsModalVisible = false;
   public selectedResponse: ReActStep | null = null;
@@ -400,15 +420,121 @@ export class AgentChatComponent implements OnInit, AfterViewChecked, OnDestroy, 
   }
 
   public sendMessage(): void {
-    if (!this.currentMessage.trim() || !this.canSendMessage()) {
+    const trimmed = this.currentMessage.trim();
+    if ((!trimmed && this.attachments.length === 0) || !this.canSendMessage()) {
       return;
     }
 
-    const userMessage = this.currentMessage.trim();
+    const userMessage = this.composeOutgoingMessage(trimmed);
     this.currentMessage = "";
+    this.attachments = [];
 
     // Fire-and-forget; responses stream in via the WebSocket subscription.
     this.agentService.sendMessage(this.agentInfo.id, userMessage);
+  }
+
+  private composeOutgoingMessage(userText: string): string {
+    if (this.attachments.length === 0) return userText;
+    const blocks = this.attachments.map(att => this.renderAttachmentBlock(att));
+    const header =
+      "[Attached files — the user has provided the following file context for this turn]";
+    return [header, ...blocks, userText].filter(Boolean).join("\n\n");
+  }
+
+  private renderAttachmentBlock(att: ChatAttachment): string {
+    const headerLine = `### File: ${att.name} (${att.summary})`;
+    if (!att.preview) {
+      return headerLine + "\n(No previewable content available.)";
+    }
+    const fence = att.fence || "";
+    return `${headerLine}\n\`\`\`${fence}\n${att.preview}\n\`\`\``;
+  }
+
+  public onAttachmentSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    const files = Array.from(input.files);
+    input.value = "";
+    files.forEach(file => this.ingestAttachment(file));
+  }
+
+  public removeAttachment(index: number): void {
+    this.attachments = this.attachments.filter((_, i) => i !== index);
+  }
+
+  private ingestAttachment(file: File): void {
+    const lower = file.name.toLowerCase();
+    if (lower.endsWith(".pdf")) {
+      this.attachments = [
+        ...this.attachments,
+        {
+          name: file.name,
+          size: file.size,
+          summary: this.formatFileSize(file.size),
+          preview: "",
+          fence: "",
+          note: "PDF text extraction is not supported in chat. Describe the contents in your message.",
+        },
+      ];
+      return;
+    }
+    if (file.size > this.MAX_INLINE_BYTES) {
+      this.attachments = [
+        ...this.attachments,
+        {
+          name: file.name,
+          size: file.size,
+          summary: this.formatFileSize(file.size) + " — too large to inline",
+          preview: "",
+          fence: "",
+          note: "File too large to read inline.",
+        },
+      ];
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = String(reader.result ?? "");
+      const isCsv = lower.endsWith(".csv") || lower.endsWith(".tsv");
+      if (isCsv) {
+        const { preview, summary } = this.summarizeCsv(text, lower.endsWith(".tsv") ? "\t" : ",");
+        this.attachments = [
+          ...this.attachments,
+          { name: file.name, size: file.size, summary, preview, fence: "csv" },
+        ];
+      } else {
+        const fence = lower.endsWith(".json") ? "json" : "";
+        this.attachments = [
+          ...this.attachments,
+          {
+            name: file.name,
+            size: file.size,
+            summary: this.formatFileSize(file.size),
+            preview: text,
+            fence,
+          },
+        ];
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  private summarizeCsv(content: string, delimiter: string): { preview: string; summary: string } {
+    const lines = content.replace(/\r\n/g, "\n").split("\n").filter(line => line.length > 0);
+    if (lines.length === 0) {
+      return { preview: "", summary: "Empty CSV" };
+    }
+    const header = lines[0];
+    const sampleLines = lines.slice(0, 6); // header + 5 rows
+    const cols = header.split(delimiter).length;
+    const summary = `CSV: ${cols} columns × ${Math.max(0, lines.length - 1)} rows (showing 5)`;
+    return { preview: sampleLines.join("\n"), summary };
+  }
+
+  private formatFileSize(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / 1024 / 1024).toFixed(2)} MB`;
   }
 
   /**

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.html
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.html
@@ -29,9 +29,7 @@
   nz-tooltip
   nzTooltipPlacement="left"
   nzTooltipTitle="AI Agents">
-  <span
-    nz-icon
-    nzType="robot"></span>
+  <span nz-icon nzType="robot"></span>
 </button>
 
 <div
@@ -49,95 +47,117 @@
   (nzResize)="onResize($event)"
   (cdkDragStarted)="handleDragStart()"
   [cdkDragFreeDragPosition]="dragPosition">
-  <!-- Minimize Button -->
-  <ul
-    id="return-button"
-    nz-menu
-    [ngClass]="{'shadow': !width}"
-    *ngIf="width">
-    <li
-      nz-menu-item
-      (click)="openPanel()">
-      <span
-        nz-icon
-        nzType="minus"></span>
+
+  <ul id="return-button" nz-menu [ngClass]="{'shadow': !width}" *ngIf="width">
+    <li nz-menu-item (click)="openPanel()">
+      <span nz-icon nzType="minus"></span>
     </li>
   </ul>
 
-  <div
-    #content
-    id="content"
-    [hidden]="!width">
-    <h4
-      id="title"
-      cdkDragHandle>
-      AI Agents
-    </h4>
+  <div #content id="content" [hidden]="!width">
+    <h4 id="title" cdkDragHandle>AI Agents</h4>
 
-    <!-- Tabs -->
-    <nz-tabs
-      [nzSelectedIndex]="selectedTabIndex"
-      (nzSelectedIndexChange)="onTabSelectChange($event)"
-      class="agent-tabs"
-      nzType="card">
-      <ng-template nzTabBarExtraContent="end">
-        <div class="tab-bar-extra">
-          <span class="agent-count">{{ agents.length }} agent(s)</span>
-        </div>
-      </ng-template>
+    <!-- VIEW 1: Conversation list (scoped to current workflow) -->
+    <div class="panel-body" *ngIf="viewMode === 'list'">
+      <div class="selector-row">
+        <span class="selector-label">New chats use</span>
+        <nz-select
+          class="selector"
+          [ngModel]="selectedAgentKey"
+          (ngModelChange)="onSelectAgentKey($event)"
+          nzShowSearch
+          nzPlaceHolder="Select an agent">
+          <nz-option [nzValue]="DEFAULT_AGENT_KEY" nzLabel="🤖 Default Agent"></nz-option>
+          <nz-option
+            *ngFor="let a of customAgents"
+            [nzValue]="a.id"
+            [nzLabel]="(a.icon || '🤖') + ' ' + a.name"></nz-option>
+        </nz-select>
+      </div>
+      <div class="selector-description" *ngIf="selectedAgentDescription()">
+        {{ selectedAgentDescription() }}
+      </div>
 
-      <!-- Registration Tab -->
-      <nz-tab
-        nzTitle="+ Agent"
-        [nzForceRender]="true">
-        <ng-template nz-tab>
-          <texera-agent-registration (agentCreated)="onAgentCreated($event)"></texera-agent-registration>
-        </ng-template>
-      </nz-tab>
+      <div class="conversation-list">
+        <nz-empty
+          *ngIf="currentWorkflowId === undefined"
+          nzNotFoundContent="Save the workflow first to start a conversation."></nz-empty>
 
-      <!-- Agent Tabs -->
-      <nz-tab
-        *ngFor="let agent of agents; let i = index"
-        [nzTitle]="agentTabTitle"
-        [nzForceRender]="true"
-        [nzDisabled]="!canSwitchToAgent(agent)">
-        <ng-template
-          #agentTabTitle
-          let-active="active">
-          <div
-            class="agent-tab-title"
-            [class.workflow-mismatch]="!canSwitchToAgent(agent)">
-            <span class="agent-tab-name">{{ agent.name }}</span>
-            <i
-              *ngIf="!canSwitchToAgent(agent)"
-              nz-icon
-              nzType="lock"
-              nzTheme="outline"
-              class="workflow-lock-icon"
-              nz-tooltip
-              nzTooltipTitle="This agent is working on a different workflow"></i>
+        <nz-empty
+          *ngIf="currentWorkflowId !== undefined && conversations.length === 0"
+          nzNotFoundContent="No conversations with this agent yet."></nz-empty>
+
+        <div
+          *ngFor="let c of conversations"
+          class="conversation-item"
+          (click)="openConversation(c)">
+          <div class="conv-head">
+            <span class="conv-agent-badge" nz-tooltip [nzTooltipTitle]="c.agentName">
+              <span class="conv-agent-icon">{{ c.agentIcon || '🤖' }}</span>
+              <span class="conv-agent-name">{{ c.agentName }}</span>
+            </span>
             <button
               nz-button
               nzType="text"
               nzSize="small"
-              class="agent-tab-close"
-              (click)="deleteAgent(agent.id, $event)"
-              nz-tooltip
-              nzTooltipTitle="Close agent">
-              <i
-                nz-icon
-                nzType="close"
-                nzTheme="outline"></i>
+              nzDanger
+              class="conv-delete"
+              nz-popconfirm
+              nzPopconfirmTitle="Delete this conversation?"
+              (nzOnConfirm)="deleteConversation(c)"
+              (click)="$event.stopPropagation()">
+              <span nz-icon nzType="delete"></span>
             </button>
           </div>
-        </ng-template>
-        <ng-template nz-tab>
-          <texera-agent-chat
-            [agentInfo]="agent"
-            [isActive]="activeAgentId === agent.id"></texera-agent-chat>
-        </ng-template>
-      </nz-tab>
-    </nz-tabs>
+          <div class="conv-title">{{ c.title }}</div>
+          <div class="conv-preview">{{ conversationPreview(c) }}</div>
+          <div class="conv-meta">
+            <span class="timestamp">{{ c.updatedAt | date:'short' }}</span>
+            <nz-tag *ngIf="c.workflowGenerated" nzColor="green">Workflow generated</nz-tag>
+          </div>
+        </div>
+      </div>
+
+      <div class="new-conversation-row">
+        <button
+          nz-button
+          nzType="primary"
+          nzBlock
+          [disabled]="isStartingConversation || currentWorkflowId === undefined"
+          (click)="newConversation()">
+          <span nz-icon nzType="plus"></span>
+          New Conversation
+        </button>
+      </div>
+    </div>
+
+    <!-- VIEW 2: Chat -->
+    <div class="panel-body chat-body" *ngIf="viewMode === 'chat'">
+      <div class="chat-header">
+        <button nz-button nzType="text" nzSize="small" (click)="backToList()">
+          <span nz-icon nzType="arrow-left"></span> Back
+        </button>
+        <div class="chat-title">
+          <div class="chat-agent">
+            <span *ngIf="activeConversation">{{ activeConversation.agentIcon }} {{ activeConversation.agentName }}</span>
+          </div>
+          <div class="chat-subtitle" *ngIf="activeConversation">{{ activeConversation.title }}</div>
+        </div>
+      </div>
+
+      <ng-container *ngIf="activeBackendAgent; else startingTpl">
+        <texera-agent-chat
+          [agentInfo]="activeBackendAgent"
+          [isActive]="true"></texera-agent-chat>
+      </ng-container>
+
+      <ng-template #startingTpl>
+        <div class="starting-state">
+          <span nz-icon nzType="loading"></span>
+          <span>Starting conversation...</span>
+        </div>
+      </ng-template>
+    </div>
 
     <nz-resize-handles [nzDirections]="['left', 'bottom', 'bottomLeft']"></nz-resize-handles>
   </div>

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.scss
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.scss
@@ -45,7 +45,7 @@
 
 #agent-docked-button {
   position: fixed;
-  bottom: 40px; // Position above the mini-map button
+  bottom: 40px;
   right: 10px;
   z-index: 4;
   box-shadow:
@@ -66,8 +66,9 @@
   width: 100%;
   height: 100%;
   padding-top: 32px;
-  display: inline-block;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .shadow {
@@ -85,95 +86,176 @@
   padding: 0 9px;
 }
 
-.agent-tabs {
-  height: calc(100% - 32px); // Account for the title bar
+.panel-body {
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-
-  ::ng-deep {
-    .ant-tabs {
-      height: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .ant-tabs-nav {
-      margin-bottom: 0;
-    }
-
-    .ant-tabs-content-holder {
-      flex: 1;
-      overflow: hidden;
-    }
-
-    .ant-tabs-content {
-      height: 100%;
-    }
-
-    .ant-tabs-tabpane {
-      height: 100%;
-      overflow: hidden;
-      padding: 0;
-    }
-  }
+  flex: 1;
+  min-height: 0;
 }
 
-.agent-tab-title {
+.selector-row {
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid #f0f0f0;
 
-  .agent-tab-name {
+  .selector-label {
+    color: rgba(0, 0, 0, 0.55);
+    font-size: 13px;
+    flex-shrink: 0;
+  }
+  .selector {
     flex: 1;
-  }
-
-  // Visual feedback for agents on different workflows
-  &.workflow-mismatch {
-    opacity: 0.6;
-
-    .agent-tab-name {
-      color: #8c8c8c;
-    }
-  }
-
-  .workflow-lock-icon {
-    color: #faad14;
-    font-size: 12px;
-    margin-left: -4px;
   }
 }
 
-.agent-tab-close {
-  padding: 0 !important;
-  width: 20px !important;
-  height: 20px !important;
-  min-width: 20px !important;
+.selector-description {
+  padding: 6px 12px;
+  font-size: 12px;
+  color: rgba(0, 0, 0, 0.55);
+  background: #fafafa;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.conversation-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 8px 12px;
+}
+
+.conversation-item {
+  border: 1px solid #f0f0f0;
+  border-radius: 6px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  background: #fff;
+  transition: border-color 0.15s, box-shadow 0.15s;
+
+  &:hover {
+    border-color: #1890ff;
+    box-shadow: 0 1px 4px rgba(24, 144, 255, 0.15);
+  }
+
+  .conv-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+  }
+  .conv-agent-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    background: #f0f5ff;
+    border: 1px solid #adc6ff;
+    border-radius: 10px;
+    font-size: 11px;
+    color: #2f54eb;
+    max-width: 70%;
+
+    .conv-agent-icon { font-size: 13px; }
+    .conv-agent-name {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+  .conv-title {
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .conv-delete {
+    flex-shrink: 0;
+    opacity: 0.5;
+    &:hover { opacity: 1; }
+  }
+  .conv-preview {
+    color: rgba(0, 0, 0, 0.55);
+    font-size: 12px;
+    margin-top: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+  }
+  .conv-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 6px;
+
+    .timestamp {
+      color: rgba(0, 0, 0, 0.45);
+      font-size: 11px;
+    }
+  }
+}
+
+.new-conversation-row {
+  padding: 10px 12px;
+  border-top: 1px solid #f0f0f0;
+  background: #fff;
+}
+
+.chat-body {
+  position: relative;
+  overflow: hidden;
+
+  texera-agent-chat {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+  }
+
+  .starting-state {
+    flex: 1;
+    min-height: 0;
+  }
+}
+
+.chat-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid #f0f0f0;
+  background: #fff;
+
+  .chat-title {
+    flex: 1;
+    overflow: hidden;
+
+    .chat-agent {
+      font-weight: 600;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .chat-subtitle {
+      color: rgba(0, 0, 0, 0.55);
+      font-size: 12px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  }
+}
+
+.starting-state {
   display: flex;
   align-items: center;
   justify-content: center;
-  opacity: 0.6;
-  margin-left: 4px;
-
-  &:hover {
-    opacity: 1;
-    color: #ff4d4f !important;
-    background: rgba(255, 77, 79, 0.1) !important;
-  }
-
-  i {
-    font-size: 12px;
-  }
-}
-
-.tab-bar-extra {
-  padding-right: 8px;
-}
-
-.agent-count {
-  font-size: 12px;
-  color: #8c8c8c;
-  padding: 4px 8px;
-  background: #f0f0f0;
-  border-radius: 4px;
+  gap: 8px;
+  padding: 24px;
+  color: rgba(0, 0, 0, 0.55);
 }

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.ts
@@ -18,25 +18,35 @@
  */
 
 import { Component, HostListener, Input, OnDestroy, OnInit, OnChanges, SimpleChanges } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { Subscription } from "rxjs";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { NzResizeEvent, NzResizableDirective, NzResizeHandlesComponent } from "ng-zorro-antd/resizable";
 import { AgentService, AgentInfo } from "../../../service/agent/agent.service";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
 import { NotificationService } from "../../../../common/service/notification/notification.service";
 import { calculateTotalTranslate3d } from "../../../../common/util/panel-dock";
-import { NgIf, NgClass, NgFor } from "@angular/common";
-import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
-import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NgIf, NgClass, NgFor, DatePipe } from "@angular/common";
+import { NzButtonComponent, NzButtonModule } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
-import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzIconDirective, NzIconModule } from "ng-zorro-antd/icon";
 import { CdkDrag, CdkDragHandle } from "@angular/cdk/drag-drop";
 import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
-import { NzTabsComponent, NzTabBarExtraContentDirective, NzTabComponent, NzTabDirective } from "ng-zorro-antd/tabs";
-import { AgentRegistrationComponent } from "./agent-registration/agent-registration.component";
+import { NzSelectModule } from "ng-zorro-antd/select";
+import { NzTagModule } from "ng-zorro-antd/tag";
+import { NzEmptyModule } from "ng-zorro-antd/empty";
+import { NzPopconfirmModule } from "ng-zorro-antd/popconfirm";
 import { AgentChatComponent } from "./agent-chat/agent-chat.component";
-import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/repeat-dnd.component";
+import { CustomAgentService } from "../../../../dashboard/service/user/custom-agent/custom-agent.service";
+import { CustomAgent } from "../../../../dashboard/type/custom-agent.interface";
+import { Conversation, ConversationService } from "../../../service/agent/conversation.service";
+import { ReActStep } from "../../../service/agent/agent-types";
+
+const DEFAULT_AGENT_KEY = "default";
+const DEFAULT_AGENT_NAME = "Default Agent";
+const DEFAULT_AGENT_ICON = "🤖";
 
 @UntilDestroy()
 @Component({
@@ -45,294 +55,358 @@ import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/r
   styleUrls: ["agent-panel.component.scss"],
   imports: [
     NgIf,
-    NzSpaceCompactItemDirective,
+    NgFor,
+    NgClass,
+    DatePipe,
+    FormsModule,
     NzButtonComponent,
+    NzButtonModule,
     NzWaveDirective,
     ɵNzTransitionPatchDirective,
     NzTooltipDirective,
     NzIconDirective,
+    NzIconModule,
     CdkDrag,
-    NzResizableDirective,
-    NzMenuDirective,
-    NgClass,
-    NzMenuItemComponent,
     CdkDragHandle,
-    NzTabsComponent,
-    NzTabBarExtraContentDirective,
-    NzTabComponent,
-    NzTabDirective,
-    AgentRegistrationComponent,
-    NgFor,
-    AgentChatComponent,
+    NzResizableDirective,
     NzResizeHandlesComponent,
-    FormlyRepeatDndComponent,
+    NzMenuDirective,
+    NzMenuItemComponent,
+    NzSelectModule,
+    NzTagModule,
+    NzEmptyModule,
+    NzPopconfirmModule,
+    AgentChatComponent,
   ],
 })
 export class AgentPanelComponent implements OnInit, OnDestroy, OnChanges {
   protected readonly window = window;
+  protected readonly DEFAULT_AGENT_KEY = DEFAULT_AGENT_KEY;
   private static readonly MIN_PANEL_WIDTH = 400;
   private static readonly MIN_PANEL_HEIGHT = 450;
 
-  /**
-   * Optional agent ID to activate when the panel loads.
-   * When provided (from agent dashboard), the panel will open
-   * and switch to this agent's tab automatically.
-   */
+  /** Optional backend agent ID to activate when the panel loads (legacy entry point). */
   @Input() agentIdToActivate?: string;
 
-  // Panel dimensions and position
-  width: number = 0; // Start with 0 to show docked button
+  // Panel dimensions / position
+  width: number = 0;
   height = Math.max(AgentPanelComponent.MIN_PANEL_HEIGHT, window.innerHeight * 0.7);
   id = -1;
   dragPosition = { x: 0, y: 0 };
   returnPosition = { x: 0, y: 0 };
   isDocked = true;
 
-  // Tab management
-  selectedTabIndex: number = 0; // 0 = registration tab, 1+ = agent tabs
-  agents: AgentInfo[] = [];
+  // Two-view state
+  public viewMode: "list" | "chat" = "list";
 
-  // Active agent tracking - only one agent can be connected at a time
-  activeAgentId: string | null = null;
+  /** The agent selected in the dropdown — used as the agent for the NEXT new conversation. */
+  public selectedAgentKey: string = DEFAULT_AGENT_KEY;
+
+  // Data sources
+  public customAgents: CustomAgent[] = [];
+  public conversations: Conversation[] = [];
+  /** Current workflow id; undefined when no workflow is open or workflow is unsaved. */
+  public currentWorkflowId?: number;
+
+  // Active chat state
+  public activeConversation: Conversation | null = null;
+  public activeBackendAgent: AgentInfo | null = null;
+  public isStartingConversation = false;
+
+  // Cached defaults
+  private defaultModelType: string | null = null;
+  private allBackendAgents: AgentInfo[] = [];
+  private persistedStepIds = new Set<string>();
+  private listSubscription?: Subscription;
 
   constructor(
     private agentService: AgentService,
     private workflowActionService: WorkflowActionService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private customAgentService: CustomAgentService,
+    private conversationService: ConversationService
   ) {}
 
   ngOnInit(): void {
     this.loadPanelSettings();
 
-    // Subscribe to agent changes
-    this.agentService.agentChange$.pipe(untilDestroyed(this)).subscribe(() => {
-      this.agentService
-        .getAllAgents()
-        .pipe(untilDestroyed(this))
-        .subscribe(agents => {
-          this.agents = agents;
-          // Try to activate the agent if agentIdToActivate is set
-          this.tryActivateAgentFromInput();
-        });
-    });
-
-    // Load initial agents
-    this.agentService
-      .getAllAgents()
+    this.customAgentService
+      .list$()
       .pipe(untilDestroyed(this))
-      .subscribe(agents => {
-        this.agents = agents;
-        // Try to activate the agent if agentIdToActivate is set
-        this.tryActivateAgentFromInput();
+      .subscribe(agents => (this.customAgents = agents));
+
+    // Seed and track current workflow id; reload conversation list on every change.
+    this.currentWorkflowId = this.workflowActionService.getWorkflowMetadata().wid;
+    this.reloadConversations();
+    this.workflowActionService
+      .workflowMetaDataChanged()
+      .pipe(untilDestroyed(this))
+      .subscribe(meta => {
+        const newWid = meta?.wid;
+        if (newWid === this.currentWorkflowId) return;
+        this.currentWorkflowId = newWid;
+        // Drop any active chat — it belongs to the previous workflow.
+        this.resetActiveChat();
+        this.reloadConversations();
       });
+
+    this.agentService
+      .fetchModelTypes()
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: models => {
+          if (models.length > 0 && !this.defaultModelType) {
+            this.defaultModelType = models[0].id;
+          }
+        },
+        error: () => {
+          // surfaced when user attempts to start a conversation
+        },
+      });
+
+    this.agentService.agentChange$.pipe(untilDestroyed(this)).subscribe(() => this.refreshBackendAgents());
+    this.refreshBackendAgents();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes["agentIdToActivate"] && this.agentIdToActivate) {
-      this.tryActivateAgentFromInput();
+      this.activateFromBackendAgentId(this.agentIdToActivate);
+      this.agentIdToActivate = undefined;
     }
-  }
-
-  /**
-   * Try to activate the agent specified by agentIdToActivate input.
-   * Opens the panel and switches to the agent's tab.
-   */
-  private tryActivateAgentFromInput(): void {
-    if (!this.agentIdToActivate || this.agents.length === 0) {
-      return;
-    }
-
-    const agentIndex = this.agents.findIndex(agent => agent.id === this.agentIdToActivate);
-    if (agentIndex === -1) {
-      return;
-    }
-
-    // Open the panel if it's closed
-    if (this.width === 0) {
-      this.width = AgentPanelComponent.MIN_PANEL_WIDTH;
-    }
-
-    // Switch to the agent's tab and activate it
-    const agent = this.agents[agentIndex];
-
-    // Deactivate previous agent if any
-    if (this.activeAgentId) {
-      this.agentService.deactivateAgent(this.activeAgentId);
-    }
-
-    // Activate the specified agent
-    this.activeAgentId = agent.id;
-    this.agentService.activateAgent(agent.id);
-    this.selectedTabIndex = agentIndex + 1; // +1 because tab 0 is registration
-
-    // Clear the input so we don't re-activate on every change
-    this.agentIdToActivate = undefined;
   }
 
   @HostListener("window:beforeunload")
   ngOnDestroy(): void {
-    // Deactivate any active agent before destroying
-    this.deactivateCurrentAgent();
+    this.deactivateCurrentBackendAgent();
     this.savePanelSettings();
   }
 
-  /**
-   * Open the panel from docked state
-   */
+  // ---------- Panel open/close ----------
+
   public openPanel(): void {
     if (this.width === 0) {
-      // Open panel
       this.width = AgentPanelComponent.MIN_PANEL_WIDTH;
     } else {
-      // Close panel (dock it)
       this.width = 0;
       this.isDocked = true;
     }
   }
 
-  /**
-   * Handle agent creation - activates and switches to the new agent
-   */
-  public onAgentCreated(agentId: string): void {
-    // Deactivate previous agent if any
-    if (this.activeAgentId) {
-      this.agentService.deactivateAgent(this.activeAgentId);
+  // ---------- Selector (controls which agent the next new conversation uses) ----------
+
+  public selectedAgentLabel(): string {
+    if (this.selectedAgentKey === DEFAULT_AGENT_KEY) return `${DEFAULT_AGENT_ICON} ${DEFAULT_AGENT_NAME}`;
+    const agent = this.customAgents.find(a => a.id === this.selectedAgentKey);
+    return agent ? `${agent.icon} ${agent.name}` : `${DEFAULT_AGENT_ICON} ${DEFAULT_AGENT_NAME}`;
+  }
+
+  public selectedAgentDescription(): string {
+    if (this.selectedAgentKey === DEFAULT_AGENT_KEY) return "Built-in Texera assistant";
+    return this.customAgents.find(a => a.id === this.selectedAgentKey)?.description ?? "";
+  }
+
+  public selectedCustomAgent(): CustomAgent | undefined {
+    return this.customAgents.find(a => a.id === this.selectedAgentKey);
+  }
+
+  public onSelectAgentKey(key: string): void {
+    if (key === this.selectedAgentKey) return;
+    this.selectedAgentKey = key;
+    // Conversations are scoped by (workflowId, agentId), so switching the
+    // selected agent shows a different list and invalidates the active chat.
+    this.resetActiveChat();
+    this.reloadConversations();
+  }
+
+  private resetActiveChat(): void {
+    this.viewMode = "list";
+    this.activeConversation = null;
+    this.deactivateCurrentBackendAgent();
+  }
+
+  // ---------- Conversation list (view 1) ----------
+
+  private reloadConversations(): void {
+    this.listSubscription?.unsubscribe();
+    if (this.currentWorkflowId === undefined) {
+      this.conversations = [];
+      return;
     }
+    this.listSubscription = this.conversationService
+      .list$(this.currentWorkflowId, this.selectedAgentKey)
+      .pipe(untilDestroyed(this))
+      .subscribe(list => (this.conversations = list));
+  }
 
-    // Set the new agent as active immediately
-    this.activeAgentId = agentId;
-    this.agentService.activateAgent(agentId);
+  public openConversation(conversation: Conversation): void {
+    // Keep the selector in sync with whatever agent owns this conversation,
+    // so the visible list matches the open chat.
+    if (conversation.agentId !== this.selectedAgentKey) {
+      this.selectedAgentKey = conversation.agentId;
+      this.reloadConversations();
+    }
+    this.activeConversation = conversation;
+    this.viewMode = "chat";
+    this.persistedStepIds.clear();
+    this.attachBackendAgent(conversation);
+  }
 
-    // Fetch the latest agent list and switch to the new agent's tab
+  public newConversation(): void {
+    if (this.isStartingConversation) return;
+    if (this.currentWorkflowId === undefined) {
+      this.notificationService.warning("Save the workflow first to start a conversation.");
+      return;
+    }
+    if (!this.defaultModelType) {
+      this.notificationService.error("No LLM models available. Check LiteLLM is running.");
+      return;
+    }
+    this.isStartingConversation = true;
+    const customAgent = this.selectedCustomAgent();
+    const conversation = this.conversationService.create({
+      workflowId: this.currentWorkflowId,
+      agentId: this.selectedAgentKey,
+      agentName: customAgent ? customAgent.name : DEFAULT_AGENT_NAME,
+      agentIcon: customAgent ? customAgent.icon || DEFAULT_AGENT_ICON : DEFAULT_AGENT_ICON,
+    });
+    this.activeConversation = conversation;
+    this.viewMode = "chat";
+    this.persistedStepIds.clear();
+    this.createBackendAgentForConversation(conversation, customAgent);
+  }
+
+  public deleteConversation(conversation: Conversation): void {
+    this.conversationService.delete(conversation.workflowId, conversation.agentId, conversation.id);
+    if (this.activeConversation?.id === conversation.id) {
+      this.activeConversation = null;
+      this.deactivateCurrentBackendAgent();
+      this.viewMode = "list";
+    }
+  }
+
+  public conversationPreview(c: Conversation): string {
+    if (c.messages.length === 0) return "No messages yet";
+    return c.messages[0].content;
+  }
+
+  // ---------- Chat view (view 2) ----------
+
+  public backToList(): void {
+    this.viewMode = "list";
+  }
+
+  private refreshBackendAgents(): void {
     this.agentService
       .getAllAgents()
       .pipe(untilDestroyed(this))
-      .subscribe(agents => {
-        this.agents = agents;
-        const agentIndex = agents.findIndex(agent => agent.id === agentId);
-        if (agentIndex !== -1) {
-          this.selectedTabIndex = agentIndex + 1; // +1 because tab 0 is registration
+      .subscribe(agents => (this.allBackendAgents = agents));
+  }
+
+  private attachBackendAgent(conversation: Conversation): void {
+    const existing = conversation.lastBackendAgentId
+      ? this.allBackendAgents.find(a => a.id === conversation.lastBackendAgentId)
+      : undefined;
+    if (existing) {
+      this.deactivateCurrentBackendAgent();
+      this.activeBackendAgent = existing;
+      this.agentService.activateAgent(existing.id);
+      this.subscribeToStepsForPersistence(existing.id, conversation);
+    } else {
+      const customAgent = this.customAgentService.list().find(a => a.id === conversation.agentId);
+      this.createBackendAgentForConversation(conversation, customAgent);
+    }
+  }
+
+  private createBackendAgentForConversation(conversation: Conversation, customAgent: CustomAgent | undefined): void {
+    // Custom agents carry their own model; the built-in default agent falls
+    // back to whatever LiteLLM offered first via /models.
+    const modelType = customAgent?.model ?? this.defaultModelType;
+    if (!modelType) {
+      this.isStartingConversation = false;
+      return;
+    }
+    if (conversation.workflowId !== this.currentWorkflowId) {
+      // Sanity check: never attach a backend agent to a conversation that
+      // belongs to a different workflow than the one currently open.
+      this.isStartingConversation = false;
+      return;
+    }
+    const customAgentName = customAgent ? `${customAgent.icon} ${customAgent.name}` : undefined;
+
+    this.deactivateCurrentBackendAgent();
+    this.agentService
+      .createAgent(modelType, customAgentName, conversation.workflowId, customAgent)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: agentInfo => {
+          this.activeBackendAgent = agentInfo;
+          this.agentService.activateAgent(agentInfo.id);
+          this.conversationService.setBackendAgentId(
+            conversation.workflowId,
+            conversation.agentId,
+            conversation.id,
+            agentInfo.id
+          );
+          this.activeConversation = { ...conversation, lastBackendAgentId: agentInfo.id };
+          this.subscribeToStepsForPersistence(agentInfo.id, conversation);
+          this.isStartingConversation = false;
+          this.refreshBackendAgents();
+        },
+        error: () => {
+          this.isStartingConversation = false;
+          this.viewMode = "list";
+          this.activeConversation = null;
+        },
+      });
+  }
+
+  private deactivateCurrentBackendAgent(): void {
+    if (this.activeBackendAgent) {
+      this.agentService.deactivateAgent(this.activeBackendAgent.id);
+      this.activeBackendAgent = null;
+    }
+  }
+
+  /**
+   * Subscribe to ReAct steps for the active backend agent and persist them to
+   * the active conversation. Each step is persisted at most once.
+   */
+  private subscribeToStepsForPersistence(backendAgentId: string, conversation: Conversation): void {
+    this.agentService
+      .getReActStepsObservable(backendAgentId)
+      .pipe(untilDestroyed(this))
+      .subscribe((steps: ReActStep[]) => {
+        for (const step of steps) {
+          if (this.persistedStepIds.has(step.id)) continue;
+          if (!step.content) continue;
+          const role = step.role === "user" ? "user" : "agent";
+          const generatedWorkflow = Boolean(step.toolCalls && step.toolCalls.length > 0);
+          this.conversationService.appendMessage(
+            conversation.workflowId,
+            conversation.agentId,
+            conversation.id,
+            role,
+            step.content,
+            generatedWorkflow
+          );
+          this.persistedStepIds.add(step.id);
         }
       });
   }
 
-  /**
-   * Handle tab selection change - validates workflow compatibility before switching
-   */
-  public onTabSelectChange(index: number): void {
-    // Tab 0 is registration - always allow
-    if (index === 0) {
-      this.deactivateCurrentAgent();
-      this.selectedTabIndex = 0;
-      return;
+  private activateFromBackendAgentId(backendAgentId: string): void {
+    if (this.width === 0) {
+      this.width = AgentPanelComponent.MIN_PANEL_WIDTH;
     }
-
-    // Get the agent for this tab (index - 1 because tab 0 is registration)
-    const agentIndex = index - 1;
-    if (agentIndex < 0 || agentIndex >= this.agents.length) {
-      return;
-    }
-
-    const agent = this.agents[agentIndex];
-    const agentWorkflowId = agent.delegate?.workflowId;
-    const currentWorkflowId = this.workflowActionService.getWorkflowMetadata().wid;
-
-    // If agent has a workflow ID, check if it matches the current workflow
-    if (agentWorkflowId !== undefined && agentWorkflowId !== 0) {
-      if (currentWorkflowId !== agentWorkflowId) {
-        // Block switching - workflow mismatch
-        this.notificationService.warning(
-          `Cannot switch to agent "${agent.name}": It's working on a different workflow. ` +
-            `Open workflow #${agentWorkflowId} to interact with this agent.`
-        );
-        return;
-      }
-    }
-
-    // Workflow matches or agent has no workflow - allow switch
-    this.switchToAgent(agent.id, index);
-  }
-
-  /**
-   * Switch to a specific agent tab
-   */
-  private switchToAgent(agentId: string, tabIndex: number): void {
-    // Skip if already on this agent and tab
-    if (this.activeAgentId === agentId && this.selectedTabIndex === tabIndex) {
-      return;
-    }
-
-    // Deactivate previous agent only if switching to a different agent
-    if (this.activeAgentId !== agentId) {
-      this.deactivateCurrentAgent();
-    }
-
-    // Activate new agent
-    this.activeAgentId = agentId;
-    this.agentService.activateAgent(agentId);
-    this.selectedTabIndex = tabIndex;
-  }
-
-  /**
-   * Deactivate the currently active agent
-   */
-  private deactivateCurrentAgent(): void {
-    if (this.activeAgentId) {
-      this.agentService.deactivateAgent(this.activeAgentId);
-      this.activeAgentId = null;
+    if (this.currentWorkflowId === undefined) return;
+    const found = this.conversationService.findByBackendAgentId(this.currentWorkflowId, backendAgentId);
+    if (found) {
+      this.openConversation(found);
     }
   }
 
-  /**
-   * Check if an agent's workflow matches the current workspace workflow
-   */
-  public canSwitchToAgent(agent: AgentInfo): boolean {
-    const agentWorkflowId = agent.delegate?.workflowId;
-    if (agentWorkflowId === undefined || agentWorkflowId === 0) {
-      return true; // Agent has no workflow - always allow
-    }
-    const currentWorkflowId = this.workflowActionService.getWorkflowMetadata().wid;
-    return currentWorkflowId === agentWorkflowId;
-  }
+  // ---------- Panel layout (resize/drag/persist) ----------
 
-  /**
-   * Delete an agent
-   */
-  public deleteAgent(agentId: string, event: Event): void {
-    event.stopPropagation(); // Prevent tab switch
-
-    if (confirm("Are you sure you want to delete this agent?")) {
-      const agentIndex = this.agents.findIndex(agent => agent.id === agentId);
-
-      // Deactivate if this is the active agent
-      if (this.activeAgentId === agentId) {
-        this.deactivateCurrentAgent();
-      }
-
-      // Must subscribe to the observable for it to execute
-      this.agentService
-        .deleteAgent(agentId)
-        .pipe(untilDestroyed(this))
-        .subscribe({
-          next: () => {
-            // If we're on the deleted agent's tab, switch to registration
-            if (agentIndex !== -1 && this.selectedTabIndex === agentIndex + 1) {
-              this.selectedTabIndex = 0;
-            } else if (this.selectedTabIndex > agentIndex + 1) {
-              // Adjust selected index if we deleted a tab before the current one
-              this.selectedTabIndex--;
-            }
-          },
-          error: (error: unknown) => {
-            console.error("Failed to delete agent:", error);
-          },
-        });
-    }
-  }
-
-  /**
-   * Handle panel resize
-   */
   onResize({ width, height }: NzResizeEvent): void {
     cancelAnimationFrame(this.id);
     this.id = requestAnimationFrame(() => {
@@ -341,23 +415,16 @@ export class AgentPanelComponent implements OnInit, OnDestroy, OnChanges {
     });
   }
 
-  /**
-   * Handle drag start
-   */
   handleDragStart(): void {
     this.isDocked = false;
   }
 
-  /**
-   * Load panel settings from localStorage
-   */
   private loadPanelSettings(): void {
     const savedWidth = localStorage.getItem("agent-panel-width");
     const savedHeight = localStorage.getItem("agent-panel-height");
     const savedStyle = localStorage.getItem("agent-panel-style");
     const savedDocked = localStorage.getItem("agent-panel-docked");
 
-    // Only restore width if the panel was not docked
     if (savedDocked === "false" && savedWidth) {
       const parsedWidth = Number(savedWidth);
       if (!isNaN(parsedWidth) && parsedWidth >= AgentPanelComponent.MIN_PANEL_WIDTH) {
@@ -384,9 +451,6 @@ export class AgentPanelComponent implements OnInit, OnDestroy, OnChanges {
     }
   }
 
-  /**
-   * Save panel settings to localStorage
-   */
   private savePanelSettings(): void {
     localStorage.setItem("agent-panel-width", String(this.width));
     localStorage.setItem("agent-panel-height", String(this.height));

--- a/frontend/src/app/workspace/component/left-panel/left-panel.component.ts
+++ b/frontend/src/app/workspace/component/left-panel/left-panel.component.ts
@@ -25,6 +25,7 @@ import { OperatorMenuComponent } from "./operator-menu/operator-menu.component";
 import { VersionsListComponent } from "./versions-list/versions-list.component";
 import { WorkflowExecutionHistoryComponent } from "../../../dashboard/component/user/user-workflow/ngbd-modal-workflow-executions/workflow-execution-history.component";
 import { TimeTravelComponent } from "./time-travel/time-travel.component";
+import { TimeMachineComponent } from "./time-machine/time-machine.component";
 import { SettingsComponent } from "./settings/settings.component";
 import { calculateTotalTranslate3d } from "../../../common/util/panel-dock";
 import { PanelService } from "../../service/panel/panel.service";
@@ -96,6 +97,12 @@ export class LeftPanelComponent implements OnDestroy, OnInit, AfterViewInit {
       title: "Time Travel",
       icon: "clock-circle",
       enabled: false,
+    },
+    {
+      component: TimeMachineComponent,
+      title: "Time Machine",
+      icon: "history",
+      enabled: true,
     },
   ];
 

--- a/frontend/src/app/workspace/component/left-panel/time-machine/time-machine.component.html
+++ b/frontend/src/app/workspace/component/left-panel/time-machine/time-machine.component.html
@@ -1,0 +1,137 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="time-machine-panel">
+  <div class="tm-header">
+    <span class="tm-title">Time Machine</span>
+    <div class="tm-header-actions">
+      <button
+        nz-button
+        nzSize="small"
+        nzType="primary"
+        (click)="saveSnapshot()"
+        title="Save a checkpoint of the current workflow">Save Snapshot</button>
+      <button
+        nz-button
+        nzSize="small"
+        nzType="text"
+        (click)="refresh()"
+        title="Reload history">⟳</button>
+    </div>
+  </div>
+
+  <div
+    class="tm-error"
+    *ngIf="error">{{ error }}</div>
+
+  <div
+    *ngIf="compareSids.length > 0"
+    class="tm-compare-bar">
+    <span>
+      <ng-container *ngIf="compareSids.length === 1">Pick one more snapshot's <b>Compare</b> button.</ng-container>
+      <ng-container *ngIf="compareSids.length === 2 && !diffResult">Computing diff…</ng-container>
+      <ng-container *ngIf="compareSids.length === 2 && diffResult">Compared v{{diffResult.v1}} ↔ v{{diffResult.v2}}.</ng-container>
+    </span>
+    <button
+      nz-button
+      nzSize="small"
+      nzType="text"
+      (click)="clearCompare()">clear</button>
+  </div>
+
+  <div
+    *ngIf="diffResult"
+    class="tm-diff">
+    <div class="tm-diff-title">Diff v{{diffResult.v1}} → v{{diffResult.v2}}</div>
+    <div class="tm-diff-line tm-add">
+      <span class="tm-diff-label">+ Added:</span>
+      {{ formatOperatorList(diffResult.operatorsAdded) }}
+    </div>
+    <div class="tm-diff-line tm-remove">
+      <span class="tm-diff-label">− Removed:</span>
+      {{ formatOperatorList(diffResult.operatorsRemoved) }}
+    </div>
+    <div class="tm-diff-line tm-modify">
+      <span class="tm-diff-label">~ Modified:</span>
+      {{ formatOperatorList(diffResult.operatorsModified) }}
+    </div>
+    <div
+      *ngIf="diffResult.linksAdded > 0"
+      class="tm-diff-line tm-add">
+      <span class="tm-diff-label">+ Links:</span>
+      {{ diffResult.linksAdded }} new connection{{ diffResult.linksAdded === 1 ? '' : 's' }}
+    </div>
+    <div
+      *ngIf="diffResult.linksRemoved > 0"
+      class="tm-diff-line tm-remove">
+      <span class="tm-diff-label">− Links:</span>
+      {{ diffResult.linksRemoved }} removed connection{{ diffResult.linksRemoved === 1 ? '' : 's' }}
+    </div>
+  </div>
+
+  <div
+    class="tm-timeline"
+    *ngIf="snapshots.length > 0; else emptyState">
+    <div
+      class="tm-entry"
+      *ngFor="let s of snapshots"
+      [ngClass]="{ 'tm-selected': selectedSid === s.sid, 'tm-in-compare': isInCompare(s) }"
+      (click)="selectSnapshot(s)">
+      <div class="tm-entry-dot"></div>
+      <div class="tm-entry-body">
+        <div class="tm-entry-time">{{ s.creationTime | date:'MM/dd HH:mm:ss' }}</div>
+        <div class="tm-entry-summary">{{ s.changeSummary }}</div>
+        <div class="tm-entry-meta">
+          <span
+            class="tm-badge"
+            [ngClass]="{ 'tm-badge-agent': s.source === 'agent', 'tm-badge-user': s.source === 'user' }">
+            {{ sourceLabel(s) }}
+          </span>
+          <span class="tm-badge tm-badge-scope">{{ scopeBadge(s) }}</span>
+          <span
+            *ngIf="compareOrdinal(s) !== null"
+            class="tm-badge tm-badge-compare">#{{ compareOrdinal(s) }}</span>
+          <span class="tm-version">v{{ s.version }}</span>
+        </div>
+        <div class="tm-entry-actions">
+          <button
+            nz-button
+            nzSize="small"
+            nzType="default"
+            (click)="toggleCompare(s, $event)">
+            {{ isInCompare(s) ? 'Uncompare' : 'Compare' }}
+          </button>
+          <button
+            *ngIf="selectedSid === s.sid"
+            nz-button
+            nzSize="small"
+            nzDanger
+            (click)="revertTo(s); $event.stopPropagation()">Revert</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <ng-template #emptyState>
+    <nz-empty
+      *ngIf="!loading"
+      [nzNotFoundContent]="error ? error : 'No snapshots yet. Edit the workflow to start capturing history.'">
+    </nz-empty>
+  </ng-template>
+</div>

--- a/frontend/src/app/workspace/component/left-panel/time-machine/time-machine.component.scss
+++ b/frontend/src/app/workspace/component/left-panel/time-machine/time-machine.component.scss
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.time-machine-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  font-size: 12px;
+  padding: 4px 6px;
+}
+
+.tm-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 2px 4px 6px;
+  border-bottom: 1px solid #eee;
+
+  .tm-title {
+    font-weight: 600;
+    font-size: 13px;
+  }
+  .tm-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+}
+
+.tm-error {
+  color: #c33;
+  background: #fff1f0;
+  padding: 4px 6px;
+  border-radius: 3px;
+  margin: 4px 0;
+  font-size: 11px;
+}
+
+.tm-compare-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #fffbe6;
+  padding: 2px 6px;
+  border-radius: 3px;
+  margin: 4px 0;
+  font-size: 11px;
+}
+
+.tm-diff {
+  background: #f6f8fa;
+  border: 1px solid #d0d7de;
+  border-radius: 4px;
+  padding: 6px 8px;
+  margin: 4px 0 8px;
+  font-size: 11px;
+
+  .tm-diff-title {
+    font-weight: 600;
+    margin-bottom: 4px;
+  }
+  .tm-diff-line {
+    word-break: break-word;
+    line-height: 1.5;
+  }
+  .tm-diff-label {
+    font-weight: 600;
+    font-family: ui-monospace, Menlo, monospace;
+    margin-right: 4px;
+  }
+  .tm-add { color: #1a7f37; }
+  .tm-remove { color: #cf222e; }
+  .tm-modify { color: #9a6700; }
+}
+
+.tm-timeline {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+.tm-entry {
+  display: flex;
+  gap: 8px;
+  padding: 6px 4px;
+  position: relative;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background 0.1s ease-in-out;
+
+  &:hover {
+    background: #f0f7ff;
+  }
+  &.tm-selected {
+    background: #e6f4ff;
+  }
+  &.tm-in-compare {
+    outline: 1px dashed #faad14;
+  }
+
+  // vertical line between dots
+  &:not(:last-child)::before {
+    content: "";
+    position: absolute;
+    left: 9px;
+    top: 18px;
+    bottom: -6px;
+    width: 2px;
+    background: #d9d9d9;
+  }
+}
+
+.tm-entry-dot {
+  flex: 0 0 auto;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #1677ff;
+  margin-top: 6px;
+  z-index: 1;
+}
+
+.tm-entry-body {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.tm-entry-time {
+  font-size: 10px;
+  color: #888;
+}
+
+.tm-entry-summary {
+  font-size: 12px;
+  margin-top: 1px;
+  word-break: break-word;
+}
+
+.tm-entry-meta {
+  margin-top: 3px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  align-items: center;
+}
+
+.tm-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  background: #f0f0f0;
+  color: #333;
+  line-height: 1.4;
+
+  &.tm-badge-agent {
+    background: #f9f0ff;
+    color: #722ed1;
+  }
+  &.tm-badge-user {
+    background: #e6fffb;
+    color: #08979c;
+  }
+  &.tm-badge-scope {
+    background: #fff7e6;
+    color: #ad6800;
+  }
+  &.tm-badge-compare {
+    background: #fff1b8;
+    color: #874d00;
+    font-weight: 600;
+  }
+}
+
+.tm-version {
+  font-size: 10px;
+  color: #888;
+  margin-left: auto;
+}
+
+.tm-entry-actions {
+  margin-top: 6px;
+  display: flex;
+  gap: 4px;
+}

--- a/frontend/src/app/workspace/component/left-panel/time-machine/time-machine.component.ts
+++ b/frontend/src/app/workspace/component/left-panel/time-machine/time-machine.component.ts
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnDestroy, OnInit } from "@angular/core";
+import { CommonModule, DatePipe, NgClass, NgFor, NgIf } from "@angular/common";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Subject } from "rxjs";
+import { takeUntil } from "rxjs/operators";
+import { NzButtonModule } from "ng-zorro-antd/button";
+import { NzTagModule } from "ng-zorro-antd/tag";
+import { NzEmptyModule } from "ng-zorro-antd/empty";
+import { NzTooltipModule } from "ng-zorro-antd/tooltip";
+import {
+  TimeMachineDiff,
+  TimeMachineOperatorDiffEntry,
+  TimeMachineService,
+  TimeMachineSnapshotEntry,
+} from "../../../service/time-machine/time-machine.service";
+import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
+import { UndoRedoService } from "../../../service/undo-redo/undo-redo.service";
+import { OperatorMetadataService } from "../../../service/operator-metadata/operator-metadata.service";
+import { Workflow, WorkflowContent } from "../../../../common/type/workflow";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-time-machine",
+  templateUrl: "time-machine.component.html",
+  styleUrls: ["time-machine.component.scss"],
+  imports: [
+    CommonModule,
+    NgIf,
+    NgFor,
+    NgClass,
+    DatePipe,
+    NzButtonModule,
+    NzTagModule,
+    NzEmptyModule,
+    NzTooltipModule,
+  ],
+})
+export class TimeMachineComponent implements OnInit, OnDestroy {
+  public snapshots: TimeMachineSnapshotEntry[] = [];
+  public selectedSid: number | null = null;
+  public previewSummary: string | null = null;
+  public compareSids: number[] = [];
+  public diffResult: TimeMachineDiff | null = null;
+  public loading = false;
+  public error: string | null = null;
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private timeMachineService: TimeMachineService,
+    private workflowActionService: WorkflowActionService,
+    private undoRedoService: UndoRedoService,
+    private operatorMetadataService: OperatorMetadataService
+  ) {}
+
+  /**
+   * Map an operator diff entry to a human-readable label. The backend already
+   * resolves `displayName` to customDisplayName || operatorType || operatorID,
+   * so it's always non-empty. We still try the schema's userFriendlyName when
+   * we only have an operatorType so the label reads nicely (e.g. "CSV File
+   * Scan" instead of "CSVFileScan").
+   */
+  public operatorLabel(entry: TimeMachineOperatorDiffEntry): string {
+    const custom = entry.customDisplayName?.trim();
+    if (custom) return custom;
+    if (entry.operatorType) {
+      try {
+        const schema = this.operatorMetadataService.getOperatorSchema(entry.operatorType);
+        const friendly = schema?.additionalMetadata?.userFriendlyName;
+        if (friendly) return friendly;
+      } catch {
+        // schema not loaded yet or unknown type — fall through to displayName
+      }
+    }
+    return entry.displayName || entry.operatorID;
+  }
+
+  /** Comma-joined friendly labels for a diff section. */
+  public formatOperatorList(entries: TimeMachineOperatorDiffEntry[]): string {
+    if (!entries || entries.length === 0) return "(none)";
+    return entries.map(e => this.operatorLabel(e)).join(", ");
+  }
+
+  ngOnInit(): void {
+    this.refresh();
+    // refresh whenever a snapshot is captured
+    this.timeMachineService
+      .onSnapshotsChanged()
+      .pipe(takeUntil(this.destroy$), untilDestroyed(this))
+      .subscribe(() => this.refresh());
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  public get currentWid(): number {
+    return this.workflowActionService.getWorkflowMetadata()?.wid ?? 0;
+  }
+
+  public refresh(): void {
+    const wid = this.currentWid;
+    if (!wid) {
+      this.snapshots = [];
+      this.error = "Save the workflow first to start capturing snapshots.";
+      return;
+    }
+    this.loading = true;
+    this.error = null;
+    this.timeMachineService
+      .listSnapshots(wid)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: list => {
+          this.snapshots = list ?? [];
+          this.loading = false;
+        },
+        error: err => {
+          this.loading = false;
+          this.error = err?.message || "Failed to load history";
+        },
+      });
+  }
+
+  public sourceLabel(entry: TimeMachineSnapshotEntry): string {
+    return entry.source === "agent" ? "🤖 agent" : "👤 user";
+  }
+
+  public scopeBadge(entry: TimeMachineSnapshotEntry): string {
+    const n = entry.changedOperators?.length ?? 0;
+    switch (entry.changeType) {
+      case "operator_added":
+        return `+${n} operator${n === 1 ? "" : "s"}`;
+      case "operator_removed":
+        return `-${n} operator${n === 1 ? "" : "s"}`;
+      case "link_added":
+        return "+1 link";
+      case "link_removed":
+        return "-1 link";
+      case "config_changed":
+        return n > 0 ? `~${n} config` : "config";
+      case "revert":
+        return "revert";
+      case "agent_generated":
+        return n > 0 ? `~${n} ops` : "agent";
+      case "manual_save":
+        return "checkpoint";
+      case "auto_save":
+        return "auto-save";
+      case "run":
+        return "run";
+      default:
+        return entry.changeType;
+    }
+  }
+
+  public saveSnapshot(): void {
+    if (!this.currentWid) {
+      this.error = "Save the workflow first to capture a snapshot.";
+      return;
+    }
+    this.timeMachineService.manualSnapshot("Manual snapshot");
+  }
+
+  public selectSnapshot(entry: TimeMachineSnapshotEntry): void {
+    this.selectedSid = entry.sid;
+    this.previewSummary = `v${entry.version} — ${entry.changeSummary}`;
+  }
+
+  public toggleCompare(entry: TimeMachineSnapshotEntry, event: MouseEvent): void {
+    event.stopPropagation();
+    const idx = this.compareSids.indexOf(entry.sid);
+    if (idx >= 0) {
+      this.compareSids.splice(idx, 1);
+    } else {
+      this.compareSids.push(entry.sid);
+      if (this.compareSids.length > 2) this.compareSids.shift();
+    }
+    this.diffResult = null;
+    if (this.compareSids.length === 2) {
+      const [a, b] = this.compareSids;
+      this.timeMachineService
+        .diff(this.currentWid, a, b)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: d => (this.diffResult = d),
+          error: err => (this.error = err?.message || "Failed to compute diff"),
+        });
+    }
+  }
+
+  public isInCompare(entry: TimeMachineSnapshotEntry): boolean {
+    return this.compareSids.includes(entry.sid);
+  }
+
+  /** 1 or 2 for the order this snapshot was added to the compare queue; null if not queued. */
+  public compareOrdinal(entry: TimeMachineSnapshotEntry): number | null {
+    const idx = this.compareSids.indexOf(entry.sid);
+    return idx >= 0 ? idx + 1 : null;
+  }
+
+  public clearCompare(): void {
+    this.compareSids = [];
+    this.diffResult = null;
+  }
+
+  /**
+   * Revert: backend writes the snapshot's content back into the workflow row,
+   * then we reload the canvas with that content. Capture is paused during the
+   * reload so we don't snapshot the cascade of "delete all + re-add" events.
+   */
+  public revertTo(entry: TimeMachineSnapshotEntry): void {
+    if (!confirm(`Revert workflow to version ${entry.version}? Current state will become a new snapshot.`)) {
+      return;
+    }
+    const wid = this.currentWid;
+    if (!wid) return;
+    this.timeMachineService.setCaptureEnabled(false);
+    this.timeMachineService
+      .revertToSnapshot(wid, entry.sid)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: full => {
+          try {
+            const content = JSON.parse(full.content) as WorkflowContent;
+            const metadata = this.workflowActionService.getWorkflowMetadata();
+            const workflow: Workflow = { ...metadata, content };
+            this.workflowActionService.reloadWorkflow(workflow);
+            this.undoRedoService.clearUndoStack();
+            this.undoRedoService.clearRedoStack();
+          } catch (e) {
+            console.error("Failed to apply reverted workflow", e);
+            this.error = "Revert saved but failed to apply on canvas. Reload the page.";
+          } finally {
+            // small delay before re-enabling so the reload's cascade of mutation
+            // events flushes without producing extra snapshots
+            setTimeout(() => this.timeMachineService.setCaptureEnabled(true), 1500);
+            this.refresh();
+          }
+        },
+        error: err => {
+          this.timeMachineService.setCaptureEnabled(true);
+          this.error = err?.message || "Revert failed";
+        },
+      });
+  }
+}

--- a/frontend/src/app/workspace/service/agent/agent.service.ts
+++ b/frontend/src/app/workspace/service/agent/agent.service.ts
@@ -689,8 +689,15 @@ export class AgentService {
    * @param modelType - The LLM model type to use
    * @param customName - Optional custom name for the agent
    * @param workflowId - Optional workflow ID for delegate mode
+   * @param customAgent - Optional Texera custom-agent config to specialize the system prompt.
+   *                     Forwarded verbatim to agent-service; ignored if not present.
    */
-  public createAgent(modelType: string, customName?: string, workflowId?: number): Observable<AgentInfo> {
+  public createAgent(
+    modelType: string,
+    customName?: string,
+    workflowId?: number,
+    customAgent?: unknown
+  ): Observable<AgentInfo> {
     return defer(() => {
       const userToken = AuthService.getAccessToken();
 
@@ -698,6 +705,10 @@ export class AgentService {
         modelType,
         name: customName,
       };
+
+      if (customAgent) {
+        body.customAgent = customAgent;
+      }
 
       // Include user token and workflowId for delegate mode if available
       if (userToken) {

--- a/frontend/src/app/workspace/service/agent/conversation.service.ts
+++ b/frontend/src/app/workspace/service/agent/conversation.service.ts
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+
+export type ConversationRole = "user" | "agent";
+
+export interface ConversationMessage {
+  role: ConversationRole;
+  content: string;
+  timestamp: number;
+}
+
+/**
+ * A conversation is scoped to a (workflowId, agentId) pair. Each agent has its
+ * own independent history within a workflow; switching agent or workflow
+ * yields a different list. The agent identity is also denormalized onto the
+ * entry so historic rows survive custom-agent deletion.
+ */
+export interface Conversation {
+  id: string;
+  workflowId: number;
+  /** "default" or custom-agent id used to create this conversation. */
+  agentId: string;
+  agentName: string;
+  agentIcon: string;
+  title: string;
+  messages: ConversationMessage[];
+  /** Backend agent runtime id last used for this conversation. */
+  lastBackendAgentId?: string;
+  /** True if any message contained workflow-generation tool calls. */
+  workflowGenerated: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+const KEY_PREFIX = "texera.workflowConversations.v1.";
+
+function storageKey(workflowId: number, agentId: string): string {
+  return `${KEY_PREFIX}${workflowId}.${agentId}`;
+}
+
+function cacheKey(workflowId: number, agentId: string): string {
+  return `${workflowId}|${agentId}`;
+}
+
+export interface NewConversationInput {
+  workflowId: number;
+  agentId: string;
+  agentName: string;
+  agentIcon: string;
+}
+
+@Injectable({ providedIn: "root" })
+export class ConversationService {
+  private cache = new Map<string, BehaviorSubject<Conversation[]>>();
+
+  public list$(workflowId: number, agentId: string): Observable<Conversation[]> {
+    return this.subject(workflowId, agentId).asObservable();
+  }
+
+  public list(workflowId: number, agentId: string): Conversation[] {
+    return this.subject(workflowId, agentId).value;
+  }
+
+  public get(workflowId: number, agentId: string, conversationId: string): Conversation | undefined {
+    return this.subject(workflowId, agentId).value.find(c => c.id === conversationId);
+  }
+
+  public create(input: NewConversationInput): Conversation {
+    const now = Date.now();
+    const conversation: Conversation = {
+      id: `conv-${now.toString(36)}-${Math.random().toString(36).slice(2, 8)}`,
+      workflowId: input.workflowId,
+      agentId: input.agentId,
+      agentName: input.agentName,
+      agentIcon: input.agentIcon,
+      title: "New conversation",
+      messages: [],
+      workflowGenerated: false,
+      createdAt: now,
+      updatedAt: now,
+    };
+    const next = [conversation, ...this.subject(input.workflowId, input.agentId).value];
+    this.persist(input.workflowId, input.agentId, next);
+    return conversation;
+  }
+
+  public appendMessage(
+    workflowId: number,
+    agentId: string,
+    conversationId: string,
+    role: ConversationRole,
+    content: string,
+    workflowGenerated: boolean = false
+  ): Conversation | undefined {
+    const all = this.subject(workflowId, agentId).value;
+    const idx = all.findIndex(c => c.id === conversationId);
+    if (idx === -1) return undefined;
+    const target = all[idx];
+    const isFirstUserMessage = role === "user" && target.messages.length === 0;
+    const updated: Conversation = {
+      ...target,
+      title: isFirstUserMessage ? this.deriveTitle(content) : target.title,
+      messages: [...target.messages, { role, content, timestamp: Date.now() }],
+      workflowGenerated: target.workflowGenerated || workflowGenerated,
+      updatedAt: Date.now(),
+    };
+    const next = [...all];
+    next[idx] = updated;
+    next.sort((a, b) => b.updatedAt - a.updatedAt);
+    this.persist(workflowId, agentId, next);
+    return updated;
+  }
+
+  public setBackendAgentId(
+    workflowId: number,
+    agentId: string,
+    conversationId: string,
+    backendAgentId: string
+  ): void {
+    const all = this.subject(workflowId, agentId).value;
+    const idx = all.findIndex(c => c.id === conversationId);
+    if (idx === -1) return;
+    const next = [...all];
+    next[idx] = { ...all[idx], lastBackendAgentId: backendAgentId, updatedAt: Date.now() };
+    this.persist(workflowId, agentId, next);
+  }
+
+  public delete(workflowId: number, agentId: string, conversationId: string): void {
+    const next = this.subject(workflowId, agentId).value.filter(c => c.id !== conversationId);
+    this.persist(workflowId, agentId, next);
+  }
+
+  /**
+   * Look up a conversation across every agent bucket for the given workflow,
+   * matching on its last bound backend agent runtime id. Used when an external
+   * entry point (e.g. dashboard activation link) hands us a backend agent id
+   * and we don't know which agent bucket the conversation lives in.
+   */
+  public findByBackendAgentId(workflowId: number, backendAgentId: string): Conversation | undefined {
+    const prefix = `${KEY_PREFIX}${workflowId}.`;
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (!key || !key.startsWith(prefix)) continue;
+      const agentId = key.slice(prefix.length);
+      const found = this.subject(workflowId, agentId).value.find(c => c.lastBackendAgentId === backendAgentId);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  private deriveTitle(firstMessage: string): string {
+    const trimmed = firstMessage.trim().replace(/\s+/g, " ");
+    if (trimmed.length <= 60) return trimmed || "New conversation";
+    return trimmed.slice(0, 57) + "...";
+  }
+
+  private subject(workflowId: number, agentId: string): BehaviorSubject<Conversation[]> {
+    const ck = cacheKey(workflowId, agentId);
+    if (!this.cache.has(ck)) {
+      this.cache.set(ck, new BehaviorSubject<Conversation[]>(this.read(workflowId, agentId)));
+    }
+    return this.cache.get(ck)!;
+  }
+
+  private read(workflowId: number, agentId: string): Conversation[] {
+    try {
+      const raw = localStorage.getItem(storageKey(workflowId, agentId));
+      if (!raw) return [];
+      const parsed = JSON.parse(raw);
+      if (!Array.isArray(parsed)) return [];
+      return (parsed as Conversation[]).sort((a, b) => b.updatedAt - a.updatedAt);
+    } catch {
+      return [];
+    }
+  }
+
+  private persist(workflowId: number, agentId: string, conversations: Conversation[]): void {
+    localStorage.setItem(storageKey(workflowId, agentId), JSON.stringify(conversations));
+    this.subject(workflowId, agentId).next(conversations);
+  }
+}

--- a/frontend/src/app/workspace/service/time-machine/time-machine.service.ts
+++ b/frontend/src/app/workspace/service/time-machine/time-machine.service.ts
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable, OnDestroy } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { BehaviorSubject, Observable, Subject, Subscription, interval, of } from "rxjs";
+import { catchError } from "rxjs/operators";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
+import { ExecutionState } from "../../types/execute-workflow.interface";
+import { AppSettings } from "../../../common/app-setting";
+
+export type SnapshotChangeType =
+  | "operator_added"
+  | "operator_removed"
+  | "operator_modified"
+  | "link_added"
+  | "link_removed"
+  | "config_changed"
+  | "agent_generated"
+  | "manual_save"
+  | "auto_save"
+  | "run"
+  | "revert";
+
+export type SnapshotSource = "user" | "agent";
+
+export interface TimeMachineSnapshotEntry {
+  sid: number;
+  wid: number;
+  version: number;
+  changeType: SnapshotChangeType;
+  changeSummary: string;
+  changedOperators: string[];
+  source: SnapshotSource;
+  uid?: number | null;
+  creationTime: string;
+}
+
+export interface TimeMachineSnapshotFull extends TimeMachineSnapshotEntry {
+  content: string;
+}
+
+export interface TimeMachineOperatorDiffEntry {
+  operatorID: string;
+  operatorType: string;
+  customDisplayName: string;
+  // Server-side pre-resolved label: customDisplayName || operatorType || operatorID.
+  // Always non-empty.
+  displayName: string;
+}
+
+export interface TimeMachineDiff {
+  v1: number;
+  v2: number;
+  operatorsAdded: TimeMachineOperatorDiffEntry[];
+  operatorsRemoved: TimeMachineOperatorDiffEntry[];
+  operatorsModified: TimeMachineOperatorDiffEntry[];
+  linksAdded: number;
+  linksRemoved: number;
+}
+
+interface CreateSnapshotPayload {
+  content: string;
+  changeType: SnapshotChangeType;
+  changeSummary: string;
+  changedOperators: string[];
+  source: SnapshotSource;
+}
+
+const TIME_MACHINE_BASE = "time-machine";
+const AUTO_SNAPSHOT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * TimeMachineService captures workflow snapshots at important moments only —
+ * not on every keystroke or canvas tweak. Triggers:
+ *
+ *   - **Auto every 5 min**: if any change has happened since the last snapshot.
+ *   - **Run**: when the user starts an execution.
+ *   - **Agent**: when an agent-driven change is explicitly flagged
+ *     (frontend integrations call `snapshotAgentChange()`, or the agent calls
+ *     the `workflow_history` tool with `action: "snapshot"`).
+ *   - **Manual**: user clicks "Save Snapshot" in the panel.
+ *
+ * Discrete graph events (add/remove operator, link, property change) still
+ * subscribe — but only to **mark the workflow dirty**, so the 5-min timer
+ * knows there's something worth saving. They no longer POST snapshots.
+ */
+@Injectable({ providedIn: "root" })
+export class TimeMachineService implements OnDestroy {
+  private readonly captureEnabledSubject = new BehaviorSubject<boolean>(true);
+  private readonly snapshotsRefreshSubject = new Subject<void>();
+  private sourceOverride: SnapshotSource | null = null;
+  private dirty = false;
+  private subscriptions: Subscription[] = [];
+
+  constructor(
+    private http: HttpClient,
+    private workflowActionService: WorkflowActionService,
+    private executeWorkflowService: ExecuteWorkflowService
+  ) {
+    this.attachDirtyTracking();
+    this.attachAutoSnapshotTimer();
+    this.attachExecutionHook();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(s => s.unsubscribe());
+    this.subscriptions = [];
+  }
+
+  /** Pause capture (e.g. while reverting). */
+  public setCaptureEnabled(enabled: boolean): void {
+    this.captureEnabledSubject.next(enabled);
+  }
+
+  /**
+   * Mark the next captured snapshot as agent-sourced. Resets after one use.
+   * Frontend integrations that proxy agent edits should call this just before
+   * the edit, then trigger a save (manual or by letting the auto-timer fire).
+   */
+  public flagNextChangeAsAgent(): void {
+    this.sourceOverride = "agent";
+  }
+
+  public onSnapshotsChanged(): Observable<void> {
+    return this.snapshotsRefreshSubject.asObservable();
+  }
+
+  public listSnapshots(wid: number): Observable<TimeMachineSnapshotEntry[]> {
+    return this.http.get<TimeMachineSnapshotEntry[]>(
+      `${AppSettings.getApiEndpoint()}/${TIME_MACHINE_BASE}/${wid}/snapshots`
+    );
+  }
+
+  public getSnapshot(wid: number, sid: number): Observable<TimeMachineSnapshotFull> {
+    return this.http.get<TimeMachineSnapshotFull>(
+      `${AppSettings.getApiEndpoint()}/${TIME_MACHINE_BASE}/${wid}/snapshots/${sid}`
+    );
+  }
+
+  public revertToSnapshot(wid: number, sid: number): Observable<TimeMachineSnapshotFull> {
+    return this.http.post<TimeMachineSnapshotFull>(
+      `${AppSettings.getApiEndpoint()}/${TIME_MACHINE_BASE}/${wid}/snapshots/${sid}/revert`,
+      {}
+    );
+  }
+
+  public diff(wid: number, v1: number, v2: number): Observable<TimeMachineDiff> {
+    return this.http.get<TimeMachineDiff>(
+      `${AppSettings.getApiEndpoint()}/${TIME_MACHINE_BASE}/${wid}/diff?v1=${v1}&v2=${v2}`
+    );
+  }
+
+  /** Manual user-triggered checkpoint. Wired to the panel's "Save Snapshot" button. */
+  public manualSnapshot(summary: string = "Manual snapshot"): void {
+    this.capture("manual_save", summary, []);
+  }
+
+  /** Explicit agent-driven snapshot. */
+  public snapshotAgentChange(summary: string, changedOperators: string[] = []): void {
+    this.sourceOverride = "agent";
+    this.capture("agent_generated", summary, changedOperators);
+  }
+
+  private attachDirtyTracking(): void {
+    const graph = this.workflowActionService.getTexeraGraph();
+    // We listen to the same events as before, but only to mark dirty. No HTTP.
+    const dirtyStreams: Observable<unknown>[] = [
+      graph.getOperatorAddStream(),
+      graph.getOperatorDeleteStream(),
+      graph.getLinkAddStream(),
+      graph.getLinkDeleteStream(),
+      graph.getOperatorPropertyChangeStream(),
+    ];
+    dirtyStreams.forEach(stream => {
+      this.subscriptions.push(stream.subscribe(() => (this.dirty = true)));
+    });
+  }
+
+  private attachAutoSnapshotTimer(): void {
+    this.subscriptions.push(
+      interval(AUTO_SNAPSHOT_INTERVAL_MS).subscribe(() => {
+        if (!this.captureEnabledSubject.value) return;
+        if (!this.dirty) return;
+        this.capture("auto_save", "Auto-saved checkpoint", []);
+      })
+    );
+  }
+
+  private attachExecutionHook(): void {
+    this.subscriptions.push(
+      this.executeWorkflowService.getExecutionStateStream().subscribe(({ previous, current }) => {
+        // Snapshot on the transition INTO Initializing — i.e. the moment the
+        // user clicks Run. Only the leading edge, not every subsequent emission.
+        if (current.state === ExecutionState.Initializing && previous.state !== ExecutionState.Initializing) {
+          this.capture("run", "Workflow run started", []);
+        }
+      })
+    );
+  }
+
+  private capture(changeType: SnapshotChangeType, summary: string, changedOperators: string[]): void {
+    if (!this.captureEnabledSubject.value) return;
+    const wid = this.workflowActionService.getWorkflowMetadata()?.wid;
+    if (!wid) return;
+    const content = JSON.stringify(this.workflowActionService.getWorkflowContent());
+    const source = this.sourceOverride ?? "user";
+    this.sourceOverride = null;
+    const payload: CreateSnapshotPayload = {
+      content,
+      changeType,
+      changeSummary: summary,
+      changedOperators,
+      source,
+    };
+    this.http
+      .post<TimeMachineSnapshotEntry>(
+        `${AppSettings.getApiEndpoint()}/${TIME_MACHINE_BASE}/${wid}/snapshots`,
+        payload
+      )
+      .pipe(
+        catchError(err => {
+          console.warn("[TimeMachine] snapshot save failed", err);
+          return of(null);
+        })
+      )
+      .subscribe(saved => {
+        if (saved) {
+          this.dirty = false;
+          this.snapshotsRefreshSubject.next();
+        }
+      });
+  }
+}

--- a/sql/texera_ddl.sql
+++ b/sql/texera_ddl.sql
@@ -55,6 +55,7 @@ DROP TABLE IF EXISTS "user" CASCADE;
 DROP TABLE IF EXISTS user_last_active_time CASCADE;
 DROP TABLE IF EXISTS workflow CASCADE;
 DROP TABLE IF EXISTS workflow_version CASCADE;
+DROP TABLE IF EXISTS workflow_snapshot CASCADE;
 DROP TABLE IF EXISTS project CASCADE;
 DROP TABLE IF EXISTS workflow_of_project CASCADE;
 DROP TABLE IF EXISTS workflow_executions CASCADE;
@@ -162,6 +163,27 @@ CREATE TABLE IF NOT EXISTS workflow_version
     creation_time  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (wid) REFERENCES workflow(wid) ON DELETE CASCADE
     );
+
+-- workflow_snapshot (Time Machine: full-snapshot history with rich metadata)
+-- This table is parallel to workflow_version (which stores JSON diffs).
+-- Each row is a full content snapshot tagged with the discrete event that produced it.
+CREATE TABLE IF NOT EXISTS workflow_snapshot
+(
+    sid                 SERIAL PRIMARY KEY,
+    wid                 INT  NOT NULL,
+    uid                 INT,
+    snapshot_version    INT  NOT NULL,
+    content             TEXT NOT NULL,
+    change_type         VARCHAR(64)  NOT NULL,
+    change_summary      TEXT NOT NULL,
+    changed_operators   TEXT NOT NULL DEFAULT '[]',
+    source              VARCHAR(16)  NOT NULL DEFAULT 'user',
+    creation_time       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (wid) REFERENCES workflow(wid) ON DELETE CASCADE,
+    UNIQUE (wid, snapshot_version)
+    );
+CREATE INDEX IF NOT EXISTS idx_workflow_snapshot_wid_time
+    ON workflow_snapshot(wid, creation_time DESC);
 
 -- project
 CREATE TABLE IF NOT EXISTS project

--- a/sql/updates/23.sql
+++ b/sql/updates/23.sql
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+\c texera_db
+
+SET search_path TO texera_db;
+
+BEGIN;
+
+-- Time Machine: full-snapshot workflow history (parallel to workflow_version
+-- which stores JSON diffs). Each row is a complete content snapshot tagged
+-- with the discrete event that produced it.
+CREATE TABLE IF NOT EXISTS workflow_snapshot
+(
+    sid                 SERIAL PRIMARY KEY,
+    wid                 INT  NOT NULL,
+    uid                 INT,
+    snapshot_version    INT  NOT NULL,
+    content             TEXT NOT NULL,
+    change_type         VARCHAR(64)  NOT NULL,
+    change_summary      TEXT NOT NULL,
+    changed_operators   TEXT NOT NULL DEFAULT '[]',
+    source              VARCHAR(16)  NOT NULL DEFAULT 'user',
+    creation_time       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (wid) REFERENCES workflow(wid) ON DELETE CASCADE,
+    UNIQUE (wid, snapshot_version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_snapshot_wid_time
+    ON workflow_snapshot(wid, creation_time DESC);
+
+COMMIT;


### PR DESCRIPTION
> Paste a URL. Drop a file. Open a SQLite database. Ask the AI agent. **Four new import paths, zero manual download.**

---

## What's New

**🔗 URL Import** — Paste any CSV/JSON URL on the Datasets page, click Import. Server-side fetch, auto-format detection.

**📁 Local File Drop** — Drag & drop CSV, JSON, XLSX, TSV, SQLite directly onto the Datasets page.

**🗄️ SQLite Import** — Drop a .sqlite file → pick tables from a list → each table becomes a dataset. Uses Bun's built-in `bun:sqlite`, no external dependencies.

**⚡ REST API Agent Tool** — `fetch_api_data` tool lets the AI agent fetch from any API endpoint. Auto-flattens nested JSON to tabular format.

---

## How It Works

```
Frontend (Datasets page)          Agent Service (port 3001)         Texera
┌─────────────────────┐          ┌─────────────────────────┐      ┌──────────┐
│ URL input ──────────┼────→     │ POST /fetch-url         │─────→│ Dataset  │
│ File drop zone ─────┼────→     │ POST /sqlite-tables     │      │ Creation │
│ Agent chat ─────────┼────→     │ POST /sqlite-export     │      │ API      │
└─────────────────────┘          │ Tool: fetch_api_data    │      └──────────┘
                                 └─────────────────────────┘
```

---

## Verified

```bash
$ curl -X POST localhost:3001/api/data-source/fetch-url \
    -H "Content-Type: application/json" \
    -d '{"url":"https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data"}'

→ {"rows":150, "columns":["5.1","3.5","1.4","0.2","Iris-setosa"], "format":"csv"} ✅
```

---

## Files Changed

**New:** `agent-service/src/api/data-source-api.ts` (3 endpoints), `data-source-tools.ts` (agent tool)

**Modified:** `user-dataset.component.*` (URL input + drop zone), `dataset.service.ts` (fetch methods), `proxy.config.json`, `DatasetSearchQueryBuilder.scala` (fix: new datasets now appear in list immediately)