### PR TITLE
chore(ci): run LICENSE-binary drift check weekly

### DIFF
--- a/.github/workflows/license-binary-checker.yml
+++ b/.github/workflows/license-binary-checker.yml
@@ -22,8 +22,8 @@ name: License Binary Checker
 # one tracking issue (label `license-binary-drift`). Sub-task of #4688.
 on:
   schedule:
-    # 11:00 UTC daily = 04:00 PDT / 03:00 PST.
-    - cron: "0 11 * * *"
+    # 11:00 UTC every Monday = 04:00 PDT / 03:00 PST.
+    - cron: "0 11 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### What changes were proposed in this PR?

Change the scheduled LICENSE-binary drift checker from daily to weekly. The workflow still runs at 11:00 UTC and still supports manual `workflow_dispatch` runs.

### Any related issues, documentation, discussions?

Closes #5405.

### How was this PR tested?

```bash
git diff --check
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5).
