### PR TITLE
feat: gdrive export ui integration

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/TexeraWebApplication.scala
+++ b/amber/src/main/scala/org/apache/texera/web/TexeraWebApplication.scala
@@ -33,7 +33,11 @@ import org.apache.texera.auth.SessionUser
 import org.apache.texera.dao.SqlServer
 import org.apache.texera.web.auth.JwtAuth.setupJwtAuth
 import org.apache.texera.web.resource._
-import org.apache.texera.web.resource.auth.{AuthResource, GoogleAuthResource}
+import org.apache.texera.web.resource.auth.{
+  AuthResource,
+  GoogleAuthResource,
+  GoogleDriveAuthResource
+}
 import org.apache.texera.web.resource.dashboard.DashboardResource
 import org.apache.texera.web.resource.dashboard.admin.execution.AdminExecutionResource
 import org.apache.texera.web.resource.dashboard.admin.settings.AdminSettingsResource
@@ -160,6 +164,7 @@ class TexeraWebApplication
     environment.jersey.register(classOf[UserQuotaResource])
     environment.jersey.register(classOf[AdminSettingsResource])
     environment.jersey.register(classOf[AIAssistantResource])
+    environment.jersey.register(classOf[GoogleDriveAuthResource])
 
     AuthResource.createAdminUser()
 

--- a/amber/src/main/scala/org/apache/texera/web/auth/GuestAuthFilter.scala
+++ b/amber/src/main/scala/org/apache/texera/web/auth/GuestAuthFilter.scala
@@ -39,7 +39,19 @@ import javax.ws.rs.core.SecurityContext
   }
 
   val GUEST: User =
-    new User(null, "guest", null, null, null, null, UserRoleEnum.REGULAR, null, null, null, null)
+    new User(
+      null,
+      "guest",
+      null,
+      null,
+      null,
+      null,
+      UserRoleEnum.REGULAR,
+      null,
+      null,
+      null,
+      null
+    )
 }
 
 @PreMatching

--- a/amber/src/main/scala/org/apache/texera/web/auth/GuestAuthFilter.scala
+++ b/amber/src/main/scala/org/apache/texera/web/auth/GuestAuthFilter.scala
@@ -39,19 +39,7 @@ import javax.ws.rs.core.SecurityContext
   }
 
   val GUEST: User =
-    new User(
-      null,
-      "guest",
-      null,
-      null,
-      null,
-      null,
-      UserRoleEnum.REGULAR,
-      null,
-      null,
-      null,
-      null
-    )
+    new User(null, "guest", null, null, null, null, UserRoleEnum.REGULAR, null, null, null, null)
 }
 
 @PreMatching

--- a/amber/src/main/scala/org/apache/texera/web/model/http/response/DriveTokenIssueResponse.scala
+++ b/amber/src/main/scala/org/apache/texera/web/model/http/response/DriveTokenIssueResponse.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.model.http.response
+
+case class DriveTokenIssueResponse(
+    status: String,
+    accessToken: Option[String]
+)

--- a/amber/src/main/scala/org/apache/texera/web/model/http/response/GoogleAuthConfigResponse.scala
+++ b/amber/src/main/scala/org/apache/texera/web/model/http/response/GoogleAuthConfigResponse.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.model.http.response
+
+case class GoogleAuthConfigResponse(clientId: String, apiKey: String)

--- a/amber/src/main/scala/org/apache/texera/web/resource/auth/GoogleAuthResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/auth/GoogleAuthResource.scala
@@ -29,6 +29,7 @@ import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
 import org.apache.texera.dao.jooq.generated.tables.daos.UserDao
 import org.apache.texera.dao.jooq.generated.tables.pojos.User
 import org.apache.texera.web.model.http.response.TokenIssueResponse
+import org.apache.texera.web.model.http.response.GoogleAuthConfigResponse
 import org.apache.texera.web.resource.auth.GoogleAuthResource.userDao
 
 import java.util.Collections
@@ -48,10 +49,20 @@ object GoogleAuthResource {
 @Path("/auth/google")
 class GoogleAuthResource {
   final private lazy val clientId = UserSystemConfig.googleClientId
+  final private lazy val apiKey = UserSystemConfig.googleApiKey
 
   @GET
   @Path("/clientid")
   def getClientId: String = clientId
+
+  @GET
+  @Path("/config")
+  def getConfig: GoogleAuthConfigResponse = {
+    GoogleAuthConfigResponse(clientId, apiKey)
+  }
+
+  @Path("/drive")
+  def getDriveResource: GoogleDriveAuthResource = new GoogleDriveAuthResource()
 
   @POST
   @Consumes(Array(MediaType.TEXT_PLAIN))

--- a/amber/src/main/scala/org/apache/texera/web/resource/auth/GoogleDriveAuthResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/auth/GoogleDriveAuthResource.scala
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.texera.web.resource.auth
+
+import io.dropwizard.auth.Auth
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.texera.auth.{JwtParser, SessionUser, TokenEncryptionService}
+import org.apache.texera.web.model.http.response.DriveTokenIssueResponse
+import org.apache.texera.web.resource.auth.GoogleDriveAuthResource._
+import org.apache.texera.dao.jooq.generated.tables.daos.UserOauthTokenDao
+import org.apache.texera.dao.jooq.generated.tables.pojos.UserOauthToken
+import org.apache.texera.dao.SqlServer
+import org.apache.texera.config.UserSystemConfig
+import org.apache.texera.auth.JwtAuth.{TOKEN_EXPIRE_TIME_IN_MINUTES, jwtClaims}
+import org.apache.texera.auth.JwtAuth
+import com.google.api.client.googleapis.auth.oauth2.{
+  GoogleAuthorizationCodeRequestUrl,
+  GoogleAuthorizationCodeTokenRequest,
+  GoogleRefreshTokenRequest,
+  GoogleTokenResponse
+}
+import com.google.api.client.auth.oauth2.TokenResponseException
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.json.gson.GsonFactory
+
+import javax.annotation.security.RolesAllowed
+import javax.ws.rs._
+import javax.ws.rs.core.MediaType
+import javax.ws.rs.core.Response
+
+object GoogleDriveAuthResource {
+  private val STATUS_OK = "ok"
+  private val STATUS_NO_REFRESH_TOKEN = "no_refresh_token"
+  private val STATUS_INVALID_GRANT = "invalid_grant"
+  private val PROVIDER_GOOGLE_DRIVE = "google_drive"
+
+  private val mapper = new ObjectMapper()
+
+  private def oauthTokenDao =
+    new UserOauthTokenDao(
+      SqlServer
+        .getInstance()
+        .createDSLContext()
+        .configuration
+    )
+}
+
+@Consumes(Array(MediaType.APPLICATION_JSON))
+@Produces(Array(MediaType.APPLICATION_JSON))
+class GoogleDriveAuthResource extends LazyLogging {
+  final private lazy val clientId = UserSystemConfig.googleClientId
+  final private lazy val clientSecret = UserSystemConfig.googleClientSecret
+  final private lazy val redirectUri = UserSystemConfig.appDomain
+    .map(domain => s"https://$domain/api/auth/google/drive/callback")
+    .getOrElse("http://localhost:4200/api/auth/google/drive/callback")
+
+  @GET
+  @Path("/token")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def getDriveAccessToken(@Auth sessionUser: SessionUser): Response = {
+    val uid = sessionUser.getUid
+    val record = oauthTokenDao.fetchByUid(uid).stream()
+      .filter(r => r.getProvider == PROVIDER_GOOGLE_DRIVE)
+      .findFirst()
+      .orElse(null)
+
+    if (record == null) {
+      return Response.ok(DriveTokenIssueResponse(STATUS_NO_REFRESH_TOKEN, None)).build()
+    }
+
+    try {
+      val blob = mapper.readTree(TokenEncryptionService.decrypt(record.getAuthBlob))
+      val refreshToken = blob.get("refreshToken").asText()
+
+      val tokenResponse = new GoogleRefreshTokenRequest(
+        new NetHttpTransport(),
+        GsonFactory.getDefaultInstance,
+        refreshToken,
+        clientId,
+        clientSecret
+      ).execute()
+
+      Response.ok(DriveTokenIssueResponse(STATUS_OK, Some(tokenResponse.getAccessToken))).build()
+    } catch {
+      case e: TokenResponseException =>
+        if (e.getDetails != null && e.getDetails.getError == STATUS_INVALID_GRANT) {
+          Response.ok(DriveTokenIssueResponse(STATUS_INVALID_GRANT, None)).build()
+        } else {
+          logger.error("Failed to refresh access token", e)
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR).build()
+        }
+      case e: Exception =>
+        logger.error("Unexpected error refreshing access token", e)
+        Response.status(Response.Status.INTERNAL_SERVER_ERROR).build()
+    }
+  }
+
+  @GET
+  @Path("/callback")
+  @Produces(Array(MediaType.TEXT_HTML, MediaType.APPLICATION_JSON))
+  def getCallback(
+      @QueryParam("code") @DefaultValue("") code: String,
+      @QueryParam("state") @DefaultValue("") state: String
+  ): Response = {
+    if (code.isEmpty || state.isEmpty) {
+      return Response.status(Response.Status.BAD_REQUEST).build()
+    }
+    try {
+      val sessionUserOpt = JwtParser.parseToken(state)
+      if (!sessionUserOpt.isPresent) {
+        return Response
+          .status(Response.Status.UNAUTHORIZED)
+          .entity("User is not authenticated")
+          .build()
+      }
+
+      val uid = sessionUserOpt.get().getUid
+
+      val tokenResponse: GoogleTokenResponse = new GoogleAuthorizationCodeTokenRequest(
+        new NetHttpTransport(),
+        GsonFactory.getDefaultInstance,
+        clientId,
+        clientSecret,
+        code,
+        redirectUri
+      ).execute()
+
+      val blobMap = new java.util.HashMap[String, String]()
+      blobMap.put("refreshToken", tokenResponse.getRefreshToken)
+      blobMap.put("scopes", tokenResponse.getScope)
+      val blobJson = mapper.writeValueAsString(blobMap)
+      val encryptedBlob = TokenEncryptionService.encrypt(blobJson)
+
+      val existing = oauthTokenDao.fetchByUid(uid).stream()
+        .filter(r => r.getProvider == PROVIDER_GOOGLE_DRIVE)
+        .findFirst()
+
+      if (existing.isPresent) {
+        existing.get().setAuthBlob(encryptedBlob)
+        oauthTokenDao.update(existing.get())
+      } else {
+        val record = new UserOauthToken()
+        record.setUid(uid)
+        record.setProvider(PROVIDER_GOOGLE_DRIVE)
+        record.setAuthBlob(encryptedBlob)
+        oauthTokenDao.insert(record)
+      }
+
+      val html =
+        """<html><body><script>
+          |window.opener.postMessage('gdrive-connected', window.location.origin);
+          |window.close();
+          |</script></body></html>""".stripMargin
+      Response.ok(html).build()
+    } catch {
+      case e: TokenResponseException =>
+        logger.error("Google token exchange failed in callback", e)
+        Response.status(Response.Status.BAD_GATEWAY).build()
+      case e: Exception =>
+        logger.error("Unexpected error in OAuth callback", e)
+        Response.status(Response.Status.INTERNAL_SERVER_ERROR).build()
+    }
+  }
+
+  @GET
+  @Path("/connect")
+  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  def getOAuth(
+      @Auth sessionUser: SessionUser,
+      @QueryParam("reauth") @DefaultValue("false") reauth: Boolean
+  ): Response = {
+    val user = sessionUser.getUser
+    val state = JwtAuth.jwtToken(jwtClaims(user, TOKEN_EXPIRE_TIME_IN_MINUTES))
+
+    val url = new GoogleAuthorizationCodeRequestUrl(
+      clientId,
+      redirectUri,
+      java.util.Arrays.asList("https://www.googleapis.com/auth/drive")
+    )
+      .setState(state)
+      .setAccessType("offline")
+      .set("prompt", if (reauth) "consent" else null)
+      .set("include_granted_scopes", true)
+      .build()
+
+    Response.ok(url).build()
+  }
+}

--- a/amber/src/main/scala/org/apache/texera/web/resource/auth/GoogleDriveAuthResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/auth/GoogleDriveAuthResource.scala
@@ -21,15 +21,13 @@ package org.apache.texera.web.resource.auth
 import io.dropwizard.auth.Auth
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.texera.auth.{JwtParser, SessionUser, TokenEncryptionService}
+import org.apache.texera.auth.{SessionUser, TokenEncryptionService}
 import org.apache.texera.web.model.http.response.DriveTokenIssueResponse
 import org.apache.texera.web.resource.auth.GoogleDriveAuthResource._
 import org.apache.texera.dao.jooq.generated.tables.daos.UserOauthTokenDao
 import org.apache.texera.dao.jooq.generated.tables.pojos.UserOauthToken
 import org.apache.texera.dao.SqlServer
 import org.apache.texera.config.UserSystemConfig
-import org.apache.texera.auth.JwtAuth.{TOKEN_EXPIRE_TIME_IN_MINUTES, jwtClaims}
-import org.apache.texera.auth.JwtAuth
 import com.google.api.client.googleapis.auth.oauth2.{
   GoogleAuthorizationCodeRequestUrl,
   GoogleAuthorizationCodeTokenRequest,
@@ -40,6 +38,7 @@ import com.google.api.client.auth.oauth2.TokenResponseException
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 
+import java.util.concurrent.ConcurrentHashMap
 import javax.annotation.security.RolesAllowed
 import javax.ws.rs._
 import javax.ws.rs.core.MediaType
@@ -51,7 +50,12 @@ object GoogleDriveAuthResource {
   private val STATUS_INVALID_GRANT = "invalid_grant"
   private val PROVIDER_GOOGLE_DRIVE = "google_drive"
 
+  private val STATE_TTL_MS = 10 * 60 * 1000L
+
   private val mapper = new ObjectMapper()
+
+  // state token → (uid, expiresAtMs)
+  private val pendingStates = new ConcurrentHashMap[String, (Int, Long)]()
 
   private def oauthTokenDao =
     new UserOauthTokenDao(
@@ -123,15 +127,15 @@ class GoogleDriveAuthResource extends LazyLogging {
       return Response.status(Response.Status.BAD_REQUEST).build()
     }
     try {
-      val sessionUserOpt = JwtParser.parseToken(state)
-      if (!sessionUserOpt.isPresent) {
+      val entry = pendingStates.remove(state)
+      if (entry == null || System.currentTimeMillis() > entry._2) {
         return Response
           .status(Response.Status.UNAUTHORIZED)
-          .entity("User is not authenticated")
+          .entity("OAuth state token is invalid or expired")
           .build()
       }
 
-      val uid = sessionUserOpt.get().getUid
+      val uid = entry._1
 
       val tokenResponse: GoogleTokenResponse = new GoogleAuthorizationCodeTokenRequest(
         new NetHttpTransport(),
@@ -186,15 +190,15 @@ class GoogleDriveAuthResource extends LazyLogging {
       @Auth sessionUser: SessionUser,
       @QueryParam("reauth") @DefaultValue("false") reauth: Boolean
   ): Response = {
-    val user = sessionUser.getUser
-    val state = JwtAuth.jwtToken(jwtClaims(user, TOKEN_EXPIRE_TIME_IN_MINUTES))
+    val stateToken = java.util.UUID.randomUUID().toString
+    pendingStates.put(stateToken, (sessionUser.getUid, System.currentTimeMillis() + STATE_TTL_MS))
 
     val url = new GoogleAuthorizationCodeRequestUrl(
       clientId,
       redirectUri,
       java.util.Arrays.asList("https://www.googleapis.com/auth/drive")
     )
-      .setState(state)
+      .setState(stateToken)
       .setAccessType("offline")
       .set("prompt", if (reauth) "consent" else null)
       .set("include_granted_scopes", true)

--- a/bin/k8s/values-development.yaml
+++ b/bin/k8s/values-development.yaml
@@ -291,6 +291,10 @@ texeraEnvVars:
     value: "true"
   - name: USER_SYS_GOOGLE_CLIENT_ID
     value: ""
+  - name: USER_SYS_GOOGLE_CLIENT_SECRET
+    value: ""
+  - name: USER_SYS_GOOGLE_API_KEY
+    value: ""
   - name: USER_SYS_GOOGLE_SMTP_GMAIL
     value: ""
   - name: USER_SYS_GOOGLE_SMTP_PASSWORD

--- a/bin/k8s/values-development.yaml
+++ b/bin/k8s/values-development.yaml
@@ -291,10 +291,6 @@ texeraEnvVars:
     value: "true"
   - name: USER_SYS_GOOGLE_CLIENT_ID
     value: ""
-  - name: USER_SYS_GOOGLE_CLIENT_SECRET
-    value: ""
-  - name: USER_SYS_GOOGLE_API_KEY
-    value: ""
   - name: USER_SYS_GOOGLE_SMTP_GMAIL
     value: ""
   - name: USER_SYS_GOOGLE_SMTP_PASSWORD

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -273,10 +273,6 @@ texeraEnvVars:
     value: "true"
   - name: USER_SYS_GOOGLE_CLIENT_ID
     value: ""
-  - name: USER_SYS_GOOGLE_CLIENT_SECRET
-    value: ""
-  - name: USER_SYS_GOOGLE_API_KEY
-    value: ""
   - name: USER_SYS_GOOGLE_SMTP_GMAIL
     value: ""
   - name: USER_SYS_GOOGLE_SMTP_PASSWORD

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -273,6 +273,10 @@ texeraEnvVars:
     value: "true"
   - name: USER_SYS_GOOGLE_CLIENT_ID
     value: ""
+  - name: USER_SYS_GOOGLE_CLIENT_SECRET
+    value: ""
+  - name: USER_SYS_GOOGLE_API_KEY
+    value: ""
   - name: USER_SYS_GOOGLE_SMTP_GMAIL
     value: ""
   - name: USER_SYS_GOOGLE_SMTP_PASSWORD

--- a/common/auth/src/main/scala/org/apache/texera/auth/TokenEncryptionService.scala
+++ b/common/auth/src/main/scala/org/apache/texera/auth/TokenEncryptionService.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.auth
+
+import org.apache.texera.config.AuthConfig
+import org.jose4j.jwe.{ContentEncryptionAlgorithmIdentifiers, JsonWebEncryption, KeyManagementAlgorithmIdentifiers}
+import org.jose4j.keys.AesKey
+
+import java.nio.charset.StandardCharsets
+
+object TokenEncryptionService {
+  private val key = new AesKey(AuthConfig.encryptionSecretKey.getBytes(StandardCharsets.UTF_8))
+
+  def encrypt(plaintext: String): String = {
+    val jwe = new JsonWebEncryption()
+    jwe.setAlgorithmHeaderValue(KeyManagementAlgorithmIdentifiers.DIRECT)
+    jwe.setEncryptionMethodHeaderParameter(ContentEncryptionAlgorithmIdentifiers.AES_256_GCM)
+    jwe.setKey(key)
+    jwe.setPayload(plaintext)
+    jwe.getCompactSerialization
+  }
+
+  def decrypt(ciphertext: String): String = {
+    val jwe = new JsonWebEncryption()
+    jwe.setKey(key)
+    jwe.setCompactSerialization(ciphertext)
+    jwe.getPayload
+  }
+}

--- a/common/auth/src/main/scala/org/apache/texera/auth/TokenEncryptionService.scala
+++ b/common/auth/src/main/scala/org/apache/texera/auth/TokenEncryptionService.scala
@@ -20,7 +20,11 @@
 package org.apache.texera.auth
 
 import org.apache.texera.config.AuthConfig
-import org.jose4j.jwe.{ContentEncryptionAlgorithmIdentifiers, JsonWebEncryption, KeyManagementAlgorithmIdentifiers}
+import org.jose4j.jwe.{
+  ContentEncryptionAlgorithmIdentifiers,
+  JsonWebEncryption,
+  KeyManagementAlgorithmIdentifiers
+}
 import org.jose4j.keys.AesKey
 
 import java.nio.charset.StandardCharsets

--- a/common/auth/src/test/scala/org/apache/texera/auth/TokenEncryptionServiceSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/TokenEncryptionServiceSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.auth
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TokenEncryptionServiceSpec extends AnyFlatSpec with Matchers {
+
+  "TokenEncryptionService" should "round-trip a plaintext string" in {
+    val plaintext = """{"refreshToken":"1//0gtoken","scopes":"https://www.googleapis.com/auth/drive"}"""
+    TokenEncryptionService.decrypt(TokenEncryptionService.encrypt(plaintext)) shouldBe plaintext
+  }
+
+  it should "throw when decrypting a non-JWE string" in {
+    an[Exception] should be thrownBy TokenEncryptionService.decrypt("not-a-jwe-token")
+  }
+}

--- a/common/config/src/main/resources/auth.conf
+++ b/common/config/src/main/resources/auth.conf
@@ -26,7 +26,7 @@ auth {
         256-bit-secret = ${?AUTH_JWT_SECRET}
     }
     encryption {
-        256-bit-secret = "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+        256-bit-secret = "9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e"
         256-bit-secret = ${?AUTH_ENCRYPTION_SECRET}
     }
 }

--- a/common/config/src/main/resources/auth.conf
+++ b/common/config/src/main/resources/auth.conf
@@ -25,4 +25,8 @@ auth {
         256-bit-secret = "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
         256-bit-secret = ${?AUTH_JWT_SECRET}
     }
+    encryption {
+        256-bit-secret = "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+        256-bit-secret = ${?AUTH_ENCRYPTION_SECRET}
+    }
 }

--- a/common/config/src/main/resources/user-system.conf
+++ b/common/config/src/main/resources/user-system.conf
@@ -26,6 +26,12 @@ user-sys {
   google {
     clientId = ""
     clientId = ${?USER_SYS_GOOGLE_CLIENT_ID}
+    
+    clientSecret = ""
+    clientSecret = ${?USER_SYS_GOOGLE_CLIENT_SECRET}
+
+    apiKey = ""
+    apiKey = ${?USER_SYS_GOOGLE_API_KEY}
 
     smtp {
       gmail = ""

--- a/common/config/src/main/scala/org/apache/texera/config/AuthConfig.scala
+++ b/common/config/src/main/scala/org/apache/texera/config/AuthConfig.scala
@@ -50,7 +50,7 @@ object AuthConfig {
       if (eSecretKey == null) {
         eSecretKey = conf.getString("auth.encryption.256-bit-secret").toLowerCase() match {
           case "random" => getRandomHexString
-          case key => key
+          case key      => key
         }
       }
     }

--- a/common/config/src/main/scala/org/apache/texera/config/AuthConfig.scala
+++ b/common/config/src/main/scala/org/apache/texera/config/AuthConfig.scala
@@ -30,6 +30,7 @@ object AuthConfig {
 
   // For storing the generated/configured secret
   @volatile private var secretKey: String = _
+  @volatile private var eSecretKey: String = _
 
   // Read JWT secret key with support for random generation
   def jwtSecretKey: String = {
@@ -42,6 +43,18 @@ object AuthConfig {
       }
     }
     secretKey
+  }
+
+  def encryptionSecretKey: String = {
+    synchronized {
+      if (eSecretKey == null) {
+        eSecretKey = conf.getString("auth.encryption.256-bit-secret").toLowerCase() match {
+          case "random" => getRandomHexString
+          case key => key
+        }
+      }
+    }
+    eSecretKey
   }
 
   private def getRandomHexString: String = {

--- a/common/config/src/main/scala/org/apache/texera/config/UserSystemConfig.scala
+++ b/common/config/src/main/scala/org/apache/texera/config/UserSystemConfig.scala
@@ -30,6 +30,8 @@ object UserSystemConfig {
   val adminUsername: String = conf.getString("user-sys.admin-username")
   val adminPassword: String = conf.getString("user-sys.admin-password")
   val googleClientId: String = conf.getString("user-sys.google.clientId")
+  val googleClientSecret: String = conf.getString("user-sys.google.clientSecret")
+  val googleApiKey: String = conf.getString("user-sys.google.apiKey")
   val gmail: String = conf.getString("user-sys.google.smtp.gmail")
   val smtpPassword: String = conf.getString("user-sys.google.smtp.password")
   val inviteOnly: Boolean = conf.getBoolean("user-sys.invite-only")

--- a/frontend/src/app/app-routing.constant.ts
+++ b/frontend/src/app/app-routing.constant.ts
@@ -46,3 +46,5 @@ export const DASHBOARD_ADMIN_EXECUTION = `${DASHBOARD_ADMIN}/execution`;
 export const DASHBOARD_ADMIN_SETTINGS = `${DASHBOARD_ADMIN}/settings`;
 
 export const DASHBOARD_SEARCH = `${DASHBOARD}/search`;
+
+export const DASHBOARD_USER_GOOGLE_DRIVE = `${DASHBOARD_USER}/google-drive`;

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -39,6 +39,7 @@ import { UserDatasetComponent } from "./dashboard/component/user/user-dataset/us
 import { HubWorkflowDetailComponent } from "./hub/component/workflow/detail/hub-workflow-detail.component";
 import { LandingPageComponent } from "./hub/component/landing-page/landing-page.component";
 import { DASHBOARD_ABOUT, DASHBOARD_USER_WORKFLOW } from "./app-routing.constant";
+import { GoogleDriveConnectComponent } from "./dashboard/component/user/google-drive-connect/google-drive-connect.component";
 import { HubSearchResultComponent } from "./hub/component/hub-search-result/hub-search-result.component";
 import { AdminSettingsComponent } from "./dashboard/component/admin/settings/admin-settings.component";
 import { GuiConfigService } from "./common/service/gui-config.service";
@@ -142,6 +143,10 @@ routes.push({
         {
           path: "discussion",
           component: FlarumComponent,
+        },
+        {
+          path: "google-drive",
+          component: GoogleDriveConnectComponent,
         },
       ],
     },

--- a/frontend/src/app/dashboard/component/user/google-drive-connect/google-drive-connect.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/google-drive-connect/google-drive-connect.component.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { GoogleDriveConnectComponent } from "./google-drive-connect.component";
+import { DriveService } from "../../../service/user/google-drive/drive.service";
+import { of, Subject, throwError } from "rxjs";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import type { Mocked } from "vitest";
+
+describe("GoogleDriveConnectComponent", () => {
+  let component: GoogleDriveConnectComponent;
+  let fixture: ComponentFixture<GoogleDriveConnectComponent>;
+  let driveServiceMock: Mocked<DriveService>;
+  let connected$: Subject<void>;
+
+  beforeEach(async () => {
+    connected$ = new Subject<void>();
+
+    driveServiceMock = {
+      getToken: vi.fn().mockReturnValue(of({ status: "ok", accessToken: "token123" })),
+      onConnected: vi.fn().mockReturnValue(connected$.asObservable()),
+      connect: vi.fn(),
+      exportToDrive: vi.fn(),
+      openFolderPicker: vi.fn(),
+    } as unknown as Mocked<DriveService>;
+
+    await TestBed.configureTestingModule({
+      imports: [GoogleDriveConnectComponent],
+      providers: [{ provide: DriveService, useValue: driveServiceMock }],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GoogleDriveConnectComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe("ngOnInit", () => {
+    it("sets status to connected when token is ok", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "ok", accessToken: "abc" }));
+      fixture.detectChanges();
+      expect(component.status).toBe("connected");
+    });
+
+    it("sets status from response when token is not ok", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "no_refresh_token" }));
+      fixture.detectChanges();
+      expect(component.status).toBe("no_refresh_token");
+    });
+
+    it("sets status to error when getToken fails", () => {
+      driveServiceMock.getToken.mockReturnValue(throwError(() => new Error("network error")));
+      fixture.detectChanges();
+      expect(component.status).toBe("error");
+    });
+
+    it("sets status to connected when onConnected emits", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "no_refresh_token" }));
+      fixture.detectChanges();
+      expect(component.status).toBe("no_refresh_token");
+
+      connected$.next();
+      expect(component.status).toBe("connected");
+    });
+  });
+
+  describe("connect", () => {
+    it("delegates to driveService.connect()", () => {
+      component.connect();
+      expect(driveServiceMock.connect).toHaveBeenCalledWith();
+    });
+  });
+
+  describe("reconnect", () => {
+    it("delegates to driveService.connect(true)", () => {
+      component.reconnect();
+      expect(driveServiceMock.connect).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe("openFolderPicker", () => {
+    it("sets selectedFolder when picker resolves", () => {
+      const folder = { id: "folder-1", name: "My Exports" };
+      driveServiceMock.openFolderPicker.mockReturnValue(of(folder));
+
+      component.openFolderPicker();
+
+      expect(component.selectedFolder).toEqual(folder);
+    });
+
+    it("does not set selectedFolder when picker is cancelled (completes without value)", () => {
+      driveServiceMock.openFolderPicker.mockReturnValue(of());
+
+      component.openFolderPicker();
+
+      expect(component.selectedFolder).toBeNull();
+    });
+  });
+});

--- a/frontend/src/app/dashboard/component/user/google-drive-connect/google-drive-connect.component.ts
+++ b/frontend/src/app/dashboard/component/user/google-drive-connect/google-drive-connect.component.ts
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit } from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { DriveService, DriveFolder } from "../../../service/user/google-drive/drive.service";
+import { NgIf } from "@angular/common";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-google-drive-connect",
+  template: `
+    <div>
+      <p>Google Drive Status: {{ status }}</p>
+      <button
+        nz-button
+        nzType="primary"
+        (click)="connect()"
+        [disabled]="status === 'connected'">
+        <span
+          nz-icon
+          nzType="google"
+          nzTheme="outline"></span>
+        Connect Google Drive
+      </button>
+      <button
+        nz-button
+        nzDanger
+        style="margin-left: 8px"
+        (click)="reconnect()"
+        *ngIf="status === 'connected'">
+        Reconnect
+      </button>
+      <button
+        nz-button
+        nzType="default"
+        style="margin-left: 8px"
+        (click)="openFolderPicker()"
+        *ngIf="status === 'connected'">
+        <span
+          nz-icon
+          nzType="folder-open"
+          nzTheme="outline"></span>
+        Choose Export Folder
+      </button>
+      <p *ngIf="selectedFolder">Export to: {{ selectedFolder.name }}</p>
+    </div>
+  `,
+  imports: [NgIf, NzButtonComponent, NzIconDirective],
+})
+export class GoogleDriveConnectComponent implements OnInit {
+  status = "checking...";
+  selectedFolder: DriveFolder | null = null;
+
+  constructor(private driveService: DriveService) {}
+
+  ngOnInit(): void {
+    this.driveService
+      .getToken()
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: res => {
+          this.status = res.status === "ok" ? "connected" : res.status;
+        },
+        error: () => {
+          this.status = "error";
+        },
+      });
+
+    this.driveService
+      .onConnected()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.status = "connected";
+      });
+  }
+
+  connect(): void {
+    this.driveService.connect();
+  }
+
+  reconnect(): void {
+    this.driveService.connect(true);
+  }
+
+  openFolderPicker(): void {
+    this.driveService
+      .openFolderPicker()
+      .pipe(untilDestroyed(this))
+      .subscribe(folder => {
+        this.selectedFolder = folder;
+      });
+  }
+}

--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -22,7 +22,8 @@
   class="list-item-card"
   [class.selected]="entry.checked"
   [class.has-button-group]="isPrivateSearch"
-  [class.editing-description]="editingDescription">
+  [class.editing-description]="editingDescription"
+  [class.export-menu-open]="exportMenuVisible">
   <div
     (mouseenter)="hovering = true"
     (mouseleave)="hovering = false"
@@ -217,12 +218,28 @@
       nz-button
       nzType="text"
       *ngIf="entry.type === 'workflow' || entry.type === 'dataset'"
-      title="Download"
-      (click)="onClickDownload()">
+      nz-dropdown
+      [(nzVisible)]="exportMenuVisible"
+      nzOverlayClassName="export-dropdown-menu"
+      [nzDropdownMenu]="exportMenu">
       <i
         nz-icon
         nzType="cloud-download"></i>
     </button>
+    <nz-dropdown-menu #exportMenu="nzDropdownMenu">
+      <ul nz-menu>
+        <li
+          nz-menu-item
+          (click)="onClickDownload()">
+          Download
+        </li>
+        <li
+          nz-menu-item
+          (click)="onClickDriveAction()">
+          {{ isDriveConnected ? 'Export to Drive' : 'Connect to Drive' }}
+        </li>
+      </ul>
+    </nz-dropdown-menu>
     <button
       nz-button
       nzType="text"

--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.scss
@@ -29,14 +29,15 @@
     z-index: 10;
   }
 
-  &:hover {
+  &:hover,
+  &.export-menu-open {
     background-color: #f0f0f0;
 
     .edit-button {
       display: flex;
     }
 
-    &.has-button-group:hover .resource-info {
+    &.has-button-group .resource-info {
       opacity: 0.3;
     }
   }
@@ -120,7 +121,8 @@
   }
 }
 
-.list-item-card:hover .button-group {
+.list-item-card:hover .button-group,
+.list-item-card.export-menu-open .button-group {
   display: flex;
   background-color: transparent;
 }
@@ -142,7 +144,8 @@
   transition: all 0.2s ease;
 }
 
-.list-item-card:hover .resource-description {
+.list-item-card:hover .resource-description,
+.list-item-card.export-menu-open .resource-description {
   font-size: 15px;
   font-weight: 500;
   color: #1e90ff;
@@ -197,4 +200,8 @@
 
 :host ::ng-deep nz-card.list-item-card.ant-card:hover .ant-card-body {
   cursor: pointer;
+}
+
+::ng-deep .export-dropdown-menu.ant-dropdown {
+  animation-duration: 0.075s !important;
 }

--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
@@ -22,7 +22,8 @@ import { ListItemComponent } from "./list-item.component";
 import { WorkflowPersistService } from "src/app/common/service/workflow-persist/workflow-persist.service";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { NzModalService } from "ng-zorro-antd/modal";
-import { of, throwError } from "rxjs";
+import { of, Subject, throwError } from "rxjs";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { RouterTestingModule } from "@angular/router/testing";
 import { StubUserService } from "../../../../common/service/user/stub-user.service";
@@ -30,19 +31,44 @@ import { UserService } from "../../../../common/service/user/user.service";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
 import type { Mocked } from "vitest";
 import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
+import { DriveService } from "../../../service/user/google-drive/drive.service";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { DatasetService } from "../../../service/user/dataset/dataset.service";
+
 describe("ListItemComponent", () => {
   let component: ListItemComponent;
   let fixture: ComponentFixture<ListItemComponent>;
   let workflowPersistService: Mocked<WorkflowPersistService>;
+  let driveServiceMock: Mocked<DriveService>;
+  let notificationServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  let connected$: Subject<void>;
 
   beforeEach(async () => {
-    const workflowPersistServiceSpy = { updateWorkflowName: vi.fn(), updateWorkflowDescription: vi.fn() };
+    connected$ = new Subject<void>();
+
+    const workflowPersistServiceSpy = {
+      updateWorkflowName: vi.fn(),
+      updateWorkflowDescription: vi.fn(),
+      retrieveWorkflow: vi.fn().mockReturnValue(of({ content: { operators: [] } })),
+    };
+
+    driveServiceMock = {
+      getToken: vi.fn().mockReturnValue(of({ status: "ok", accessToken: "token" })),
+      onConnected: vi.fn().mockReturnValue(connected$.asObservable()),
+      connect: vi.fn(),
+      exportToDrive: vi.fn().mockReturnValue(of(undefined)),
+    } as unknown as Mocked<DriveService>;
+
+    notificationServiceMock = { success: vi.fn(), error: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [ListItemComponent, HttpClientTestingModule, BrowserAnimationsModule, RouterTestingModule],
       providers: [
         { provide: WorkflowPersistService, useValue: workflowPersistServiceSpy },
         { provide: UserService, useClass: StubUserService },
+        { provide: DriveService, useValue: driveServiceMock },
+        { provide: NotificationService, useValue: notificationServiceMock },
+        { provide: DatasetService, useValue: { retrieveDatasetVersionZip: vi.fn().mockReturnValue(of(new Blob())) } },
         NzModalService,
         ...commonTestProviders,
       ],
@@ -118,5 +144,61 @@ describe("ListItemComponent", () => {
     expect(workflowPersistService.updateWorkflowDescription).toHaveBeenCalledWith(1, newDescription);
     expect(component.entry.description).toBe("Old Description");
     expect(component.editingDescription).toBe(false);
+  });
+
+  describe("Drive integration", () => {
+    it("should set isDriveConnected = true when token status is ok", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "ok", accessToken: "token" }));
+      component.ngOnInit();
+      expect(component.isDriveConnected).toBe(true);
+    });
+
+    it("should set isDriveConnected = false when token status is not ok", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "error", accessToken: "" }));
+      component.ngOnInit();
+      expect(component.isDriveConnected).toBe(false);
+    });
+
+    it("should set isDriveConnected = true and show toast when onConnected fires", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "error", accessToken: "" }));
+      component.ngOnInit();
+      expect(component.isDriveConnected).toBe(false);
+
+      connected$.next();
+
+      expect(component.isDriveConnected).toBe(true);
+      expect(notificationServiceMock.success).toHaveBeenCalledWith("Google Drive connected");
+    });
+
+    it("should call connect() when not connected and onClickDriveAction is called", () => {
+      component.isDriveConnected = false;
+      component.entry = { id: 1, name: "My Workflow", type: "workflow" } as unknown as DashboardEntry;
+
+      component.onClickDriveAction();
+
+      expect(driveServiceMock.connect).toHaveBeenCalled();
+      expect(driveServiceMock.exportToDrive).not.toHaveBeenCalled();
+    });
+
+    it("should export workflow to Drive and show success toast", () => {
+      component.isDriveConnected = true;
+      component.entry = { id: 1, name: "My Workflow", type: "workflow" } as unknown as DashboardEntry;
+
+      component.onClickDriveAction();
+
+      expect(workflowPersistService.retrieveWorkflow).toHaveBeenCalledWith(1);
+      expect(driveServiceMock.exportToDrive).toHaveBeenCalled();
+      expect(notificationServiceMock.success).toHaveBeenCalledWith("Exported to Google Drive");
+    });
+
+    it("should export dataset to Drive and show success toast", () => {
+      component.isDriveConnected = true;
+      component.entry = { id: 2, name: "My Dataset", type: "dataset" } as unknown as DashboardEntry;
+
+      component.onClickDriveAction();
+
+      expect(driveServiceMock.exportToDrive).toHaveBeenCalledWith(expect.any(Blob), "My Dataset.zip");
+      expect(notificationServiceMock.success).toHaveBeenCalledWith("Exported to Google Drive");
+    });
   });
 });

--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -23,6 +23,7 @@ import {
   EventEmitter,
   Input,
   OnChanges,
+  OnInit,
   Output,
   SimpleChanges,
   ViewChild,
@@ -38,6 +39,7 @@ import {
   WorkflowPersistService,
 } from "src/app/common/service/workflow-persist/workflow-persist.service";
 import { firstValueFrom } from "rxjs";
+import { switchMap } from "rxjs/operators";
 import { HubWorkflowDetailComponent } from "../../../../hub/component/workflow/detail/hub-workflow-detail.component";
 import { ActionType, HubService } from "../../../../hub/service/hub.service";
 import { DownloadService } from "src/app/dashboard/service/user/download/download.service";
@@ -64,6 +66,9 @@ import { FormsModule } from "@angular/forms";
 import { UserAvatarComponent } from "../user-avatar/user-avatar.component";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
+import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
+import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
+import { DriveService } from "../../../service/user/google-drive/drive.service";
 
 @UntilDestroy()
 @Component({
@@ -85,9 +90,13 @@ import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
     UserAvatarComponent,
     NzWaveDirective,
     NzPopconfirmDirective,
+    NzDropdownDirective,
+    NzDropdownMenuComponent,
+    NzMenuDirective,
+    NzMenuItemComponent,
   ],
 })
-export class ListItemComponent implements OnChanges {
+export class ListItemComponent implements OnChanges, OnInit {
   private owners: number[] = [];
   public originalName: string = "";
   public originalDescription: string | undefined = undefined;
@@ -109,6 +118,9 @@ export class ListItemComponent implements OnChanges {
   @Input() editable = false;
   private _entry?: DashboardEntry;
   hovering: boolean = false;
+  isDriveConnected = false;
+  driveNeedsReauth = false;
+  exportMenuVisible = false;
 
   @Input()
   get entry(): DashboardEntry {
@@ -135,8 +147,26 @@ export class ListItemComponent implements OnChanges {
     private hubService: HubService,
     private downloadService: DownloadService,
     private cdr: ChangeDetectorRef,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private driveService: DriveService
   ) {}
+
+  ngOnInit(): void {
+    this.driveService
+      .getToken()
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        this.isDriveConnected = res.status === "ok";
+        this.driveNeedsReauth = res.status === "invalid_grant";
+      });
+    this.driveService
+      .onConnected()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.isDriveConnected = true;
+        this.notificationService.success("Google Drive connected");
+      });
+  }
 
   initializeEntry() {
     if (this.entry.type === "workflow") {
@@ -255,6 +285,34 @@ export class ListItemComponent implements OnChanges {
       this.downloadService.downloadDataset(this.entry.id, this.entry.name).pipe(untilDestroyed(this)).subscribe();
     }
   };
+
+  public onClickDriveAction(): void {
+    if (!this.isDriveConnected) {
+      this.driveService.connect(this.driveNeedsReauth);
+      return;
+    }
+    if (!this.entry.id) return;
+    if (this.entry.type === "workflow") {
+      this.workflowPersistService
+        .retrieveWorkflow(this.entry.id)
+        .pipe(
+          switchMap(({ content }) => {
+            const blob = new Blob([JSON.stringify(content, null, 2)], { type: "application/json" });
+            return this.driveService.exportToDrive(blob, `${this.entry.name}.json`);
+          }),
+          untilDestroyed(this)
+        )
+        .subscribe({ next: () => this.notificationService.success("Exported to Google Drive") });
+    } else if (this.entry.type === "dataset") {
+      this.datasetService
+        .retrieveDatasetVersionZip(this.entry.id)
+        .pipe(
+          switchMap(blob => this.driveService.exportToDrive(blob, `${this.entry.name}.zip`)),
+          untilDestroyed(this)
+        )
+        .subscribe({ next: () => this.notificationService.success("Exported to Google Drive") });
+    }
+  }
 
   onEditName(): void {
     this.originalName = this.entry.name;

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -181,15 +181,32 @@
           <button
             nz-button
             *ngIf="selectedVersion"
-            nz-tooltip="Download the file"
+            nz-tooltip="Download / Export file"
             [disabled]="!isLogin || !isDownloadAllowed()"
-            (click)="onClickDownloadCurrentFile()">
+            nz-dropdown
+            [(nzVisible)]="fileExportMenuVisible"
+            [nzDropdownMenu]="fileExportMenu"
+            [class.export-menu-open]="fileExportMenuVisible">
             <i
               nz-icon
               nzTheme="outline"
               nzType="download">
             </i>
           </button>
+          <nz-dropdown-menu #fileExportMenu="nzDropdownMenu">
+            <ul nz-menu>
+              <li
+                nz-menu-item
+                (click)="onClickDownloadCurrentFile()">
+                Download
+              </li>
+              <li
+                nz-menu-item
+                (click)="onClickDriveExportFile()">
+                {{ isDriveConnected ? 'Export to Drive' : 'Connect to Drive' }}
+              </li>
+            </ul>
+          </nz-dropdown-menu>
           <button
             nz-button
             *ngIf="!isMaximized && selectedVersion"
@@ -292,16 +309,33 @@
               </nz-select>
               <button
                 nz-button
-                nz-tooltip="Download Dataset"
-                (click)="onClickDownloadVersionAsZip()"
+                nz-tooltip="Download / Export file"
                 *ngIf="selectedVersion"
                 [disabled]="!isLogin || !isDownloadAllowed()"
-                class="spaced-button">
+                class="spaced-button"
+                nz-dropdown
+                [(nzVisible)]="versionExportMenuVisible"
+                [nzDropdownMenu]="versionExportMenu"
+                [class.export-menu-open]="versionExportMenuVisible">
                 <i
                   nz-icon
                   nzType="download"
                   nzTheme="outline"></i>
               </button>
+              <nz-dropdown-menu #versionExportMenu="nzDropdownMenu">
+                <ul nz-menu>
+                  <li
+                    nz-menu-item
+                    (click)="onClickDownloadVersionAsZip()">
+                    Download
+                  </li>
+                  <li
+                    nz-menu-item
+                    (click)="onClickDriveExportVersion()">
+                    {{ isDriveConnected ? 'Export to Drive' : 'Connect to Drive' }}
+                  </li>
+                </ul>
+              </nz-dropdown-menu>
             </div>
             <ng-container *ngIf="selectedVersion">
               <div class="version-size">

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
@@ -333,3 +333,9 @@ nz-select {
   border-radius: 8px;
   margin-right: 80px;
 }
+
+button.export-menu-open {
+  color: #1890ff;
+  border-color: #1890ff;
+  background-color: #e6f7ff;
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { RouterTestingModule } from "@angular/router/testing";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { of, Subject } from "rxjs";
+
+import { DatasetDetailComponent } from "./dataset-detail.component";
+import { DatasetService } from "../../../../service/user/dataset/dataset.service";
+import { NotificationService } from "../../../../../common/service/notification/notification.service";
+import { DriveService } from "../../../../service/user/google-drive/drive.service";
+import { UserService } from "../../../../../common/service/user/user.service";
+import { StubUserService } from "../../../../../common/service/user/stub-user.service";
+import { commonTestProviders } from "../../../../../common/testing/test-utils";
+import { ActivatedRoute } from "@angular/router";
+import { HubService } from "../../../../../hub/service/hub.service";
+import { AdminSettingsService } from "../../../../service/admin/settings/admin-settings.service";
+import { DownloadService } from "../../../../service/user/download/download.service";
+import { NzModalService } from "ng-zorro-antd/modal";
+
+describe("DatasetDetailComponent - Drive integration", () => {
+  let component: DatasetDetailComponent;
+  let fixture: ComponentFixture<DatasetDetailComponent>;
+  let driveServiceMock: {
+    getToken: ReturnType<typeof vi.fn>;
+    onConnected: ReturnType<typeof vi.fn>;
+    connect: ReturnType<typeof vi.fn>;
+    exportToDrive: ReturnType<typeof vi.fn>;
+  };
+  let datasetServiceMock: Record<string, ReturnType<typeof vi.fn>>;
+  let notificationServiceMock: { success: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+  let connected$: Subject<void>;
+
+  beforeEach(async () => {
+    connected$ = new Subject<void>();
+
+    driveServiceMock = {
+      getToken: vi.fn().mockReturnValue(of({ status: "ok", accessToken: "token" })),
+      onConnected: vi.fn().mockReturnValue(connected$.asObservable()),
+      connect: vi.fn(),
+      exportToDrive: vi.fn().mockReturnValue(of(undefined)),
+    };
+
+    datasetServiceMock = {
+      retrieveDatasetVersionZip: vi.fn().mockReturnValue(of(new Blob(["zip"], { type: "application/zip" }))),
+      retrieveDatasetVersionSingleFile: vi.fn().mockReturnValue(of(new Blob(["file"]))),
+      getDataset: vi.fn().mockReturnValue(
+        of({
+          dataset: { name: "test", description: "", isPublic: false, isDownloadable: true, creationTime: undefined },
+          accessPrivilege: "WRITE",
+          ownerEmail: "test@test.com",
+          isOwner: true,
+        })
+      ),
+      retrieveDatasetVersionList: vi.fn().mockReturnValue(of([])),
+    };
+
+    notificationServiceMock = { success: vi.fn(), error: vi.fn() };
+
+    TestBed.overrideComponent(DatasetDetailComponent, { set: { template: "" } });
+
+    await TestBed.configureTestingModule({
+      imports: [DatasetDetailComponent, HttpClientTestingModule, BrowserAnimationsModule, RouterTestingModule],
+      providers: [
+        { provide: UserService, useClass: StubUserService },
+        { provide: DriveService, useValue: driveServiceMock },
+        { provide: DatasetService, useValue: datasetServiceMock },
+        { provide: NotificationService, useValue: notificationServiceMock },
+        {
+          provide: ActivatedRoute,
+          useValue: { params: of({ did: 1 }), data: of({}) },
+        },
+        {
+          provide: HubService,
+          useValue: {
+            getCounts: vi.fn().mockReturnValue(of([])),
+            postView: vi.fn().mockReturnValue(of(0)),
+            isLiked: vi.fn().mockReturnValue(of([])),
+          },
+        },
+        {
+          provide: AdminSettingsService,
+          useValue: { getSetting: vi.fn().mockReturnValue(of("10")) },
+        },
+        {
+          provide: DownloadService,
+          useValue: {
+            downloadDatasetVersion: vi.fn().mockReturnValue(of(undefined)),
+            downloadDatasetFile: vi.fn().mockReturnValue(of(undefined)),
+          },
+        },
+        NzModalService,
+        ...commonTestProviders,
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasetDetailComponent);
+    component = fixture.componentInstance;
+    component.currentUid = 1;
+    fixture.detectChanges();
+  });
+
+  it("should set isDriveConnected = true when token status is ok", () => {
+    expect(component.isDriveConnected).toBe(true);
+  });
+
+  it("should set isDriveConnected = false when getToken returns error status", () => {
+    driveServiceMock.getToken.mockReturnValue(of({ status: "error", accessToken: "" }));
+    const newFixture = TestBed.createComponent(DatasetDetailComponent);
+    const newComponent = newFixture.componentInstance;
+    newComponent.currentUid = 1;
+    newComponent.ngOnInit();
+    expect(newComponent.isDriveConnected).toBe(false);
+  });
+
+  it("should set isDriveConnected = true and show toast when onConnected fires", () => {
+    // Drive subscription is already active from beforeEach fixture.detectChanges()
+    component.isDriveConnected = false;
+
+    connected$.next();
+
+    expect(component.isDriveConnected).toBe(true);
+    expect(notificationServiceMock.success).toHaveBeenCalledWith("Google Drive connected");
+  });
+
+  describe("onClickDriveExportVersion", () => {
+    it("should call connect() when not connected", () => {
+      component.isDriveConnected = false;
+
+      component.onClickDriveExportVersion();
+
+      expect(driveServiceMock.connect).toHaveBeenCalled();
+      expect(driveServiceMock.exportToDrive).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when did or selectedVersion is missing", () => {
+      component.isDriveConnected = true;
+      component.did = undefined;
+
+      component.onClickDriveExportVersion();
+
+      expect(driveServiceMock.exportToDrive).not.toHaveBeenCalled();
+    });
+
+    it("should export version zip to Drive and show success toast", () => {
+      component.isDriveConnected = true;
+      component.did = 42;
+      component.selectedVersion = { dvid: 7, name: "v1" } as any;
+      component.datasetName = "my-dataset";
+
+      component.onClickDriveExportVersion();
+
+      expect(datasetServiceMock.retrieveDatasetVersionZip).toHaveBeenCalledWith(42, 7);
+      expect(driveServiceMock.exportToDrive).toHaveBeenCalledWith(expect.any(Blob), "my-dataset-v1.zip");
+      expect(notificationServiceMock.success).toHaveBeenCalledWith("Exported to Google Drive");
+    });
+  });
+
+  describe("onClickDriveExportFile", () => {
+    it("should call connect() when not connected", () => {
+      component.isDriveConnected = false;
+
+      component.onClickDriveExportFile();
+
+      expect(driveServiceMock.connect).toHaveBeenCalled();
+      expect(driveServiceMock.exportToDrive).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when no file is selected", () => {
+      component.isDriveConnected = true;
+      component.currentDisplayedFileName = "";
+
+      component.onClickDriveExportFile();
+
+      expect(driveServiceMock.exportToDrive).not.toHaveBeenCalled();
+    });
+
+    it("should export the selected file to Drive and show success toast", () => {
+      component.isDriveConnected = true;
+      component.currentDisplayedFileName = "path/to/report.csv";
+      component.datasetIsPublic = false;
+      component.isOwner = true;
+
+      component.onClickDriveExportFile();
+
+      expect(datasetServiceMock.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith("path/to/report.csv", true);
+      expect(driveServiceMock.exportToDrive).toHaveBeenCalledWith(expect.any(Blob), "report.csv");
+      expect(notificationServiceMock.success).toHaveBeenCalledWith("Exported to Google Drive");
+    });
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -68,6 +68,9 @@ import { NzProgressComponent } from "ng-zorro-antd/progress";
 import { UserDatasetStagedObjectsListComponent } from "./user-dataset-staged-objects-list/user-dataset-staged-objects-list.component";
 import { NzInputDirective } from "ng-zorro-antd/input";
 import { AppSettings } from "../../../../../common/app-setting";
+import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
+import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
+import { DriveService } from "../../../../service/user/google-drive/drive.service";
 
 export const THROTTLE_TIME_MS = 1000;
 export const ABORT_RETRY_MAX_ATTEMPTS = 10;
@@ -112,6 +115,10 @@ const DEFAULT_COVER_IMAGE = "assets/card_background.jpg";
     NzProgressComponent,
     UserDatasetStagedObjectsListComponent,
     NzInputDirective,
+    NzDropdownDirective,
+    NzDropdownMenuComponent,
+    NzMenuDirective,
+    NzMenuItemComponent,
   ],
 })
 export class DatasetDetailComponent implements OnInit {
@@ -147,6 +154,10 @@ export class DatasetDetailComponent implements OnInit {
   public currentUid: number | undefined;
   public viewCount: number = 0;
   public displayPreciseViewCount = false;
+  public isDriveConnected = false;
+  public driveNeedsReauth = false;
+  public fileExportMenuVisible = false;
+  public versionExportMenuVisible = false;
 
   userHasPendingChanges: boolean = false;
   pendingChangesCount: number = 0;
@@ -184,7 +195,8 @@ export class DatasetDetailComponent implements OnInit {
     private downloadService: DownloadService,
     private userService: UserService,
     private hubService: HubService,
-    private adminSettingsService: AdminSettingsService
+    private adminSettingsService: AdminSettingsService,
+    private driveService: DriveService
   ) {
     this.userService
       .userChanged()
@@ -251,6 +263,21 @@ export class DatasetDetailComponent implements OnInit {
       });
 
     this.loadUploadSettings();
+
+    this.driveService
+      .getToken()
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        this.isDriveConnected = res.status === "ok";
+        this.driveNeedsReauth = res.status === "invalid_grant";
+      });
+    this.driveService
+      .onConnected()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.isDriveConnected = true;
+        this.notificationService.success("Google Drive connected");
+      });
   }
 
   public onClickOpenVersionCreator() {
@@ -275,6 +302,40 @@ export class DatasetDetailComponent implements OnInit {
           },
         });
     }
+  }
+
+  public onClickDriveExportVersion(): void {
+    if (!this.isDriveConnected) {
+      this.driveService.connect(this.driveNeedsReauth);
+      return;
+    }
+    if (!this.did || !this.selectedVersion?.dvid) return;
+    this.datasetService
+      .retrieveDatasetVersionZip(this.did, this.selectedVersion.dvid)
+      .pipe(
+        switchMap(blob =>
+          this.driveService.exportToDrive(blob, `${this.datasetName}-${this.selectedVersion!.name}.zip`)
+        ),
+        untilDestroyed(this)
+      )
+      .subscribe({ next: () => this.notificationService.success("Exported to Google Drive") });
+  }
+
+  public onClickDriveExportFile(): void {
+    if (!this.isDriveConnected) {
+      this.driveService.connect(this.driveNeedsReauth);
+      return;
+    }
+    if (!this.currentDisplayedFileName) return;
+    const shouldUsePublicEndpoint = this.datasetIsPublic && !this.isOwner;
+    const fileName = this.currentDisplayedFileName.split("/").pop() || "download";
+    this.datasetService
+      .retrieveDatasetVersionSingleFile(this.currentDisplayedFileName, !shouldUsePublicEndpoint)
+      .pipe(
+        switchMap(blob => this.driveService.exportToDrive(blob, fileName)),
+        untilDestroyed(this)
+      )
+      .subscribe({ next: () => this.notificationService.success("Exported to Google Drive") });
   }
 
   public onClickDownloadVersionAsZip() {

--- a/frontend/src/app/dashboard/service/user/google-drive/drive.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/google-drive/drive.service.spec.ts
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { NgZone } from "@angular/core";
+import { DriveService } from "./drive.service";
+import { AppSettings } from "../../../../common/app-setting";
+import { firstValueFrom } from "rxjs";
+import { commonTestProviders } from "../../../../common/testing/test-utils";
+
+describe("DriveService", () => {
+  let service: DriveService;
+  let httpMock: HttpTestingController;
+  let ngZone: NgZone;
+
+  const BASE = `${AppSettings.getApiEndpoint()}/auth/google/drive`;
+
+  beforeEach(() => {
+    // Stub gapi so loadPicker() resolves without the real script
+    vi.stubGlobal("gapi", {
+      load: (_feature: string, cb: () => void) => cb(),
+    });
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [DriveService, ...commonTestProviders],
+    });
+
+    service = TestBed.inject(DriveService);
+    httpMock = TestBed.inject(HttpTestingController);
+    ngZone = TestBed.inject(NgZone);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    vi.unstubAllGlobals();
+  });
+
+  describe("getToken", () => {
+    it("calls the token endpoint and returns the response", async () => {
+      const promise = firstValueFrom(service.getToken());
+
+      const req = httpMock.expectOne(`${BASE}/token`);
+      expect(req.request.method).toBe("GET");
+      req.flush({ status: "ok", accessToken: "abc123" });
+
+      const result = await promise;
+      expect(result.status).toBe("ok");
+      expect(result.accessToken).toBe("abc123");
+    });
+
+    it("returns no_refresh_token status when user has not connected Drive", async () => {
+      const promise = firstValueFrom(service.getToken());
+
+      httpMock.expectOne(`${BASE}/token`).flush({ status: "no_refresh_token" });
+
+      const result = await promise;
+      expect(result.status).toBe("no_refresh_token");
+      expect(result.accessToken).toBeUndefined();
+    });
+  });
+
+  describe("connect", () => {
+    it("fetches the connect URL and opens a popup", () => {
+      const openSpy = vi.spyOn(window, "open").mockReturnValue(null);
+
+      service.connect();
+
+      const req = httpMock.expectOne(`${BASE}/connect?reauth=false`);
+      expect(req.request.method).toBe("GET");
+      req.flush("https://accounts.google.com/o/oauth2/auth?...");
+
+      expect(openSpy).toHaveBeenCalledWith(
+        "https://accounts.google.com/o/oauth2/auth?...",
+        "gdrive-connect",
+        "width=500,height=600"
+      );
+    });
+
+    it("passes reauth=true when reauth flag is set", () => {
+      vi.spyOn(window, "open").mockReturnValue(null);
+
+      service.connect(true);
+
+      httpMock.expectOne(`${BASE}/connect?reauth=true`).flush("https://accounts.google.com/...");
+    });
+
+    it("emits on onConnected() when the popup posts gdrive-connected", fakeAsync(() => {
+      const mockPopup = { close: vi.fn() } as unknown as Window;
+      vi.spyOn(window, "open").mockReturnValue(mockPopup);
+
+      let connected = false;
+      service.onConnected().subscribe(() => {
+        connected = true;
+      });
+
+      service.connect();
+      httpMock.expectOne(`${BASE}/connect?reauth=false`).flush("https://accounts.google.com/...");
+
+      ngZone.run(() => {
+        window.dispatchEvent(new MessageEvent("message", { data: "gdrive-connected" }));
+      });
+      tick();
+
+      expect(connected).toBe(true);
+      expect(mockPopup.close).toHaveBeenCalled();
+    }));
+
+    it("does not emit on onConnected() for unrelated messages", fakeAsync(() => {
+      vi.spyOn(window, "open").mockReturnValue(null);
+
+      let connected = false;
+      service.onConnected().subscribe(() => {
+        connected = true;
+      });
+
+      service.connect();
+      httpMock.expectOne(`${BASE}/connect?reauth=false`).flush("https://accounts.google.com/...");
+
+      window.dispatchEvent(new MessageEvent("message", { data: "some-other-message" }));
+      tick();
+
+      expect(connected).toBe(false);
+    }));
+  });
+
+  describe("exportToDrive", () => {
+    it("errors the observable when no access token is available", fakeAsync(async () => {
+      // Token endpoint returns no_refresh_token so getAccessToken returns null
+      const result$ = service.exportToDrive(new Blob(["test"]), "test.json");
+
+      // getToken is called inside getAccessToken
+      httpMock.expectOne(`${BASE}/token`).flush({ status: "no_refresh_token" });
+
+      tick();
+
+      let errorMessage = "";
+      result$.subscribe({ error: (e: unknown) => (errorMessage = (e as Error).message) });
+      tick();
+
+      expect(errorMessage).toBe("Not connected to Google Drive");
+    }));
+  });
+});

--- a/frontend/src/app/dashboard/service/user/google-drive/drive.service.ts
+++ b/frontend/src/app/dashboard/service/user/google-drive/drive.service.ts
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable, NgZone } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable, Subject, from, firstValueFrom } from "rxjs";
+import { AppSettings } from "../../../../common/app-setting";
+
+export interface DriveTokenResponse {
+  status: string;
+  accessToken?: string;
+}
+
+export interface DriveFolder {
+  id: string;
+  name: string;
+}
+
+// gapi is loaded via the script tag in index.html
+declare var gapi: any;
+declare var google: any;
+
+@Injectable({
+  providedIn: "root",
+})
+export class DriveService {
+  private readonly BASE = `${AppSettings.getApiEndpoint()}/auth/google/drive`;
+  private readonly CONFIG_URL = `${AppSettings.getApiEndpoint()}/auth/google/config`;
+
+  private connected$ = new Subject<void>();
+  private pickerLoaded = false;
+
+  constructor(
+    private http: HttpClient,
+    private ngZone: NgZone
+  ) {}
+
+  connect(reauth = false): void {
+    this.http.get(`${this.BASE}/connect?reauth=${reauth}`, { responseType: "text" }).subscribe(url => {
+      const popup = window.open(url, "gdrive-connect", "width=500,height=600");
+
+      const onMessage = (event: MessageEvent) => {
+        if (event.data === "gdrive-connected") {
+          window.removeEventListener("message", onMessage);
+          popup?.close();
+          this.ngZone.run(() => this.connected$.next());
+        }
+      };
+
+      window.addEventListener("message", onMessage);
+    });
+  }
+
+  onConnected(): Observable<void> {
+    return this.connected$.asObservable();
+  }
+
+  getToken(): Observable<DriveTokenResponse> {
+    return this.http.get<DriveTokenResponse>(`${this.BASE}/token`);
+  }
+
+  exportToDrive(blob: Blob, fileName: string): Observable<void> {
+    const result$ = new Subject<void>();
+
+    Promise.all([this.loadPicker(), this.getAccessToken()]).then(([, accessToken]) => {
+      if (!accessToken) {
+        result$.error(new Error("Not connected to Google Drive"));
+        return;
+      }
+
+      this.http.get<{ clientId: string; apiKey: string }>(this.CONFIG_URL).subscribe(config => {
+        const folderView = new google.picker.DocsView(google.picker.ViewId.FOLDERS)
+          .setIncludeFolders(true)
+          .setSelectFolderEnabled(true)
+          .setMimeTypes("application/vnd.google-apps.folder");
+
+        const picker = new google.picker.PickerBuilder()
+          .addView(folderView)
+          .setOAuthToken(accessToken)
+          .setDeveloperKey(config.apiKey)
+          .setTitle("Choose a folder to export to")
+          .setCallback((data: any) => {
+            if (data.action === google.picker.Action.PICKED) {
+              const folderId = data.docs[0].id;
+              this.ngZone.run(() => {
+                this.uploadToDrive(blob, fileName, folderId, accessToken).subscribe({
+                  next: () => {
+                    result$.next();
+                    result$.complete();
+                  },
+                  error: (err: unknown) => result$.error(err),
+                });
+              });
+            } else if (data.action === google.picker.Action.CANCEL) {
+              this.ngZone.run(() => result$.complete());
+            }
+          })
+          .build();
+
+        picker.setVisible(true);
+      });
+    });
+
+    return result$.asObservable();
+  }
+
+  openFolderPicker(): Observable<DriveFolder> {
+    const result$ = new Subject<DriveFolder>();
+
+    Promise.all([this.loadPicker(), this.getAccessToken()]).then(([, accessToken]) => {
+      if (!accessToken) {
+        result$.error(new Error("Not connected to Google Drive"));
+        return;
+      }
+
+      this.http.get<{ clientId: string; apiKey: string }>(this.CONFIG_URL).subscribe(config => {
+        const folderView = new google.picker.DocsView(google.picker.ViewId.FOLDERS)
+          .setIncludeFolders(true)
+          .setSelectFolderEnabled(true)
+          .setMimeTypes("application/vnd.google-apps.folder");
+
+        const picker = new google.picker.PickerBuilder()
+          .addView(folderView)
+          .setOAuthToken(accessToken)
+          .setDeveloperKey(config.apiKey)
+          .setTitle("Choose a folder to export to")
+          .setCallback((data: any) => {
+            if (data.action === google.picker.Action.PICKED) {
+              const doc = data.docs[0];
+              this.ngZone.run(() => {
+                result$.next({ id: doc.id, name: doc.name });
+                result$.complete();
+              });
+            } else if (data.action === google.picker.Action.CANCEL) {
+              this.ngZone.run(() => result$.complete());
+            }
+          })
+          .build();
+
+        picker.setVisible(true);
+      });
+    });
+
+    return result$.asObservable();
+  }
+
+  private uploadToDrive(blob: Blob, fileName: string, folderId: string, accessToken: string): Observable<void> {
+    const boundary = "texera_gdrive_boundary";
+    const metadata = JSON.stringify({ name: fileName, parents: [folderId] });
+    const contentType = blob.type || "application/octet-stream";
+
+    const body = new Blob([
+      `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n--${boundary}\r\nContent-Type: ${contentType}\r\n\r\n`,
+      blob,
+      `\r\n--${boundary}--`,
+    ]);
+
+    return from(
+      fetch("https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": `multipart/related; boundary="${boundary}"`,
+        },
+        body,
+      }).then(res => {
+        if (!res.ok) throw new Error(`Drive upload failed: ${res.status}`);
+      })
+    );
+  }
+
+  private loadPicker(): Promise<void> {
+    if (this.pickerLoaded) return Promise.resolve();
+    return new Promise(resolve => {
+      gapi.load("picker", () => {
+        this.pickerLoaded = true;
+        resolve();
+      });
+    });
+  }
+
+  private async getAccessToken(): Promise<string | null> {
+    const res = await firstValueFrom(this.getToken());
+    return res.status === "ok" ? res.accessToken ?? null : null;
+  }
+}

--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -134,13 +134,30 @@
           </button>
         </nz-upload>
         <button
-          (click)="onClickExportWorkflow()"
           nz-button
-          title="export workflow">
+          title="export workflow"
+          nz-dropdown
+          [(nzVisible)]="exportMenuVisible"
+          [nzDropdownMenu]="exportWorkflowMenu"
+          [class.export-menu-open]="exportMenuVisible">
           <i
             nz-icon
             nzType="download"></i>
         </button>
+        <nz-dropdown-menu #exportWorkflowMenu="nzDropdownMenu">
+          <ul nz-menu>
+            <li
+              nz-menu-item
+              (click)="onClickExportWorkflow()">
+              Download
+            </li>
+            <li
+              nz-menu-item
+              (click)="onClickDriveExportWorkflow()">
+              {{ isDriveConnected ? 'Export to Drive' : 'Connect to Drive' }}
+            </li>
+          </ul>
+        </nz-dropdown-menu>
         <button
           (click)="onClickEditDescription()"
           nz-button

--- a/frontend/src/app/workspace/component/menu/menu.component.scss
+++ b/frontend/src/app/workspace/component/menu/menu.component.scss
@@ -111,6 +111,12 @@ i {
 [nz-button] {
   width: 32px;
   padding: 0;
+
+  &.export-menu-open {
+    color: #1890ff;
+    border-color: #1890ff;
+    background-color: #e6f7ff;
+  }
 }
 
 #save-state {

--- a/frontend/src/app/workspace/component/menu/menu.component.spec.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.spec.ts
@@ -22,7 +22,8 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { RouterTestingModule } from "@angular/router/testing";
 import { NzModalService, NzModalModule, NzModalRef } from "ng-zorro-antd/modal";
-import { BehaviorSubject, of, throwError } from "rxjs";
+import { BehaviorSubject, of, Subject, throwError } from "rxjs";
+import { DriveService } from "../../../dashboard/service/user/google-drive/drive.service";
 
 import { MenuComponent } from "./menu.component";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
@@ -62,8 +63,28 @@ describe("MenuComponent", () => {
   let notificationService: NotificationService;
   let location: Location;
   let validationStream$: BehaviorSubject<ValidationOutput>;
+  let driveServiceMock: {
+    getToken: ReturnType<typeof vi.fn>;
+    onConnected: ReturnType<typeof vi.fn>;
+    connect: ReturnType<typeof vi.fn>;
+    exportToDrive: ReturnType<typeof vi.fn>;
+  };
+  let driveConnected$: Subject<void>;
 
   beforeEach(async () => {
+    driveConnected$ = new Subject<void>();
+    driveServiceMock = {
+      getToken: vi.fn().mockReturnValue(of({ status: "ok", accessToken: "token" })),
+      onConnected: vi.fn().mockReturnValue(driveConnected$.asObservable()),
+      connect: vi.fn(),
+      exportToDrive: vi.fn().mockReturnValue(of(undefined)),
+    };
+
+    TestBed.overrideComponent(MenuComponent, {
+      set: { template: "" },
+    });
+
+
     await TestBed.configureTestingModule({
       imports: [MenuComponent, HttpClientTestingModule, RouterTestingModule.withRoutes([]), NzModalModule],
       providers: [
@@ -80,6 +101,7 @@ describe("MenuComponent", () => {
           },
         },
         { provide: UserService, useClass: StubUserService },
+        { provide: DriveService, useValue: driveServiceMock },
         ...commonTestProviders,
       ],
     }).compileComponents();
@@ -525,5 +547,55 @@ describe("MenuComponent", () => {
     const config = createSpy.mock.calls[0][0] as ModalOptions;
     expect(config.nzTitle).toBe("Export All Operators Result");
     expect(config.nzData).toEqual(expect.objectContaining({ workflowName: "report-wf", sourceTriggered: "menu" }));
+  });
+
+  describe("Drive integration", () => {
+    it("should set isDriveConnected = true when token status is ok", () => {
+      expect(component.isDriveConnected).toBe(true);
+    });
+
+    it("should set isDriveConnected = false when token status is not ok", async () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "error", accessToken: "" }));
+      fixture = TestBed.createComponent(MenuComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      expect(component.isDriveConnected).toBe(false);
+    });
+
+    it("should set isDriveConnected = true and show toast when onConnected fires", () => {
+      driveServiceMock.getToken.mockReturnValue(of({ status: "error", accessToken: "" }));
+      fixture = TestBed.createComponent(MenuComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+      expect(component.isDriveConnected).toBe(false);
+
+      const successSpy = vi.spyOn(notificationService, "success").mockImplementation(() => {});
+      driveConnected$.next();
+
+      expect(component.isDriveConnected).toBe(true);
+      expect(successSpy).toHaveBeenCalledWith("Google Drive connected");
+    });
+
+    it("should call connect() when not connected and onClickDriveExportWorkflow is called", () => {
+      component.isDriveConnected = false;
+
+      component.onClickDriveExportWorkflow();
+
+      expect(driveServiceMock.connect).toHaveBeenCalled();
+      expect(driveServiceMock.exportToDrive).not.toHaveBeenCalled();
+    });
+
+    it("should export workflow to Drive and show success toast when connected", () => {
+      const fakeContent = { operators: [], links: [], commentBoxes: [], settings: {} } as unknown as WorkflowContent;
+      vi.spyOn(workflowActionService, "getWorkflowContent").mockReturnValue(fakeContent);
+      const successSpy = vi.spyOn(notificationService, "success").mockImplementation(() => {});
+      component.isDriveConnected = true;
+      component.currentWorkflowName = "my-workflow";
+
+      component.onClickDriveExportWorkflow();
+
+      expect(driveServiceMock.exportToDrive).toHaveBeenCalledWith(expect.any(Blob), "my-workflow.json");
+      expect(successSpy).toHaveBeenCalledWith("Exported to Google Drive");
+    });
   });
 });

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -68,6 +68,7 @@ import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { CoeditorUserIconComponent } from "./coeditor-user-icon/coeditor-user-icon.component";
 import { UserIconComponent } from "../../../dashboard/component/user/user-icon/user-icon.component";
 import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
+import { DriveService } from "../../../dashboard/service/user/google-drive/drive.service";
 import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
 import { NzCheckboxComponent } from "ng-zorro-antd/checkbox";
 import { NzPopoverDirective } from "ng-zorro-antd/popover";
@@ -135,6 +136,9 @@ export class MenuComponent implements OnInit, OnDestroy {
   public workflowId?: number;
   public isExportDeactivate: boolean = false;
   public showRegion: boolean = false;
+  public isDriveConnected = false;
+  public driveNeedsReauth = false;
+  public exportMenuVisible = false;
   public showGrid: boolean = false;
   public showNumWorkers: boolean = false;
   public showStatus: boolean = false;
@@ -189,7 +193,8 @@ export class MenuComponent implements OnInit, OnDestroy {
     private panelService: PanelService,
     private computingUnitStatusService: ComputingUnitStatusService,
     protected config: GuiConfigService,
-    private router: Router
+    private router: Router,
+    private driveService: DriveService
   ) {
     workflowWebsocketService
       .subscribeToEvent("ExecutionDurationUpdateEvent")
@@ -250,6 +255,21 @@ export class MenuComponent implements OnInit, OnDestroy {
 
     this.registerWorkflowMetadataDisplayRefresh();
     this.handleWorkflowVersionDisplay();
+
+    this.driveService
+      .getToken()
+      .pipe(untilDestroyed(this))
+      .subscribe(res => {
+        this.isDriveConnected = res.status === "ok";
+        this.driveNeedsReauth = res.status === "invalid_grant";
+      });
+    this.driveService
+      .onConnected()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.isDriveConnected = true;
+        this.notificationService.success("Google Drive connected");
+      });
   }
 
   ngOnDestroy(): void {
@@ -650,6 +670,19 @@ export class MenuComponent implements OnInit, OnDestroy {
     const workflowContentJson = JSON.stringify(workflowContent, null, 2);
     const fileName = this.currentWorkflowName + ".json";
     saveAs(new Blob([workflowContentJson], { type: "text/plain;charset=utf-8" }), fileName);
+  }
+
+  public onClickDriveExportWorkflow(): void {
+    if (!this.isDriveConnected) {
+      this.driveService.connect(this.driveNeedsReauth);
+      return;
+    }
+    const workflowContent: WorkflowContent = this.workflowActionService.getWorkflowContent();
+    const blob = new Blob([JSON.stringify(workflowContent, null, 2)], { type: "application/json" });
+    this.driveService
+      .exportToDrive(blob, `${this.currentWorkflowName}.json`)
+      .pipe(untilDestroyed(this))
+      .subscribe({ next: () => this.notificationService.success("Exported to Google Drive") });
   }
 
   /**

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -58,6 +58,9 @@
       href="https://fonts.googleapis.com/icon?family=Material+Icons&display=block"
       rel="stylesheet" />
 
+    <!-- Google API (for Drive Picker) -->
+    <script src="https://apis.google.com/js/api.js"></script>
+
     <!-- Add JSON Editor CSS and JS -->
     <link
       href="https://cdn.jsdelivr.net/npm/jsoneditor@10.1.0/dist/jsoneditor.min.css"

--- a/sql/updates/23.sql
+++ b/sql/updates/23.sql
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+\c texera_db
+
+SET search_path TO texera_db;
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_oauth_token  (
+    otid       SERIAL PRIMARY KEY,
+    uid     INT NOT NULL,
+    provider VARCHAR(64) NOT NULL,
+    auth_blob TEXT NOT NULL,
+
+    UNIQUE (uid, provider),
+    FOREIGN KEY (uid) REFERENCES "user"(uid) ON DELETE CASCADE
+);
+
+COMMIT;


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?

Wires the Drive export action into the three UI surfaces where download is currently available. The download button in each location has been converted to a dropdown with "Download" and "Export to Drive" (or "Connect to Drive" when not connected) options:

- **Dashboard list items** (`list-item.component`) — for workflows and datasets
- **Dataset detail page** (`dataset-detail.component`) — separate dropdowns for per-version ZIP download and per-file download
- **Workflow editor menu** (`menu.component`) — for the workflow JSON export button

All three surfaces:
- Call `DriveService.getToken()` on init to set initial connection state
- Subscribe to `DriveService.onConnected()` to update state live and show a "Google Drive connected" toast when the OAuth flow completes in the popup
- Show a "Exported to Google Drive" success toast on successful export
- Keep the dropdown button highlighted while the menu is open
- Fall back to `connect()` (or `connect(true)` on `invalid_grant`) when the user clicks "Connect to Drive" while not connected

<img width="400" height="179" alt="Screenshot 2026-05-21 at 4 12 15 PM" src="https://github.com/user-attachments/assets/a505e328-9648-49b8-9161-5f77cb003a54" />
<img width="1496" height="763" alt="Screenshot 2026-05-21 at 4 12 44 PM" src="https://github.com/user-attachments/assets/c0f410cf-1503-4c0a-b202-64efd25058c2" />
<img width="1268" height="538" alt="Screenshot 2026-05-21 at 4 10 32 PM" src="https://github.com/user-attachments/assets/830dcd2c-8205-4746-9dfc-52bc15f99f42" />
<img width="1054" height="659" alt="Screenshot 2026-05-21 at 4 10 47 PM" src="https://github.com/user-attachments/assets/08950920-9988-42ce-9348-4f6266ad6413" />
<img width="252" height="67" alt="Screenshot 2026-05-21 at 4 11 02 PM" src="https://github.com/user-attachments/assets/b7b43ed2-6663-4246-a84b-23f3ff75a1ef" />

### Any related issues, documentation, discussions?

Closes #4240

### How was this PR tested?

Unit tests added for all three components:

- **`list-item.component.spec.ts`** — `Drive integration` describe block: token status sets `isDriveConnected`, `onConnected` emission updates state and shows toast, `connect()` called when not connected, workflow and dataset export paths call `exportToDrive` and show success toast
- **`menu.component.spec.ts`** — `Drive integration` describe block: same connection state coverage, plus `onClickDriveExportWorkflow` serializes workflow content and shows success toast
- **`dataset-detail.component.spec.ts`** — new spec file: token status, `onConnected` toast, `onClickDriveExportVersion` and `onClickDriveExportFile` across connected/disconnected/missing-selection/success paths

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6
