### PR TITLE
改进 hocon-parser 模块的类型定义，使用更精确的类型替代 any

### DIFF
--- a/pyright-language-service/src/types/hocon-parser.d.ts
+++ b/pyright-language-service/src/types/hocon-parser.d.ts
@@ -21,7 +21,7 @@ declare module 'hocon-parser' {
   /**
    * The module itself is callable, accepting a string (HOCON config) and returning a parsed object.
    */
-  function hoconParser(input: string): any;
+  function hoconParser(input: string): Record<string, unknown>;
 
   export = hoconParser;
 }


### PR DESCRIPTION
## 问题背景
在 `pyright-language-service` 的类型定义文件中，`hocon-parser` 模块的 `hoconParser` 函数返回类型被声明为 `any`。`any` 类型会完全绕过 TypeScript 的类型检查，使得调用该函数的代码无法获得类型安全保证，也无法享受自动补全和重构支持。

## 修改内容
本次修改将 `hoconParser` 函数的返回类型从 `any` 替换为 `Record<string, unknown>`。

**修改原因**：
1.  **增强类型安全**：`Record<string, unknown>` 明确表示返回一个键为字符串、值为任意类型的对象。这比 `any` 更精确，能捕获部分类型错误（如误用数组方法）。
2.  **保持灵活性**：HOCON 解析器的输出结构是动态的，无法预先定义具体接口。使用 `Record<string, unknown>` 在不损失灵活性的前提下，提供了比 `any` 更好的类型基础。
3.  **遵循最佳实践**：在 TypeScript 中，应尽量避免使用 `any` 类型，优先使用更具体的类型如 `unknown` 或 `Record` 以提高代码的可维护性和健壮性。

**兼容性**：这是一个纯类型层面的修改，不改变函数的任何运行时行为，因此完全向后兼容。

## 验证方式
1.  TypeScript 类型检查通过，没有引入新的类型错误。
2.  调用 `hoconParser` 的现有代码在类型推断和编译上不受影响，因为 `Record<string, unknown>` 是对 `any` 的一个更严格的替代。

感谢审阅！