### PR TITLE
test(frontend): call fixture.detectChanges() in three dashboard component specs

### DIFF
--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
@@ -53,6 +53,23 @@ describe("ListItemComponent", () => {
     fixture = TestBed.createComponent(ListItemComponent);
     component = fixture.componentInstance;
     workflowPersistService = TestBed.inject(WorkflowPersistService) as unknown as Mocked<WorkflowPersistService>;
+    // initializeEntry() needs a fully-formed workflow entry to avoid throwing
+    // when the template renders for the first time. Each test below overwrites
+    // component.entry directly, which exercises confirm methods without going
+    // back through change detection.
+    component.entry = {
+      id: 0,
+      name: "default",
+      description: "",
+      type: "workflow",
+      workflow: { isOwner: true },
+      accessibleUserIds: [],
+      likeCount: 0,
+      viewCount: 0,
+      isLiked: false,
+      size: 0,
+    } as unknown as DashboardEntry;
+    fixture.detectChanges();
   });
 
   it("should update workflow name successfully", () => {

--- a/frontend/src/app/dashboard/component/user/share-access/share-access.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/share-access/share-access.component.spec.ts
@@ -70,7 +70,9 @@ describe("ShareAccessComponent.grantAccess", () => {
         { provide: WorkflowActionService, useValue: {} },
       ],
     });
-    return TestBed.createComponent(ShareAccessComponent).componentInstance;
+    const fixture = TestBed.createComponent(ShareAccessComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
   }
 
   beforeEach(() => {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
@@ -40,6 +40,7 @@ describe("UserDatasetFileRendererComponent", () => {
     });
     const fixture = TestBed.createComponent(UserDatasetFileRendererComponent);
     component = fixture.componentInstance;
+    fixture.detectChanges();
   });
 
   it("should return true for supported MIME type", () => {


### PR DESCRIPTION
### What changes were proposed in this PR?

`list-item`, `share-access`, and `user-dataset-file-renderer` each constructed a `ComponentFixture` via `TestBed.createComponent` but never triggered change detection. The template's creation pass therefore never ran, the source-map-attributed v8 coverage stayed at 0 % for the corresponding `.component.html`, and the specs still passed green.

Adds `fixture.detectChanges()` to each:

- `list-item.component.spec.ts` — seeds `component.entry` with a fully-formed workflow entry in `beforeEach` before calling `detectChanges()`. The component's `entry` getter throws when `_entry` is undefined and `initializeEntry()` (called from `ngOnChanges`) reads `entry.workflow.isOwner`, `accessibleUserIds`, and counters, so a minimal stub is not enough. Each `it` block continues to overwrite `component.entry` and assert on confirm-method behavior; no existing assertions change.
- `share-access.component.spec.ts` — `detectChanges()` lives in the `setupComponent` helper so every test case picks it up.
- `user-dataset-file-renderer.component.spec.ts` — `detectChanges()` in `beforeEach` after `createComponent`. `ngOnInit -> reloadFileContent` hits the unsupported-MIME bail with the default empty `filePath`, so no service calls fire.

### Any related issues, documentation, discussions?

Closes #5180. 

### How was this PR tested?

`yarn ng test --watch=false --include=…` against the three affected specs locally: 3 files, 10 tests, all pass. `yarn format:ci` clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7