### PR TITLE
ci: match system-requirements-lock.txt in labeler globs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -91,8 +91,7 @@ pyamber:
           - 'amber/src/test/python/**'
           - 'amber/pyproject.toml'
           - '**/*.py'
-          - '**/requirements.txt'
-          - '**/*-requirements.txt'
+          - '**/*requirements*.txt'
 
 docs:
   - changed-files:
@@ -117,7 +116,7 @@ dev:
 dependencies:
   - changed-files:
       - any-glob-to-any-file:
-          - '**/requirements.txt'
+          - '**/*requirements*.txt'
           - '**/package.json'
           - '**/build.sbt'
           - '**/project.sbt'


### PR DESCRIPTION
### What changes were proposed in this PR?

A Dependabot bump that touches **only** `amber/system-requirements-lock.txt` silently skips all CI — surfaced on #5364 ("There was no CI ran for this PR").

**Root cause.** The `pyamber` and `dependencies` labeler globs match pip manifests with `**/requirements.txt` + `**/*-requirements.txt`. The lockfile ends in `-lock.txt`, so it matches *neither*:

```
amber/requirements.txt              match   (**/requirements.txt, **/*-requirements.txt)
amber/dev-requirements.txt          match   (**/*-requirements.txt)
amber/operator-requirements.txt     match   (**/*-requirements.txt)
amber/system-requirements-lock.txt  MISS    (ends in -lock.txt, not -requirements.txt)
```

With no `pyamber` label, `required-checks` computes an empty stack union and skips every build stack:

```
diff -> labeler -> (no pyamber/dependencies label) -> empty LABEL_STACKS union -> 0 build stacks
```

(The green checks on #5364's merge commit are from the post-merge push to `main`, which runs all stacks unconditionally — not PR validation.)

**Fix.** Collapse the two requirement globs into a single `**/*requirements*.txt` in both the `pyamber` and `dependencies` sections.

| Changed file | Labels before | Labels after |
| --- | --- | --- |
| `amber/system-requirements-lock.txt` | _(none)_ → no CI | `pyamber`, `dependencies` |
| `amber/requirements.txt` | `pyamber`, `dependencies` | `pyamber`, `dependencies` |
| `frontend/package.json` | `frontend`, `dependencies` | `frontend`, `dependencies` |

`pyamber` maps to the `pyamber` + `amber-integration` stacks (`LABEL_STACKS` in `required-checks.yml`), so a future lockfile-only bump now runs the Python CI that actually exercises the changed deps.

### Any related issues, documentation, discussions?

Closes #5401. Follows up on the review comment by @Yicong-Huang on #5364. The four `amber/` manifests above are the repo's only `*requirements*.txt`/`*-lock.txt` files, so the broadened glob cannot widen label scope unexpectedly.

### How was this PR tested?

Simulated `actions/labeler`'s minimatch matching against the **edited** config for the changed file plus controls:

```
amber/system-requirements-lock.txt  => pyamber, dependencies   (was: none)
amber/requirements.txt              => pyamber, dependencies   (unchanged)
frontend/package.json               => frontend, dependencies  (unchanged)
docs/foo.md                         => docs                    (unchanged)
```

YAML validated with `yaml.safe_load`. CI config only — no source or test code paths are affected.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8 (1M context)

