### PR TITLE
fix: remove duplicate NOTICE file under bin/single-node

### DIFF
--- a/.github/workflows/create-release-candidate.yml
+++ b/.github/workflows/create-release-candidate.yml
@@ -174,14 +174,14 @@ jobs:
 
           # Export the single-node directory from the tagged source
           mkdir -p "$TEMP_DIR/_raw"
-          git archive --format=tar "$TAG_NAME" -- bin/single-node/ sql/ | tar -x -C "$TEMP_DIR/_raw"
+          git archive --format=tar "$TAG_NAME" -- bin/single-node/ sql/ NOTICE | tar -x -C "$TEMP_DIR/_raw"
 
           # Copy deployment files
           cp "$TEMP_DIR/_raw/bin/single-node/docker-compose.yml" "$BUNDLE_DIR/"
           cp "$TEMP_DIR/_raw/bin/single-node/nginx.conf" "$BUNDLE_DIR/"
           cp "$TEMP_DIR/_raw/bin/single-node/litellm-config.yaml" "$BUNDLE_DIR/"
           cp "$TEMP_DIR/_raw/bin/single-node/LICENSE" "$BUNDLE_DIR/"
-          cp "$TEMP_DIR/_raw/bin/single-node/NOTICE" "$BUNDLE_DIR/"
+          cp "$TEMP_DIR/_raw/NOTICE" "$BUNDLE_DIR/"
           cp "$TEMP_DIR/_raw/bin/single-node/DISCLAIMER" "$BUNDLE_DIR/"
           cp -r "$TEMP_DIR/_raw/sql" "$BUNDLE_DIR/"
 

--- a/bin/single-node/NOTICE
+++ b/bin/single-node/NOTICE
@@ -1,5 +1,0 @@
-Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this PR?
- Removed the duplicate `NOTICE` file under `bin/single-node/`, which was identical to the project root `NOTICE`, to avoid the two-copy drift problem.
- Updated `.github/workflows/create-release-candidate.yml` so the Docker Compose release bundle still includes a `NOTICE`, now sourced from the root copy (added `NOTICE` to the `git archive` paths and repointed the `cp`).
### Any related issues, documentation, or discussions?
Closes: #5296
### How was this PR tested?
- Verified the root `NOTICE` and removed `bin/single-node/NOTICE` were byte-for-byte identical before deletion.
- Grepped the repo to confirm the release workflow was the only reference, and updated it so the bundle copy still resolves.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.7 in compliance with ASF
