### PR TITLE
fix(dataset): load cover image on detail page for private datasets

### DIFF
--- a/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
+++ b/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
@@ -2139,9 +2139,11 @@ class DatasetResource extends LazyLogging {
   }
 
   /**
-    * 307 redirect to a presigned S3 URL for the dataset cover.
-    * For `<img src>` consumption of public covers; for JWT-aware callers
-    * (e.g., private datasets), use GET /{did}/cover-url.
+    * Get the cover image for a dataset.
+    * Returns a 307 redirect to the presigned S3 URL.
+    *
+    * @param did Dataset ID
+    * @return 307 Temporary Redirect to cover image
     */
   @GET
   @Path("/{did}/cover")

--- a/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
+++ b/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
@@ -2139,11 +2139,9 @@ class DatasetResource extends LazyLogging {
   }
 
   /**
-    * Get the cover image for a dataset.
-    * Returns a 307 redirect to the presigned S3 URL.
-    *
-    * @param did Dataset ID
-    * @return 307 Temporary Redirect to cover image
+    * 307 redirect to a presigned S3 URL for the dataset cover.
+    * For `<img src>` consumption of public covers; for JWT-aware callers
+    * (e.g., private datasets), use GET /{did}/cover-url.
     */
   @GET
   @Path("/{did}/cover")
@@ -2180,6 +2178,51 @@ class DatasetResource extends LazyLogging {
       )
 
       Response.temporaryRedirect(new URI(presignedUrl)).build()
+    }
+  }
+
+  /**
+    * Get a presigned S3 URL for the dataset cover image as JSON.
+    * JWT-aware variant of GET /{did}/cover; required for private datasets
+    * since `<img src>` cannot attach the Authorization header.
+    */
+  @GET
+  @Path("/{did}/cover-url")
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def getDatasetCoverUrl(
+      @PathParam("did") did: Integer,
+      @Auth sessionUser: Optional[SessionUser]
+  ): Response = {
+    withTransaction(context) { ctx =>
+      val dataset = getDatasetByID(ctx, did)
+
+      val requesterUid = if (sessionUser.isPresent) Some(sessionUser.get().getUid) else None
+
+      if (requesterUid.isEmpty && !dataset.getIsPublic) {
+        throw new ForbiddenException(ERR_USER_HAS_NO_ACCESS_TO_DATASET_MESSAGE)
+      } else if (requesterUid.exists(uid => !userHasReadAccess(ctx, did, uid))) {
+        throw new ForbiddenException(ERR_USER_HAS_NO_ACCESS_TO_DATASET_MESSAGE)
+      }
+
+      Option(dataset.getCoverImage) match {
+        case None =>
+          Response.ok(Map("url" -> null)).build()
+        case Some(coverImage) =>
+          val owner = getOwner(ctx, did)
+          val fullPath = s"${owner.getEmail}/${dataset.getName}/$coverImage"
+
+          val document = DocumentFactory
+            .openReadonlyDocument(FileResolver.resolve(fullPath))
+            .asInstanceOf[OnDataset]
+
+          val presignedUrl = LakeFSStorageClient.getFilePresignedUrl(
+            document.getRepositoryName(),
+            document.getVersionHash(),
+            document.getFileRelativePath()
+          )
+
+          Response.ok(Map("url" -> presignedUrl)).build()
+      }
     }
   }
 }

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
@@ -2531,6 +2531,50 @@ class DatasetResourceSpec
     response.getHeaderString("Location") should not be null
   }
 
+  "getDatasetCoverUrl" should "return presigned url for owner of private dataset" in {
+    testDatasetVersion
+
+    val dataset = datasetDao.fetchOneByDid(baseDataset.getDid)
+    dataset.setIsPublic(false)
+    dataset.setCoverImage(testCoverImagePath)
+    datasetDao.update(dataset)
+
+    val response = datasetResource.getDatasetCoverUrl(
+      baseDataset.getDid,
+      Optional.of(sessionUser)
+    )
+
+    response.getStatus shouldEqual 200
+    Option(entityAsScalaMap(response)("url")) shouldBe defined
+  }
+
+  it should "reject private dataset cover for users without access" in {
+    val dataset = datasetDao.fetchOneByDid(baseDataset.getDid)
+    dataset.setOwnerUid(ownerUser.getUid)
+    dataset.setIsPublic(false)
+    dataset.setCoverImage("v1/cover.jpg")
+    datasetDao.update(dataset)
+
+    assertThrows[ForbiddenException] {
+      datasetResource.getDatasetCoverUrl(baseDataset.getDid, Optional.of(sessionUser2))
+    }
+  }
+
+  it should "return null url when no cover image is set" in {
+    val dataset = datasetDao.fetchOneByDid(baseDataset.getDid)
+    dataset.setCoverImage(null)
+    dataset.setIsPublic(true)
+    datasetDao.update(dataset)
+
+    val response = datasetResource.getDatasetCoverUrl(
+      baseDataset.getDid,
+      Optional.of(sessionUser)
+    )
+
+    response.getStatus shouldEqual 200
+    Option(entityAsScalaMap(response)("url")) shouldBe empty
+  }
+
   "LakeFS error handling" should "return 500 when ETag is invalid, with the message included in the error response body" in {
     val filePath = uniqueFilePath("error-body")
 

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -118,13 +118,10 @@
         </div>
       </div>
       <img
-        *ngIf="coverImageUrl; else coverPlaceholder"
+        *ngIf="coverImageUrl"
         class="dataset-cover-image"
         [src]="coverImageUrl"
         alt="Dataset cover" />
-      <ng-template #coverPlaceholder>
-        <div class="dataset-cover-image"></div>
-      </ng-template>
     </div>
 
     <div class="description-section">

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -67,12 +67,10 @@ import { FilesUploaderComponent } from "../../files-uploader/files-uploader.comp
 import { NzProgressComponent } from "ng-zorro-antd/progress";
 import { UserDatasetStagedObjectsListComponent } from "./user-dataset-staged-objects-list/user-dataset-staged-objects-list.component";
 import { NzInputDirective } from "ng-zorro-antd/input";
-import { AppSettings } from "../../../../../common/app-setting";
 
 export const THROTTLE_TIME_MS = 1000;
 export const ABORT_RETRY_MAX_ATTEMPTS = 10;
 export const ABORT_RETRY_BACKOFF_BASE_MS = 100;
-const DEFAULT_COVER_IMAGE = "assets/card_background.jpg";
 
 @UntilDestroy()
 @Component({
@@ -121,7 +119,7 @@ export class DatasetDetailComponent implements OnInit {
   public datasetCreationTime: string = "";
   public datasetCreationTimeTooltip: string = "";
   public datasetIsPublic: boolean = false;
-  public coverImageUrl: string = "";
+  public coverImageUrl: string | null = null;
   public datasetIsDownloadable: boolean = true;
   public userDatasetAccessLevel: "READ" | "WRITE" | "NONE" = "NONE";
   public ownerEmail: string = "";
@@ -332,8 +330,9 @@ export class DatasetDetailComponent implements OnInit {
 
   retrieveDatasetInfo() {
     if (this.did) {
+      const did = this.did;
       this.datasetService
-        .getDataset(this.did, this.isLogin)
+        .getDataset(did, this.isLogin)
         .pipe(untilDestroyed(this))
         .subscribe(dashboardDataset => {
           const dataset = dashboardDataset.dataset;
@@ -344,9 +343,17 @@ export class DatasetDetailComponent implements OnInit {
           this.datasetIsDownloadable = dataset.isDownloadable;
           this.ownerEmail = dashboardDataset.ownerEmail;
           this.isOwner = dashboardDataset.isOwner;
-          this.coverImageUrl = dataset.coverImage
-            ? `${AppSettings.getApiEndpoint()}/dataset/${this.did}/cover?v=${encodeURIComponent(dataset.coverImage)}`
-            : DEFAULT_COVER_IMAGE;
+          if (dataset.coverImage) {
+            this.datasetService
+              .getDatasetCoverUrl(did)
+              .pipe(untilDestroyed(this))
+              .subscribe({
+                next: ({ url }) => (this.coverImageUrl = url),
+                error: () => (this.coverImageUrl = null),
+              });
+          } else {
+            this.coverImageUrl = null;
+          }
           if (typeof dataset.creationTime === "number") {
             const date = new Date(dataset.creationTime);
             this.datasetCreationTime = format(date, "MM/dd/yyyy HH:mm:ss");
@@ -781,14 +788,21 @@ export class DatasetDetailComponent implements OnInit {
     if (!this.did || !this.selectedVersion) {
       return;
     }
+    const did = this.did;
 
     const newCoverPath = `${this.selectedVersion.name}/${filePath}`;
     this.datasetService
-      .updateDatasetCoverImage(this.did, newCoverPath)
+      .updateDatasetCoverImage(did, newCoverPath)
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => {
-          this.coverImageUrl = `${AppSettings.getApiEndpoint()}/dataset/${this.did}/cover?v=${encodeURIComponent(newCoverPath)}`;
+          this.datasetService
+            .getDatasetCoverUrl(did)
+            .pipe(untilDestroyed(this))
+            .subscribe({
+              next: ({ url }) => (this.coverImageUrl = url),
+              error: () => (this.coverImageUrl = null),
+            });
           this.notificationService.success("Cover image updated.");
         },
         error: (err: unknown) => {

--- a/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -557,4 +557,8 @@ export class DatasetService {
       coverImage: coverImage,
     });
   }
+
+  public getDatasetCoverUrl(did: number): Observable<{ url: string | null }> {
+    return this.http.get<{ url: string | null }>(`${AppSettings.getApiEndpoint()}/dataset/${did}/cover-url`);
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR fixes the cover image failing to load on the dataset detail page for private datasets, and removes the default placeholder shown when no cover image is set.

Changes:
- Adds a JWT-aware endpoint `GET /dataset/{did}/cover-url` that returns the presigned S3 URL as JSON. The detail page calls it via Angular `HttpClient` (which carries the JWT), then sets the returned URL on `<img src>` (presigned URL needs no auth).
- Removes the meaningless default blue placeholder on the detail page: if no cover image is set, nothing is rendered.
- The existing 307-redirect endpoint `/cover` is preserved for the hub browse page, which serves only public datasets and consumes the redirect directly. Both endpoints now have doc comments cross-referencing each other.

Demo:
With cover image:
<img width="1340" height="265" alt="with-cover" src="https://github.com/user-attachments/assets/d84f63ee-870e-43bf-8f44-c46b9e06b741" />

Without cover image:
<img width="1352" height="253" alt="without-cover" src="https://github.com/user-attachments/assets/9ca89b09-4e73-4546-adb5-3233c1247468" />

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Closes #5283 

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
Added test cases for the new endpoint.
Manually verified on a local instance.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.7