### PR TITLE
chore(asf): Allow texera committers to bypass branch protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -114,7 +114,7 @@ github:
           - "rel/*"
         excludes: []
       bypass_teams:
-        - root
+        - texera-committers
       restrict_deletion: true
       restrict_force_push: true
 notifications:


### PR DESCRIPTION
### What changes were proposed in this PR?
Change bypass team for protected branch to `texera-committers` so that selected committers can operate on branches.

### Any related issues, documentation, discussions?
Closes #5286 

### How was this PR tested?
This is related to asf change, unfortunately cannot be tested without merging into main. 

### Was this PR authored or co-authored using generative AI tooling?
No.