### PR TITLE
fix: enable ASF nextgen config

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,6 +19,7 @@
 
 meta:
   environment: github_rulesets
+  nextgen: true
 
 github:
   description: "Human-AI Collaborative Data Science Using Visual Workflows"


### PR DESCRIPTION
### What changes were proposed in this PR?

Enable the ASF `.asf.yaml` next-generation parser by adding `meta.nextgen: true`.

This lets ASF Infra apply repository feature settings that are already present in this file, including `github.features.discussions: true`.

### Any related issues, documentation, discussions?

Related mailing list discussion: https://lists.apache.org/thread/hso97tz18zd6s9zpbr1gfj2o7m5rcr92

ASF Infra documentation:
- https://infra.apache.org/blog/newsletter_02_25.html
- https://github.com/apache/infrastructure-asfyaml/tree/ng-parser?tab=readme-ov-file#repository-features

### How was this PR tested?

```bash
ruby -e 'require "yaml"; YAML.load_file(".asf.yaml"); puts "YAML OK"'
gh api repos/apache/texera --jq '{has_discussions:.has_discussions, default_branch:.default_branch, full_name:.full_name}'
```

The YAML parses successfully. The GitHub API check currently reports `has_discussions: false`, confirming the repository feature still needs ASF Infra to apply the updated `.asf.yaml` config after merge.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex
