### PR TITLE
chore: bump main version to 1.3.0-incubating-SNAPSHOT

### DIFF
--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -19,7 +19,7 @@ texera:
   # Container image registry and tag for all Texera services
   # Override these to use a different registry or version
   imageRegistry: docker.io/apache
-  imageTag: 1.3.0-incubating
+  imageTag: 1.3.0-incubating-SNAPSHOT
 
 global:
   # Required by Bitnami sub-charts (postgresql, minio) to allow custom images

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -19,7 +19,7 @@ texera:
   # Container image registry and tag for all Texera services
   # Override these to use a different registry or version
   imageRegistry: docker.io/apache
-  imageTag: 1.1.0-incubating
+  imageTag: 1.3.0-incubating
 
 global:
   # Required by Bitnami sub-charts (postgresql, minio) to allow custom images

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 // under the License.
 
 ThisBuild / organization := "org.apache.texera"
-ThisBuild / version      := "1.1.0-incubating"
+ThisBuild / version      := "1.3.0-incubating"
 ThisBuild / scalaVersion := "2.13.18"
 
 // Pull JDK 17+ JVM flags from .jvmopts so every JVM the build launches sees the same list.

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 // under the License.
 
 ThisBuild / organization := "org.apache.texera"
-ThisBuild / version      := "1.3.0-incubating"
+ThisBuild / version      := "1.3.0-incubating-SNAPSHOT"
 ThisBuild / scalaVersion := "2.13.18"
 
 // Pull JDK 17+ JVM flags from .jvmopts so every JVM the build launches sees the same list.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui",
-  "version": "0.0.0",
+  "version": "1.3.0-incubating",
   "engines": {
     "node": ">=24.0.0"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui",
-  "version": "1.3.0-incubating",
+  "version": "1.3.0-incubating-SNAPSHOT",
   "engines": {
     "node": ">=24.0.0"
   },


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR bumps the project version on main from 1.1.0-incubating to 1.3.0-incubating. Since release/v1.2 has already been cut from main, main should now advance to the next version line.

Updated version references:
- build.sbt: ThisBuild / version → 1.3.0-incubating-SNAPSHOT
- bin/k8s/values.yaml: imageTag → 1.3.0-incubating-SNAPSHOT
- frontend/package.json: version → 1.3.0-incubating-SNAPSHOT

### Any related issues, documentation, or discussions?
Per the discussion in #5385, version bumps should target main and then be backported if needed. release/v1.2 is already at 1.2.0-incubating via #5386, so main now moves to 1.3.0-incubating.

Closes #5385

### How was this PR tested?
Version-string-only change. 

### Was this PR authored or co-authored using generative AI tooling?

Co-authored with Claude Code (Opus 4.8) in compliance with ASF policy.