### PR TITLE
fix(frontend): use default import for package.json version in dev build

### DIFF
--- a/frontend/src/environments/version.spec.ts
+++ b/frontend/src/environments/version.spec.ts
@@ -17,12 +17,16 @@
  * under the License.
  */
 
-// Default import: Angular's webpack rejects named JSON imports.
 import packageJson from "../../package.json";
+import { Version } from "./version";
 
-// Dev placeholder. Production builds replace this file with the generated
-// version.prod.ts (see angular.json fileReplacements + frontend/build-version.js).
-export const Version = {
-  buildNumber: "dev",
-  version: packageJson.version,
-};
+describe("Version (dev environment)", () => {
+  it("exposes the version from package.json", () => {
+    expect(Version.version).toBe(packageJson.version);
+    expect(Version.version.length).toBeGreaterThan(0);
+  });
+
+  it('uses the "dev" build number placeholder', () => {
+    expect(Version.buildNumber).toBe("dev");
+  });
+});

--- a/frontend/src/environments/version.ts
+++ b/frontend/src/environments/version.ts
@@ -17,11 +17,12 @@
  * under the License.
  */
 
-import { version } from "../../package.json";
+// Default import: Angular's webpack rejects named JSON imports.
+import packageJson from "../../package.json";
 
 // Dev placeholder. Production builds replace this file with the generated
 // version.prod.ts (see angular.json fileReplacements + frontend/build-version.js).
 export const Version = {
   buildNumber: "dev",
-  version,
+  version: packageJson.version,
 };


### PR DESCRIPTION
### What changes were proposed in this PR?
- Change `frontend/src/environments/version.ts` to import `package.json` with a default import (`packageJson.version`) instead of a named import (`import { version }`).
- Why it is a bug: Angular 21's webpack rejects named imports from JSON modules, so `ng serve` (dev) fails to compile and the dev server serves "Cannot GET /" (HTTP 404). Production builds are unaffected because `angular.json` fileReplacements swaps in `version.prod.ts`.
### Any related issues, documentation, discussions?
Closes #5443 (regression introduced by #5153).
### How was this PR tested?
- From `frontend/` on Node >=24, run `yarn start` and confirm the dev server compiles with no errors (previously failed on `version.ts` with `Failed to compile.`).
- Open http://localhost:4200/ and confirm the app loads (HTTP 200, page title "Texera") instead of "Cannot GET /".
- Confirm the UI footer still shows the version string from `package.json`.
### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.8)