### PR TITLE
fix(agent-service): align auto-layout rank separation

### DIFF
--- a/agent-service/src/agent/util/auto-layout.test.ts
+++ b/agent-service/src/agent/util/auto-layout.test.ts
@@ -90,6 +90,20 @@ describe("autoLayoutWorkflow", () => {
     expect(b.x).toBeLessThan(c.x);
   });
 
+  test("matches the frontend rank separation for linked operators", () => {
+    const state = new WorkflowState();
+    state.addOperator(makeOperator("a"), SENTINEL_POS);
+    state.addOperator(makeOperator("b"), SENTINEL_POS);
+    state.addLink(makeLink("l1", "a", "b"));
+
+    autoLayoutWorkflow(state);
+
+    const a = state.getOperatorPosition("a")!;
+    const b = state.getOperatorPosition("b")!;
+    // dagre stores node centers, so the gap is node width (200) + ranksep (80).
+    expect(b.x - a.x).toBe(280);
+  });
+
   test("assigns positions to disconnected operators as well", () => {
     const state = new WorkflowState();
     // Seeding each disconnected node with the same sentinel forces the

--- a/agent-service/src/agent/util/auto-layout.ts
+++ b/agent-service/src/agent/util/auto-layout.ts
@@ -25,7 +25,7 @@ import type { WorkflowState } from "../workflow-state";
 const LAYOUT_CONFIG: dagre.GraphLabel = {
   nodesep: 100,
   edgesep: 150,
-  ranksep: 100,
+  ranksep: 80,
   ranker: "tight-tree",
   rankdir: "LR",
 };


### PR DESCRIPTION
### What changes were proposed in this PR?

The agent service and frontend both use dagre for workflow auto-layout, but the agent service used `ranksep: 100` while the frontend uses `rankSep: 80`. That made agent-generated layouts wider than layouts produced by the frontend auto-layout button.

This PR updates the agent-service layout config to `ranksep: 80` and adds a regression test that pins the produced two-node spacing to the frontend-equivalent value.

### Any related issues, documentation, discussions?

Closes #4577.

### How was this PR tested?

Installed agent-service dependencies from `bun.lock` in the worktree, then ran:

```
npm_config_cache=/tmp/texera-npm-cache npx --yes bun@1.3.3 test src/agent/util/auto-layout.test.ts
```

Result: 7 passed.

```
npm_config_cache=/tmp/texera-npm-cache npx --yes bun@1.3.3 run typecheck
```

Result: passed.

```
npm_config_cache=/tmp/texera-npm-cache npx --yes bun@1.3.3 run format:check
```

Result: passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
