### PR TITLE
fix(asf): restore root bypass team

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -114,7 +114,8 @@ github:
           - "rel/*"
         excludes: []
       bypass_teams:
-        - texera-committers
+        - "root"
+        - "texera-committers"
       restrict_deletion: true
       restrict_force_push: true
 notifications:


### PR DESCRIPTION
### What changes were proposed in this PR?

Restore the ASF `root` team in `.asf.yaml` branch protection bypasses while keeping `texera-committers` from #5287. Quote both team names for consistency.

### Any related issues, documentation, discussions?

Closes #5289
Follow-up to #5287

### How was this PR tested?

```bash
ruby -e 'require "yaml"; YAML.load_file(".asf.yaml"); puts "YAML OK"'
git diff --check
```

### Was this PR authored or co-authored using generative AI tooling?

Yes. Used OpenAI Codex.
