### PR TITLE
fix(amber): persist operator port result URIs through a ClientEvent

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/coordinator/ClientEvent.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/coordinator/ClientEvent.scala
@@ -21,13 +21,21 @@ package org.apache.texera.amber.engine.architecture.coordinator
 
 import org.apache.texera.amber.core.tuple.Tuple
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
+import org.apache.texera.amber.core.workflow.GlobalPortIdentity
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import org.apache.texera.amber.engine.common.ambermessage.WorkflowFIFOMessagePayload
 import org.apache.texera.amber.engine.common.executionruntimestate.OperatorMetrics
 
+import java.net.URI
+
 trait ClientEvent extends WorkflowFIFOMessagePayload
 
 case class ExecutionStateUpdate(state: WorkflowAggregatedState) extends ClientEvent
+
+case class OperatorPortResultUriAvailable(
+    globalPortId: GlobalPortIdentity,
+    uri: URI
+) extends ClientEvent
 
 case class ExecutionStatsUpdate(operatorMetrics: Map[String, OperatorMetrics]) extends ClientEvent
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/scheduling/RegionExecutionManager.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/scheduling/RegionExecutionManager.scala
@@ -23,7 +23,6 @@ import org.apache.pekko.pattern.gracefulStop
 import com.twitter.util.{Duration => TwitterDuration, Future, JavaTimer, Return, Throw, Timer}
 import org.apache.texera.amber.core.state.State
 import org.apache.texera.amber.core.storage.{DocumentFactory, VFSURIFactory}
-import org.apache.texera.amber.core.storage.VFSURIFactory.decodeURI
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
 import org.apache.texera.amber.core.workflow.{GlobalPortIdentity, PhysicalLink, PhysicalOp}
 import org.apache.texera.amber.engine.architecture.common.{
@@ -39,6 +38,7 @@ import org.apache.texera.amber.engine.architecture.coordinator.execution.{
 import org.apache.texera.amber.engine.architecture.coordinator.{
   CoordinatorConfig,
   ExecutionStatsUpdate,
+  OperatorPortResultUriAvailable,
   RuntimeStatisticsPersist,
   WorkerAssignmentUpdate
 }
@@ -58,7 +58,6 @@ import org.apache.texera.amber.engine.common.rpc.AsyncRPCClient
 import org.apache.texera.amber.engine.common.virtualidentity.util.COORDINATOR
 import org.apache.texera.web.SessionState
 import org.apache.texera.web.model.websocket.event.RegionStateEvent
-import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -642,11 +641,8 @@ class RegionExecutionManager(
             DocumentFactory.createOrReuseDocument(uri, sch, reuseStorage)
         }
         if (!isRestart) {
-          val (_, eid, _, _) = decodeURI(resultURI)
-          WorkflowExecutionsResource.insertOperatorPortResultUri(
-            eid = eid,
-            globalPortId = outputPortId,
-            uri = resultURI
+          asyncRPCClient.sendToClient(
+            OperatorPortResultUriAvailable(outputPortId, resultURI)
           )
         }
     }

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
@@ -234,22 +234,6 @@ object WorkflowExecutionsResource {
     restrictionMap.toMap
   }
 
-  def insertOperatorPortResultUri(
-      eid: ExecutionIdentity,
-      globalPortId: GlobalPortIdentity,
-      uri: URI
-  ): Unit = {
-    context
-      .insertInto(OPERATOR_PORT_EXECUTIONS)
-      .columns(
-        OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID,
-        OPERATOR_PORT_EXECUTIONS.GLOBAL_PORT_ID,
-        OPERATOR_PORT_EXECUTIONS.RESULT_URI
-      )
-      .values(eid.id.toInt, globalPortId.serializeAsString, uri.toString)
-      .execute()
-  }
-
   def insertOperatorExecutions(
       eid: Long,
       opId: String,

--- a/amber/src/main/scala/org/apache/texera/web/service/ExecutionResultService.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/ExecutionResultService.scala
@@ -28,6 +28,10 @@ import org.apache.texera.amber.core.storage.model.VirtualDocument
 import org.apache.texera.amber.core.storage.result._
 import org.apache.texera.amber.core.storage.{DocumentFactory, VFSURIFactory}
 import org.apache.texera.amber.core.tuple.{AttributeType, Tuple, TupleUtils}
+import org.apache.texera.amber.util.serde.GlobalPortIdentitySerde.SerdeOps
+import org.apache.texera.dao.SqlServer
+import org.apache.texera.dao.jooq.generated.tables.daos.OperatorPortExecutionsDao
+import org.apache.texera.dao.jooq.generated.tables.pojos.OperatorPortExecutions
 import org.apache.texera.amber.core.virtualidentity.{
   ExecutionIdentity,
   OperatorIdentity,
@@ -35,7 +39,11 @@ import org.apache.texera.amber.core.virtualidentity.{
 }
 import org.apache.texera.amber.core.workflow.OutputPort.OutputMode
 import org.apache.texera.amber.core.workflow.{PhysicalOp, PhysicalPlan, PortIdentity}
-import org.apache.texera.amber.engine.architecture.coordinator.{ExecutionStateUpdate, FatalError}
+import org.apache.texera.amber.engine.architecture.coordinator.{
+  ExecutionStateUpdate,
+  FatalError,
+  OperatorPortResultUriAvailable
+}
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
   COMPLETED,
   FAILED,
@@ -65,6 +73,29 @@ import scala.concurrent.duration.DurationInt
 import scala.language.existentials
 
 object ExecutionResultService {
+
+  /**
+    * Callback body for `OperatorPortResultUriAvailable`: persist the URI to
+    * `operator_port_executions`. Lives on the companion (not the class) so
+    * tests and fixture-row writers can drive the same insert as the
+    * production callback without re-implementing the schema mapping.
+    *
+    * `executionId` comes from the caller rather than the event payload —
+    * the engine→web event is execution-scoped, so re-encoding the eid into
+    * the wire and decoding it on receipt would be redundant.
+    */
+  def persistOperatorPortResultUri(
+      executionId: ExecutionIdentity,
+      evt: OperatorPortResultUriAvailable
+  ): Unit = {
+    val pojo = new OperatorPortExecutions()
+    pojo.setWorkflowExecutionId(executionId.id.toInt)
+    pojo.setGlobalPortId(evt.globalPortId.serializeAsString)
+    pojo.setResultUri(evt.uri.toString)
+    new OperatorPortExecutionsDao(
+      SqlServer.getInstance().createDSLContext().configuration()
+    ).insert(pojo)
+  }
 
   private val defaultPageSize: Int = 5
   private val binaryPreviewLeadingBits: Int = 10
@@ -350,6 +381,19 @@ class ExecutionResultService(
         if (resultUpdateCancellable != null) {
           resultUpdateCancellable.cancel()
         }
+      )
+    )
+
+    // Must be registered before the workflow starts. The engine fires
+    // OperatorPortResultUriAvailable as soon as each port's storage doc
+    // is materialized; if no subscriber is attached at that point the
+    // URI is silently never persisted to operator_port_executions, which
+    // means the dashboard can later compute results just fine but can
+    // never look them up. Today the WS and sync REST entry points both
+    // call attachToExecution before startWorkflow — keep that ordering.
+    addSubscription(
+      client.registerCallback[OperatorPortResultUriAvailable](evt =>
+        ExecutionResultService.persistOperatorPortResultUri(executionId, evt)
       )
     )
 

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -36,6 +36,7 @@ import org.apache.texera.amber.engine.architecture.coordinator.{
   CoordinatorConfig,
   ExecutionStateUpdate,
   FatalError,
+  OperatorPortResultUriAvailable,
   Workflow
 }
 import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
@@ -66,6 +67,7 @@ import org.apache.texera.dao.jooq.generated.tables.pojos.{
 }
 import org.apache.texera.web.model.websocket.request.LogicalPlanPojo
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource.getResultUriByLogicalPortId
+import org.apache.texera.web.service.ExecutionResultService
 import org.apache.texera.workflow.{LogicalLink, WorkflowCompiler}
 
 object TestUtils {
@@ -162,6 +164,14 @@ object TestUtils {
     )
     try {
       client.registerCallback[FatalError](evt => completion.updateIfEmpty(Throw(evt.e)))
+      // The engine emits `OperatorPortResultUriAvailable` for each
+      // materialized output port; production wires this to a DB insert in
+      // `ExecutionResultService.persistOperatorPortResultUri`. The e2e
+      // harness doesn't construct an `ExecutionResultService` (it builds an
+      // `AmberClient` directly), so register the same callback here so the
+      // post-completion `readMaterializedResults` lookup via
+      // `getResultUriByLogicalPortId` finds the rows.
+      registerResultUriPersistence(client, workflow.context.executionId)
       client.registerCallback[ExecutionStateUpdate](evt => {
         if (evt.state == COMPLETED) {
           completion.updateIfEmpty(
@@ -175,6 +185,18 @@ object TestUtils {
       client.shutdown()
     }
   }
+
+  /**
+    * Mirror the production `OperatorPortResultUriAvailable` → DB write that
+    * `ExecutionResultService.persistOperatorPortResultUri` does, but driven
+    * from a test-owned `AmberClient`. Specs that build their own client
+    * (the harness above, or `shouldReconfigure` for the pause/resume flow)
+    * call this so subsequent `getResultUriByLogicalPortId` lookups succeed.
+    */
+  def registerResultUriPersistence(client: AmberClient, executionId: ExecutionIdentity): Unit =
+    client.registerCallback[OperatorPortResultUriAvailable](evt =>
+      ExecutionResultService.persistOperatorPortResultUri(executionId, evt)
+    )
 
   /**
     * Convenience over `runWorkflowAndReadResults` for the common case: run
@@ -303,6 +325,7 @@ object TestUtils {
     )
     // Timeout for control-command acks (start/pause/reconfigure/resume).
     val commandTimeout = Duration.fromSeconds(30)
+    registerResultUriPersistence(client, workflow.context.executionId)
     val completion = Promise[Unit]()
     var result: Map[OperatorIdentity, List[Tuple]] = null
     client.registerCallback[ExecutionStateUpdate](evt => {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
@@ -47,6 +47,8 @@ import org.apache.texera.dao.jooq.generated.tables.pojos.{
   WorkflowExecutions,
   WorkflowVersion
 }
+import org.apache.texera.amber.engine.architecture.coordinator.OperatorPortResultUriAvailable
+import org.apache.texera.web.service.ExecutionResultService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, PrivateMethodTester}
 
@@ -228,6 +230,19 @@ class WorkflowExecutionsResourceSpec
     execution
   }
 
+  // Local convenience over the production callback: fixture rows the
+  // lookup specs below need go through the same insert prod uses, so a
+  // regression in the column list shows up here too.
+  private def insertOperatorPortResult(
+      eid: ExecutionIdentity,
+      globalPortId: GlobalPortIdentity,
+      uri: URI
+  ): Unit =
+    ExecutionResultService.persistOperatorPortResultUri(
+      eid,
+      OperatorPortResultUriAvailable(globalPortId, uri)
+    )
+
   // ─── existing tests (preserved) ───────────────────────────────────────────
 
   "WorkflowExecutionsResource.getWorkflowExecutions" should "return executions with EIDs in descending order" in {
@@ -264,28 +279,8 @@ class WorkflowExecutionsResourceSpec
     )
   }
 
-  "WorkflowExecutionsResource.insertOperatorPortResultUri" should "insert a result URI row" in {
-    val execution = insertExecution(name = "Execution with duplicate result URI insert")
-
-    val executionId = ExecutionIdentity(execution.getEid.longValue())
-    val globalPortId = GlobalPortIdentity(
-      PhysicalOpIdentity(OperatorIdentity("operator-1"), "main"),
-      PortIdentity(),
-      input = false
-    )
-    val uri = URI.create("vfs:///test-result")
-
-    WorkflowExecutionsResource.insertOperatorPortResultUri(executionId, globalPortId, uri)
-
-    val rows = getDSLContext
-      .selectFrom(OPERATOR_PORT_EXECUTIONS)
-      .where(OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID.eq(execution.getEid))
-      .and(OPERATOR_PORT_EXECUTIONS.GLOBAL_PORT_ID.eq(globalPortId.serializeAsString))
-      .fetch()
-
-    assert(rows.size() == 1)
-    assert(rows.get(0).getResultUri == uri.toString)
-  }
+  // (The production callback body that writes operator_port_executions is
+  // covered by `ExecutionResultServiceSpec.persistOperatorPortResultUri`.)
 
   // ─── new: status-filtered execution listing ───────────────────────────────
 
@@ -441,8 +436,8 @@ class WorkflowExecutionsResourceSpec
       input = false
     )
 
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, opA, URI.create("vfs:///A"))
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, opB, URI.create("vfs:///B"))
+    insertOperatorPortResult(eid, opA, URI.create("vfs:///A"))
+    insertOperatorPortResult(eid, opB, URI.create("vfs:///B"))
     // Empty-string URI row — the helper should drop it from the returned list.
     getDSLContext
       .insertInto(OPERATOR_PORT_EXECUTIONS)
@@ -522,7 +517,7 @@ class WorkflowExecutionsResourceSpec
       PortIdentity(),
       input = false
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(
+    insertOperatorPortResult(
       eid,
       globalPortId,
       URI.create("vfs:///r")
@@ -576,7 +571,7 @@ class WorkflowExecutionsResourceSpec
       PortIdentity(),
       input = false
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(
+    insertOperatorPortResult(
       eid,
       globalPortId,
       URI.create("vfs:///r")
@@ -610,7 +605,7 @@ class WorkflowExecutionsResourceSpec
     val targetUri = VFSURIFactory.resultURI(
       VFSURIFactory.createPortBaseURI(wfId, eid, targetGlobalPort)
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, targetGlobalPort, targetUri)
+    insertOperatorPortResult(eid, targetGlobalPort, targetUri)
 
     // Distractor: same workflow, different op id.
     val otherGlobalPort = GlobalPortIdentity(
@@ -621,7 +616,7 @@ class WorkflowExecutionsResourceSpec
     val otherUri = VFSURIFactory.resultURI(
       VFSURIFactory.createPortBaseURI(wfId, eid, otherGlobalPort)
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, otherGlobalPort, otherUri)
+    insertOperatorPortResult(eid, otherGlobalPort, otherUri)
 
     val found =
       WorkflowExecutionsResource.getResultUriByLogicalPortId(eid, targetOpId, targetPortId)

--- a/amber/src/test/scala/org/apache/texera/web/service/ExecutionResultServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/ExecutionResultServiceSpec.scala
@@ -22,11 +22,35 @@ package org.apache.texera.web.service
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema, Tuple}
+import org.apache.texera.amber.core.virtualidentity.{
+  ExecutionIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
+import org.apache.texera.amber.core.workflow.{GlobalPortIdentity, PortIdentity}
+import org.apache.texera.amber.engine.architecture.coordinator.OperatorPortResultUriAvailable
 import org.apache.texera.amber.util.JSONUtils.objectMapper
-
-import java.sql.Timestamp
-
-import scala.jdk.CollectionConverters._
+import org.apache.texera.amber.util.serde.GlobalPortIdentitySerde.SerdeOps
+import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.jooq.generated.Tables.{
+  OPERATOR_PORT_EXECUTIONS,
+  USER,
+  WORKFLOW,
+  WORKFLOW_EXECUTIONS,
+  WORKFLOW_VERSION
+}
+import org.apache.texera.dao.jooq.generated.tables.daos.{
+  UserDao,
+  WorkflowDao,
+  WorkflowExecutionsDao,
+  WorkflowVersionDao
+}
+import org.apache.texera.dao.jooq.generated.tables.pojos.{
+  User,
+  Workflow,
+  WorkflowExecutions,
+  WorkflowVersion
+}
 import org.apache.texera.web.service.ExecutionResultService.{
   PaginationMode,
   SetDeltaMode,
@@ -36,8 +60,119 @@ import org.apache.texera.web.service.ExecutionResultService.{
 }
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
-class ExecutionResultServiceSpec extends AnyFlatSpec with Matchers {
+import java.net.URI
+import java.sql.Timestamp
+import scala.jdk.CollectionConverters._
+
+class ExecutionResultServiceSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with MockTexeraDB {
+
+  // Fixed (not random) so a failure replays identically across runs. The
+  // spec owns its embedded DB so collision with other specs isn't a concern.
+  private val testWid: Integer = 9001
+  private val testUid: Integer = 9001
+  private var executionsDao: WorkflowExecutionsDao = _
+  private var testVid: Integer = _
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdownDB()
+  }
+
+  override protected def beforeEach(): Unit = {
+    val user = new User
+    user.setUid(testUid)
+    user.setName("execution-result-test-user")
+    user.setEmail(s"u$testUid@example.com")
+    user.setPassword("password")
+    new UserDao(getDSLContext.configuration()).insert(user)
+
+    val workflow = new Workflow
+    workflow.setWid(testWid)
+    workflow.setName(s"execution-result-test-$testWid")
+    workflow.setContent("{}")
+    workflow.setDescription("")
+    workflow.setCreationTime(new Timestamp(System.currentTimeMillis()))
+    workflow.setLastModifiedTime(new Timestamp(System.currentTimeMillis()))
+    new WorkflowDao(getDSLContext.configuration()).insert(workflow)
+
+    val version = new WorkflowVersion
+    version.setWid(testWid)
+    version.setContent("{}")
+    version.setCreationTime(new Timestamp(System.currentTimeMillis()))
+    new WorkflowVersionDao(getDSLContext.configuration()).insert(version)
+    // The vid sequence isn't reset between tests, so capture the
+    // generated key here instead of assuming it's `1` later.
+    testVid = version.getVid
+
+    executionsDao = new WorkflowExecutionsDao(getDSLContext.configuration())
+  }
+
+  override protected def afterEach(): Unit = {
+    val ctx = getDSLContext
+    // Scope every delete to the test's own ids so this spec stays safe
+    // if it ever shares a DB with another spec.
+    ctx
+      .deleteFrom(OPERATOR_PORT_EXECUTIONS)
+      .where(
+        OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID.in(
+          ctx
+            .select(WORKFLOW_EXECUTIONS.EID)
+            .from(WORKFLOW_EXECUTIONS)
+            .where(WORKFLOW_EXECUTIONS.UID.eq(testUid))
+        )
+      )
+      .execute()
+    ctx
+      .deleteFrom(WORKFLOW_EXECUTIONS)
+      .where(WORKFLOW_EXECUTIONS.UID.eq(testUid))
+      .execute()
+    ctx.deleteFrom(WORKFLOW_VERSION).where(WORKFLOW_VERSION.WID.eq(testWid)).execute()
+    ctx.deleteFrom(WORKFLOW).where(WORKFLOW.WID.eq(testWid)).execute()
+    ctx.deleteFrom(USER).where(USER.UID.eq(testUid)).execute()
+  }
+
+  "persistOperatorPortResultUri" should
+    "insert the URI carried by an OperatorPortResultUriAvailable event" in {
+    val execution = new WorkflowExecutions
+    execution.setVid(testVid)
+    execution.setUid(testUid)
+    execution.setStatus(0.toByte)
+    execution.setStartingTime(new Timestamp(System.currentTimeMillis()))
+    execution.setBookmarked(false)
+    execution.setName("execution-result-callback-test")
+    execution.setEnvironmentVersion("test-env")
+    executionsDao.insert(execution)
+    val eid = ExecutionIdentity(execution.getEid.longValue())
+    val globalPortId = GlobalPortIdentity(
+      PhysicalOpIdentity(OperatorIdentity("op-X"), "main"),
+      PortIdentity(),
+      input = false
+    )
+    val uri = URI.create("vfs:///exec-result-callback")
+
+    ExecutionResultService.persistOperatorPortResultUri(
+      eid,
+      OperatorPortResultUriAvailable(globalPortId, uri)
+    )
+
+    val rows = getDSLContext
+      .selectFrom(OPERATOR_PORT_EXECUTIONS)
+      .where(OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID.eq(execution.getEid))
+      .and(OPERATOR_PORT_EXECUTIONS.GLOBAL_PORT_ID.eq(globalPortId.serializeAsString))
+      .fetch()
+    rows.size() shouldBe 1
+    rows.get(0).getResultUri shouldBe uri.toString
+  }
 
   "convertTuplesToJson" should "convert tuples with various field types correctly" in {
     // Create a schema with different attribute types


### PR DESCRIPTION
### What changes were proposed in this PR?

`WorkflowExecutionsResource.insertOperatorPortResultUri` was a static method on a JAX-RS resource that the engine (`RegionExecutionManager`, named `RegionExecutionCoordinator` before #6123) called directly to write `operator_port_executions` rows — two layering problems in one helper: a JAX-RS resource that wasn't an HTTP endpoint, and an engine actor reaching across into the web layer to write the DB.

The fix follows the codebase's existing engine→web channel. Engine actors call `asyncRPCClient.sendToClient(event: ClientEvent)`; web services call `client.registerCallback[T](handler)` to react. `RuntimeStatisticsPersist` is the closest precedent — engine emits, `ExecutionStatsService` writes the DB.

Concretely:

- Add `OperatorPortResultUriAvailable(globalPortId, uri)` to `ClientEvent`. The event is execution-scoped, so it carries no `eid` — the subscriber already holds its own `executionId`, which also removes the old `decodeURI(resultURI)` round-trip in `RegionExecutionManager`.
- `RegionExecutionManager` emits this event in place of calling the web helper.
- `ExecutionResultService.attachToExecution` registers a callback that inserts the row via the generated `OperatorPortExecutionsDao` (extracted as `ExecutionResultService.persistOperatorPortResultUri` so tests can drive the same insert). The registration site carries a comment documenting the ordering invariant: the callback must be attached before `startWorkflow`, otherwise result URIs are silently never persisted.
- Delete `WorkflowExecutionsResource.insertOperatorPortResultUri`. The engine no longer imports `WorkflowExecutionsResource`; the resource spec inserts its fixture rows through `OperatorPortExecutionsDao` directly.
- E2E specs (`DataProcessingSpec`, reconfiguration specs) register the same production callback body via `TestUtils.registerResultUriPersistence` and read results back through `getResultUriByLogicalPortId`, so the event→DB-insert seam stays covered end to end.

### Any related issues, documentation, discussions?

Closes #5430. Sub-issue of #5424 — eliminates one of the four engine→web import leaks blocking the amber Dropwizard upgrade tracked in #5423.

### How was this PR tested?

`sbt 'WorkflowExecutionService/testOnly *ExecutionResultServiceSpec *WorkflowExecutionsResourceSpec *DataProcessingSpec *ReconfigurationSpec'` — 58 tests pass across the 4 affected suites. `sbt scalafmtCheckAll` clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7)
