### PR TITLE
docs: make in-repo docs/ the single source of truth (#5001)

### DIFF
--- a/docs/getting-started/deploy-on-aws.md
+++ b/docs/getting-started/deploy-on-aws.md
@@ -1,0 +1,295 @@
+---
+title: "Deploying Texera on Amazon Web Services (AWS)"
+weight: 62
+---
+
+This document explains how to deploy Texera on Amazon Web Services (AWS) using an Elastic Kubernetes Service (EKS) cluster.
+
+---
+
+## 1. Create an EKS cluster on AWS
+Go to the [EKS Console](https://console.aws.amazon.com/eks/home) and log in with your AWS account. Click "Create Cluster".
+
+<img width="1759" alt="eks" src="https://github.com/user-attachments/assets/d115d4c1-bfd4-4565-9431-756cdfb54f68" />
+
+---
+
+Use the default configuration to create your cluster, and give it a name of your choice.
+If "Cluster IAM role" and "Node IAM role" are empty, click "Create recommended role" and follow the guided steps.
+Then, click "Create".
+
+<img width="1653" alt="create" src="https://github.com/user-attachments/assets/a25d289d-d4be-4ba9-b024-fe51b65e1d6b" />
+
+---
+
+The cluster will take about 15–20 minutes to be created and reach an Active state. You can refresh the dashboard to monitor the progress.
+
+<img width="1650" alt="dashboard" src="https://github.com/user-attachments/assets/93e47083-2c5a-48e4-95cd-97d9a73b19bd" />
+
+## 2. Install AWS CLI and Helm
+To access the cluster, you have the following 2 options:
+
+1. Follow the [AWS CLI installation guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) to install the AWS CLI on your local enviornment.
+    Once installed, create a passkey by clicking your account name in the top right corner → Security credentials.
+
+    <img width="2250" alt="pass1" src="https://github.com/user-attachments/assets/7517ad37-6ec3-4a35-841a-554264320eed" />
+
+    ---
+
+    On the security credentials page, click "Create access key".
+
+    <img width="1644" alt="pass2" src="https://github.com/user-attachments/assets/4a5327be-18df-4fb5-8f34-caf90f67bedf" />
+
+    ---
+
+    Follow the prompt and copy the access key and secret.
+
+    <img width="1488" alt="pass3" src="https://github.com/user-attachments/assets/f64da71a-9461-4005-a2ea-ba8b24fd029f" />
+
+    ---
+    Then open a terminal on your computer and enter `aws configure`, paste the copied credentials.
+    Also enter the default region shown on your cluster dashboard when prompted, leave the "output format" as its default value:
+
+    <img width="1647" alt="conf1" src="https://github.com/user-attachments/assets/8ae32560-dcca-44ce-97db-00207e491773" />
+
+    ---
+2. Use [AWS CloudShell](https://aws.amazon.com/cloudshell/). Make sure the cloudshell is running on the same region with your cluster.
+
+   <img width="2026" alt="cloudshell" src="https://github.com/user-attachments/assets/0de96a2d-7792-4758-bb00-35bd88e0edbe" />
+
+   ---
+
+Once you have a terminal (either local or CloudShell) ready to run `aws` commands, set the environment variable:
+
+```
+EKS_CLUSTER_NAME=<your-cluster-name>
+```
+Update your kubeconfig to use the new cluster:
+
+```
+aws eks update-kubeconfig --name $EKS_CLUSTER_NAME
+```
+Verify the connection:
+
+```
+kubectl get all
+```
+
+By default, AWS does not assign external IPs to LoadBalancers unless the subnets are properly tagged.
+To enable both public and internal LoadBalancers, run the following command to tag your subnets:
+```
+aws ec2 create-tags \
+  --resources $(aws eks describe-cluster --name $EKS_CLUSTER_NAME --query "cluster.resourcesVpcConfig.subnetIds" --output text) \
+  --tags Key=kubernetes.io/role/elb,Value=1 Key=kubernetes.io/role/internal-elb,Value=1
+```
+
+## 3. Create two Nginx controllers for texera:
+
+Install Helm by following the [Helm installation guide](https://helm.sh/docs/intro/install/). Then execute the following commands in your terminal:
+
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+
+helm upgrade --install nginx-texera ingress-nginx/ingress-nginx \
+  --namespace texera --create-namespace \
+  --set controller.replicaCount=1 \
+  --set controller.ingressClassResource.name=nginx \
+  --set controller.ingressClassResource.controllerValue="k8s.io/ingress-nginx" \
+  --set controller.ingressClass=nginx \
+  --set controller.service.type=LoadBalancer \
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-scheme"="internet-facing"
+
+helm upgrade --install nginx-minio ingress-nginx/ingress-nginx \
+  --namespace texera --create-namespace \
+  --set controller.replicaCount=1 \
+  --set controller.ingressClassResource.name=nginx-minio \
+  --set controller.ingressClassResource.controllerValue="k8s.io/nginx-minio" \
+  --set controller.ingressClass=nginx-minio \
+  --set controller.service.type=LoadBalancer \
+  --set controller.service.annotations."service\.beta\.kubernetes\.io/aws-load-balancer-scheme"="internet-facing"
+```
+
+Wait for 1-2 minutes, then run:
+```
+kubectl get svc -n texera
+```
+
+When the EXTERNAL-IP fields are populated, assign the hostnames to environment variables:
+```
+TEXERA_IP=$(kubectl get svc nginx-texera-ingress-nginx-controller -n texera -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+MINIO_IP=$(kubectl get svc nginx-minio-ingress-nginx-controller -n texera -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+```
+
+## 4. Create a StorageClass for Texera
+Create a file named `ebs-storage.yaml` with the following content:
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: auto-ebs-sc
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: ebs.csi.eks.amazonaws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: gp3
+  encrypted: "true"
+```
+Then apply it:
+```
+kubectl apply -f ebs-storage.yaml
+```
+Validate the StorageClass:
+```
+kubectl get storageclass --all-namespaces
+```
+
+## 5. Prepare Texera deployment:
+Execute the following bash commands.
+
+```bash
+curl -L -o texera.zip https://github.com/Texera/texera/releases/download/1.1.0/texera-cluster-1-1-0-release.zip
+unzip texera.zip -d texera-cluster
+rm texera.zip
+helm dependency build texera-cluster
+```
+
+## 6. Deploy Texera
+
+```bash
+helm install texera texera-cluster --namespace texera --create-namespace \
+  --set postgresql.primary.persistence.storageClass="auto-ebs-sc" \
+  --set ingress-nginx.enabled=false \
+  --set metrics-server.enabled=false \
+  --set exampleDataLoader.enabled=false \
+  --set minio.customIngress.enabled=true \
+  --set minio.customIngress.ingressClassName=nginx-minio \
+  --set minio.customIngress.texeraHostname="http://$TEXERA_IP" \
+  --set minio.persistence.storageClass="auto-ebs-sc" \
+  --set-string lakefs.lakefsConfig="$(cat <<EOF
+database:
+  type: postgres
+blockstore:
+  type: s3
+  s3:
+    endpoint: http://texera-minio:9000
+    pre_signed_expiry: 15m
+    pre_signed_endpoint: http://$MINIO_IP
+    force_path_style: true
+    credentials:
+      access_key_id: texera_minio
+      secret_access_key: password
+EOF
+)" \
+  --set ingressPaths.hostname=""
+```
+
+---
+
+## Done!
+
+* It may take 10-15 minutes to fully launch the deployment.
+* During the process, you can periodically execute `kubectl get pods -n texera` to see the status of the deployed pods.
+* Once every pod is in a `Running` or `Completed` status, you can execute `echo $TEXERA_IP` to get the public IP of the Texera WebUI.
+* Then you can access Texera using `http://<TEXERA_IP>`.
+
+
+**To remove the Texera deployment from your Kubernetes cluster, execute the following bash commands.**
+
+```
+helm uninstall texera -n texera
+helm uninstall nginx-texera -n texera
+helm uninstall nginx-minio -n texera
+```
+---
+
+
+## Advanced Configuration
+You can customize the deployment by adding the following --set flags to your helm install command. These flags allow you to configure authentication, resource limits, and the number of pods for Texera deployment.
+
+### Texera Credentials
+Texera relies on Postgres, MinIO and LakeFS that require credentials. You can change the default values to make your deployment more secure.
+
+**Default Texera Admin User**
+
+Texera ships with a built-in administrator account (username: texera, password: texera).
+To supply your own credentials during installation, pass the following Helm overrides:
+
+```bash
+# USER_SYS_ADMIN_USERNAME
+--set texeraEnvVars[0].value="<user-name>" \
+# USER_SYS_ADMIN_PASSWORD
+--set texeraEnvVars[1].value="<password>" \
+```
+
+**MinIO Authentication**
+```
+--set minio.auth.rootUser=texera_minio \
+--set minio.auth.rootPassword=password \
+```
+
+**PostgreSQL Authentication (username is always postgres)**
+```
+--set postgresql.auth.postgresPassword=root_password \
+```
+
+> 💡 Note: If you change the PostgreSQL password, you also need to change the following and add it to the install command:
+<pre><code>--set lakefs.secrets.databaseConnectionString="postgres://postgres:<b>root_password</b>@texera-postgresql:5432/texera_lakefs?sslmode=disable" \</code></pre>
+
+**LakeFS Authentication**
+```
+--set lakefs.auth.username=texera-admin \
+--set lakefs.auth.accessKey=AKIAIOSFOLKFSSAMPLES \
+--set lakefs.auth.secretKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+--set lakefs.secrets.authEncryptSecretKey=random_string_for_lakefs \
+```
+
+### Allocating Resources
+If your cluster has more available resources, you can allocate additional CPU, memory, and disks to Texera to improve the performance.
+
+**Postgres**
+
+To allocate more CPU, Memory and disk to Postgres, do:
+```
+--set postgresql.primary.resources.requests.cpu=4 \
+--set postgresql.primary.resources.requests.memory=4Gi \
+--set postgresql.primary.persistence.size=50Gi \
+```
+
+**MinIO**
+
+To increase the storage for user's input dataset, do:
+```
+--set minio.persistence.size=100Gi
+```
+
+**Computing Unit**
+
+To customize options for the computing unit, do:
+```bash
+# MAX_NUM_OF_RUNNING_COMPUTING_UNITS_PER_USER
+--set texeraEnvVars[5].value="2" \
+# CPU_OPTION_FOR_COMPUTING_UNIT
+--set texeraEnvVars[6].value="1,2,4" \
+# MEMORY_OPTION_FOR_COMPUTING_UNIT
+--set texeraEnvVars[7].value="2Gi,4Gi,16Gi" \
+# GPU_LIMIT_OPTIONS
+--set texeraEnvVars[8].value="0,1" \ # to allow 0 or 1 GPU resource to be allocated
+```
+
+### Adjusting Number of Pods
+Scale out individual services for high availability or increased performance:
+
+```
+--set webserver.numOfPods=2 \
+--set workflowCompilingService.numOfPods=2 \
+--set pythonLanguageServer.replicaCount=2 \
+```
+
+
+### Retaining User Data
+By default, all user data stored by Texera will be deleted when the cluster deployment is removed. Since user data is valuable, you can preserve all datasets and files even after uninstalling the cluster by setting:
+```
+--set persistence.removeAfterUninstall=false
+```

--- a/docs/getting-started/deploy-on-gcp.md
+++ b/docs/getting-started/deploy-on-gcp.md
@@ -1,0 +1,238 @@
+---
+title: "Deploying Texera on Google Cloud Platform (GCP)"
+weight: 64
+---
+
+This document explains how to deploy Texera on Google Cloud Platform (GCP) using a Google Kubernetes Engine (GKE) cluster.
+
+---
+
+## Prerequisites: Check your quota
+
+Your GCP account should be able to allocate at least 20 vCPUs and 1 TB of SSD. To check your quota, go to the [GCP Quotas](https://console.cloud.google.com/iam-admin/quotas?referrer=search&pageState=(%22allQuotasTable%22:(%22f%22:%22%255B%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22CPUs_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22displayName_22%257D_2C%257B_22k_22_3A_22_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22OR_5C_22_22_2C_22o_22_3Atrue_2C_22s_22_3Atrue%257D_2C%257B_22k_22_3A_22Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22Persistent%2520Disk%2520SSD%2520%2528GB%2529_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22displayName_22%257D_2C%257B_22k_22_3A_22Dimensions%2520%2528e.g.%2520location%2529_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22region_3Aus-central1_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22displayDimensions_22%257D%255D%22))) page.
+You should be able to see a pre-populated query for listing the CPUs and SSDs in the `us-central1` region by default. If you plan to deploy Texera in another region, you need to change the `Dimensions` part of the query.
+<img width="1420" alt="quota2" src="https://github.com/user-attachments/assets/cf0c9b41-20df-463a-b15e-9673de29d9fa" />
+If your quota does not have at least 20 CPUs and 1 TB SSD, you need to request a quota increase by clicking the 3-dot button on the right -> "Edit Quota".
+<img width="1528" alt="quota3" src="https://github.com/user-attachments/assets/d9132094-3e35-4a50-9993-d10de5aa6ad4" />
+
+
+---
+## 1. Create an Autopilot GKE cluster
+
+> 💡 Note: If you already have a GKE cluster and wish to use it for deploying Texera, you can skip this step and proceed directly to Step 2.
+
+Navigate to GCP console -> Kubernetes Engine -> [Clusters](https://console.cloud.google.com/kubernetes/list/overview). Click on the `create` button.
+
+> 💡 Note: You may need to enable the Kubernetes API if you haven't done so.
+
+<img width="2318" alt="step0 1" src="https://github.com/user-attachments/assets/081720e9-96a2-41cc-bd4c-49363099d3bb" />
+
+Use all default values to create a cluster. You can also customize the cluster accordingly if needed.
+After 15-20 minutes, you should be able to see the status of your cluster to be in a green checkmark(<img width="25" alt="step0 0" src="https://github.com/user-attachments/assets/e949dfb3-9699-40e1-a963-08f1bcdd1f57" />) state, with 0 vCPUs and 0 memory usage.
+<img width="1406" alt="step-0-2" src="https://github.com/user-attachments/assets/9cdf3fc4-8164-477c-a583-e328efd782c0" />
+Click the three dots on the right, and choose "connect".
+<img width="1141" alt="step-0-3" src="https://github.com/user-attachments/assets/a0249ee2-9a1d-44c2-93a3-72fa48eb5e08" />
+
+---
+
+In the pop-up window, copy the **project** and **region** to your clipboard. Then click **"Run in Cloud Shell"**.
+Press Enter for the first command shown on the terminal.
+<img width="994" alt="step-0-4" src="https://github.com/user-attachments/assets/085b2147-2192-4766-a3b6-6ba01fac05d2" />
+
+
+## 2. Reserve Two Static IPs (for Texera website and MinIO)
+
+After accessing your cluster using Cloud Shell, define the following variables based on your region and project in Step 1.
+```bash
+REGION="<YOUR_REGION>"
+PROJECT="<YOUR_PROJECT>"
+```
+
+Execute the following bash commands to reserve two Public IP addresses.
+
+```bash
+gcloud compute addresses create texera-ip  --region=$REGION --project=$PROJECT
+TEXERA_IP=$(gcloud compute addresses describe texera-ip --region=$REGION --format="get(address)"  --project $PROJECT)
+gcloud compute addresses create minio-ip  --region=$REGION --project=$PROJECT
+MINIO_IP=$(gcloud compute addresses describe minio-ip   --region=$REGION --format="get(address)"  --project $PROJECT)
+```
+
+Execute the following bash commands to create two nginx controllers with helm.
+```bash
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+helm repo update
+helm install nginx-texera ingress-nginx/ingress-nginx \
+  --namespace texera --create-namespace \
+  --set controller.ingressClassResource.name=nginx \
+  --set controller.ingressClassResource.controllerValue="k8s.io/ingress-nginx" \
+  --set controller.ingressClass=nginx \
+  --set controller.service.loadBalancerIP=$TEXERA_IP \
+  --set controller.service.annotations."cloud\.google\.com/load-balancer-type"="External" \
+  --set rbac.create=true
+
+helm install nginx-minio ingress-nginx/ingress-nginx \
+  --namespace texera \
+  --set controller.ingressClassResource.name=nginx-minio \
+  --set controller.ingressClassResource.controllerValue="k8s.io/nginx-minio" \
+  --set controller.ingressClass=nginx-minio \
+  --set controller.service.loadBalancerIP=$MINIO_IP \
+  --set controller.service.annotations."cloud\.google\.com/load-balancer-type"="External" \
+  --set rbac.create=true
+```
+
+---
+
+## 3. Prepare Texera Installation
+
+Execute the following bash commands.
+
+```bash
+curl -L -o texera.zip https://github.com/Texera/texera/releases/download/1.1.0/texera-cluster-1-1-0-release.zip
+unzip texera.zip -d texera-cluster
+rm texera.zip
+helm dependency build texera-cluster
+```
+
+---
+
+## 4. Deploy Texera
+
+Execute the following bash command.
+
+```bash
+helm install texera texera-cluster --namespace texera --create-namespace \
+  --set postgresql.primary.persistence.storageClass=standard-rwo \
+  --set ingress-nginx.enabled=false \
+  --set metrics-server.enabled=false \
+  --set exampleDataLoader.enabled=false \
+  --set minio.customIngress.enabled=true \
+  --set minio.customIngress.ingressClassName=nginx-minio \
+  --set minio.customIngress.texeraHostname="http://$TEXERA_IP" \
+  --set minio.persistence.storageClass=standard-rwo \
+  --set-string lakefs.lakefsConfig="$(cat <<EOF
+database:
+  type: postgres
+blockstore:
+  type: s3
+  s3:
+    endpoint: http://texera-minio:9000
+    pre_signed_expiry: 15m
+    pre_signed_endpoint: http://$MINIO_IP
+    force_path_style: true
+    credentials:
+      access_key_id: texera_minio
+      secret_access_key: password
+EOF
+)" \
+  --set ingressPaths.hostname=""
+```
+
+---
+
+## Done!
+
+* It may take 10-15 minutes to fully launch the deployment.
+* During the process, you can periodically execute `kubectl get pods -n texera` to see the status of the deployed pods.
+* Once every pod is in a `Running` or `Completed` status, you can execute `echo $TEXERA_IP` to get the public IP of the Texera WebUI.
+* Then you can access Texera using `http://<TEXERA_IP>`.
+
+
+**To remove the Texera deployment from your Kubernetes cluster, execute the following bash commands.**
+
+```
+helm uninstall texera -n texera
+helm uninstall nginx-texera -n texera
+helm uninstall nginx-minio -n texera
+```
+> Note: You also need to release the 2 allocated IP addresses on [GCP](https://console.cloud.google.com/networking/addresses/list)
+
+---
+
+## Advanced Configuration
+You can customize the deployment by adding the following --set flags to your helm install command. These flags allow you to configure authentication, resource limits, and the number of pods for Texera deployment.
+
+### Texera Credentials
+Texera relies on Postgres, MinIO and LakeFS that require credentials. You can change the default values to make your deployment more secure.
+
+**Default Texera Admin User**
+
+Texera ships with a built-in administrator account (username: texera, password: texera).
+To supply your own credentials during installation, pass the following Helm overrides:
+
+```bash
+# USER_SYS_ADMIN_USERNAME
+--set texeraEnvVars[0].value="<user-name>" \
+# USER_SYS_ADMIN_PASSWORD
+--set texeraEnvVars[1].value="<password>" \
+```
+
+**MinIO Authentication**
+```
+--set minio.auth.rootUser=texera_minio \
+--set minio.auth.rootPassword=password \
+```
+
+**PostgreSQL Authentication (username is always postgres)**
+```
+--set postgresql.auth.postgresPassword=root_password \
+```
+
+> 💡 Note: If you change the PostgreSQL password, you also need to change the following and add it to the install command:
+<pre><code>--set lakefs.secrets.databaseConnectionString="postgres://postgres:<b>root_password</b>@texera-postgresql:5432/texera_lakefs?sslmode=disable" \</code></pre>
+
+**LakeFS Authentication**
+```
+--set lakefs.auth.username=texera-admin \
+--set lakefs.auth.accessKey=AKIAIOSFOLKFSSAMPLES \
+--set lakefs.auth.secretKey=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY \
+--set lakefs.secrets.authEncryptSecretKey=random_string_for_lakefs \
+```
+
+### Allocating Resources
+If your cluster has more available resources, you can allocate additional CPU, memory, and disks to Texera to improve the performance.
+
+**Postgres**
+
+To allocate more CPU, Memory and disk to Postgres, do:
+```
+--set postgresql.primary.resources.requests.cpu=4 \
+--set postgresql.primary.resources.requests.memory=4Gi \
+--set postgresql.primary.persistence.size=50Gi \
+```
+
+**MinIO**
+
+To increase the storage for user's input dataset, do:
+```
+--set minio.persistence.size=100Gi
+```
+
+**Computing Unit**
+
+To customize options for the computing unit, do:
+```bash
+# MAX_NUM_OF_RUNNING_COMPUTING_UNITS_PER_USER
+--set texeraEnvVars[5].value="2" \
+# CPU_OPTION_FOR_COMPUTING_UNIT
+--set texeraEnvVars[6].value="1,2,4" \
+# MEMORY_OPTION_FOR_COMPUTING_UNIT
+--set texeraEnvVars[7].value="2Gi,4Gi,16Gi" \
+# GPU_LIMIT_OPTIONS
+--set texeraEnvVars[8].value="0,1" \ # to allow 0 or 1 GPU resource to be allocated
+```
+
+### Adjusting Number of Pods
+Scale out individual services for high availability or increased performance:
+
+```
+--set webserver.numOfPods=2 \
+--set workflowCompilingService.numOfPods=2 \
+--set pythonLanguageServer.replicaCount=2 \
+```
+
+
+### Retaining User Data
+By default, all user data stored by Texera will be deleted when the cluster deployment is removed. Since user data is valuable, you can preserve all datasets and files even after uninstalling the cluster by setting:
+```
+--set persistence.removeAfterUninstall=false
+```

--- a/docs/getting-started/install-texera.md
+++ b/docs/getting-started/install-texera.md
@@ -8,3 +8,8 @@ To install Texera, you may choose one of the two supported architectures dependi
 - **Single Node Deployment**: ideal for quickly starting Texera on a local machine or testing deployments serving a small number of users. See [Installing Apache Texera using Docker](/docs/getting-started/installing-using-docker/).
 
 - **Kubernetes-based Deployment**: recommended for production-level deployments at scale, supporting high availability serving a larger number of users. See [Installing Apache Texera on a Kubernetes Cluster](/docs/getting-started/run-on-kubernetes/).
+
+For production deployments on a managed cloud Kubernetes service, see the provider-specific guides:
+
+- [Deploying Texera on Amazon Web Services (AWS)](/docs/getting-started/deploy-on-aws/)
+- [Deploying Texera on Google Cloud Platform (GCP)](/docs/getting-started/deploy-on-gcp/)

--- a/docs/getting-started/installing-using-docker.md
+++ b/docs/getting-started/installing-using-docker.md
@@ -50,10 +50,10 @@ If either command produces output, that port is occupied by another process. You
 
 ---
 
+## Download Texera
 
-## Download the docker compose tarball from the release
+Download the [docker compose tarball](https://downloads.apache.org/incubator/texera/1.1.0-incubating/apache-texera-1.1.0-incubating-docker-compose.tar.gz) and extract it.
 
-Download by clicking [here](https://dist.apache.org/repos/dist/dev/incubator/texera/1.1.0-incubating-RC5/apache-texera-1.1.0-incubating-docker-compose.tar.gz) and extract it.
 
 ## Launch Texera
 
@@ -62,17 +62,11 @@ Enter the extracted directory and run the following command to start Texera:
 docker compose --profile examples up
 ```
 
-This command will start docker containers that host the  Texera services, and pre-create two example workflows and datasets. 
+This command will start docker containers that host the  Texera services, and pre-create two example workflows and datasets.
 
 If you don't want to have these examples pre-created, run the following command instead:
 ```bash
 docker compose up
-```
-
-To enable the AI copilot panel, also pass your LLM provider key inline. For example, with Anthropic:
-```bash
-export ANTHROPIC_API_KEY=<your-api-key>
-docker compose --profile examples up
 ```
 
 > If you see the error message like `unable to get image 'nginx:alpine': Cannot connect to the Docker daemon at unix:///Users/kunwoopark/.docker/run/docker.sock. Is the docker daemon running?`, please make sure Docker Desktop is installed and running
@@ -103,7 +97,7 @@ Press `Ctrl+C` in the terminal to stop Texera.
 
 If you already closed the terminal, you can go to the installation folder and run:
 ```bash
-docker compose stop
+docker compose --profile examples stop
 ```
 to stop Texera.
 
@@ -116,6 +110,28 @@ To remove Texera and all its data, go to the installation folder and run:
 docker compose --profile examples down -v
 ```
 > ⚠️ Warning: This will permanently delete all the data used by Texera.
+
+
+## Enable the Texera Agent
+
+The Texera agent is powered by a large language model (LLM). By default, Texera uses [Claude Haiku 4.5](https://www.anthropic.com/claude/haiku) as the LLM and queries it through [LiteLLM](https://docs.litellm.ai/). Without an API key, the Texera agent panel still appears but model calls will fail with a provider auth error.
+
+To enable it:
+
+1. [Stop Texera](#stop) if it is already running.
+2. Get an API key for the LLM. Since Claude Haiku 4.5 is enabled by default, you need an [Anthropic API key](https://console.anthropic.com/settings/keys).
+3. Export the key and restart Texera:
+   ```bash
+   export ANTHROPIC_API_KEY=sk-ant-...
+   docker compose --profile examples up
+   ```
+
+Once Texera is up, create a new workflow and open the Texera agent panel at the bottom right. Type a task like:
+
+> For /texera/popular-movies-of-imdb/v1/TMDb_updated.csv, visualize the top 10 most-voted movies.
+
+To switch providers or add more LLMs, see [Add more LLMs or providers](#add-more-llms-or-providers).
+
 
 
 ## Advanced Settings
@@ -160,6 +176,45 @@ $ docker compose up
 ? Volume "texera-single-node-release-1-1-0_workflow_result_data" exists but doesn't match configuration in compose file. Recreate (data will be lost)? (y/N)
 y // answer y to this prompt
 ```
+
+### Add more LLMs or providers
+Only Claude Haiku 4.5 is enabled by default. To add more LLMs, open `litellm-config.yaml` in the installation folder and append entries under `model_list`. Each entry follows this shape:
+```diff
+  model_list:
+    ...
++   - model_name: <name shown in Texera>
++     litellm_params:
++       model: <provider model id>
++       api_key: "os.environ/<API_KEY_ENV_VAR>"
+```
+For example, to add OpenAI's GPT-5.2 and Google's Gemini 2.5 Pro:
+```diff
+  model_list:
+    ...
++   - model_name: gpt-5.2
++     litellm_params:
++       model: gpt-5.2
++       api_key: "os.environ/OPENAI_API_KEY"
++
++   - model_name: gemini-2.5-pro
++     litellm_params:
++       model: gemini/gemini-2.5-pro
++       api_key: "os.environ/GEMINI_API_KEY"
+```
+Make sure to set the corresponding API key environment variable when you launch Texera (see [Enable the Texera Agent](#enable-the-texera-agent)). Get keys from each provider's console — for example, [OpenAI](https://platform.openai.com/api-keys) or [Google](https://aistudio.google.com/apikey).
+
+If your provider is not Anthropic, OpenAI, or Google, also pass its key into the LiteLLM container by editing `docker-compose.yml`:
+```diff
+  litellm:
+    ...
+    environment:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
++     <NEW_API_KEY>: ${<NEW_API_KEY>:-}
+```
+
+For the full list of supported providers and model IDs, see the [LiteLLM proxy config docs](https://docs.litellm.ai/docs/providers).
 
 ## Troubleshooting
 


### PR DESCRIPTION
### What changes were proposed in this PR?
- Reconcile docs/ with the Hugo website (apache/incubator-texera-site): of all 229 doc files, only getting-started/installing-using-docker.md had real content drift, now synced to the newer website copy (released download URL, plus "Enable the Texera Agent" and "Add more LLMs or providers" sections).
- Migrate the AWS (EKS) and GCP (GKE) deployment guides from the GitHub wiki into docs/getting-started/, the only wiki pages whose content was not already covered in docs/.
- Link the new cloud-deployment guides from getting-started/install-texera.md.
- Website-specific Hugo artifacts (aliases, menu, /docs/latest/ links) are intentionally kept out of docs/, since the website build re-adds them when it pulls docs/ as source.
### Any related issues, documentation, or discussions?
Closes: #5001
### How was this PR tested?
- Diffed every file in docs/ against the website content tree to confirm installing-using-docker.md was the only real content drift (others differ only by website build artifacts).
- Compared all 26 wiki pages against docs/ to confirm AWS and GCP were the only unique, current pages worth migrating.
- Verified the reconciled installing-using-docker.md matches the website body exactly except for the intentionally-omitted aliases block.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF