### PR TITLE
chore(asf): use raw payload bypass_actors for branch protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -106,21 +106,27 @@ github:
               - context: Validate PR title
 
     - name: "Default Branch Protection"
-      type: branch
-      branches:
-        includes:
-          - "~DEFAULT_BRANCH"
-          - "release/*"
-          - "rel/*"
-        excludes: []
-      bypass_teams:
-        - "root"
-        # Individual user (xuang7, v1.2 release manager) — listed here per INFRA
-        # guidance even though the open-source asfyaml parser only documents team
-        # slugs.
-        - "xuang7"
-      restrict_deletion: true
-      restrict_force_push: true
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - "~DEFAULT_BRANCH"
+            - "refs/heads/release/*"
+            - "refs/heads/rel/*"
+          exclude: []
+      bypass_actors:
+        # apache/root — ASF Infra team.
+        - actor_id: 118420
+          actor_type: Team
+          bypass_mode: always
+        # xuang7 — granted bypass as the v1.2 release manager.
+        - actor_id: 162244362
+          actor_type: User
+          bypass_mode: always
+      rules:
+        - type: deletion
+        - type: non_fast_forward
 notifications:
   commits: commits@texera.apache.org
   issues: notifications@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?

Convert the `Default Branch Protection` ruleset in `.asf.yaml` from convenience syntax to raw payload so individual users can actually be registered as bypass actors — the convenience parser resolves `bypass_teams` via `get_team_by_slug(...)`, leaving a username unresolved (live `bypass_actors` on the ruleset is currently `null`). Raw payload also skips the parser's `_to_ref()` prefix step, so branch include patterns are spelled out in full (`refs/heads/release/*`, `refs/heads/rel/*`).

### Any related issues, documentation, discussions?

Closes #5412. Follow-up to #5354 and INFRA-27977 (https://issues.apache.org/jira/browse/INFRA-27977).

### How was this PR tested?

Normalized `.asf.yaml` through `apache/infrastructure-asfyaml`'s real `normalize_rulesets` and `configure_rulesets` (FakeRequester harness from its own test suite); the resulting POST payload matches the live ruleset shape on `apache/texera`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7