### PR TITLE
refactor: Remove dead project routing

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -22,8 +22,6 @@ import { CanActivateFn, Router, RouterModule, Routes } from "@angular/router";
 import { DashboardComponent } from "./dashboard/component/dashboard.component";
 import { UserWorkflowComponent } from "./dashboard/component/user/user-workflow/user-workflow.component";
 import { UserQuotaComponent } from "./dashboard/component/user/user-quota/user-quota.component";
-import { UserProjectSectionComponent } from "./dashboard/component/user/user-project/user-project-section/user-project-section.component";
-import { UserProjectComponent } from "./dashboard/component/user/user-project/user-project.component";
 import { UserComputingUnitComponent } from "./dashboard/component/user/user-computing-unit/user-computing-unit.component";
 import { WorkspaceComponent } from "./workspace/component/workspace.component";
 import { AboutComponent } from "./hub/component/about/about.component";
@@ -103,14 +101,6 @@ routes.push({
       path: "user",
       canActivate: [AuthGuardService],
       children: [
-        {
-          path: "project",
-          component: UserProjectComponent,
-        },
-        {
-          path: "project/:pid",
-          component: UserProjectSectionComponent,
-        },
         {
           path: "workflow",
           component: UserWorkflowComponent,

--- a/frontend/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -49,7 +49,6 @@ import {
   DASHBOARD_HUB_DATASET_RESULT_DETAIL,
   DASHBOARD_HUB_WORKFLOW_RESULT_DETAIL,
   DASHBOARD_USER_DATASET,
-  DASHBOARD_USER_PROJECT,
   DASHBOARD_USER_WORKSPACE,
 } from "../../../../app-routing.constant";
 import { isDefined } from "../../../../common/util/predicate";
@@ -152,9 +151,6 @@ export class ListItemComponent implements OnChanges {
         this.size = this.entry.size;
       }
       this.iconType = "project";
-    } else if (this.entry.type === "project") {
-      this.entryLink = [DASHBOARD_USER_PROJECT, String(this.entry.id)];
-      this.iconType = "container";
     } else if (this.entry.type === "dataset") {
       if (typeof this.entry.id === "number") {
         this.disableDelete = !this.entry.dataset.isOwner;


### PR DESCRIPTION
### What changes were proposed in this PR?
- Removed the `project` and `project/:pid` route definitions from `app-routing.module.ts`, along with the now-unused `UserProjectComponent` and `UserProjectSectionComponent` imports there.
- Removed the `type === "project"` arm from `ListItemComponent.initializeEntry` and dropped its now-unused `DASHBOARD_USER_PROJECT` import.
### Any related issues, documentation, or discussions?
Closes: #5172
### How was this PR tested?
- Ran `yarn format:fix` (clean, 514 files unchanged).
- Verified via grep that no project route or `DASHBOARD_USER_PROJECT` references remain in the two edited files.
- The referenced `list-item.component.spec.ts` project routing test case was already absent, so no spec change was needed.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.7 in compliance with ASF
