### PR TITLE
chore(asf): remove non-public team from bypass and grant v1.2 release manager

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -115,7 +115,8 @@ github:
         excludes: []
       bypass_teams:
         - "root"
-        - "texera-committers"
+      bypass_users:
+        - "xuang7"
       restrict_deletion: true
       restrict_force_push: true
 notifications:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -115,7 +115,9 @@ github:
         excludes: []
       bypass_teams:
         - "root"
-      bypass_users:
+        # Individual user (xuang7, v1.2 release manager) — listed here per INFRA
+        # guidance even though the open-source asfyaml parser only documents team
+        # slugs.
         - "xuang7"
       restrict_deletion: true
       restrict_force_push: true


### PR DESCRIPTION
### What changes were proposed in this PR?

Drop `texera-committers` from the `Default Branch Protection` ruleset's `bypass_teams` list — [INFRA-27977](https://issues.apache.org/jira/browse/INFRA-27977) flagged it as not a public team. Add `xuang7` (Xuan Gu, v1.2 release manager) to the same list per INFRA's suggestion to put individual GitHub users directly in `bypass_teams`.

Investigation note: the open-source [asfyaml parser](https://github.com/apache/infrastructure-asfyaml/blob/HEAD/asfyaml/feature/github/rulesets.py) only documents team slugs for `bypass_teams` and resolves each entry via `get_team_by_slug(...)` — a username would raise `UnknownObjectException`. If ASF Infra's production path also rejects it, the post-merge ruleset will end up with empty `bypass_actors` (the same null state the repo has today), at which point we'll follow up separately. Worst case is no behavior change from main.

### Any related issues, documentation, discussions?

Closes #5353. Driven by [INFRA-27977](https://issues.apache.org/jira/browse/INFRA-27977).

Email thread https://lists.apache.org/thread/6qt853kj96t7kcr09h38h0zj927rbxcl

### How was this PR tested?

`ruby -e 'require "yaml"; YAML.load_file(".asf.yaml"); puts "yaml ok"'` — file still parses. Runtime validation will come from ASF Infra after merge; if `xuang7` is rejected as a non-team slug we'll get an email and follow up with a separate ticket.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7