### PR TITLE
fix(pyamber): prevent indefinite worker shutdown hang

### DIFF
--- a/amber/src/main/python/core/models/internal_queue.py
+++ b/amber/src/main/python/core/models/internal_queue.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from threading import RLock
-from typing import TypeVar, Set
+from typing import Optional, TypeVar, Set
 
 from core.models.internal_marker import InternalMarker
 from core.models.payload import DataPayload
@@ -71,8 +71,8 @@ class InternalQueue(IQueue):
     def is_empty(self, key=None) -> bool:
         return self._queue.is_empty(key)
 
-    def get(self) -> T:
-        return self._queue.get()
+    def get(self, timeout: Optional[float] = None) -> T:
+        return self._queue.get(timeout)
 
     def put(self, item: T) -> None:
         if isinstance(item, InternalQueueElement):

--- a/amber/src/main/python/core/util/base_protocols.py
+++ b/amber/src/main/python/core/util/base_protocols.py
@@ -37,7 +37,7 @@ class KeyedPutable(Protocol):
 
 class Getable(Protocol):
     @abstractmethod
-    def get(self) -> T:
+    def get(self, timeout: Optional[float] = None) -> T:
         pass
 
 

--- a/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
+++ b/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import sys
+from queue import Empty
 from threading import RLock, Condition
 from typing import List, Optional, Generic, TypeVar, MutableMapping
 
@@ -296,19 +297,26 @@ class LinkedBlockingMultiQueue(IKeyedQueue):
         """
         self.get_sub_queue(key).put(item)
 
-    def get(self) -> T:
+    def get(self, timeout: Optional[float] = None) -> T:
         """
         Blocking get the next available item from the queue.
         - Disabled SubQueues are considered empty and will not be fetched.
         - When multiple SubQueues are enabled and have items, it selects the SubQueue
         by the order specified by the self.sub_queue_selection strategy.
 
+        :param timeout: optional seconds to block for; when given and no item
+            becomes available in time, raises queue.Empty. None blocks forever.
         :return: T, Any item that is available to the fetched.
         """
         self.take_lock.acquire()
         try:
-            while self.total_count.value == 0:
-                self.not_empty.wait()
+            if timeout is None:
+                while self.total_count.value == 0:
+                    self.not_empty.wait()
+            elif not self.not_empty.wait_for(
+                lambda: self.total_count.value > 0, timeout
+            ):
+                raise Empty
 
             # at this point we know there is an element
             sub_queue = self.sub_queue_selection.get_next()

--- a/amber/src/main/python/core/util/stoppable/stoppable_queue_blocking_thread.py
+++ b/amber/src/main/python/core/util/stoppable/stoppable_queue_blocking_thread.py
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from queue import Empty
+from threading import Event
+
 from loguru import logger
 from overrides import overrides
 
@@ -51,10 +54,13 @@ class StoppableQueueBlockingRunnable(Runnable, Stoppable):
     """
 
     RUNNABLE_STOP = QueueControl(msg="__RUNNABLE__STOP__MARKER__")
+    # seconds to block on each get before re-checking the stop flag
+    STOP_POLL_INTERVAL = 1.0
 
     def __init__(self, name: str, queue: IQueue):
         self._internal_queue = queue
         self.name = name
+        self._stopped = Event()
 
     @logger.catch(reraise=True)
     @overrides
@@ -84,13 +90,23 @@ class StoppableQueueBlockingRunnable(Runnable, Stoppable):
     @logger.catch(reraise=True)
     @overrides
     def stop(self):
+        self._stopped.set()
         self._internal_queue.put(StoppableQueueBlockingRunnable.RUNNABLE_STOP)
 
     def interruptible_get(self):
-        next_entry = self._internal_queue.get()
-        if next_entry == StoppableQueueBlockingRunnable.RUNNABLE_STOP:
-            raise StoppableQueueBlockingRunnable.InterruptRunnable
-        return next_entry
+        # Poll with a timeout so a missed RUNNABLE_STOP marker cannot park the
+        # thread forever; re-check the stop flag on every wakeup.
+        while not self._stopped.is_set():
+            try:
+                next_entry = self._internal_queue.get(
+                    timeout=StoppableQueueBlockingRunnable.STOP_POLL_INTERVAL
+                )
+            except Empty:
+                continue
+            if next_entry == StoppableQueueBlockingRunnable.RUNNABLE_STOP:
+                raise StoppableQueueBlockingRunnable.InterruptRunnable
+            return next_entry
+        raise StoppableQueueBlockingRunnable.InterruptRunnable
 
     class InterruptRunnable(Exception):
         """

--- a/amber/src/test/python/core/models/test_internal_queue.py
+++ b/amber/src/test/python/core/models/test_internal_queue.py
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+from queue import Empty
+from threading import Thread
+
+import pytest
+
+from core.models.internal_queue import InternalQueue
+
+
+class TestInternalQueueGetTimeout:
+    """Covers the optional `timeout` plumbed through InternalQueue.get."""
+
+    @pytest.mark.timeout(2)
+    def test_get_with_timeout_raises_empty_when_no_item(self):
+        queue = InternalQueue()
+        with pytest.raises(Empty):
+            queue.get(timeout=0.05)
+
+    @pytest.mark.timeout(2)
+    def test_get_with_timeout_returns_available_item(self):
+        queue = InternalQueue()
+        queue.put("system-item")
+        assert queue.get(timeout=0.05) == "system-item"
+
+    @pytest.mark.timeout(2)
+    def test_get_with_timeout_returns_item_arriving_during_wait(self, reraise):
+        queue = InternalQueue()
+
+        def producer():
+            with reraise:
+                time.sleep(0.1)
+                queue.put("late")
+
+        producer_thread = Thread(target=producer)
+        producer_thread.start()
+        assert queue.get(timeout=2) == "late"
+        producer_thread.join()
+        reraise()
+
+    @pytest.mark.timeout(2)
+    def test_get_without_timeout_still_blocks_until_item(self, reraise):
+        # Default timeout=None must preserve the original blocking behavior.
+        queue = InternalQueue()
+
+        def producer():
+            with reraise:
+                time.sleep(0.1)
+                queue.put("blocking")
+
+        producer_thread = Thread(target=producer)
+        producer_thread.start()
+        assert queue.get() == "blocking"
+        producer_thread.join()
+        reraise()

--- a/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
+++ b/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
@@ -18,6 +18,7 @@
 import pytest
 import random
 import time
+from queue import Empty
 from threading import Thread
 
 from core.util.customized_queue.linked_blocking_multi_queue import (
@@ -97,6 +98,29 @@ class TestLinkedBlockingMultiQueue:
 
         assert res == [1, 99, 3]
         assert queue.is_empty()
+
+    @pytest.mark.timeout(2)
+    def test_get_with_timeout_raises_empty_when_no_item(self, queue):
+        with pytest.raises(Empty):
+            queue.get(timeout=0.05)
+
+    @pytest.mark.timeout(2)
+    def test_get_with_timeout_returns_available_item(self, queue):
+        queue.put("data", 1)
+        assert queue.get(timeout=0.05) == 1
+
+    @pytest.mark.timeout(2)
+    def test_get_with_timeout_returns_item_arriving_during_wait(self, queue, reraise):
+        def producer():
+            with reraise:
+                time.sleep(0.1)
+                queue.put("data", 7)
+
+        producer_thread = Thread(target=producer)
+        producer_thread.start()
+        assert queue.get(timeout=2) == 7
+        producer_thread.join()
+        reraise()
 
     @pytest.mark.timeout(2)
     def test_producer_first_insert_sub(self, queue, reraise):

--- a/amber/src/test/python/core/util/stoppable/test_stoppable_queue_blocking_thread.py
+++ b/amber/src/test/python/core/util/stoppable/test_stoppable_queue_blocking_thread.py
@@ -21,9 +21,12 @@ from threading import Thread
 
 import pytest
 
+from core.models.internal_queue import InternalQueue
 from core.util.stoppable.stoppable_queue_blocking_thread import (
     StoppableQueueBlockingRunnable,
 )
+
+RUNNABLE_STOP = StoppableQueueBlockingRunnable.RUNNABLE_STOP
 
 
 class _Recorder(StoppableQueueBlockingRunnable):
@@ -32,9 +35,17 @@ class _Recorder(StoppableQueueBlockingRunnable):
     def __init__(self, queue):
         super().__init__(name="recorder", queue=queue)
         self.received = []
+        self.pre_start_calls = 0
+        self.post_stop_calls = 0
 
     def receive(self, next_entry):
         self.received.append(next_entry)
+
+    def pre_start(self):
+        self.pre_start_calls += 1
+
+    def post_stop(self):
+        self.post_stop_calls += 1
 
 
 def _wait_until(predicate, timeout=2.0):
@@ -80,3 +91,88 @@ class TestStoppableQueueBlockingRunnable:
         runnable._stopped.set()
         thread.join(timeout=3)
         assert not thread.is_alive()
+
+    # ---- interruptible_get() unit-level behavior ----
+
+    def test_interruptible_get_returns_a_normal_entry(self):
+        queue = Queue()
+        runnable = _Recorder(queue)
+        queue.put("x")
+        assert runnable.interruptible_get() == "x"
+
+    def test_interruptible_get_raises_on_stop_marker(self):
+        # A consumed RUNNABLE_STOP marker breaks the loop even when the stop
+        # flag was never set (e.g. an out-of-band marker enqueued directly).
+        queue = Queue()
+        runnable = _Recorder(queue)
+        queue.put(RUNNABLE_STOP)
+        with pytest.raises(StoppableQueueBlockingRunnable.InterruptRunnable):
+            runnable.interruptible_get()
+
+    def test_interruptible_get_raises_immediately_when_stop_flag_set(self):
+        # When the flag is already set the loop body never runs, so the queue is
+        # never consulted and the pending item is left untouched.
+        queue = Queue()
+        runnable = _Recorder(queue)
+        queue.put("untouched")
+        runnable._stopped.set()
+        with pytest.raises(StoppableQueueBlockingRunnable.InterruptRunnable):
+            runnable.interruptible_get()
+        assert queue.get_nowait() == "untouched"
+
+    @pytest.mark.timeout(5)
+    def test_interruptible_get_retries_after_empty_timeout(self, reraise):
+        # An item arriving after at least one Empty timeout is still returned,
+        # exercising the `except Empty: continue` recheck branch.
+        queue = Queue()
+        runnable = _Recorder(queue)
+
+        def producer():
+            with reraise:
+                time.sleep(StoppableQueueBlockingRunnable.STOP_POLL_INTERVAL * 2)
+                queue.put("late")
+
+        producer_thread = Thread(target=producer)
+        producer_thread.start()
+        assert runnable.interruptible_get() == "late"
+        producer_thread.join()
+        reraise()
+
+    # ---- stop() and lifecycle hooks ----
+
+    def test_stop_sets_flag_and_enqueues_marker(self):
+        queue = Queue()
+        runnable = _Recorder(queue)
+        runnable.stop()
+        assert runnable._stopped.is_set()
+        assert queue.get_nowait() == RUNNABLE_STOP
+
+    @pytest.mark.timeout(5)
+    def test_lifecycle_hooks_called_once_around_run(self):
+        queue = Queue()
+        runnable = _Recorder(queue)
+        thread = Thread(target=runnable.run, daemon=True)
+        thread.start()
+
+        runnable.stop()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+        assert runnable.pre_start_calls == 1
+        assert runnable.post_stop_calls == 1
+
+    @pytest.mark.timeout(5)
+    def test_stop_unblocks_thread_waiting_on_empty_internal_queue(self):
+        # End-to-end against the real InternalQueue -> LinkedBlockingMultiQueue
+        # plumbing: a thread parked on an empty queue is released by stop().
+        queue = InternalQueue()
+        runnable = _Recorder(queue)
+        thread = Thread(target=runnable.run, daemon=True)
+        thread.start()
+
+        queue.put("hello")
+        assert _wait_until(lambda: runnable.received == ["hello"])
+
+        runnable.stop()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+        assert runnable.post_stop_calls == 1

--- a/amber/src/test/python/core/util/stoppable/test_stoppable_queue_blocking_thread.py
+++ b/amber/src/test/python/core/util/stoppable/test_stoppable_queue_blocking_thread.py
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+from queue import Queue
+from threading import Thread
+
+import pytest
+
+from core.util.stoppable.stoppable_queue_blocking_thread import (
+    StoppableQueueBlockingRunnable,
+)
+
+
+class _Recorder(StoppableQueueBlockingRunnable):
+    """Minimal concrete runnable that records what it receives."""
+
+    def __init__(self, queue):
+        super().__init__(name="recorder", queue=queue)
+        self.received = []
+
+    def receive(self, next_entry):
+        self.received.append(next_entry)
+
+
+def _wait_until(predicate, timeout=2.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return predicate()
+
+
+class TestStoppableQueueBlockingRunnable:
+    @pytest.fixture(autouse=True)
+    def fast_poll(self, monkeypatch):
+        # keep the stop-flag recheck snappy so tests don't wait a full second
+        monkeypatch.setattr(StoppableQueueBlockingRunnable, "STOP_POLL_INTERVAL", 0.05)
+
+    @pytest.mark.timeout(5)
+    def test_delivers_items_then_stops_via_marker(self):
+        queue = Queue()
+        runnable = _Recorder(queue)
+        thread = Thread(target=runnable.run, daemon=True)
+        thread.start()
+
+        queue.put("a")
+        queue.put("b")
+        assert _wait_until(lambda: runnable.received == ["a", "b"])
+
+        runnable.stop()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+        assert runnable.received == ["a", "b"]
+
+    @pytest.mark.timeout(5)
+    def test_stop_flag_alone_terminates_run_without_marker(self):
+        # Setting only the flag (no RUNNABLE_STOP marker enqueued) must still end
+        # run(): the timeout recheck is what guards against an indefinite hang.
+        queue = Queue()
+        runnable = _Recorder(queue)
+        thread = Thread(target=runnable.run, daemon=True)
+        thread.start()
+
+        runnable._stopped.set()
+        thread.join(timeout=3)
+        assert not thread.is_alive()


### PR DESCRIPTION
### What changes were proposed in this PR?
Hardens the shutdown path of the three `StoppableQueueBlockingRunnable` threads (`MainLoop`, `NetworkSender`, `PortStorageWriter`) so a stop request no longer depends solely on a single queue wakeup.

- Add a `threading.Event` stop flag to `StoppableQueueBlockingRunnable`. `stop()` now sets the flag **and** enqueues the existing `RUNNABLE_STOP` marker. `interruptible_get` blocks on `get(timeout=STOP_POLL_INTERVAL)` and treats a `queue.Empty` timeout as a cue to re-check the flag and exit.
- Plumb an optional `timeout` through `Getable.get`, `InternalQueue.get`, and `LinkedBlockingMultiQueue.get` (via `Condition.wait_for`). The default `timeout=None` preserves the existing blocking behavior exactly, so the tuple data path is untouched and only the stoppable threads opt into polling.

### Why?
This is defensive hardening, not a fix for a currently-reproducible hang. As the code stands today, `stop()` always sets the flag and enqueues the marker through correctly-locked queues, so the wakeup is reliably delivered and no thread parks indefinitely. The value of the change is to decouple "stop was requested" (the flag, checked on a timer) from "the queue delivered the marker" (the notify), so that a future refactor (a new stop path that forgets the marker, or a change to the queue's notify logic) cannot silently reintroduce a shutdown hang.

### Performance
- Data/tuple path: no change (`timeout=None` everywhere except the stop threads).
- Shutdown latency: unchanged. The marker still wakes the thread immediately; the timeout is a fallback not hit in normal operation.
- Idle cost: each stop-eligible thread wakes once per `STOP_POLL_INTERVAL` (1s) to re-check the flag instead of sleeping indefinitely, a no-op wakeup with negligible CPU cost. The interval can be raised if needed.

### Any related issues, documentation, or discussions?
Closes: #5325

### How was this PR tested?
- `test_stoppable_queue_blocking_thread.py`: items reach `receive()` and `stop()` ends `run()`; and setting only the stop flag (no marker) still terminates `run()`, exercising the timeout recheck path. This last case injects a state the production code does not currently produce, verifying the safety-net mechanism directly.
- Added 3 timeout cases to `test_linked_blocking_multi_queue.py` (raises `Empty` on expiry, returns an available item, returns an item arriving mid-wait); the file is 17 passing tests.

### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.7 in compliance with ASF

