### PR TITLE
chore(ci): rename python job/flag/label to pyamber

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,8 +47,8 @@ agent-service:
 engine:
   # Non-Python, non-integration parts of amber/. Pure Python changes
   # under amber/src/{main,test}/python/** intentionally fall through to
-  # the `python` label (which the labeler also matches via **/*.py),
-  # so they only trigger the python + amber-integration stacks rather
+  # the `pyamber` label (which the labeler also matches via **/*.py),
+  # so they only trigger the pyamber + amber-integration stacks rather
   # than the full Scala-only `amber` stack. Integration specs live
   # under amber/src/test/integration/** (added to sbt's Test sources
   # via amber/build.sbt) and are caught by the `amber-integration`
@@ -80,9 +80,9 @@ amber-integration:
       - any-glob-to-any-file:
           - 'amber/src/test/integration/**'
 
-python:
+pyamber:
   # Includes pip requirement manifests so dependency-only PRs still
-  # exercise the Python + amber-integration stacks. Without this a
+  # exercise the pyamber + amber-integration stacks. Without this a
   # bumped requirements.txt would only get `dependencies` (no stack
   # mapping) and silently skip CI for the very deps it's changing.
   - changed-files:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ on:
         required: false
         type: boolean
         default: true
-      run_python:
+      run_pyamber:
         required: false
         type: boolean
         default: true
@@ -624,8 +624,8 @@ jobs:
           disable_search: true
           fail_ci_if_error: false
 
-  python:
-    if: ${{ inputs.run_python }}
+  pyamber:
+    if: ${{ inputs.run_pyamber }}
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -715,15 +715,15 @@ jobs:
         # test PR comments and flaky-test detection on main.
         run: |
           cd amber && pytest -m "not integration" --cov=src/main/python --cov-report=xml --junit-xml=junit.xml -sv
-      - name: Upload python coverage to Codecov
+      - name: Upload pyamber coverage to Codecov
         if: matrix.python-version == '3.12' && always()
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./amber/coverage.xml
-          flags: python
+          flags: pyamber
           fail_ci_if_error: false
-      - name: Upload python test results to Codecov
+      - name: Upload pyamber test results to Codecov
         # Test Analytics ingestion. Runs on the same 3.12 leg that uploads
         # coverage to keep one canonical source per flag. `!cancelled()`
         # rather than `always()` so we still upload on test failure (the
@@ -733,22 +733,22 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./amber/junit.xml
-          flags: python
+          flags: pyamber
           report_type: test_results
           disable_search: true
           fail_ci_if_error: false
 
-  python-state-materialization-mac:
+  pyamber-state-materialization-mac:
     # Diagnostic leg: cross-region state materialization is reported to
-    # fail on macOS while working on Windows / Linux. The main `python`
+    # fail on macOS while working on Windows / Linux. The main `pyamber`
     # job above runs only on ubuntu-latest because it depends on a
     # postgres service container (service containers don't work on
     # macOS runners). The state-materialization integration tests use
     # an in-process sqlite-backed SqlCatalog instead, so we can run
     # them on macOS without postgres infra. If they fail here but pass
-    # in the main `python` job, we've reproduced the macOS-specific
+    # in the main `pyamber` job, we've reproduced the macOS-specific
     # regression in CI.
-    if: ${{ inputs.run_python }}
+    if: ${{ inputs.run_pyamber }}
     runs-on: macos-latest
     steps:
       - name: Checkout Texera

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -47,7 +47,7 @@ jobs:
   #   - On PR events, wait for the Pull Request Labeler workflow to finish so
   #     the labels it applies (frontend, docs, dev, ...) are available, then
   #     gate run_* outputs on those labels.
-  #   - run_frontend / run_amber / run_platform / run_python /
+  #   - run_frontend / run_amber / run_platform / run_pyamber /
   #     run_agent_service: gate the main build stacks. Each labeler-applied
   #     label maps to the stacks it requires (LABEL_STACKS below); the run
   #     set is the union across all PR labels. Empty union (e.g. docs-only
@@ -63,7 +63,7 @@ jobs:
       run_amber: ${{ steps.decide.outputs.run_amber }}
       run_amber_integration: ${{ steps.decide.outputs.run_amber_integration }}
       run_platform: ${{ steps.decide.outputs.run_platform }}
-      run_python: ${{ steps.decide.outputs.run_python }}
+      run_pyamber: ${{ steps.decide.outputs.run_pyamber }}
       run_agent_service: ${{ steps.decide.outputs.run_agent_service }}
       backport_targets: ${{ steps.decide.outputs.backport_targets }}
     steps:
@@ -117,50 +117,50 @@ jobs:
             // labeler matches lives under a component dir and is already
             // covered by that component's label.
             //
-            //   label             | frontend | amber | amber-integ | platform | python | agent-service
-            //   ------------------|----------|-------|-------------|----------|--------|--------------
-            //   frontend          |    x     |       |             |          |        |
-            //   python            |          |       |      x      |          |   x    |
-            //   engine            |          |   x   |      x      |          |        |
-            //   amber-integration |          |       |      x      |          |        |
-            //   platform          |          |       |             |    x     |        |
-            //   agent-service     |          |       |             |          |        |     x
-            //   common            |          |   x   |      x      |    x     |        |  (root
-            //                                                                            scala
-            //                                                                            build/lint
-            //                                                                            config)
-            //   ddl-change        |          |   x   |      x      |    x     |        |
-            //   ci                |    x     |   x   |      x      |    x     |   x    |     x
-            //   docs / dev /      |          |       |             |          |        |
-            //   deps / release/   |          |       |             |          |        |
-            //   * / branch        |          |       |             |          |        |
+            //   label             | frontend | amber | amber-integ | platform | pyamber | agent-service
+            //   ------------------|----------|-------|-------------|----------|---------|--------------
+            //   frontend          |    x     |       |             |          |         |
+            //   pyamber           |          |       |      x      |          |    x    |
+            //   engine            |          |   x   |      x      |          |         |
+            //   amber-integration |          |       |      x      |          |         |
+            //   platform          |          |       |             |    x     |         |
+            //   agent-service     |          |       |             |          |         |     x
+            //   common            |          |   x   |      x      |    x     |         |  (root
+            //                                                                             scala
+            //                                                                             build/lint
+            //                                                                             config)
+            //   ddl-change        |          |   x   |      x      |    x     |         |
+            //   ci                |    x     |   x   |      x      |    x     |    x    |     x
+            //   docs / dev /      |          |       |             |          |         |
+            //   deps / release/   |          |       |             |          |         |
+            //   * / branch        |          |       |             |          |         |
             //
             // amber-integration runs the Scala tests tagged
             // @org.apache.texera.amber.tags.IntegrationTest (e2e specs that
-            // spawn Python UDF workers). The labeler attaches `python` to
+            // spawn Python UDF workers). The labeler attaches `pyamber` to
             // any *.py change (including amber/src/{main,test}/python/**),
-            // so `engine` does not need to fire the python stack itself —
-            // pure-Python amber changes pick up `python` directly. The
+            // so `engine` does not need to fire the pyamber stack itself —
+            // pure-Python amber changes pick up `pyamber` directly. The
             // `amber-integration` label catches *IntegrationSpec.scala
             // edits so a test-only change does not trigger the full
             // Scala-only amber stack.
             const LABEL_STACKS = {
               frontend: ["frontend"],
-              python: ["amber-integration", "python"],
+              pyamber: ["amber-integration", "pyamber"],
               engine: ["amber", "amber-integration"],
               "amber-integration": ["amber-integration"],
               platform: ["platform"],
               "agent-service": ["agent-service"],
               common: ["amber", "amber-integration", "platform"],
               "ddl-change": ["amber", "amber-integration", "platform"],
-              ci: ["frontend", "amber", "amber-integration", "platform", "python", "agent-service"],
+              ci: ["frontend", "amber", "amber-integration", "platform", "pyamber", "agent-service"],
             };
 
             let runFrontend = true;
             let runAmber = true;
             let runAmberIntegration = true;
             let runPlatform = true;
-            let runPython = true;
+            let runPyamber = true;
             let runAgentService = true;
 
             if (eventName === "pull_request") {
@@ -174,7 +174,7 @@ jobs:
               runAmber = stacks.has("amber");
               runAmberIntegration = stacks.has("amber-integration");
               runPlatform = stacks.has("platform");
-              runPython = stacks.has("python");
+              runPyamber = stacks.has("pyamber");
               runAgentService = stacks.has("agent-service");
               core.info(
                 `Stacks selected by label union: ${[...stacks].sort().join(", ") || "(none)"}`
@@ -185,7 +185,7 @@ jobs:
             core.setOutput("run_amber", runAmber ? "true" : "false");
             core.setOutput("run_amber_integration", runAmberIntegration ? "true" : "false");
             core.setOutput("run_platform", runPlatform ? "true" : "false");
-            core.setOutput("run_python", runPython ? "true" : "false");
+            core.setOutput("run_pyamber", runPyamber ? "true" : "false");
             core.setOutput("run_agent_service", runAgentService ? "true" : "false");
 
             // Backport targets: all current release/* labels on the PR.
@@ -240,7 +240,7 @@ jobs:
       run_amber: ${{ needs.precheck.outputs.run_amber == 'true' }}
       run_amber_integration: ${{ needs.precheck.outputs.run_amber_integration == 'true' }}
       run_platform: ${{ needs.precheck.outputs.run_platform == 'true' }}
-      run_python: ${{ needs.precheck.outputs.run_python == 'true' }}
+      run_pyamber: ${{ needs.precheck.outputs.run_pyamber == 'true' }}
       run_agent_service: ${{ needs.precheck.outputs.run_agent_service == 'true' }}
     secrets: inherit
 
@@ -261,7 +261,7 @@ jobs:
       run_amber: ${{ needs.precheck.outputs.run_amber == 'true' }}
       run_amber_integration: ${{ needs.precheck.outputs.run_amber_integration == 'true' }}
       run_platform: ${{ needs.precheck.outputs.run_platform == 'true' }}
-      run_python: ${{ needs.precheck.outputs.run_python == 'true' }}
+      run_pyamber: ${{ needs.precheck.outputs.run_pyamber == 'true' }}
       run_agent_service: ${{ needs.precheck.outputs.run_agent_service == 'true' }}
     secrets: inherit
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Codecov configuration for apache/texera. The repo uploads four flags
-# (frontend, scala, python, agent-service); without an explicit config,
+# (frontend, scala, pyamber, agent-service); without an explicit config,
 # defaults bite us in three places that this file fixes:
 #   1. Single-stack PRs leave non-uploaded flags as `?` in the comment
 #      and drop them from the rollup. Carry forward instead.
@@ -77,7 +77,7 @@ comment:
   # `flag_management.default_rules.carryforward: true` above already
   # backfills missing flags from main, but Codecov's default still
   # hides those rows from the PR comment. Show them so a frontend-only
-  # or python-only PR's table lists every flag — fresh-data rows track
+  # or pyamber-only PR's table lists every flag — fresh-data rows track
   # the patch and carryforward'd rows render with `<ø>` to make their
   # unchanged status obvious.
   show_carryforward_flags: true


### PR DESCRIPTION
### What changes were proposed in this PR?

Rename the Python worker CI identifier from `python` to `pyamber` so it matches the module name and no longer collides with the actual Python language used elsewhere in the same workflows (`actions/setup-python`, `matrix.python-version`, real `.py` paths, the `check_binary_deps.py python` CLI category). The rename touches the labeler entry, the `run_python` workflow input/output and its JS plumbing in `Precheck`, the GHA job key (and its `python-state-materialization-mac` companion), and the Codecov `flags:` argument.

**Pre-merge step:** `actions/labeler@v6` does not auto-create labels, so the `pyamber` label must be created on the repo before this is merged, otherwise the labeler will 404 when it tries to apply it. The old `python` label can be deleted afterwards.

### Any related issues, documentation, discussions?

Closes #5306.

### How was this PR tested?

Validated YAML parses for all four touched files; grep confirms no `python` stack/flag/input identifier remains.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)