### PR TITLE
feat: add card view to the private dataset listing

### DIFF
--- a/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.html
+++ b/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.html
@@ -23,11 +23,28 @@
   [nzCover]="coverTpl"
   [routerLink]="entryLink">
   <div class="dataset-card-body-link">
-    <span
-      class="card-title"
-      [title]="entry.name">
-      {{ entry.name }}
-    </span>
+    <div class="card-title-row">
+      <span
+        class="card-title"
+        [title]="entry.name">
+        {{ entry.name }}
+      </span>
+      <button
+        *ngIf="showActions"
+        type="button"
+        class="more-btn"
+        nz-dropdown
+        nzTrigger="click"
+        nzPlacement="bottomRight"
+        [nzDropdownMenu]="actionMenu"
+        (click)="$event.stopPropagation(); $event.preventDefault()"
+        nz-tooltip="More actions">
+        <i
+          nz-icon
+          nzType="more"
+          nzTheme="outline"></i>
+      </button>
+    </div>
 
     <div class="card-meta">
       <div class="meta-line meta-line--owner">
@@ -99,3 +116,36 @@
     <span class="cover-id-badge">#{{ entry.id }}</span>
   </div>
 </ng-template>
+
+<nz-dropdown-menu #actionMenu="nzDropdownMenu">
+  <ul nz-menu>
+    <li
+      nz-menu-item
+      (click)="onClickOpenShareAccess()">
+      <i
+        nz-icon
+        nzType="share-alt"
+        class="action-menu-icon"></i>
+      Share
+    </li>
+    <li
+      nz-menu-item
+      (click)="onClickDownload()">
+      <i
+        nz-icon
+        nzType="cloud-download"
+        class="action-menu-icon"></i>
+      Download
+    </li>
+    <li
+      nz-menu-item
+      [nzDisabled]="disableDelete"
+      (click)="onClickDelete()">
+      <i
+        nz-icon
+        nzType="delete"
+        class="action-menu-icon"></i>
+      Delete
+    </li>
+  </ul>
+</nz-dropdown-menu>

--- a/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.scss
@@ -60,10 +60,46 @@
   }
 }
 
+.action-menu-icon {
+  margin-right: 10px;
+}
+
+.card-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  margin-bottom: 10px;
+
+  .more-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    padding: 0;
+    border: none;
+    border-radius: 4px;
+    background: transparent;
+    color: #8c8c8c;
+    cursor: pointer;
+
+    i {
+      font-size: 18px;
+    }
+
+    &:hover {
+      background: #f0f0f0;
+      color: #1f1f1f;
+    }
+  }
+}
+
 .card-title {
+  flex: 1;
   display: -webkit-box;
   height: calc(15px * 1.35 * 2);
-  margin-bottom: 10px;
+  min-width: 0;
   font-size: 15px;
   font-weight: 600;
   line-height: 1.35;

--- a/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.spec.ts
@@ -26,7 +26,9 @@ import type { Mocked } from "vitest";
 
 import { DatasetCardItemComponent } from "./dataset-card-item.component";
 import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
+import { NzModalService } from "ng-zorro-antd/modal";
 import { DatasetService } from "../../../service/user/dataset/dataset.service";
+import { DownloadService } from "../../../service/user/download/download.service";
 import { HubService } from "../../../../hub/service/hub.service";
 import { UserService } from "../../../../common/service/user/user.service";
 import { StubUserService } from "../../../../common/service/user/stub-user.service";
@@ -37,10 +39,13 @@ function makeDatasetEntry(overrides: Partial<any> = {}): DashboardEntry {
   return {
     type: "dataset",
     id: 42,
+    name: "ds",
+    accessLevel: "WRITE",
     accessibleUserIds: [1, 2],
     coverImageUrl: undefined,
     likeCount: 5,
     isLiked: false,
+    dataset: { isOwner: true },
     ...overrides,
   } as unknown as DashboardEntry;
 }
@@ -49,6 +54,8 @@ describe("DatasetCardItemComponent", () => {
   let component: DatasetCardItemComponent;
   let fixture: ComponentFixture<DatasetCardItemComponent>;
   let hubService: Mocked<HubService>;
+  let downloadService: Mocked<DownloadService>;
+  let modalService: Mocked<NzModalService>;
 
   beforeEach(async () => {
     const hubServiceSpy = {
@@ -62,6 +69,18 @@ describe("DatasetCardItemComponent", () => {
           provide: DatasetService,
           useValue: {
             getDatasetCoverUrl: vi.fn().mockReturnValue(of({ url: "https://s3.example/presigned" })),
+            retrieveOwners: vi.fn().mockReturnValue(of(["owner@example.com"])),
+          },
+        },
+        {
+          provide: DownloadService,
+          useValue: { downloadDataset: vi.fn().mockReturnValue(of(new Blob())) },
+        },
+        {
+          provide: NzModalService,
+          useValue: {
+            create: vi.fn().mockReturnValue({ componentInstance: { refresh: of() } }),
+            confirm: vi.fn(),
           },
         },
         { provide: HubService, useValue: hubServiceSpy },
@@ -73,6 +92,8 @@ describe("DatasetCardItemComponent", () => {
     fixture = TestBed.createComponent(DatasetCardItemComponent);
     component = fixture.componentInstance;
     hubService = TestBed.inject(HubService) as unknown as Mocked<HubService>;
+    downloadService = TestBed.inject(DownloadService) as unknown as Mocked<DownloadService>;
+    modalService = TestBed.inject(NzModalService) as unknown as Mocked<NzModalService>;
   });
 
   describe("entryLink", () => {
@@ -153,6 +174,64 @@ describe("DatasetCardItemComponent", () => {
       expect(hubService.toggleLike).toHaveBeenCalledWith(42, "dataset", true);
       expect(component.isLiked).toBe(false);
       expect(component.likeCount).toBe(6);
+    });
+  });
+
+  describe("actions menu", () => {
+    beforeEach(() => {
+      component.entry = makeDatasetEntry();
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+    });
+
+    it("disableDelete mirrors dataset ownership", () => {
+      component.entry = makeDatasetEntry({ dataset: { isOwner: false } });
+      component.ngOnChanges({ entry: { currentValue: component.entry } } as any);
+      expect(component.disableDelete).toBe(true);
+    });
+
+    it("onClickDownload downloads the dataset by id and name", () => {
+      component.onClickDownload();
+      expect(downloadService.downloadDataset).toHaveBeenCalledWith(42, "ds");
+    });
+
+    it("onClickOpenShareAccess opens the share modal for the dataset", async () => {
+      await component.onClickOpenShareAccess();
+      expect(modalService.create).toHaveBeenCalledTimes(1);
+      const cfg = modalService.create.mock.calls[0][0] as any;
+      expect(cfg.nzData).toMatchObject({ type: "dataset", id: 42, writeAccess: true });
+    });
+
+    it("onClickDelete asks for confirmation and emits deleted on confirm", () => {
+      modalService.confirm.mockImplementation((cfg: any) => {
+        cfg.nzOnOk();
+        return {} as any;
+      });
+      const deletedSpy = vi.fn();
+      component.deleted.subscribe(deletedSpy);
+      component.onClickDelete();
+      expect(modalService.confirm).toHaveBeenCalledTimes(1);
+      expect(deletedSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it("onClickDelete is a no-op when delete is disabled", () => {
+      component.disableDelete = true;
+      component.onClickDelete();
+      expect(modalService.confirm).not.toHaveBeenCalled();
+    });
+
+    it("renders the more-btn trigger in the title row when showActions is true", () => {
+      component.showActions = true;
+      component.entry = makeDatasetEntry();
+      fixture.detectChanges();
+      const trigger = fixture.nativeElement.querySelector(".card-title-row .more-btn");
+      expect(trigger).toBeTruthy();
+    });
+
+    it("does not render the more-btn trigger when showActions is false", () => {
+      component.showActions = false;
+      component.entry = makeDatasetEntry();
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector(".more-btn")).toBeNull();
     });
   });
 });

--- a/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/dataset-card-item/dataset-card-item.component.ts
@@ -17,14 +17,30 @@
  * under the License.
  */
 
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges } from "@angular/core";
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+} from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { NgIf } from "@angular/common";
 import { RouterLink } from "@angular/router";
+import { firstValueFrom } from "rxjs";
 import { NzCardComponent } from "ng-zorro-antd/card";
 import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
+import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
+import { NzModalService } from "ng-zorro-antd/modal";
 import { DashboardEntry } from "../../../type/dashboard-entry";
 import { UserAvatarComponent } from "../user-avatar/user-avatar.component";
+import { ShareAccessComponent } from "../share-access/share-access.component";
 import { DatasetService } from "../../../service/user/dataset/dataset.service";
+import { DownloadService } from "../../../service/user/download/download.service";
 import { HubService } from "../../../../hub/service/hub.service";
 import { formatSize } from "../../../../common/util/size-formatter.util";
 import { formatCount, formatRelativeTime } from "../../../../common/util/format.util";
@@ -37,11 +53,26 @@ import { HUB_DATASET_RESULT_DETAIL, USER_DATASET } from "../../../../app-routing
   templateUrl: "./dataset-card-item.component.html",
   styleUrls: ["./dataset-card-item.component.scss"],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [RouterLink, NzCardComponent, NzIconDirective, UserAvatarComponent],
+  imports: [
+    NgIf,
+    RouterLink,
+    NzCardComponent,
+    NzIconDirective,
+    NzDropdownDirective,
+    NzDropdownMenuComponent,
+    NzMenuDirective,
+    NzMenuItemComponent,
+    UserAvatarComponent,
+  ],
 })
 export class DatasetCardItemComponent implements OnChanges {
   @Input() currentUid: number | undefined;
   @Input() entry!: DashboardEntry;
+  /** When true, render the management actions menu (share / download / delete). */
+  @Input() showActions = false;
+
+  @Output() deleted = new EventEmitter<void>();
+  @Output() refresh = new EventEmitter<void>();
 
   entryLink: string[] = [];
   coverImageSrc: string = "";
@@ -49,10 +80,13 @@ export class DatasetCardItemComponent implements OnChanges {
   likeCount = 0;
   viewCount = 0;
   isLiked = false;
+  disableDelete = false;
 
   constructor(
     private datasetService: DatasetService,
+    private downloadService: DownloadService,
     private hubService: HubService,
+    private modalService: NzModalService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -78,6 +112,7 @@ export class DatasetCardItemComponent implements OnChanges {
     } else {
       this.entryLink = [HUB_DATASET_RESULT_DETAIL, String(did)];
     }
+    this.disableDelete = !this.entry.dataset.isOwner;
 
     this.coverImageSrc = this.defaultCover;
     if (this.entry.coverImageUrl) {
@@ -126,6 +161,39 @@ export class DatasetCardItemComponent implements OnChanges {
           this.cdr.markForCheck();
         },
       });
+  }
+
+  async onClickOpenShareAccess(): Promise<void> {
+    if (this.entry.type !== "dataset") return;
+    const modal = this.modalService.create({
+      nzContent: ShareAccessComponent,
+      nzData: {
+        writeAccess: this.entry.accessLevel === "WRITE",
+        type: "dataset",
+        id: this.entry.id,
+        allOwners: await firstValueFrom(this.datasetService.retrieveOwners()),
+      },
+      nzFooter: null,
+      nzTitle: "Share this dataset with others",
+      nzCentered: true,
+      nzWidth: "700px",
+    });
+    modal.componentInstance?.refresh.pipe(untilDestroyed(this)).subscribe(() => this.refresh.emit());
+  }
+
+  onClickDownload(): void {
+    if (!isDefined(this.entry.id)) return;
+    this.downloadService.downloadDataset(this.entry.id, this.entry.name).pipe(untilDestroyed(this)).subscribe();
+  }
+
+  onClickDelete(): void {
+    if (this.disableDelete) return;
+    this.modalService.confirm({
+      nzTitle: "Confirm to delete this dataset.",
+      nzOkText: "Delete",
+      nzOkDanger: true,
+      nzOnOk: () => this.deleted.emit(),
+    });
   }
 
   formatSize = formatSize;

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.html
@@ -33,6 +33,30 @@
         <span>Create Dataset</span>
       </button>
       <texera-filters #filters></texera-filters>
+      <div class="view-toggle">
+        <button
+          nz-button
+          nzType="text"
+          [class.active]="viewMode === 'list'"
+          (click)="setViewMode('list')"
+          nz-tooltip="List view">
+          <i
+            nz-icon
+            nzType="bars"
+            nzTheme="outline"></i>
+        </button>
+        <button
+          nz-button
+          nzType="text"
+          [class.active]="viewMode === 'card'"
+          (click)="setViewMode('card')"
+          nz-tooltip="Card view">
+          <i
+            nz-icon
+            nzType="table"
+            nzTheme="outline"></i>
+        </button>
+      </div>
     </div>
   </nz-card>
 
@@ -52,10 +76,24 @@
     </nz-select>
   </div>
 
+  <ng-template
+    #datasetCardTpl
+    let-entry>
+    <texera-dataset-card-item
+      [entry]="entry"
+      [currentUid]="currentUid"
+      [showActions]="true"
+      (deleted)="deleteDataset(entry)"
+      (refresh)="ngAfterViewInit()">
+    </texera-dataset-card-item>
+  </ng-template>
+
   <texera-search-results
     [editable]="true"
     [isPrivateSearch]="true"
     (deleted)="deleteDataset($event)"
     (refresh)="ngAfterViewInit()"
-    [currentUid]="currentUid"></texera-search-results>
+    [currentUid]="currentUid"
+    [viewMode]="viewMode"
+    [cardTemplate]="datasetCardTpl"></texera-search-results>
 </div>

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
@@ -25,3 +25,30 @@
   height: 55px;
   overflow-y: hidden;
 }
+
+.view-toggle {
+  display: inline-flex;
+  background: #f5f5f5;
+  border-radius: 6px;
+  padding: 2px;
+
+  button {
+    height: 28px;
+    padding: 0 10px;
+    border: none;
+    background: transparent;
+    color: #8c8c8c;
+    border-radius: 4px;
+
+    &:hover {
+      color: #595959;
+      background: rgba(255, 255, 255, 0.6);
+    }
+
+    &.active {
+      background: #fff;
+      color: #1f1f1f;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.spec.ts
@@ -130,6 +130,25 @@ describe("UserDatasetComponent", () => {
     });
   });
 
+  describe("view mode", () => {
+    const STORAGE_KEY = "texera.user.dataset.viewMode";
+
+    afterEach(() => localStorage.removeItem(STORAGE_KEY));
+
+    it("setViewMode switches to card and persists it", () => {
+      component.setViewMode("card");
+      expect(component.viewMode).toBe("card");
+      expect(localStorage.getItem(STORAGE_KEY)).toBe("card");
+    });
+
+    it("setViewMode switches back to list and persists it", () => {
+      component.setViewMode("card");
+      component.setViewMode("list");
+      expect(component.viewMode).toBe("list");
+      expect(localStorage.getItem(STORAGE_KEY)).toBe("list");
+    });
+  });
+
   describe("ngAfterViewInit", () => {
     it("subscribes to userChanged and calls search on each emission", () => {
       const searchSpy = vi.spyOn(component, "search").mockResolvedValue();

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -25,7 +25,8 @@ import { SearchService } from "../../../service/user/search.service";
 import { DatasetService } from "../../../service/user/dataset/dataset.service";
 import { SortMethod } from "../../../type/sort-method";
 import { DashboardEntry } from "../../../type/dashboard-entry";
-import { SearchResultsComponent } from "../search-results/search-results.component";
+import { SearchResultsComponent, SearchResultsViewMode } from "../search-results/search-results.component";
+import { DatasetCardItemComponent } from "../dataset-card-item/dataset-card-item.component";
 import { FiltersComponent } from "../filters/filters.component";
 import { firstValueFrom } from "rxjs";
 import { USER_DATASET } from "../../../../app-routing.constant";
@@ -40,9 +41,12 @@ import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzTooltipModule } from "ng-zorro-antd/tooltip";
 import { FiltersInstructionsComponent } from "../filters-instructions/filters-instructions.component";
 import { NzSelectComponent } from "ng-zorro-antd/select";
 import { FormsModule } from "@angular/forms";
+
+const USER_DATASET_VIEW_MODE_STORAGE_KEY = "texera.user.dataset.viewMode";
 
 @UntilDestroy()
 @Component({
@@ -59,14 +63,25 @@ import { FormsModule } from "@angular/forms";
     FiltersComponent,
     FiltersInstructionsComponent,
     NzSelectComponent,
+    NzTooltipModule,
     FormsModule,
     SearchResultsComponent,
+    DatasetCardItemComponent,
   ],
 })
 export class UserDatasetComponent implements AfterViewInit {
   public sortMethod = SortMethod.EditTimeDesc;
   lastSortMethod: SortMethod | null = null;
   public isLogin = this.userService.isLogin();
+  public viewMode: SearchResultsViewMode =
+    localStorage.getItem(USER_DATASET_VIEW_MODE_STORAGE_KEY) === "card" ? "card" : "list";
+
+  setViewMode(mode: SearchResultsViewMode): void {
+    if (this.viewMode === mode) return;
+    this.viewMode = mode;
+    localStorage.setItem(USER_DATASET_VIEW_MODE_STORAGE_KEY, mode);
+  }
+
   public currentUid = this.userService.getCurrentUser()?.uid;
   public hasMismatch = false; // Display warning when there are mismatched datasets
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
This PR adds the card view to the user's private dataset listing (/dashboard/user/dataset), with a toggle to switch between the existing list view and the card view. It is the follow-up to the public dataset card view and reuses the same framework.

Changes:
- List/card toggle on the personal dataset listing. A bars/grid toggle next to the filters switches SearchResultsComponent between list and card mode. The selected mode persists per-user via localStorage (key texera.user.dataset.viewMode).
- Reused DatasetCardItemComponent through the existing cardTemplate projection on SearchResultsComponent, so the personal listing and the public hub share one card component.
- Added a management actions menu (⋮) to the dataset card, mirroring what the list view already exposes for datasets: Share, Download, and Delete (Delete is disabled for non-owners and asks for confirmation). The menu is gated behind a new `showActions` input, so it renders only on the private listing and not on the public hub.
- Added showActions input and deleted/refresh outputs to DatasetCardItemComponent to wire the actions back to UserDatasetComponent.

Demo:
<img width="1479" height="518" alt="card-view" src="https://github.com/user-attachments/assets/05097ad3-22d2-4400-836e-17c36b7461bd" />

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Closes #5312 

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
Added test cases and manually tested.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Opus 4.8