### PR TITLE
chore: ignore vendored and generated paths in Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -36,6 +36,7 @@ flag_management:
 ignore:
   # Generated protobuf — line counts swamp real code.
   - "amber/src/main/python/proto/**"
+  - "frontend/src/app/common/type/proto/**"
   - "**/src_managed/**"          # sbt JOOQ / scalapb-generated sources
   # Build / install output — never source-of-truth.
   - "**/target/**"
@@ -45,6 +46,17 @@ ignore:
   - "**/test_*.py"
   - "**/*.spec.ts"
   - "**/src/test/**"             # sbt test source roots
+  # Third-party vendored sources. These mirror the corresponding entries
+  # in .licenserc.yaml — we don't maintain them, so their coverage figure
+  # carries no signal.
+  - "common/workflow-operator/src/main/scala/com/kjetland/**"          # MIT JSON schema generator
+  - "frontend/src/app/common/formly/array.type.ts"                     # MIT ngx-formly derived
+  - "frontend/src/app/common/formly/object.type.ts"
+  - "frontend/src/app/common/formly/multischema.type.ts"
+  - "frontend/src/app/common/formly/null.type.ts"
+  - "pyright-language-service/src/main.ts"                             # MIT monaco-languageclient derived
+  - "pyright-language-service/src/language-server-runner.ts"
+  - "pyright-language-service/src/server-commons.ts"
 
 coverage:
   status:


### PR DESCRIPTION
### What changes were proposed in this PR?

`codecov.yml` already ignores generated Python protobuf, build output, and test files. `.licenserc.yaml` exempts a third set of paths from its header check on the basis that we don't maintain them — vendored MIT code and the frontend protobuf TS codegen. Their coverage figures carry no signal about Texera's test quality, but they sit in the project denominator and drag the headline percentage down. Mirror those entries in Codecov's `ignore` list so the rollup reflects only code we own.

### Any related issues, documentation, discussions?

Closes #5186. The ignored paths match the corresponding `paths-ignore` entries in `.licenserc.yaml`.

### How was this PR tested?

`codecov.yml` parses as valid YAML; every concrete path in the new entries resolves to a real file on `main`. Codecov re-evaluates the config on the next upload to `main`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7