### PR TITLE
fix(frontend): exclude /api/config/pre-login from JwtModule

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -206,7 +206,7 @@ registerLocaleData(en);
         tokenGetter: AuthService.getAccessToken,
         skipWhenExpired: true,
         throwNoTokenError: false,
-        disallowedRoutes: ["forum/api/users"],
+        disallowedRoutes: ["forum/api/users", "api/config/pre-login"],
       },
     }),
     BrowserAnimationsModule,


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds `api/config/pre-login` to `JwtModule.forRoot`'s `disallowedRoutes` so the anonymous pre-login config fetch is no longer auto-attached with `Authorization: Bearer …`. Before this change a stored JWT whose signature can't be verified server-side (key rotation, manual tampering, cross-deployment bleed) would make the eager `JwtAuthFilter` return 401 to the pre-login request, leaving `GuiConfigService` in an unrecoverable error state and the login form blank until a manual reload.

### Any related issues, documentation, discussions?

Closes #5407. Companion to #5404 — without this change, the eager filter introduced there exposes the regression described above.

### How was this PR tested?

Manually tested in the browser against #5404's backend with a forged JWT in localStorage; confirmed `/api/config/pre-login` no longer carries `Authorization` and the login form renders without a manual reload.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)