### PR TITLE
chore(ci): add stale workflow to auto-close inactive PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -32,6 +32,7 @@ on:
 
 permissions:
   pull-requests: write
+  issues: write
 
 jobs:
   stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Auto-close stale pull requests after a total of 90 days of inactivity
+# (60 days to mark stale, +30 days to close). Issues are not touched.
+#
+# Escape hatches (any one keeps a PR alive):
+#   - Add the `pinned` label
+#   - Attach a milestone
+#   - Keep the PR in draft state
+#   - Push a commit, comment, or address review feedback
+
+name: Close stale pull requests
+
+on:
+  schedule:
+    - cron: '0 1 * * 1'   # weekly, Monday 01:00 UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # Issues: disabled entirely.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # PRs: 60 days inactive -> stale, +30 days -> close.
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
+          stale-pr-label: 'stale'
+          exempt-pr-labels: 'pinned'
+          exempt-all-pr-milestones: true
+          exempt-draft-pr: true
+          remove-stale-when-updated: true
+
+          stale-pr-message: |
+            This pull request has been automatically marked as **stale** because it has
+            not had any activity for 60 days. It will be closed in **30 days** if no
+            further activity occurs.
+
+            If this PR is still relevant, please:
+            - Push new commits or rebase onto the latest `main`, or
+            - Comment with a status update, or
+            - Address any open review feedback.
+
+            To exempt this PR from auto-close, a maintainer can add the `pinned` label.
+            Thank you for your contribution to Apache Texera (incubating)!
+          close-pr-message: |
+            This pull request has been automatically closed due to 90 days of inactivity.
+            If you would like to continue this work, please re-open the PR or open a new
+            one referencing this. Thank you for your contribution.
+
+          ascending: true            # process oldest first under the per-run cap
+          operations-per-run: 100


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds `.github/workflows/stale.yml`, which marks open pull requests as `stale` after 60 days of inactivity and closes them after another 30 days. Issues are not affected. The workflow runs weekly on Mondays at 01:00 UTC and can also be triggered manually via `workflow_dispatch`.

Three escape hatches keep a PR alive: the `pinned` label, an attached milestone, or draft state. Any push, comment, or review action automatically removes the `stale` label.

Note for maintainers: the `pinned` label does not exist in the repository yet and should be created (any color) before the first scheduled run, otherwise the escape-hatch path is empty.

### Any related issues, documentation, discussions?

Closes #5418.

### How was this PR tested?

Manually verified the YAML parses cleanly and the `actions/stale@v9` input schema accepts every option used.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)