### PR TITLE
docs(frontend): add testing guide and refresh README

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,79 +1,56 @@
 # AGENTS.md — frontend
 
-Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md). For recipes, the mental model behind these rules, and troubleshooting, read [`TESTING.md`](TESTING.md) — it is the canonical reference for both humans and agents and should be consulted before writing or fixing any component spec.
+Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md). Use [`README.md`](README.md) for commands and prerequisites; [`TESTING.md`](TESTING.md) for the testing reference.
 
 ## Stack
 
-Angular (standalone components) · Vitest · `@angular/build:unit-test` builder · jsdom by default; Playwright Chromium via `gui:test-browser` for specs that need real DOM/SVG geometry · v8 coverage. Test setup file `src/test-zone-setup.ts` wraps `it`/`test` in a ProxyZone so Angular's `fakeAsync` works under Vitest.
+Angular (standalone components) · Vitest (unit tests, jsdom default; Playwright Chromium via `gui:test-browser` for SVG / pointer geometry) · `@angular/build` builder · Yarn (Berry, ships in-repo).
 
-## Golden rules
+## Layout — where to look and where to put things
 
-1. **Always call `fixture.detectChanges()` at least once.** Without it the component constructor runs but the template never does — the template is AOT-emitted code that only executes during change detection, and v8 coverage attributes template hits back to the `.html` file via source maps. No `detectChanges()` ⇒ `.component.html` stays at 0 % even when the spec passes green.
-2. **Standalone components go in `imports:`, not `declarations:`.** Angular errors at compile time if a standalone component appears in `declarations:`. To strip a standalone child for shallow rendering use `TestBed.overrideComponent(Parent, { set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` before `compileComponents()`.
-3. **`beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.** `test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but not `beforeEach`; `waitForAsync` inside `beforeEach` throws "Expected to be running in 'ProxyZone'".
+The tree is split by user-facing area, not by Angular role. New code goes next to its feature, never into a flat type-bucket.
 
-## Minimum viable spec template
+| If you're touching…                                                             | Look in…                                                        |
+| ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| The workflow editor (operator graph, property panel, result panel, code editor) | `src/app/workspace/`                                            |
+| The dashboard (workflows, datasets, projects, computing units, admin)           | `src/app/dashboard/`                                            |
+| The public hub (discover and share workflows)                                   | `src/app/hub/`                                                  |
+| Cross-cutting services, types, formly extensions, shared utils                  | `src/app/common/`                                               |
+| Shared test infrastructure (`commonTestProviders`, mock GUI config service)     | `src/app/common/testing/`                                       |
+| Operator metadata and the canonical `Stub…Service` doubles                      | `src/app/workspace/service/operator-metadata/`                  |
+| Vitest configuration (jsdom default; browser mode)                              | `vitest.config.ts`, `vitest.browser.config.ts`                  |
+| Per-spec inclusion / exclusion routing                                          | `angular.json` (`gui:test` and `gui:test-browser` targets)      |
+| ProxyZone setup that makes `fakeAsync` work under Vitest                        | `src/test-zone-setup.ts`                                        |
+| Generated protobuf TS (do not edit by hand)                                     | `src/app/common/type/proto/**`                                  |
+| Vendored third-party formly type files (separate license)                       | `src/app/common/formly/{array,object,multischema,null}.type.ts` |
 
-```ts
-import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { HttpClientTestingModule } from "@angular/common/http/testing";
-import { commonTestProviders } from "../../../common/testing/test-utils";
-import { MyComponent } from "./my.component";
+Placement rules:
 
-describe("MyComponent", () => {
-  let fixture: ComponentFixture<MyComponent>;
+- **Components, services, and types live next to their feature.** A new workspace service goes in `src/app/workspace/service/<feature>/`, not in a flat global bucket.
+- **`Stub…Service` doubles live next to the real service** (`stub-operator-metadata.service.ts` sits alongside `operator-metadata.service.ts`). Specs import the stub by name; this keeps the mock surface consistent across the codebase.
+- **Types shared across more than one feature area** go in `src/app/common/type/`. Types owned by one feature stay with that feature.
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [MyComponent, HttpClientTestingModule],
-      providers: [...commonTestProviders],
-    }).compileComponents();
-  });
+## Conventions
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(MyComponent);
-    fixture.detectChanges(); // ⇐ this line is the HTML-coverage switch
-  });
+- **Components are standalone.** Declare them in `imports:`, never `declarations:` (the latter errors at compile time). The same applies inside `TestBed.configureTestingModule({...})`.
+- **Run `yarn format:fix` before pushing**; `yarn format:ci` mirrors what CI runs. ESLint and Prettier are wired together via `prettier-eslint`.
+- **Reuse shared test infrastructure** before inventing parallel one-off mocks. If a service already has a `Stub…Service`, extend the stub rather than ship a new partial mock from inside a spec.
+- **Do not hand-edit the files listed as generated or vendored above** — protobuf TS is produced by codegen, and the formly type files come from upstream under a different license.
 
-  it("should create", () => {
-    expect(fixture.componentInstance).toBeTruthy();
-  });
-});
-```
+## Before writing or fixing a spec
 
-Anything more complex (event handlers, `*ngIf` branches, async data) — read [`TESTING.md`](TESTING.md).
+Read [`TESTING.md`](TESTING.md) — the canonical testing reference for both humans and agents. It ships the recipes, anti-patterns, jsdom-vs-browser-mode decision, and coverage troubleshooting checklist. The three rules that surface most often in PR review:
 
-## Shared test infrastructure
-
-- **Common providers**: `commonTestProviders` from `common/testing/test-utils.ts`. Always spread these; do not redeclare `GuiConfigService` etc. per spec.
-- **Service stubs**: reuse the existing `Stub…Service` siblings (for example `StubOperatorMetadataService`). When a service has no stub yet, add a `*.stub.ts` or `*.mock.ts` next to the real implementation rather than inlining a `vi.fn()` chain inside each spec.
-- **Mocks**: `vi.fn()` + `.mockReturnValue(...)`. RxJS-returning methods use `.mockReturnValue(of(...))` or `EMPTY`. For partial method replacement, `vi.spyOn(obj, "method").mockReturnValue(...)`.
-
-## Anti-patterns (review will flag these)
-
-| Pattern                                                                | Why it's wrong                                                                                                                                                                          |
-| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Spec body entirely commented out, only the license header survives     | The file runs to "0 tests" and reports green; the template never renders. If a spec is dead, delete it; don't leave `//` as a graveyard.                                                |
-| `NO_ERRORS_SCHEMA` on a spec that asserts about children               | Children silently fail to render; branches inside `*ngIf="child.ready"` stay uncovered and broken templates pass. Use `MockComponent` or `overrideComponent({ set: { imports: [] } })`. |
-| `TestBed.overrideComponent(C, { set: { template: '' } })`              | Destroys the very thing under test; HTML coverage will be permanently 0 %.                                                                                                              |
-| `declarations: [StandaloneComponent]`                                  | Angular throws at compile time — standalone components can't be declared in an NgModule. Use `imports:`.                                                                                |
-| `beforeEach(waitForAsync(() => …))`                                    | Throws "Expected to be running in 'ProxyZone'" under Vitest. Use `async () => { … }`.                                                                                                   |
-| Spec depends on a real HTTP / WebSocket call                           | Use `HttpClientTestingModule` and stub WS observables with `Subject` / `of(...)`.                                                                                                       |
-| Inventing a one-off provider mock when a `Stub…Service` already exists | Drift: the next spec invents another mock. Reuse and extend the existing stub.                                                                                                          |
-
-## When to use browser mode (`gui:test-browser`)
-
-The default `yarn test` path runs every spec under jsdom — fast, no browser boot. Switch a spec to browser mode **only** when it depends on real DOM or SVG behavior jsdom can't fake:
-
-- `SVGSVGElement.getScreenCTM()` / `getBoundingClientRect()` returning real layout coordinates (jointjs paper).
-- Pointer-event hit testing — `elementFromPoint`, drag-and-drop with real geometry.
-- CSS-layout-dependent assertions (offsetWidth / offsetHeight, scroll positions).
-
-Per-spec routing lives in `angular.json` (`gui:test` excludes, `gui:test-browser` runs only what's routed there). Do not duplicate the list in `vitest.config.ts` — see the comment in that file.
+1. Call `fixture.detectChanges()` at least once. Without it `.component.html` coverage stays at 0 % even when the spec passes.
+2. Standalone components go in `imports:`, not `declarations:`.
+3. `beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.
 
 ## Pointers
 
-- Recipes, decision trees, coverage troubleshooting: [`TESTING.md`](TESTING.md).
-- Minimum-viable reference spec (jsdom): `src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts`.
-- Browser-mode reference spec (real DOM): `src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts`.
-- Two-target jsdom / browser-mode setup rationale: [#5017](https://github.com/apache/texera/pull/5017).
+- **Commands and prerequisites** (dev server, build, test, format): [`README.md`](README.md).
+- **Testing reference** (recipes, anti-patterns, coverage troubleshooting, jsdom-vs-browser-mode decision): [`TESTING.md`](TESTING.md).
+- **Repo-wide testing philosophy** ("Tests come first" — TDD, characterization tests, every test covers a specific failure mode): [`../AGENTS.md`](../AGENTS.md).
+- **PR / commit / branch conventions** (Conventional Commits, fork-based workflow, license header check, the four-section PR template): [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+- **Architecture map** (where the backend services live, what they own): [`../AGENTS.md`](../AGENTS.md) "Architecture Map".
+- **Coverage dashboard** for this repo: [app.codecov.io/gh/apache/texera](https://app.codecov.io/gh/apache/texera).
+- **Vitest browser-mode setup rationale**: [#5017](https://github.com/apache/texera/pull/5017).

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -2,7 +2,7 @@
 
 Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md).
 
-**Start at [`README.md`](README.md)** for the stack, prerequisites, common commands, project layout, and the basic doc pointers. This file only carries what is not already in the README — placement rules, agent-relevant conventions, the testing checklist, and deeper pointers.
+**Start at [`README.md`](README.md)** for the stack, prerequisites, common commands, the testing entry-point, and the project layout. This file only carries what is not already in the README — placement rules, agent-relevant conventions, the testing checklist, and deeper pointers.
 
 ## Placement rules
 
@@ -29,7 +29,7 @@ Read [`TESTING.md`](TESTING.md) — the canonical testing reference for both hum
 2. Standalone components go in `imports:`, not `declarations:`.
 3. `beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.
 
-## Pointers (deeper than the README's "Where to read next")
+## Pointers
 
 - **Repo-wide testing philosophy** ("Tests come first" — TDD, characterization tests, every test covers a specific failure mode): [`../AGENTS.md`](../AGENTS.md) §"Tests come first".
 - **Architecture map** (where the backend services live, what they own): [`../AGENTS.md`](../AGENTS.md) §"Architecture Map".

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,41 +1,25 @@
 # AGENTS.md — frontend
 
-Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md). Use [`README.md`](README.md) for commands and prerequisites; [`TESTING.md`](TESTING.md) for the testing reference.
+Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md).
 
-## Stack
+**Start at [`README.md`](README.md)** for the stack, prerequisites, common commands, project layout, and the basic doc pointers. This file only carries what is not already in the README — placement rules, agent-relevant conventions, the testing checklist, and deeper pointers.
 
-Angular (standalone components) · Vitest (unit tests, jsdom default; Playwright Chromium via `gui:test-browser` for SVG / pointer geometry) · `@angular/build` builder · Yarn (Berry, ships in-repo).
+## Placement rules
 
-## Layout — where to look and where to put things
-
-The tree is split by user-facing area, not by Angular role. New code goes next to its feature, never into a flat type-bucket.
-
-| If you're touching…                                                             | Look in…                                                        |
-| ------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| The workflow editor (operator graph, property panel, result panel, code editor) | `src/app/workspace/`                                            |
-| The dashboard (workflows, datasets, projects, computing units, admin)           | `src/app/dashboard/`                                            |
-| The public hub (discover and share workflows)                                   | `src/app/hub/`                                                  |
-| Cross-cutting services, types, formly extensions, shared utils                  | `src/app/common/`                                               |
-| Shared test infrastructure (`commonTestProviders`, mock GUI config service)     | `src/app/common/testing/`                                       |
-| Operator metadata and the canonical `Stub…Service` doubles                      | `src/app/workspace/service/operator-metadata/`                  |
-| Vitest configuration (jsdom default; browser mode)                              | `vitest.config.ts`, `vitest.browser.config.ts`                  |
-| Per-spec inclusion / exclusion routing                                          | `angular.json` (`gui:test` and `gui:test-browser` targets)      |
-| ProxyZone setup that makes `fakeAsync` work under Vitest                        | `src/test-zone-setup.ts`                                        |
-| Generated protobuf TS (do not edit by hand)                                     | `src/app/common/type/proto/**`                                  |
-| Vendored third-party formly type files (separate license)                       | `src/app/common/formly/{array,object,multischema,null}.type.ts` |
-
-Placement rules:
+The layout table in [`README.md`](README.md) tells you where things live; these rules tell you where new things go.
 
 - **Components, services, and types live next to their feature.** A new workspace service goes in `src/app/workspace/service/<feature>/`, not in a flat global bucket.
 - **`Stub…Service` doubles live next to the real service** (`stub-operator-metadata.service.ts` sits alongside `operator-metadata.service.ts`). Specs import the stub by name; this keeps the mock surface consistent across the codebase.
-- **Types shared across more than one feature area** go in `src/app/common/type/`. Types owned by one feature stay with that feature.
+- **Types shared across more than one feature area** go in `src/app/common/type/`. Types owned by a single feature stay with that feature.
+- **Do not hand-edit codegen or vendored files:**
+  - `src/app/common/type/proto/**` — generated protobuf TypeScript.
+  - `src/app/common/formly/{array,object,multischema,null}.type.ts` — vendored upstream under a separate license.
 
 ## Conventions
 
 - **Components are standalone.** Declare them in `imports:`, never `declarations:` (the latter errors at compile time). The same applies inside `TestBed.configureTestingModule({...})`.
 - **Run `yarn format:fix` before pushing**; `yarn format:ci` mirrors what CI runs. ESLint and Prettier are wired together via `prettier-eslint`.
 - **Reuse shared test infrastructure** before inventing parallel one-off mocks. If a service already has a `Stub…Service`, extend the stub rather than ship a new partial mock from inside a spec.
-- **Do not hand-edit the files listed as generated or vendored above** — protobuf TS is produced by codegen, and the formly type files come from upstream under a different license.
 
 ## Before writing or fixing a spec
 
@@ -45,12 +29,9 @@ Read [`TESTING.md`](TESTING.md) — the canonical testing reference for both hum
 2. Standalone components go in `imports:`, not `declarations:`.
 3. `beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.
 
-## Pointers
+## Pointers (deeper than the README's "Where to read next")
 
-- **Commands and prerequisites** (dev server, build, test, format): [`README.md`](README.md).
-- **Testing reference** (recipes, anti-patterns, coverage troubleshooting, jsdom-vs-browser-mode decision): [`TESTING.md`](TESTING.md).
-- **Repo-wide testing philosophy** ("Tests come first" — TDD, characterization tests, every test covers a specific failure mode): [`../AGENTS.md`](../AGENTS.md).
-- **PR / commit / branch conventions** (Conventional Commits, fork-based workflow, license header check, the four-section PR template): [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
-- **Architecture map** (where the backend services live, what they own): [`../AGENTS.md`](../AGENTS.md) "Architecture Map".
-- **Coverage dashboard** for this repo: [app.codecov.io/gh/apache/texera](https://app.codecov.io/gh/apache/texera).
+- **Repo-wide testing philosophy** ("Tests come first" — TDD, characterization tests, every test covers a specific failure mode): [`../AGENTS.md`](../AGENTS.md) §"Tests come first".
+- **Architecture map** (where the backend services live, what they own): [`../AGENTS.md`](../AGENTS.md) §"Architecture Map".
+- **Coverage dashboard**: [app.codecov.io/gh/apache/texera](https://app.codecov.io/gh/apache/texera).
 - **Vitest browser-mode setup rationale**: [#5017](https://github.com/apache/texera/pull/5017).

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,116 @@
+# AGENTS.md — frontend
+
+Scoped agent rules for `frontend/`. Loaded automatically on top of the
+repo-root [`AGENTS.md`](../AGENTS.md). The detailed reference for humans
+(and for agents that need recipes, not just rules) lives in
+[`TESTING.md`](TESTING.md) — read it before writing or fixing any
+component spec.
+
+## Stack
+
+Angular 19 (standalone components) · Vitest 4 · `@angular/build:unit-test`
+builder · jsdom by default; Playwright Chromium via `gui:test-browser`
+for specs that need real DOM/SVG geometry · v8 coverage. Test setup file
+`src/test-zone-setup.ts` wraps `it`/`test` in a ProxyZone so Angular's
+`fakeAsync` works under Vitest.
+
+## Golden rules
+
+1. **Always call `fixture.detectChanges()` at least once.** Without it
+   the component constructor runs but the template never does — the
+   template is AOT-emitted code that only executes during change
+   detection, and v8 coverage attributes template hits back to the
+   `.html` file via source maps. No `detectChanges()` ⇒
+   `.component.html` stays at 0 % even when the spec passes green.
+2. **Standalone components go in `imports:`, not `declarations:`.**
+   Angular 19 errors at compile if a standalone component appears in
+   `declarations:`. To strip a standalone child for shallow rendering
+   use `TestBed.overrideComponent(Parent, { set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })`
+   before `compileComponents()`.
+3. **`beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.**
+   `test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but not
+   `beforeEach`; `waitForAsync` inside `beforeEach` throws
+   "Expected to be running in 'ProxyZone'".
+
+## Minimum viable spec template
+
+```ts
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { MyComponent } from "./my.component";
+
+describe("MyComponent", () => {
+  let fixture: ComponentFixture<MyComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyComponent, HttpClientTestingModule],
+      providers: [...commonTestProviders],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyComponent);
+    fixture.detectChanges(); // ⇐ this line is the HTML-coverage switch
+  });
+
+  it("should create", () => {
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+});
+```
+
+Anything more complex (event handlers, `*ngIf` branches, async data) —
+read [`TESTING.md`](TESTING.md).
+
+## Shared test infrastructure
+
+- **Common providers**: `commonTestProviders` from
+  `common/testing/test-utils.ts`. Always spread these; do not redeclare
+  `GuiConfigService` etc. per spec.
+- **Service stubs**: reuse the existing `Stub…Service` siblings (for
+  example `StubOperatorMetadataService`). When a service has no stub
+  yet, add a `*.stub.ts` or `*.mock.ts` next to the real implementation
+  rather than inlining a `vi.fn()` chain inside each spec.
+- **Mocks**: `vi.fn()` + `.mockReturnValue(...)`. RxJS-returning methods
+  use `.mockReturnValue(of(...))` or `EMPTY`. Do not introduce new
+  `jasmine.createSpy(...)` calls — those are leftover Karma idioms and
+  will be rewritten on touch.
+
+## Anti-patterns (review will flag these)
+
+| Pattern                                                                | Why it's wrong                                                                                                                                                                          |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Spec body entirely commented out, only the license header survives     | The file runs to "0 tests" and reports green; the template never renders. If a spec is dead, delete it; don't leave `//` as a graveyard.                                                |
+| `NO_ERRORS_SCHEMA` on a spec that asserts about children               | Children silently fail to render; branches inside `*ngIf="child.ready"` stay uncovered and broken templates pass. Use `MockComponent` or `overrideComponent({ set: { imports: [] } })`. |
+| `TestBed.overrideComponent(C, { set: { template: '' } })`              | Destroys the very thing under test; HTML coverage will be permanently 0 %.                                                                                                              |
+| `declarations: [StandaloneComponent]`                                  | Angular 19 throws at compile time. Use `imports:`.                                                                                                                                      |
+| `beforeEach(waitForAsync(() => …))`                                    | Throws "Expected to be running in 'ProxyZone'" under Vitest. Use `async () => { … }`.                                                                                                   |
+| `jasmine.createSpy(...)` / `spyOn(...).and.returnValue(...)`           | Karma idiom; rewrite as `vi.fn()` / `.mockReturnValue(...)`.                                                                                                                            |
+| Spec depends on a real HTTP / WebSocket call                           | Use `HttpClientTestingModule` and stub WS observables with `Subject` / `of(...)`.                                                                                                       |
+| Inventing a one-off provider mock when a `Stub…Service` already exists | Drift: the next spec invents another mock. Reuse and extend the existing stub.                                                                                                          |
+
+## When to use browser mode (`gui:test-browser`)
+
+The default `yarn test` path runs every spec under jsdom — fast, no
+browser boot. Switch a spec to browser mode **only** when it depends on
+real DOM or SVG behavior jsdom can't fake:
+
+- `SVGSVGElement.getScreenCTM()` / `getBoundingClientRect()` returning
+  real layout coordinates (jointjs paper).
+- Pointer-event hit testing — `elementFromPoint`, drag-and-drop with
+  real geometry.
+- CSS-layout-dependent assertions (offsetWidth / offsetHeight, scroll
+  positions).
+
+Per-spec routing lives in `angular.json` (`gui:test` excludes,
+`gui:test-browser` runs only what's routed there). Do not duplicate the
+list in `vitest.config.ts` — see the comment in that file.
+
+## Pointers
+
+- Recipes, decision trees, coverage troubleshooting: [`TESTING.md`](TESTING.md).
+- Minimum-viable reference spec (jsdom): `src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts`.
+- Browser-mode reference spec (real DOM): `src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts`.
+- The PR that migrated this frontend from Karma to Vitest: [#5017](https://github.com/apache/texera/pull/5017).

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — frontend
 
-Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md). The detailed reference for humans (and for agents that need recipes, not just rules) lives in [`TESTING.md`](TESTING.md) — read it before writing or fixing any component spec.
+Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md). For recipes, the mental model behind these rules, and troubleshooting, read [`TESTING.md`](TESTING.md) — it is the canonical reference for both humans and agents and should be consulted before writing or fixing any component spec.
 
 ## Stack
 

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -4,12 +4,12 @@ Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root
 
 ## Stack
 
-Angular 19 (standalone components) · Vitest 4 · `@angular/build:unit-test` builder · jsdom by default; Playwright Chromium via `gui:test-browser` for specs that need real DOM/SVG geometry · v8 coverage. Test setup file `src/test-zone-setup.ts` wraps `it`/`test` in a ProxyZone so Angular's `fakeAsync` works under Vitest.
+Angular (standalone components) · Vitest · `@angular/build:unit-test` builder · jsdom by default; Playwright Chromium via `gui:test-browser` for specs that need real DOM/SVG geometry · v8 coverage. Test setup file `src/test-zone-setup.ts` wraps `it`/`test` in a ProxyZone so Angular's `fakeAsync` works under Vitest.
 
 ## Golden rules
 
 1. **Always call `fixture.detectChanges()` at least once.** Without it the component constructor runs but the template never does — the template is AOT-emitted code that only executes during change detection, and v8 coverage attributes template hits back to the `.html` file via source maps. No `detectChanges()` ⇒ `.component.html` stays at 0 % even when the spec passes green.
-2. **Standalone components go in `imports:`, not `declarations:`.** Angular 19 errors at compile if a standalone component appears in `declarations:`. To strip a standalone child for shallow rendering use `TestBed.overrideComponent(Parent, { set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` before `compileComponents()`.
+2. **Standalone components go in `imports:`, not `declarations:`.** Angular errors at compile time if a standalone component appears in `declarations:`. To strip a standalone child for shallow rendering use `TestBed.overrideComponent(Parent, { set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` before `compileComponents()`.
 3. **`beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.** `test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but not `beforeEach`; `waitForAsync` inside `beforeEach` throws "Expected to be running in 'ProxyZone'".
 
 ## Minimum viable spec template
@@ -56,7 +56,7 @@ Anything more complex (event handlers, `*ngIf` branches, async data) — read [`
 | Spec body entirely commented out, only the license header survives     | The file runs to "0 tests" and reports green; the template never renders. If a spec is dead, delete it; don't leave `//` as a graveyard.                                                |
 | `NO_ERRORS_SCHEMA` on a spec that asserts about children               | Children silently fail to render; branches inside `*ngIf="child.ready"` stay uncovered and broken templates pass. Use `MockComponent` or `overrideComponent({ set: { imports: [] } })`. |
 | `TestBed.overrideComponent(C, { set: { template: '' } })`              | Destroys the very thing under test; HTML coverage will be permanently 0 %.                                                                                                              |
-| `declarations: [StandaloneComponent]`                                  | Angular 19 throws at compile time. Use `imports:`.                                                                                                                                      |
+| `declarations: [StandaloneComponent]`                                  | Angular throws at compile time — standalone components can't be declared in an NgModule. Use `imports:`.                                                                                |
 | `beforeEach(waitForAsync(() => …))`                                    | Throws "Expected to be running in 'ProxyZone'" under Vitest. Use `async () => { … }`.                                                                                                   |
 | Spec depends on a real HTTP / WebSocket call                           | Use `HttpClientTestingModule` and stub WS observables with `Subject` / `of(...)`.                                                                                                       |
 | Inventing a one-off provider mock when a `Stub…Service` already exists | Drift: the next spec invents another mock. Reuse and extend the existing stub.                                                                                                          |

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,36 +1,16 @@
 # AGENTS.md — frontend
 
-Scoped agent rules for `frontend/`. Loaded automatically on top of the
-repo-root [`AGENTS.md`](../AGENTS.md). The detailed reference for humans
-(and for agents that need recipes, not just rules) lives in
-[`TESTING.md`](TESTING.md) — read it before writing or fixing any
-component spec.
+Scoped agent rules for `frontend/`. Loaded automatically on top of the repo-root [`AGENTS.md`](../AGENTS.md). The detailed reference for humans (and for agents that need recipes, not just rules) lives in [`TESTING.md`](TESTING.md) — read it before writing or fixing any component spec.
 
 ## Stack
 
-Angular 19 (standalone components) · Vitest 4 · `@angular/build:unit-test`
-builder · jsdom by default; Playwright Chromium via `gui:test-browser`
-for specs that need real DOM/SVG geometry · v8 coverage. Test setup file
-`src/test-zone-setup.ts` wraps `it`/`test` in a ProxyZone so Angular's
-`fakeAsync` works under Vitest.
+Angular 19 (standalone components) · Vitest 4 · `@angular/build:unit-test` builder · jsdom by default; Playwright Chromium via `gui:test-browser` for specs that need real DOM/SVG geometry · v8 coverage. Test setup file `src/test-zone-setup.ts` wraps `it`/`test` in a ProxyZone so Angular's `fakeAsync` works under Vitest.
 
 ## Golden rules
 
-1. **Always call `fixture.detectChanges()` at least once.** Without it
-   the component constructor runs but the template never does — the
-   template is AOT-emitted code that only executes during change
-   detection, and v8 coverage attributes template hits back to the
-   `.html` file via source maps. No `detectChanges()` ⇒
-   `.component.html` stays at 0 % even when the spec passes green.
-2. **Standalone components go in `imports:`, not `declarations:`.**
-   Angular 19 errors at compile if a standalone component appears in
-   `declarations:`. To strip a standalone child for shallow rendering
-   use `TestBed.overrideComponent(Parent, { set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })`
-   before `compileComponents()`.
-3. **`beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.**
-   `test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but not
-   `beforeEach`; `waitForAsync` inside `beforeEach` throws
-   "Expected to be running in 'ProxyZone'".
+1. **Always call `fixture.detectChanges()` at least once.** Without it the component constructor runs but the template never does — the template is AOT-emitted code that only executes during change detection, and v8 coverage attributes template hits back to the `.html` file via source maps. No `detectChanges()` ⇒ `.component.html` stays at 0 % even when the spec passes green.
+2. **Standalone components go in `imports:`, not `declarations:`.** Angular 19 errors at compile if a standalone component appears in `declarations:`. To strip a standalone child for shallow rendering use `TestBed.overrideComponent(Parent, { set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` before `compileComponents()`.
+3. **`beforeEach` is `async () => { ... }`, not `waitForAsync(() => …)`.** `test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but not `beforeEach`; `waitForAsync` inside `beforeEach` throws "Expected to be running in 'ProxyZone'".
 
 ## Minimum viable spec template
 
@@ -61,22 +41,13 @@ describe("MyComponent", () => {
 });
 ```
 
-Anything more complex (event handlers, `*ngIf` branches, async data) —
-read [`TESTING.md`](TESTING.md).
+Anything more complex (event handlers, `*ngIf` branches, async data) — read [`TESTING.md`](TESTING.md).
 
 ## Shared test infrastructure
 
-- **Common providers**: `commonTestProviders` from
-  `common/testing/test-utils.ts`. Always spread these; do not redeclare
-  `GuiConfigService` etc. per spec.
-- **Service stubs**: reuse the existing `Stub…Service` siblings (for
-  example `StubOperatorMetadataService`). When a service has no stub
-  yet, add a `*.stub.ts` or `*.mock.ts` next to the real implementation
-  rather than inlining a `vi.fn()` chain inside each spec.
-- **Mocks**: `vi.fn()` + `.mockReturnValue(...)`. RxJS-returning methods
-  use `.mockReturnValue(of(...))` or `EMPTY`. Do not introduce new
-  `jasmine.createSpy(...)` calls — those are leftover Karma idioms and
-  will be rewritten on touch.
+- **Common providers**: `commonTestProviders` from `common/testing/test-utils.ts`. Always spread these; do not redeclare `GuiConfigService` etc. per spec.
+- **Service stubs**: reuse the existing `Stub…Service` siblings (for example `StubOperatorMetadataService`). When a service has no stub yet, add a `*.stub.ts` or `*.mock.ts` next to the real implementation rather than inlining a `vi.fn()` chain inside each spec.
+- **Mocks**: `vi.fn()` + `.mockReturnValue(...)`. RxJS-returning methods use `.mockReturnValue(of(...))` or `EMPTY`. For partial method replacement, `vi.spyOn(obj, "method").mockReturnValue(...)`.
 
 ## Anti-patterns (review will flag these)
 
@@ -87,30 +58,22 @@ read [`TESTING.md`](TESTING.md).
 | `TestBed.overrideComponent(C, { set: { template: '' } })`              | Destroys the very thing under test; HTML coverage will be permanently 0 %.                                                                                                              |
 | `declarations: [StandaloneComponent]`                                  | Angular 19 throws at compile time. Use `imports:`.                                                                                                                                      |
 | `beforeEach(waitForAsync(() => …))`                                    | Throws "Expected to be running in 'ProxyZone'" under Vitest. Use `async () => { … }`.                                                                                                   |
-| `jasmine.createSpy(...)` / `spyOn(...).and.returnValue(...)`           | Karma idiom; rewrite as `vi.fn()` / `.mockReturnValue(...)`.                                                                                                                            |
 | Spec depends on a real HTTP / WebSocket call                           | Use `HttpClientTestingModule` and stub WS observables with `Subject` / `of(...)`.                                                                                                       |
 | Inventing a one-off provider mock when a `Stub…Service` already exists | Drift: the next spec invents another mock. Reuse and extend the existing stub.                                                                                                          |
 
 ## When to use browser mode (`gui:test-browser`)
 
-The default `yarn test` path runs every spec under jsdom — fast, no
-browser boot. Switch a spec to browser mode **only** when it depends on
-real DOM or SVG behavior jsdom can't fake:
+The default `yarn test` path runs every spec under jsdom — fast, no browser boot. Switch a spec to browser mode **only** when it depends on real DOM or SVG behavior jsdom can't fake:
 
-- `SVGSVGElement.getScreenCTM()` / `getBoundingClientRect()` returning
-  real layout coordinates (jointjs paper).
-- Pointer-event hit testing — `elementFromPoint`, drag-and-drop with
-  real geometry.
-- CSS-layout-dependent assertions (offsetWidth / offsetHeight, scroll
-  positions).
+- `SVGSVGElement.getScreenCTM()` / `getBoundingClientRect()` returning real layout coordinates (jointjs paper).
+- Pointer-event hit testing — `elementFromPoint`, drag-and-drop with real geometry.
+- CSS-layout-dependent assertions (offsetWidth / offsetHeight, scroll positions).
 
-Per-spec routing lives in `angular.json` (`gui:test` excludes,
-`gui:test-browser` runs only what's routed there). Do not duplicate the
-list in `vitest.config.ts` — see the comment in that file.
+Per-spec routing lives in `angular.json` (`gui:test` excludes, `gui:test-browser` runs only what's routed there). Do not duplicate the list in `vitest.config.ts` — see the comment in that file.
 
 ## Pointers
 
 - Recipes, decision trees, coverage troubleshooting: [`TESTING.md`](TESTING.md).
 - Minimum-viable reference spec (jsdom): `src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts`.
 - Browser-mode reference spec (real DOM): `src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts`.
-- The PR that migrated this frontend from Karma to Vitest: [#5017](https://github.com/apache/texera/pull/5017).
+- Two-target jsdom / browser-mode setup rationale: [#5017](https://github.com/apache/texera/pull/5017).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,11 +1,8 @@
 # Texera Angular UI
 
-The web UI for [Apache Texera](https://github.com/apache/texera). An Angular
-single-page app that talks to the JVM backend services (`amber`,
-`access-control-service`, `file-service`, …) and to the agent service.
+The web UI for [Apache Texera](https://github.com/apache/texera). An Angular single-page app that talks to the JVM backend services (`amber`, `access-control-service`, `file-service`, …) and to the agent service.
 
-Angular 19 (standalone components) · Vitest 4 (unit tests) ·
-`@angular/build` builder · Yarn 4 (Berry).
+Angular 19 (standalone components) · Vitest 4 (unit tests) · `@angular/build` builder · Yarn 4 (Berry).
 
 ## Prerequisites
 
@@ -51,10 +48,7 @@ Run `ng help` for the full Angular CLI surface.
 
 ## Where to read next
 
-- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) for the
-  Vitest stack, recipes, jsdom-vs-browser-mode decisions, anti-patterns,
-  and coverage troubleshooting.
-- **Working as (or with) an AI agent in this directory?** See
-  [`AGENTS.md`](AGENTS.md) for the scoped rules that auto-load for agents.
+- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) for the Vitest stack, recipes, jsdom-vs-browser-mode decisions, anti-patterns, and coverage troubleshooting.
+- **Working as (or with) an AI agent in this directory?** See [`AGENTS.md`](AGENTS.md) for the scoped rules that auto-load for agents.
 - **Repo-wide contribution / PR rules?** See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
 - **Repo-wide agent context?** See [`../AGENTS.md`](../AGENTS.md).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -46,9 +46,3 @@ The full testing reference (Vitest stack, recipes, anti-patterns, coverage troub
 | `src/app/workspace/service/operator-metadata/` | Operator metadata service + the `Stub…Service` test doubles other specs reuse.                              |
 | `vitest.config.ts`, `vitest.browser.config.ts` | Test-runner configs (jsdom default; Playwright Chromium for SVG/pointer-heavy specs).                       |
 | `src/test-zone-setup.ts`                       | Vitest setup file — wraps `it`/`test` in an Angular ProxyZone so `fakeAsync` works.                         |
-
-## Where to read next
-
-- **AI agent working in this directory?** [`AGENTS.md`](AGENTS.md) auto-loads as scoped rules.
-- **Repo-wide contribution / PR rules?** See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
-- **Repo-wide agent context?** See [`../AGENTS.md`](../AGENTS.md).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,16 +2,11 @@
 
 The web UI for [Apache Texera](https://github.com/apache/texera). An Angular single-page app that talks to the JVM backend services (`amber`, `access-control-service`, `file-service`, …) and to the agent service.
 
-Angular 19 (standalone components) · Vitest 4 (unit tests) · `@angular/build` builder · Yarn 4 (Berry).
-
-## Prerequisites
-
-| Tool    | Version                                                  |
-| ------- | -------------------------------------------------------- |
-| Node.js | ≥ 24.0.0                                                 |
-| Yarn    | 4.14.x (ships in-repo via `.yarn/`; no separate install) |
+Angular (standalone components) · Vitest (unit tests) · `@angular/build` builder · Yarn (Berry).
 
 ## Setup
+
+Requires Node.js and Yarn — see the `engines` field in `package.json` for the supported versions. Yarn ships in-repo via `.yarn/`, no separate install.
 
 ```bash
 cd frontend

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -31,7 +31,7 @@ Run `ng help` for the full Angular CLI surface.
 
 ## Testing
 
-Tests come first — write the failing test before the source change. See the repo-wide [`../AGENTS.md`](../AGENTS.md) §"Tests come first" for the TDD workflow.
+Tests come first — write the failing test before the source change.
 
 The full testing reference (Vitest stack, recipes, anti-patterns, coverage troubleshooting) is in [`TESTING.md`](TESTING.md).
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,12 @@ yarn install
 
 Run `ng help` for the full Angular CLI surface.
 
+## Testing
+
+Tests come first — write the failing test before the source change. See the repo-wide [`../AGENTS.md`](../AGENTS.md) §"Tests come first" for the TDD workflow.
+
+The full testing reference (Vitest stack, recipes, anti-patterns, coverage troubleshooting) is in [`TESTING.md`](TESTING.md).
+
 ## Project layout
 
 | Path                                           | What lives here                                                                                             |
@@ -43,5 +49,6 @@ Run `ng help` for the full Angular CLI surface.
 
 ## Where to read next
 
-- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) — the canonical testing reference for both humans and AI agents.
-- **Repo-wide testing philosophy** (TDD, characterization tests, every test covers a specific failure mode): [`../AGENTS.md`](../AGENTS.md) §"Tests come first".
+- **AI agent working in this directory?** [`AGENTS.md`](AGENTS.md) auto-loads as scoped rules.
+- **Repo-wide contribution / PR rules?** See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+- **Repo-wide agent context?** See [`../AGENTS.md`](../AGENTS.md).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,7 +43,5 @@ Run `ng help` for the full Angular CLI surface.
 
 ## Where to read next
 
-- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) — the canonical testing reference for both humans and AI agents. Covers the Vitest stack, recipes, jsdom-vs-browser-mode decisions, anti-patterns, and coverage troubleshooting.
-- **AI agent working in this directory?** [`AGENTS.md`](AGENTS.md) auto-loads as scoped rules; consult [`TESTING.md`](TESTING.md) on demand for the underlying mental model and recipes.
-- **Repo-wide contribution / PR rules?** See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
-- **Repo-wide agent context?** See [`../AGENTS.md`](../AGENTS.md).
+- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) — the canonical testing reference for both humans and AI agents.
+- **Repo-wide testing philosophy** (TDD, characterization tests, every test covers a specific failure mode): [`../AGENTS.md`](../AGENTS.md) §"Tests come first".

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,23 +1,60 @@
-# NewGui
+# Texera Angular UI
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli)
+The web UI for [Apache Texera](https://github.com/apache/texera). An Angular
+single-page app that talks to the JVM backend services (`amber`,
+`access-control-service`, `file-service`, …) and to the agent service.
 
-## Development server
+Angular 19 (standalone components) · Vitest 4 (unit tests) ·
+`@angular/build` builder · Yarn 4 (Berry).
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+## Prerequisites
 
-## Code scaffolding
+| Tool    | Version                                                  |
+| ------- | -------------------------------------------------------- |
+| Node.js | ≥ 24.0.0                                                 |
+| Yarn    | 4.14.x (ships in-repo via `.yarn/`; no separate install) |
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+## Setup
 
-## Build
+```bash
+cd frontend
+yarn install
+```
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
+## Common commands
 
-## Running unit tests
+| What                                                  | Command                              |
+| ----------------------------------------------------- | ------------------------------------ |
+| Dev server (UI + y-websocket sidecar)                 | `yarn start` → http://localhost:4200 |
+| Production build                                      | `yarn build`                         |
+| Unit tests (jsdom, watch off)                         | `yarn test`                          |
+| Unit tests in real browser mode (Playwright Chromium) | `ng run gui:test-browser`            |
+| Unit tests with coverage in lcov form (CI shape)      | `yarn test:ci`                       |
+| Format (Prettier + ESLint --fix)                      | `yarn format:fix`                    |
+| Format check (CI shape)                               | `yarn format:ci`                     |
+| Lint only                                             | `yarn lint`                          |
+| Bundle analyzer                                       | `yarn analyze`                       |
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+Run `ng help` for the full Angular CLI surface.
 
-## Further help
+## Project layout
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+| Path                                           | What lives here                                                                                             |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `src/app/workspace/`                           | Workflow editor — operator graph, property panel, result panel, code editor.                                |
+| `src/app/dashboard/`                           | User dashboard — workflows, datasets, projects, computing units, admin.                                     |
+| `src/app/hub/`                                 | Public hub — discover and share workflows.                                                                  |
+| `src/app/common/`                              | Cross-cutting services, types, formly extensions, and shared test helpers (`common/testing/test-utils.ts`). |
+| `src/app/workspace/service/operator-metadata/` | Operator metadata service + the `Stub…Service` test doubles other specs reuse.                              |
+| `vitest.config.ts`, `vitest.browser.config.ts` | Test-runner configs (jsdom default; Playwright Chromium for SVG/pointer-heavy specs).                       |
+| `src/test-zone-setup.ts`                       | Vitest setup file — wraps `it`/`test` in an Angular ProxyZone so `fakeAsync` works.                         |
+
+## Where to read next
+
+- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) for the
+  Vitest stack, recipes, jsdom-vs-browser-mode decisions, anti-patterns,
+  and coverage troubleshooting.
+- **Working as (or with) an AI agent in this directory?** See
+  [`AGENTS.md`](AGENTS.md) for the scoped rules that auto-load for agents.
+- **Repo-wide contribution / PR rules?** See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
+- **Repo-wide agent context?** See [`../AGENTS.md`](../AGENTS.md).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,7 +43,7 @@ Run `ng help` for the full Angular CLI surface.
 
 ## Where to read next
 
-- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) for the Vitest stack, recipes, jsdom-vs-browser-mode decisions, anti-patterns, and coverage troubleshooting.
-- **Working as (or with) an AI agent in this directory?** See [`AGENTS.md`](AGENTS.md) for the scoped rules that auto-load for agents.
+- **Writing or fixing a unit test?** See [`TESTING.md`](TESTING.md) — the canonical testing reference for both humans and AI agents. Covers the Vitest stack, recipes, jsdom-vs-browser-mode decisions, anti-patterns, and coverage troubleshooting.
+- **AI agent working in this directory?** [`AGENTS.md`](AGENTS.md) auto-loads as scoped rules; consult [`TESTING.md`](TESTING.md) on demand for the underlying mental model and recipes.
 - **Repo-wide contribution / PR rules?** See [`../CONTRIBUTING.md`](../CONTRIBUTING.md).
 - **Repo-wide agent context?** See [`../AGENTS.md`](../AGENTS.md).

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -119,9 +119,6 @@ describe("MyComponent", () => {
   });
 });
 ```
-
-Working reference: `src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts` (63 lines, achieves ~87 % template coverage off this pattern alone).
-
 ### B. `*ngIf` branches
 
 Each `*ngIf` is a separate sub-template. To cover both sides, run `detectChanges()` once per branch:

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -21,9 +21,9 @@ For repo-wide testing philosophy (TDD, characterization tests, "every test must 
 
 | Layer                    | Choice                                                                                                                                 |
 | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
-| Test framework           | Vitest 4.1.x                                                                                                                           |
+| Test framework           | Vitest                                                                                                                                 |
 | Angular test integration | `@angular/build:unit-test` builder (two targets in `angular.json`: `gui:test` and `gui:test-browser`)                                  |
-| Default DOM              | jsdom 25                                                                                                                               |
+| Default DOM              | jsdom                                                                                                                                  |
 | Real-browser DOM         | `@vitest/browser` + Playwright (Chromium, headless)                                                                                    |
 | Coverage                 | `@vitest/coverage-v8`                                                                                                                  |
 | Test setup               | `src/test-zone-setup.ts` wraps `it`/`test` in an Angular ProxyZone (Vitest does not provide one and Angular's `fakeAsync` requires it) |
@@ -210,7 +210,7 @@ it("debounces the query before firing", fakeAsync(() => {
 
 ## Standalone components
 
-Angular 19 made every newly-generated component standalone. The component itself goes into `imports:`, never `declarations:`:
+Newly-generated components are standalone. The component itself goes into `imports:`, never `declarations:`:
 
 ```ts
 TestBed.configureTestingModule({
@@ -295,7 +295,7 @@ Used historically to bypass a child template that wouldn't compile. Side effect:
 
 ### 4. `declarations: [StandaloneComponent]`
 
-Angular 19 errors out at compile time with "Component is standalone and can't be declared in any NgModule".
+Angular errors out at compile time with "Component is standalone and can't be declared in any NgModule".
 
 **Fix**: move the component to `imports:`.
 

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -119,6 +119,7 @@ describe("MyComponent", () => {
   });
 });
 ```
+
 ### B. `*ngIf` branches
 
 Each `*ngIf` is a separate sub-template. To cover both sides, run `detectChanges()` once per branch:

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -1,6 +1,6 @@
 # Frontend testing guide
 
-This document is the canonical reference for writing, running, and maintaining unit tests in `frontend/`. The TL;DR rules live in [`AGENTS.md`](AGENTS.md); the recipes, mental model, and troubleshooting live here.
+Canonical reference for writing, running, and maintaining unit tests in `frontend/`. Written for both human contributors and AI agents — read it on demand when [`AGENTS.md`](AGENTS.md)'s rules need a deeper recipe, the mental model behind a constraint, or troubleshooting steps.
 
 For repo-wide testing philosophy (TDD, characterization tests, "every test must cover a specific failure mode") see [`../AGENTS.md`](../AGENTS.md) "Tests come first".
 

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -1,0 +1,484 @@
+# Frontend testing guide
+
+This document is the canonical reference for writing, running, and
+maintaining unit tests in `frontend/`. The TL;DR rules live in
+[`AGENTS.md`](AGENTS.md); the recipes, mental model, and troubleshooting
+live here.
+
+For repo-wide testing philosophy (TDD, characterization tests,
+"every test must cover a specific failure mode") see
+[`../AGENTS.md`](../AGENTS.md) "Tests come first".
+
+## Contents
+
+1. [The stack](#the-stack)
+2. [Running tests](#running-tests)
+3. [Why `detectChanges()` is the coverage switch](#why-detectchanges-is-the-coverage-switch)
+4. [Recipes](#recipes)
+5. [Standalone components](#standalone-components)
+6. [jsdom vs browser mode](#jsdom-vs-browser-mode)
+7. [Mocking](#mocking)
+8. [Anti-patterns](#anti-patterns)
+9. [Coverage troubleshooting](#coverage-troubleshooting)
+10. [Migrating an old Karma spec](#migrating-an-old-karma-spec)
+11. [References](#references)
+
+## The stack
+
+| Layer                    | Choice                                                                                                                                                |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Test framework           | Vitest 4.1.x                                                                                                                                          |
+| Angular test integration | `@angular/build:unit-test` builder (two targets in `angular.json`: `gui:test` and `gui:test-browser`)                                                 |
+| Default DOM              | jsdom 25                                                                                                                                              |
+| Real-browser DOM         | `@vitest/browser` + Playwright (Chromium, headless)                                                                                                   |
+| Coverage                 | `@vitest/coverage-v8`                                                                                                                                 |
+| Test setup               | `src/test-zone-setup.ts` wraps `it`/`test` in an Angular ProxyZone (needed because Vitest does not provide one and Angular's `fakeAsync` requires it) |
+| Globals                  | `globals: true` in `vitest.config.ts`, so `describe / it / expect / vi / beforeEach` come from the runtime — no per-file imports                      |
+
+`src/main.test.ts` is intentionally a near-empty `export {}`. The
+`unit-test` builder uses `buildTarget`'s `main` to seed the bundle graph;
+if it pointed at the real `main.ts`, every component declared in
+`AppModule` would be type-checked for every spec, surfacing template
+errors for components no active spec touches. Keeping `main.test.ts`
+empty narrows the graph to what each spec actually imports.
+
+## Running tests
+
+```bash
+# default — jsdom, watch off
+yarn test
+
+# the same, with coverage in lcov form (CI shape)
+yarn test:ci
+
+# only the specs routed to real browser DOM (Playwright Chromium)
+ng run gui:test-browser
+
+# coverage report you can open in a browser
+yarn test -- --coverage --coverage.reporter=html
+# then open coverage/index.html
+```
+
+Single-file and watch loops use Vitest's own filtering:
+
+```bash
+ng test --test-file src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts
+```
+
+## Why `detectChanges()` is the coverage switch
+
+Angular's Ivy compiler turns each component template into a TypeScript
+function:
+
+```ts
+function MiniMapComponent_Template(rf, ctx) {
+  if (rf & 1) {
+    // creation pass
+    ɵɵelementStart(0, "div");
+    ɵɵlistener("click", () => ctx.onClick());
+    ɵɵtext(1);
+    ɵɵelementEnd();
+  }
+  if (rf & 2) {
+    // update pass
+    ɵɵadvance(1);
+    ɵɵtextInterpolate(ctx.label);
+  }
+}
+```
+
+This function is **not** invoked by the component constructor; it runs
+only during change detection. The Vite build emits source maps that map
+each `ɵɵ…` call back to the `.html` line that produced it, and v8
+coverage records hits against that source-mapped location.
+
+Consequences:
+
+- `TestBed.createComponent(C)` alone covers the constructor but leaves
+  the template at 0 %.
+- A single `fixture.detectChanges()` runs the creation pass and the
+  first update pass; most ordinary `.component.html` files jump to
+  70 – 90 % from this one call.
+- Branches gated by `*ngIf="cond"` need a second `detectChanges()` with
+  `cond` toggled to cover the other side. The same applies to
+  `*ngFor` over an empty vs non-empty array, and to `[ngSwitch]` cases.
+
+If `.component.html` shows 0 % after your spec runs, you almost
+certainly hit one of the [anti-patterns](#anti-patterns) — most often
+the constructor compiled and "should create" passed but `detectChanges`
+was never reached.
+
+## Recipes
+
+### A. Minimum viable spec
+
+Use this as the starting point for any new component. It already covers
+the template's creation pass.
+
+```ts
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { MyComponent } from "./my.component";
+
+describe("MyComponent", () => {
+  let fixture: ComponentFixture<MyComponent>;
+  let component: MyComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MyComponent, HttpClientTestingModule],
+      providers: [...commonTestProviders],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+});
+```
+
+Working reference: `src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts` (63 lines, achieves ~87 % template coverage off this pattern alone).
+
+### B. `*ngIf` branches
+
+Each `*ngIf` is a separate sub-template. To cover both sides, run
+`detectChanges()` once per branch:
+
+```ts
+it("hides the run button while running", () => {
+  component.isRunning = false;
+  fixture.detectChanges();
+  expect(fixture.nativeElement.querySelector(".run-btn")).toBeTruthy();
+
+  component.isRunning = true;
+  fixture.detectChanges();
+  expect(fixture.nativeElement.querySelector(".run-btn")).toBeNull();
+  expect(fixture.nativeElement.querySelector(".pause-btn")).toBeTruthy();
+});
+```
+
+### C. Event handler
+
+```ts
+import { By } from "@angular/platform-browser";
+
+it("calls onRun() when the run button is clicked", () => {
+  const spy = vi.spyOn(component, "onRun");
+  fixture.detectChanges();
+  fixture.debugElement.query(By.css(".run-btn")).triggerEventHandler("click", null);
+  expect(spy).toHaveBeenCalledOnce();
+});
+```
+
+Prefer `triggerEventHandler("click", null)` over `nativeElement.click()`
+when the binding goes through Angular event syntax — it goes through the
+Angular renderer and survives renderer-2 vs DOM-renderer differences.
+
+### D. Component talking to a stubbed service
+
+Reuse existing `Stub…Service` doubles where they exist. Where they don't,
+spread a fresh `vi.fn()` mock through `providers`:
+
+```ts
+import { OperatorMetadataService } from "../service/operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../service/operator-metadata/stub-operator-metadata.service";
+import { of } from "rxjs";
+
+beforeEach(async () => {
+  await TestBed.configureTestingModule({
+    imports: [MyComponent, HttpClientTestingModule],
+    providers: [
+      { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
+      {
+        provide: WorkflowPersistService,
+        useValue: {
+          persistWorkflow: vi.fn().mockReturnValue(of(stubWorkflow)),
+        },
+      },
+      ...commonTestProviders,
+    ],
+  }).compileComponents();
+});
+```
+
+### E. Component with async data (HTTP, RxJS)
+
+For HTTP-driven flows, `HttpClientTestingModule` is enough; `await
+fixture.whenStable()` flushes pending microtasks:
+
+```ts
+it("loads the workflow on init", async () => {
+  fixture.detectChanges();
+  await fixture.whenStable();
+  expect(component.workflow).toEqual(stubWorkflow);
+});
+```
+
+For timers (`debounceTime`, `setTimeout`, `interval`), use `fakeAsync` +
+`tick`:
+
+```ts
+import { fakeAsync, tick } from "@angular/core/testing";
+
+it("debounces the query before firing", fakeAsync(() => {
+  component.query$.next("foo");
+  tick(199);
+  expect(search).not.toHaveBeenCalled();
+  tick(1);
+  expect(search).toHaveBeenCalledWith("foo");
+}));
+```
+
+`fakeAsync` works because `test-zone-setup.ts` installs a ProxyZone
+around `it`/`test`. It does **not** install one around `beforeEach`, so
+do not write `beforeEach(fakeAsync(...))` — set component state and call
+`tick()` from inside the `it` body instead.
+
+## Standalone components
+
+Angular 19 made every newly-generated component standalone. The
+component itself goes into `imports:`, never `declarations:`:
+
+```ts
+TestBed.configureTestingModule({
+  imports: [MyStandaloneComponent, HttpClientTestingModule],
+  providers: [...commonTestProviders],
+});
+```
+
+To replace heavy or hard-to-instantiate child components with stubs
+while keeping the parent template under test, use the
+`set / remove / add` form of `overrideComponent` **before**
+`compileComponents()`:
+
+```ts
+TestBed.overrideComponent(WorkspaceComponent, {
+  set: { imports: [], providers: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] },
+});
+```
+
+Working reference: `src/app/workspace/component/workspace.component.spec.ts`.
+
+This drops the children's transitive dependency tree but leaves the
+parent template rendering — `<ng-template>` tags, `@ViewChild` queries,
+and event bindings still work because the template itself is unchanged.
+Do **not** use `set: { template: "" }` — that erases the template and
+guarantees 0 % HTML coverage.
+
+## jsdom vs browser mode
+
+Default path (`gui:test`, `vitest.config.ts`) runs every spec under
+jsdom. Fast, no browser boot, works for the overwhelming majority of
+component logic.
+
+Browser path (`gui:test-browser`, `vitest.browser.config.ts`) runs in
+real Chromium via Playwright. Use it **only** for the cases jsdom can't
+fake:
+
+| Spec needs                                                            | jsdom verdict           | Action       |
+| --------------------------------------------------------------------- | ----------------------- | ------------ |
+| `getBoundingClientRect()` / `offsetWidth` with real layout            | Returns zeros           | Browser mode |
+| `SVGGraphicsElement.getScreenCTM()` for SVG coordinate math (jointjs) | Returns identity matrix | Browser mode |
+| Pointer-event hit testing (`elementFromPoint`, drag-and-drop)         | Misses elements         | Browser mode |
+| CSS-driven visibility / scroll measurements                           | Unreliable              | Browser mode |
+| Plain DOM tree assertions, classes, attributes, text content          | Fine                    | jsdom        |
+| Event handlers, observables, services, routing                        | Fine                    | jsdom        |
+
+Routing rules: per-spec inclusion / exclusion is set in `angular.json`,
+not in `vitest.config.ts`. The comment in `vitest.config.ts` explains
+why — duplicating the list there triggers a Vite warning and the
+builder-side filter wins anyway.
+
+Working reference (browser mode): `src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts` (uses real pointer hit testing on the jointjs paper). PR [#5017](https://github.com/apache/texera/pull/5017) introduced this two-target setup and explains the rationale.
+
+## Mocking
+
+### Functions / spies
+
+```ts
+const onClick = vi.fn(); // bare mock
+const persist = vi.fn().mockReturnValue(of(stubWorkflow)); // returns Observable
+const search = vi.fn().mockResolvedValue([1, 2]); // returns Promise
+const spy = vi.spyOn(component, "onRun"); // spy without replacing
+```
+
+### Service doubles
+
+Prefer a sibling `Stub…Service` class (the
+`StubOperatorMetadataService` pattern is the model) when the service is
+used by more than one spec. They live next to the real service and are
+imported by name; they keep the spec setup terse and the mock surface
+consistent across the codebase.
+
+For one-shot mocks, an inline `useValue` with `vi.fn()` is fine, but if
+you find yourself copying the same `useValue` block across specs, lift
+it to a `*.stub.ts` next to the service.
+
+### RxJS
+
+Replace methods that return `Observable<T>` with `vi.fn().mockReturnValue(of(value))`
+or `mockReturnValue(EMPTY)` / `mockReturnValue(throwError(() => err))`.
+For multi-emission streams expose a `Subject` you control and call
+`subject.next(...)` from inside the test.
+
+## Anti-patterns
+
+The patterns listed below are the ones that have actually appeared in
+this codebase. Each ships a real fix.
+
+### 1. Fully commented-out spec
+
+The license header is the only live code; the file reports "0 tests, 0
+failures" and Vitest counts it as a pass. The corresponding
+`.component.html` stays at 0 %.
+
+**Fix**: delete the commented code outright (git history keeps it).
+Either replace it with the minimum-viable spec from Recipe A, or remove
+the spec file entirely.
+
+### 2. `NO_ERRORS_SCHEMA` everywhere
+
+A spec adds `schemas: [NO_ERRORS_SCHEMA]` to silence "unknown element"
+errors from un-imported children, but then asserts something about the
+parent template that depends on the child rendering. Branches inside
+`*ngIf="child.ready"` are dead because `child.ready` never fires.
+
+**Fix**: import the real child, or use `overrideComponent({ set:
+{ imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` to drop the
+child's transitive imports while letting the unknown element render as
+an inert tag. `CUSTOM_ELEMENTS_SCHEMA` says "I know what I'm doing",
+`NO_ERRORS_SCHEMA` says "swallow all template errors" — the second is
+almost never what you want.
+
+### 3. `overrideComponent({ set: { template: "" } })`
+
+Used historically to bypass a child template that wouldn't compile.
+Side effect: the parent's template is wiped, so HTML coverage is
+permanently 0 %.
+
+**Fix**: see Anti-pattern 2 — override `imports` and `schemas` instead,
+keep the template intact.
+
+### 4. `declarations: [StandaloneComponent]`
+
+Angular 19 errors out at compile time with "Component is standalone and
+can't be declared in any NgModule". The error is loud, but specs
+copy-pasted from pre-19 Karma days will still ship the wrong shape.
+
+**Fix**: move the component to `imports:`.
+
+### 5. `beforeEach(waitForAsync(() => …))`
+
+`test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but **not**
+`beforeEach`. `waitForAsync` throws "Expected to be running in
+'ProxyZone'" the moment it tries to detect the zone.
+
+**Fix**: `beforeEach(async () => { await TestBed.configureTestingModule(...).compileComponents(); })`.
+
+### 6. Karma-style spies
+
+```ts
+const spy = jasmine.createSpy("onClick");
+spyOn(service, "fetch").and.returnValue(of(value));
+```
+
+Vitest provides a Jasmine-compat shim for most call sites, but new code
+should use the Vitest API directly:
+
+```ts
+const spy = vi.fn();
+vi.spyOn(service, "fetch").mockReturnValue(of(value));
+```
+
+The shim does not cover every Jasmine matcher, and Vitest mocks come
+with `mockClear`/`mockReset`/`mockImplementationOnce` etc. that are
+strictly better.
+
+### 7. Real HTTP / WebSocket calls
+
+A spec that requires the dev server to be running, or that opens a real
+WebSocket, is not a unit test. It will fail in CI for unrelated reasons
+and slow the whole suite down.
+
+**Fix**: `HttpClientTestingModule` for HTTP; a `Subject` you `.next()`
+into for WebSocket-shaped observables.
+
+### 8. One-off `useValue` mock when a `Stub…Service` exists
+
+Drift: spec A invents a partial mock for `OperatorMetadataService`,
+spec B invents a different partial mock, none of them agrees with the
+real interface, and a refactor breaks all three differently.
+
+**Fix**: use `StubOperatorMetadataService`. When you find yourself
+wanting a new method on the stub, add it to the stub class, not to the
+spec.
+
+## Coverage troubleshooting
+
+`yarn test:ci` produces `coverage/lcov.info`; the GitHub-side dashboard
+is at [app.codecov.io/gh/apache/texera](https://app.codecov.io/gh/apache/texera).
+If a `.component.html` shows 0 % even though the spec passes, walk this
+list top-to-bottom:
+
+1. **Did `compileComponents()` actually resolve?** A missing provider
+   makes `TestBed.configureTestingModule(...).compileComponents()`
+   reject; Vitest reports the spec as failed but coverage still says
+   0 %. Run the spec locally, read the actual error in the output, and
+   add the missing provider (commonly `HttpClient`, `Router`,
+   `ActivatedRoute`, or a service that pulls in `GuiConfigService`).
+2. **Is `fixture.detectChanges()` actually called?** Step through
+   `beforeEach`; an early-throw or a typo means the line is dead code.
+3. **Has the template been overridden to `""`**? See Anti-pattern 3.
+4. **Does the spec use `NO_ERRORS_SCHEMA` to silence missing children,
+   and then assert nothing about the rendered children**? Coverage will
+   reflect that the children's branches were never reached. See
+   Anti-pattern 2.
+5. **Is the build source-map-enabled?** `angular.json` `gui:test`
+   inherits from `build.test`. Confirm `sourceMap: true` (the default).
+   A custom builder swap can silently turn it off; without source maps,
+   v8 hits land on the compiled JS, not on the `.html`.
+6. **Is the file on the exclusion list?** Check `angular.json` for
+   `unit-test` `polyfills` / `include` / `exclude` patterns. Some
+   third-party-ish files in `common/formly/*.type.ts` are intentionally
+   excluded (their license header file mentions TypeFox).
+7. **Is the spec routed to a different builder than expected?** If a
+   file is in `gui:test-browser`'s include list, `yarn test` won't run
+   it. Inspect both targets' `include` arrays.
+8. **Is the spec file fully commented out?** See Anti-pattern 1. If
+   Vitest reports "0 tests" for the file, this is the cause.
+
+## Migrating an old Karma spec
+
+If you're cherry-picking a pre-#5017 spec, or you find a spec that has
+escaped the migration, this checklist gets it green under Vitest:
+
+| Before (Karma + Jasmine)                                                                       | After (Vitest + Angular 19)                                                                  |
+| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| `beforeEach(waitForAsync(() => { TestBed.configureTestingModule(...).compileComponents(); }))` | `beforeEach(async () => { await TestBed.configureTestingModule(...).compileComponents(); })` |
+| `declarations: [MyStandaloneComponent]`                                                        | `imports: [MyStandaloneComponent]`                                                           |
+| `jasmine.createSpy("name")`                                                                    | `vi.fn()`                                                                                    |
+| `spyOn(obj, "m").and.returnValue(v)`                                                           | `vi.spyOn(obj, "m").mockReturnValue(v)`                                                      |
+| `spyOn(obj, "m").and.callFake(fn)`                                                             | `vi.spyOn(obj, "m").mockImplementation(fn)`                                                  |
+| `expect(spy).toHaveBeenCalledTimes(1)`                                                         | unchanged                                                                                    |
+| Real DOM assertions on SVG geometry or pointer events                                          | Route the spec to `gui:test-browser` in `angular.json`                                       |
+
+Worked example: PR [#5017](https://github.com/apache/texera/pull/5017)
+migrated the `workflow-editor` spec, including routing it to browser
+mode for the parts that needed real DOM. The diff is small and reads
+as a checklist of the rules above.
+
+## References
+
+- [Angular testing guide — components](https://angular.dev/guide/testing/components-basics)
+- [Angular testing scenarios](https://angular.dev/guide/testing/components-scenarios)
+- [Angular component harnesses overview](https://angular.dev/guide/testing/component-harnesses-overview)
+- [Vitest docs — browser mode](https://vitest.dev/guide/browser/)
+- [`@angular/build:unit-test` builder](https://angular.dev/tools/cli/build-system-migration)
+- [PR #5017 — Karma → Vitest migration](https://github.com/apache/texera/pull/5017)

--- a/frontend/TESTING.md
+++ b/frontend/TESTING.md
@@ -1,13 +1,8 @@
 # Frontend testing guide
 
-This document is the canonical reference for writing, running, and
-maintaining unit tests in `frontend/`. The TL;DR rules live in
-[`AGENTS.md`](AGENTS.md); the recipes, mental model, and troubleshooting
-live here.
+This document is the canonical reference for writing, running, and maintaining unit tests in `frontend/`. The TL;DR rules live in [`AGENTS.md`](AGENTS.md); the recipes, mental model, and troubleshooting live here.
 
-For repo-wide testing philosophy (TDD, characterization tests,
-"every test must cover a specific failure mode") see
-[`../AGENTS.md`](../AGENTS.md) "Tests come first".
+For repo-wide testing philosophy (TDD, characterization tests, "every test must cover a specific failure mode") see [`../AGENTS.md`](../AGENTS.md) "Tests come first".
 
 ## Contents
 
@@ -20,27 +15,21 @@ For repo-wide testing philosophy (TDD, characterization tests,
 7. [Mocking](#mocking)
 8. [Anti-patterns](#anti-patterns)
 9. [Coverage troubleshooting](#coverage-troubleshooting)
-10. [Migrating an old Karma spec](#migrating-an-old-karma-spec)
-11. [References](#references)
+10. [References](#references)
 
 ## The stack
 
-| Layer                    | Choice                                                                                                                                                |
-| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Test framework           | Vitest 4.1.x                                                                                                                                          |
-| Angular test integration | `@angular/build:unit-test` builder (two targets in `angular.json`: `gui:test` and `gui:test-browser`)                                                 |
-| Default DOM              | jsdom 25                                                                                                                                              |
-| Real-browser DOM         | `@vitest/browser` + Playwright (Chromium, headless)                                                                                                   |
-| Coverage                 | `@vitest/coverage-v8`                                                                                                                                 |
-| Test setup               | `src/test-zone-setup.ts` wraps `it`/`test` in an Angular ProxyZone (needed because Vitest does not provide one and Angular's `fakeAsync` requires it) |
-| Globals                  | `globals: true` in `vitest.config.ts`, so `describe / it / expect / vi / beforeEach` come from the runtime — no per-file imports                      |
+| Layer                    | Choice                                                                                                                                 |
+| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Test framework           | Vitest 4.1.x                                                                                                                           |
+| Angular test integration | `@angular/build:unit-test` builder (two targets in `angular.json`: `gui:test` and `gui:test-browser`)                                  |
+| Default DOM              | jsdom 25                                                                                                                               |
+| Real-browser DOM         | `@vitest/browser` + Playwright (Chromium, headless)                                                                                    |
+| Coverage                 | `@vitest/coverage-v8`                                                                                                                  |
+| Test setup               | `src/test-zone-setup.ts` wraps `it`/`test` in an Angular ProxyZone (Vitest does not provide one and Angular's `fakeAsync` requires it) |
+| Globals                  | `globals: true` in `vitest.config.ts`, so `describe / it / expect / vi / beforeEach` come from the runtime — no per-file imports       |
 
-`src/main.test.ts` is intentionally a near-empty `export {}`. The
-`unit-test` builder uses `buildTarget`'s `main` to seed the bundle graph;
-if it pointed at the real `main.ts`, every component declared in
-`AppModule` would be type-checked for every spec, surfacing template
-errors for components no active spec touches. Keeping `main.test.ts`
-empty narrows the graph to what each spec actually imports.
+`src/main.test.ts` is intentionally a near-empty `export {}`. The `unit-test` builder uses `buildTarget`'s `main` to seed the bundle graph; if it pointed at the real `main.ts`, every component declared in `AppModule` would be type-checked for every spec, surfacing template errors for components no active spec touches. Keeping `main.test.ts` empty narrows the graph to what each spec actually imports.
 
 ## Running tests
 
@@ -67,8 +56,7 @@ ng test --test-file src/app/workspace/component/workflow-editor/mini-map/mini-ma
 
 ## Why `detectChanges()` is the coverage switch
 
-Angular's Ivy compiler turns each component template into a TypeScript
-function:
+Angular's Ivy compiler turns each component template into a TypeScript function:
 
 ```ts
 function MiniMapComponent_Template(rf, ctx) {
@@ -87,33 +75,21 @@ function MiniMapComponent_Template(rf, ctx) {
 }
 ```
 
-This function is **not** invoked by the component constructor; it runs
-only during change detection. The Vite build emits source maps that map
-each `ɵɵ…` call back to the `.html` line that produced it, and v8
-coverage records hits against that source-mapped location.
+This function is **not** invoked by the component constructor; it runs only during change detection. The Vite build emits source maps that map each `ɵɵ…` call back to the `.html` line that produced it, and v8 coverage records hits against that source-mapped location.
 
 Consequences:
 
-- `TestBed.createComponent(C)` alone covers the constructor but leaves
-  the template at 0 %.
-- A single `fixture.detectChanges()` runs the creation pass and the
-  first update pass; most ordinary `.component.html` files jump to
-  70 – 90 % from this one call.
-- Branches gated by `*ngIf="cond"` need a second `detectChanges()` with
-  `cond` toggled to cover the other side. The same applies to
-  `*ngFor` over an empty vs non-empty array, and to `[ngSwitch]` cases.
+- `TestBed.createComponent(C)` alone covers the constructor but leaves the template at 0 %.
+- A single `fixture.detectChanges()` runs the creation pass and the first update pass; most ordinary `.component.html` files jump to 70 – 90 % from this one call.
+- Branches gated by `*ngIf="cond"` need a second `detectChanges()` with `cond` toggled to cover the other side. The same applies to `*ngFor` over an empty vs non-empty array, and to `[ngSwitch]` cases.
 
-If `.component.html` shows 0 % after your spec runs, you almost
-certainly hit one of the [anti-patterns](#anti-patterns) — most often
-the constructor compiled and "should create" passed but `detectChanges`
-was never reached.
+If `.component.html` shows 0 % after your spec runs, you almost certainly hit one of the [anti-patterns](#anti-patterns) — most often the constructor compiled and "should create" passed but `detectChanges` was never reached.
 
 ## Recipes
 
 ### A. Minimum viable spec
 
-Use this as the starting point for any new component. It already covers
-the template's creation pass.
+Use this as the starting point for any new component. It already covers the template's creation pass.
 
 ```ts
 import { ComponentFixture, TestBed } from "@angular/core/testing";
@@ -148,8 +124,7 @@ Working reference: `src/app/workspace/component/workflow-editor/mini-map/mini-ma
 
 ### B. `*ngIf` branches
 
-Each `*ngIf` is a separate sub-template. To cover both sides, run
-`detectChanges()` once per branch:
+Each `*ngIf` is a separate sub-template. To cover both sides, run `detectChanges()` once per branch:
 
 ```ts
 it("hides the run button while running", () => {
@@ -177,14 +152,11 @@ it("calls onRun() when the run button is clicked", () => {
 });
 ```
 
-Prefer `triggerEventHandler("click", null)` over `nativeElement.click()`
-when the binding goes through Angular event syntax — it goes through the
-Angular renderer and survives renderer-2 vs DOM-renderer differences.
+Prefer `triggerEventHandler("click", null)` over `nativeElement.click()` when the binding goes through Angular event syntax — it goes through the Angular renderer and survives renderer-2 vs DOM-renderer differences.
 
 ### D. Component talking to a stubbed service
 
-Reuse existing `Stub…Service` doubles where they exist. Where they don't,
-spread a fresh `vi.fn()` mock through `providers`:
+Reuse existing `Stub…Service` doubles where they exist. Where they don't, spread a fresh `vi.fn()` mock through `providers`:
 
 ```ts
 import { OperatorMetadataService } from "../service/operator-metadata/operator-metadata.service";
@@ -210,8 +182,7 @@ beforeEach(async () => {
 
 ### E. Component with async data (HTTP, RxJS)
 
-For HTTP-driven flows, `HttpClientTestingModule` is enough; `await
-fixture.whenStable()` flushes pending microtasks:
+For HTTP-driven flows, `HttpClientTestingModule` is enough; `await fixture.whenStable()` flushes pending microtasks:
 
 ```ts
 it("loads the workflow on init", async () => {
@@ -221,8 +192,7 @@ it("loads the workflow on init", async () => {
 });
 ```
 
-For timers (`debounceTime`, `setTimeout`, `interval`), use `fakeAsync` +
-`tick`:
+For timers (`debounceTime`, `setTimeout`, `interval`), use `fakeAsync` + `tick`:
 
 ```ts
 import { fakeAsync, tick } from "@angular/core/testing";
@@ -236,15 +206,11 @@ it("debounces the query before firing", fakeAsync(() => {
 }));
 ```
 
-`fakeAsync` works because `test-zone-setup.ts` installs a ProxyZone
-around `it`/`test`. It does **not** install one around `beforeEach`, so
-do not write `beforeEach(fakeAsync(...))` — set component state and call
-`tick()` from inside the `it` body instead.
+`fakeAsync` works because `test-zone-setup.ts` installs a ProxyZone around `it`/`test`. It does **not** install one around `beforeEach`, so do not write `beforeEach(fakeAsync(...))` — set component state and call `tick()` from inside the `it` body instead.
 
 ## Standalone components
 
-Angular 19 made every newly-generated component standalone. The
-component itself goes into `imports:`, never `declarations:`:
+Angular 19 made every newly-generated component standalone. The component itself goes into `imports:`, never `declarations:`:
 
 ```ts
 TestBed.configureTestingModule({
@@ -253,10 +219,7 @@ TestBed.configureTestingModule({
 });
 ```
 
-To replace heavy or hard-to-instantiate child components with stubs
-while keeping the parent template under test, use the
-`set / remove / add` form of `overrideComponent` **before**
-`compileComponents()`:
+To replace heavy or hard-to-instantiate child components with stubs while keeping the parent template under test, use the `set / remove / add` form of `overrideComponent` **before** `compileComponents()`:
 
 ```ts
 TestBed.overrideComponent(WorkspaceComponent, {
@@ -266,21 +229,13 @@ TestBed.overrideComponent(WorkspaceComponent, {
 
 Working reference: `src/app/workspace/component/workspace.component.spec.ts`.
 
-This drops the children's transitive dependency tree but leaves the
-parent template rendering — `<ng-template>` tags, `@ViewChild` queries,
-and event bindings still work because the template itself is unchanged.
-Do **not** use `set: { template: "" }` — that erases the template and
-guarantees 0 % HTML coverage.
+This drops the children's transitive dependency tree but leaves the parent template rendering — `<ng-template>` tags, `@ViewChild` queries, and event bindings still work because the template itself is unchanged. Do **not** use `set: { template: "" }` — that erases the template and guarantees 0 % HTML coverage.
 
 ## jsdom vs browser mode
 
-Default path (`gui:test`, `vitest.config.ts`) runs every spec under
-jsdom. Fast, no browser boot, works for the overwhelming majority of
-component logic.
+Default path (`gui:test`, `vitest.config.ts`) runs every spec under jsdom. Fast, no browser boot, works for the overwhelming majority of component logic.
 
-Browser path (`gui:test-browser`, `vitest.browser.config.ts`) runs in
-real Chromium via Playwright. Use it **only** for the cases jsdom can't
-fake:
+Browser path (`gui:test-browser`, `vitest.browser.config.ts`) runs in real Chromium via Playwright. Use it **only** for the cases jsdom can't fake:
 
 | Spec needs                                                            | jsdom verdict           | Action       |
 | --------------------------------------------------------------------- | ----------------------- | ------------ |
@@ -291,12 +246,9 @@ fake:
 | Plain DOM tree assertions, classes, attributes, text content          | Fine                    | jsdom        |
 | Event handlers, observables, services, routing                        | Fine                    | jsdom        |
 
-Routing rules: per-spec inclusion / exclusion is set in `angular.json`,
-not in `vitest.config.ts`. The comment in `vitest.config.ts` explains
-why — duplicating the list there triggers a Vite warning and the
-builder-side filter wins anyway.
+Routing rules: per-spec inclusion / exclusion is set in `angular.json`, not in `vitest.config.ts`. The comment in `vitest.config.ts` explains why — duplicating the list there triggers a Vite warning and the builder-side filter wins anyway.
 
-Working reference (browser mode): `src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts` (uses real pointer hit testing on the jointjs paper). PR [#5017](https://github.com/apache/texera/pull/5017) introduced this two-target setup and explains the rationale.
+Working reference (browser mode): `src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts`. See [#5017](https://github.com/apache/texera/pull/5017) for the rationale behind the two-target split.
 
 ## Mocking
 
@@ -311,168 +263,72 @@ const spy = vi.spyOn(component, "onRun"); // spy without replacing
 
 ### Service doubles
 
-Prefer a sibling `Stub…Service` class (the
-`StubOperatorMetadataService` pattern is the model) when the service is
-used by more than one spec. They live next to the real service and are
-imported by name; they keep the spec setup terse and the mock surface
-consistent across the codebase.
+Prefer a sibling `Stub…Service` class (the `StubOperatorMetadataService` pattern is the model) when the service is used by more than one spec. They live next to the real service and are imported by name; they keep the spec setup terse and the mock surface consistent across the codebase.
 
-For one-shot mocks, an inline `useValue` with `vi.fn()` is fine, but if
-you find yourself copying the same `useValue` block across specs, lift
-it to a `*.stub.ts` next to the service.
+For one-shot mocks, an inline `useValue` with `vi.fn()` is fine, but if you find yourself copying the same `useValue` block across specs, lift it to a `*.stub.ts` next to the service.
 
 ### RxJS
 
-Replace methods that return `Observable<T>` with `vi.fn().mockReturnValue(of(value))`
-or `mockReturnValue(EMPTY)` / `mockReturnValue(throwError(() => err))`.
-For multi-emission streams expose a `Subject` you control and call
-`subject.next(...)` from inside the test.
+Replace methods that return `Observable<T>` with `vi.fn().mockReturnValue(of(value))` or `mockReturnValue(EMPTY)` / `mockReturnValue(throwError(() => err))`. For multi-emission streams expose a `Subject` you control and call `subject.next(...)` from inside the test.
 
 ## Anti-patterns
 
-The patterns listed below are the ones that have actually appeared in
-this codebase. Each ships a real fix.
+The patterns listed below are the ones that have actually appeared in this codebase. Each ships a real fix.
 
 ### 1. Fully commented-out spec
 
-The license header is the only live code; the file reports "0 tests, 0
-failures" and Vitest counts it as a pass. The corresponding
-`.component.html` stays at 0 %.
+The license header is the only live code; the file reports "0 tests, 0 failures" and Vitest counts it as a pass. The corresponding `.component.html` stays at 0 %.
 
-**Fix**: delete the commented code outright (git history keeps it).
-Either replace it with the minimum-viable spec from Recipe A, or remove
-the spec file entirely.
+**Fix**: delete the commented code outright (git history keeps it). Either replace it with the minimum-viable spec from Recipe A, or remove the spec file entirely.
 
 ### 2. `NO_ERRORS_SCHEMA` everywhere
 
-A spec adds `schemas: [NO_ERRORS_SCHEMA]` to silence "unknown element"
-errors from un-imported children, but then asserts something about the
-parent template that depends on the child rendering. Branches inside
-`*ngIf="child.ready"` are dead because `child.ready` never fires.
+A spec adds `schemas: [NO_ERRORS_SCHEMA]` to silence "unknown element" errors from un-imported children, but then asserts something about the parent template that depends on the child rendering. Branches inside `*ngIf="child.ready"` are dead because `child.ready` never fires.
 
-**Fix**: import the real child, or use `overrideComponent({ set:
-{ imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` to drop the
-child's transitive imports while letting the unknown element render as
-an inert tag. `CUSTOM_ELEMENTS_SCHEMA` says "I know what I'm doing",
-`NO_ERRORS_SCHEMA` says "swallow all template errors" — the second is
-almost never what you want.
+**Fix**: import the real child, or use `overrideComponent({ set: { imports: [], schemas: [CUSTOM_ELEMENTS_SCHEMA] } })` to drop the child's transitive imports while letting the unknown element render as an inert tag. `CUSTOM_ELEMENTS_SCHEMA` says "I know what I'm doing", `NO_ERRORS_SCHEMA` says "swallow all template errors" — the second is almost never what you want.
 
 ### 3. `overrideComponent({ set: { template: "" } })`
 
-Used historically to bypass a child template that wouldn't compile.
-Side effect: the parent's template is wiped, so HTML coverage is
-permanently 0 %.
+Used historically to bypass a child template that wouldn't compile. Side effect: the parent's template is wiped, so HTML coverage is permanently 0 %.
 
-**Fix**: see Anti-pattern 2 — override `imports` and `schemas` instead,
-keep the template intact.
+**Fix**: see Anti-pattern 2 — override `imports` and `schemas` instead, keep the template intact.
 
 ### 4. `declarations: [StandaloneComponent]`
 
-Angular 19 errors out at compile time with "Component is standalone and
-can't be declared in any NgModule". The error is loud, but specs
-copy-pasted from pre-19 Karma days will still ship the wrong shape.
+Angular 19 errors out at compile time with "Component is standalone and can't be declared in any NgModule".
 
 **Fix**: move the component to `imports:`.
 
 ### 5. `beforeEach(waitForAsync(() => …))`
 
-`test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but **not**
-`beforeEach`. `waitForAsync` throws "Expected to be running in
-'ProxyZone'" the moment it tries to detect the zone.
+`test-zone-setup.ts` wraps `it`/`test` in a ProxyZone but **not** `beforeEach`. `waitForAsync` throws "Expected to be running in 'ProxyZone'" the moment it tries to detect the zone.
 
 **Fix**: `beforeEach(async () => { await TestBed.configureTestingModule(...).compileComponents(); })`.
 
-### 6. Karma-style spies
+### 6. Real HTTP / WebSocket calls
 
-```ts
-const spy = jasmine.createSpy("onClick");
-spyOn(service, "fetch").and.returnValue(of(value));
-```
+A spec that requires the dev server to be running, or that opens a real WebSocket, is not a unit test. It will fail in CI for unrelated reasons and slow the whole suite down.
 
-Vitest provides a Jasmine-compat shim for most call sites, but new code
-should use the Vitest API directly:
+**Fix**: `HttpClientTestingModule` for HTTP; a `Subject` you `.next()` into for WebSocket-shaped observables.
 
-```ts
-const spy = vi.fn();
-vi.spyOn(service, "fetch").mockReturnValue(of(value));
-```
+### 7. One-off `useValue` mock when a `Stub…Service` exists
 
-The shim does not cover every Jasmine matcher, and Vitest mocks come
-with `mockClear`/`mockReset`/`mockImplementationOnce` etc. that are
-strictly better.
+Drift: spec A invents a partial mock for `OperatorMetadataService`, spec B invents a different partial mock, none of them agrees with the real interface, and a refactor breaks all three differently.
 
-### 7. Real HTTP / WebSocket calls
-
-A spec that requires the dev server to be running, or that opens a real
-WebSocket, is not a unit test. It will fail in CI for unrelated reasons
-and slow the whole suite down.
-
-**Fix**: `HttpClientTestingModule` for HTTP; a `Subject` you `.next()`
-into for WebSocket-shaped observables.
-
-### 8. One-off `useValue` mock when a `Stub…Service` exists
-
-Drift: spec A invents a partial mock for `OperatorMetadataService`,
-spec B invents a different partial mock, none of them agrees with the
-real interface, and a refactor breaks all three differently.
-
-**Fix**: use `StubOperatorMetadataService`. When you find yourself
-wanting a new method on the stub, add it to the stub class, not to the
-spec.
+**Fix**: use `StubOperatorMetadataService`. When you find yourself wanting a new method on the stub, add it to the stub class, not to the spec.
 
 ## Coverage troubleshooting
 
-`yarn test:ci` produces `coverage/lcov.info`; the GitHub-side dashboard
-is at [app.codecov.io/gh/apache/texera](https://app.codecov.io/gh/apache/texera).
-If a `.component.html` shows 0 % even though the spec passes, walk this
-list top-to-bottom:
+`yarn test:ci` produces `coverage/lcov.info`; the GitHub-side dashboard is at [app.codecov.io/gh/apache/texera](https://app.codecov.io/gh/apache/texera). If a `.component.html` shows 0 % even though the spec passes, walk this list top-to-bottom:
 
-1. **Did `compileComponents()` actually resolve?** A missing provider
-   makes `TestBed.configureTestingModule(...).compileComponents()`
-   reject; Vitest reports the spec as failed but coverage still says
-   0 %. Run the spec locally, read the actual error in the output, and
-   add the missing provider (commonly `HttpClient`, `Router`,
-   `ActivatedRoute`, or a service that pulls in `GuiConfigService`).
-2. **Is `fixture.detectChanges()` actually called?** Step through
-   `beforeEach`; an early-throw or a typo means the line is dead code.
+1. **Did `compileComponents()` actually resolve?** A missing provider makes `TestBed.configureTestingModule(...).compileComponents()` reject; Vitest reports the spec as failed but coverage still says 0 %. Run the spec locally, read the actual error in the output, and add the missing provider (commonly `HttpClient`, `Router`, `ActivatedRoute`, or a service that pulls in `GuiConfigService`).
+2. **Is `fixture.detectChanges()` actually called?** Step through `beforeEach`; an early-throw or a typo means the line is dead code.
 3. **Has the template been overridden to `""`**? See Anti-pattern 3.
-4. **Does the spec use `NO_ERRORS_SCHEMA` to silence missing children,
-   and then assert nothing about the rendered children**? Coverage will
-   reflect that the children's branches were never reached. See
-   Anti-pattern 2.
-5. **Is the build source-map-enabled?** `angular.json` `gui:test`
-   inherits from `build.test`. Confirm `sourceMap: true` (the default).
-   A custom builder swap can silently turn it off; without source maps,
-   v8 hits land on the compiled JS, not on the `.html`.
-6. **Is the file on the exclusion list?** Check `angular.json` for
-   `unit-test` `polyfills` / `include` / `exclude` patterns. Some
-   third-party-ish files in `common/formly/*.type.ts` are intentionally
-   excluded (their license header file mentions TypeFox).
-7. **Is the spec routed to a different builder than expected?** If a
-   file is in `gui:test-browser`'s include list, `yarn test` won't run
-   it. Inspect both targets' `include` arrays.
-8. **Is the spec file fully commented out?** See Anti-pattern 1. If
-   Vitest reports "0 tests" for the file, this is the cause.
-
-## Migrating an old Karma spec
-
-If you're cherry-picking a pre-#5017 spec, or you find a spec that has
-escaped the migration, this checklist gets it green under Vitest:
-
-| Before (Karma + Jasmine)                                                                       | After (Vitest + Angular 19)                                                                  |
-| ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
-| `beforeEach(waitForAsync(() => { TestBed.configureTestingModule(...).compileComponents(); }))` | `beforeEach(async () => { await TestBed.configureTestingModule(...).compileComponents(); })` |
-| `declarations: [MyStandaloneComponent]`                                                        | `imports: [MyStandaloneComponent]`                                                           |
-| `jasmine.createSpy("name")`                                                                    | `vi.fn()`                                                                                    |
-| `spyOn(obj, "m").and.returnValue(v)`                                                           | `vi.spyOn(obj, "m").mockReturnValue(v)`                                                      |
-| `spyOn(obj, "m").and.callFake(fn)`                                                             | `vi.spyOn(obj, "m").mockImplementation(fn)`                                                  |
-| `expect(spy).toHaveBeenCalledTimes(1)`                                                         | unchanged                                                                                    |
-| Real DOM assertions on SVG geometry or pointer events                                          | Route the spec to `gui:test-browser` in `angular.json`                                       |
-
-Worked example: PR [#5017](https://github.com/apache/texera/pull/5017)
-migrated the `workflow-editor` spec, including routing it to browser
-mode for the parts that needed real DOM. The diff is small and reads
-as a checklist of the rules above.
+4. **Does the spec use `NO_ERRORS_SCHEMA` to silence missing children, and then assert nothing about the rendered children**? Coverage will reflect that the children's branches were never reached. See Anti-pattern 2.
+5. **Is the build source-map-enabled?** `angular.json` `gui:test` inherits from `build.test`. Confirm `sourceMap: true` (the default). A custom builder swap can silently turn it off; without source maps, v8 hits land on the compiled JS, not on the `.html`.
+6. **Is the file on the exclusion list?** Check `angular.json` for `unit-test` `polyfills` / `include` / `exclude` patterns. Some files in `common/formly/*.type.ts` are intentionally excluded (their license header file mentions TypeFox).
+7. **Is the spec routed to a different builder than expected?** If a file is in `gui:test-browser`'s include list, `yarn test` won't run it. Inspect both targets' `include` arrays.
+8. **Is the spec file fully commented out?** See Anti-pattern 1. If Vitest reports "0 tests" for the file, this is the cause.
 
 ## References
 
@@ -481,4 +337,4 @@ as a checklist of the rules above.
 - [Angular component harnesses overview](https://angular.dev/guide/testing/component-harnesses-overview)
 - [Vitest docs — browser mode](https://vitest.dev/guide/browser/)
 - [`@angular/build:unit-test` builder](https://angular.dev/tools/cli/build-system-migration)
-- [PR #5017 — Karma → Vitest migration](https://github.com/apache/texera/pull/5017)
+- [#5017 — Vitest browser-mode setup](https://github.com/apache/texera/pull/5017)


### PR DESCRIPTION
### What changes were proposed in this PR?

Three docs at the root of `frontend/`:

- `README.md` — replaces the default Angular-CLI stub. Quickstart with stack, setup, common commands, a short Testing section, and the project layout.
- `TESTING.md` — canonical testing reference for humans and agents. Stack, the `fixture.detectChanges()` mental model, recipes, jsdom-vs-browser-mode decision, anti-patterns, and coverage troubleshooting.
- `AGENTS.md` — scoped agent rules. Placement rules for new files, frontend conventions, the testing checklist that fronts `TESTING.md`, and deeper pointers.

The three are deduplicated: README is the source of truth for stack / commands / layout; AGENTS.md points back to it; TESTING.md holds the testing depth.

### Any related issues, documentation, discussions?

Closes #5169. Captures the conventions in use today (`async () =>` in `beforeEach`, standalone components in `imports:`, `vi.fn()` mocks, the two-target jsdom / browser-mode split from #5017).

### How was this PR tested?

Documentation-only. `prettier --check` passes on all three files. Inline code samples come from existing specs (`mini-map.component.spec.ts`, `workspace.component.spec.ts`, `workflow-editor.component.spec.ts`); the helpers and configs they reference all exist on `main`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7