### PR TITLE
fix(workflow-operator): default boolean metadata fields

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/json/JSONLScanSourceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/json/JSONLScanSourceOpDesc.scala
@@ -37,7 +37,7 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
 
 class JSONLScanSourceOpDesc extends ScanSourceOpDesc {
 
-  @JsonProperty(required = true)
+  @JsonProperty(required = true, defaultValue = "false")
   @JsonPropertyDescription("flatten nested objects and arrays")
   var flatten: Boolean = false
 

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -81,7 +81,7 @@ class DumbbellPlotOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(value = "dots", required = false)
   var dots: util.List[DumbbellDotConfig] = _
 
-  @JsonProperty(value = "showLegends", required = false)
+  @JsonProperty(value = "showLegends", required = false, defaultValue = "false")
   @JsonSchemaTitle("Show Legends?")
   @JsonPropertyDescription("whether to show legends in the graph")
   var showLegends: Boolean = false

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -60,7 +60,7 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var color: EncodableString = ""
 
-  @JsonProperty(required = true)
+  @JsonProperty(required = true, defaultValue = "false")
   @JsonSchemaTitle("Split Plot by Line Group")
   @JsonPropertyDescription("Do you want to split the graph")
   var facetColumn: Boolean = false

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/OperatorBooleanDefaultSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/OperatorBooleanDefaultSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.metadata
+
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.source.scan.json.JSONLScanSourceOpDesc
+import org.apache.texera.amber.operator.visualization.dumbbellPlot.DumbbellPlotOpDesc
+import org.apache.texera.amber.operator.visualization.filledAreaPlot.FilledAreaPlotOpDesc
+import org.scalatest.flatspec.AnyFlatSpec
+
+class OperatorBooleanDefaultSpec extends AnyFlatSpec {
+
+  private def assertFalseDefault(
+      opDescClass: Class[_ <: LogicalOp],
+      propertyName: String
+  ): Unit = {
+    val propertySchema =
+      OperatorMetadataGenerator
+        .generateOperatorJsonSchema(opDescClass)
+        .path("properties")
+        .path(propertyName)
+
+    assert(propertySchema.path("type").asText() == "boolean")
+    assert(propertySchema.has("default"))
+    assert(!propertySchema.path("default").asBoolean())
+  }
+
+  "Operator metadata generation" should "emit false defaults for visualization checkbox fields" in {
+    assertFalseDefault(classOf[FilledAreaPlotOpDesc], "facetColumn")
+    assertFalseDefault(classOf[DumbbellPlotOpDesc], "showLegends")
+  }
+
+  it should "emit a false default for JSONL flattening" in {
+    assertFalseDefault(classOf[JSONLScanSourceOpDesc], "flatten")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Some operator boolean properties initialized to `false` did not declare a JSON-schema default value, so the frontend form could render them as neutral checkboxes instead of unchecked checkboxes.

This PR adds explicit `defaultValue = "false"` metadata for:

- `FilledAreaPlotOpDesc.facetColumn`
- `DumbbellPlotOpDesc.showLegends`
- `JSONLScanSourceOpDesc.flatten`

It also adds a focused metadata-generation spec that asserts these boolean schemas include a `false` default.

### Any related issues, documentation, discussions?

Closes #4015.

### How was this PR tested?

Validated locally with a temporary Postgres container loaded with the same DDL files used by CI for JOOQ generation.

```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 COURSIER_CACHE=/tmp/texera-coursier-cache /usr/lib/jvm/java-17-openjdk-amd64/bin/java -Dsbt.ivy.home=/tmp/texera-ivy-cache -Dsbt.boot.directory=/tmp/texera-sbt-boot -Dsbt.global.base=/tmp/texera-sbt-global -jar /tmp/sbt-launch-1.12.9.jar "WorkflowOperator/testOnly org.apache.texera.amber.operator.metadata.OperatorBooleanDefaultSpec"
```

Result: 2 passed.

```
JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 COURSIER_CACHE=/tmp/texera-coursier-cache /usr/lib/jvm/java-17-openjdk-amd64/bin/java -Dsbt.ivy.home=/tmp/texera-ivy-cache -Dsbt.boot.directory=/tmp/texera-sbt-boot -Dsbt.global.base=/tmp/texera-sbt-global -jar /tmp/sbt-launch-1.12.9.jar scalafmtCheckAll
```

Result: passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
