### PR TITLE
fix(amber): regenerate Python proto bindings on local sbt build

### DIFF
--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -214,7 +214,8 @@ genPythonProto := {
         "Install protoc and `pip install betterproto[compiler]` before launching a Python worker or running pytest."
     )
   } else {
-    val exit = scala.sys.process.Process(Seq("bash", script.getAbsolutePath), repoRoot).!(log)
+    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.error(line))
+    val exit = scala.sys.process.Process(Seq("bash", script.getAbsolutePath), repoRoot).!(procLogger)
     if (exit != 0) sys.error(s"python-proto-gen.sh failed with exit code $exit")
   }
 }

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -200,6 +200,26 @@ libraryDependencies += "com.thesamet.scalapb" %% "scalapb-json4s" % "0.12.0"
 // enable protobuf compilation in Test
 Test / PB.protoSources += PB.externalSourcePath.value
 
+// Regenerate Python betterproto bindings on compile; skipped if protoc is absent.
+val genPythonProto = taskKey[Unit]("Generate Python betterproto bindings from .proto sources.")
+genPythonProto := {
+  val log = streams.value.log
+  val repoRoot = (ThisBuild / baseDirectory).value
+  val script = repoRoot / "bin" / "python-proto-gen.sh"
+  def onPath(bin: String): Boolean =
+    scala.sys.process.Process(Seq("bash", "-c", s"command -v $bin >/dev/null 2>&1")).! == 0
+  if (!onPath("protoc") || !onPath("protoc-gen-python_betterproto")) {
+    log.warn(
+      "protoc or protoc-gen-python_betterproto not found on PATH; skipping Python proto generation. " +
+        "Install protoc and `pip install betterproto[compiler]` before launching a Python worker or running pytest."
+    )
+  } else {
+    val exit = scala.sys.process.Process(Seq("bash", script.getAbsolutePath), repoRoot).!(log)
+    if (exit != 0) sys.error(s"python-proto-gen.sh failed with exit code $exit")
+  }
+}
+Compile / compile := (Compile / compile).dependsOn(genPythonProto).value
+
 /////////////////////////////////////////////////////////////////////////////
 // Test related
 // https://mvnrepository.com/artifact/org.scalamock/scalamock

--- a/amber/src/main/python/texera_run_python_worker.py
+++ b/amber/src/main/python/texera_run_python_worker.py
@@ -18,8 +18,19 @@
 import sys
 from loguru import logger
 
-from core.python_worker import PythonWorker
-from core.storage.storage_config import StorageConfig
+try:
+    from core.python_worker import PythonWorker
+    from core.storage.storage_config import StorageConfig
+except ModuleNotFoundError as e:
+    if e.name == "proto" or (e.name or "").startswith("proto."):
+        sys.exit(
+            "Python proto bindings are missing (amber/src/main/python/proto/). "
+            "They are generated, not checked in. Generate them by running "
+            "`bash bin/python-proto-gen.sh` from the repo root (requires protoc and "
+            '`pip install "betterproto[compiler]"`), or build the engine with sbt, '
+            "which regenerates them on compile."
+        )
+    raise
 
 
 def init_loguru_logger(stream_log_level) -> None:


### PR DESCRIPTION
### What changes were proposed in this PR?
- Restore the `genPythonProto` sbt task and wire it to `Compile / compile`, so a local `sbt` build regenerates the Python betterproto bindings (`amber/src/main/python/proto/`) via `bin/python-proto-gen.sh`.
- Guard the task: if `protoc` or `protoc-gen-python_betterproto` is not on PATH it logs a warning and skips, so JDK-only and docker stages (which already run the script out-of-band) are unaffected.
- Make the Python worker entrypoint exit with an actionable message when the `proto` package is missing, instead of a raw `ModuleNotFoundError`.
### Any related issues, documentation, or discussions?
Closes: #5357
### How was this PR tested?
- Verified the worker entrypoint exits with the actionable message when the `proto` package is absent (simulated a missing `proto` import).
- Confirmed `bin/python-proto-gen.sh` regenerates a complete, importable `proto/` tree (protoc 3.19.x, `betterproto[compiler]==2.0.0b7`).
- Confirmed the PR diff is limited to the two intended files (`amber/build.sbt`, `texera_run_python_worker.py`).
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF