### PR TITLE
fix(frontend): clean up websocket state when returning to the dashboard

### DIFF
--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
@@ -97,4 +97,27 @@ describe("ComputingUnitStatusService", () => {
     service.disconnect();
     expect(latest).toBeNull();
   });
+
+  it("emits a connection-reset signal when switching to a different computing unit (issue #3120)", () => {
+    let connected = false;
+    vi.spyOn(websocketService, "openWebsocket").mockImplementation(() => {
+      connected = true;
+    });
+    vi.spyOn(websocketService, "closeWebsocket").mockImplementation(() => {
+      connected = false;
+    });
+    vi.spyOn(websocketService, "isConnected", "get").mockImplementation(() => connected);
+    (service as any).allComputingUnitsSubject.next([mockUnit(7), mockUnit(8)]);
+
+    let resetCount = 0;
+    service.getConnectionResetStream().subscribe(() => resetCount++);
+
+    // First connection on unit 7: nothing to tear down yet → no signal.
+    service.selectComputingUnit(5, 7);
+    expect(resetCount).toBe(0);
+
+    // Switch to a different unit while connected → tear-down signal fires once.
+    service.selectComputingUnit(5, 8);
+    expect(resetCount).toBe(1);
+  });
 });

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
@@ -61,6 +61,12 @@ describe("ComputingUnitStatusService", () => {
     websocketService = TestBed.inject(WorkflowWebsocketService);
   });
 
+  afterEach(() => {
+    // selectComputingUnit() starts an RxJS interval poll; tear the service down so
+    // the timer doesn't outlive the test and make the suite hang/flap.
+    service.ngOnDestroy();
+  });
+
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
@@ -116,6 +122,26 @@ describe("ComputingUnitStatusService", () => {
     expect(resetCount).toBe(0);
 
     // Switch to a different unit while connected → tear-down signal fires once.
+    service.selectComputingUnit(5, 8);
+    expect(resetCount).toBe(1);
+  });
+
+  it("emits a connection-reset signal when switching units even if the socket already dropped (issue #3120)", () => {
+    vi.spyOn(websocketService, "openWebsocket").mockImplementation(() => {});
+    vi.spyOn(websocketService, "closeWebsocket").mockImplementation(() => {});
+    // socket reports disconnected throughout, e.g. the previous unit was terminated
+    vi.spyOn(websocketService, "isConnected", "get").mockReturnValue(false);
+    (service as any).allComputingUnitsSubject.next([mockUnit(7), mockUnit(8)]);
+
+    let resetCount = 0;
+    service.getConnectionResetStream().subscribe(() => resetCount++);
+
+    // First connection on unit 7: nothing to tear down yet → no signal.
+    service.selectComputingUnit(5, 7);
+    expect(resetCount).toBe(0);
+
+    // Switch units while the socket is already disconnected: stale state from
+    // unit 7 must still be cleared, so the signal fires regardless of isConnected.
     service.selectComputingUnit(5, 8);
     expect(resetCount).toBe(1);
   });

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { of } from "rxjs";
+import { ComputingUnitStatusService } from "./computing-unit-status.service";
+import { WorkflowComputingUnitManagingService } from "../workflow-computing-unit/workflow-computing-unit-managing.service";
+import { WorkflowWebsocketService } from "../../../../workspace/service/workflow-websocket/workflow-websocket.service";
+import { WorkflowStatusService } from "../../../../workspace/service/workflow-status/workflow-status.service";
+import { UserService } from "../../user/user.service";
+import { StubUserService } from "../../user/stub-user.service";
+import { AuthService } from "../../user/auth.service";
+import { StubAuthService } from "../../user/stub-auth.service";
+import { DashboardWorkflowComputingUnit } from "../../../type/workflow-computing-unit";
+import { commonTestProviders } from "../../../testing/test-utils";
+
+describe("ComputingUnitStatusService", () => {
+  let service: ComputingUnitStatusService;
+  let websocketService: WorkflowWebsocketService;
+
+  const mockUnit = (cuid: number) => ({ computingUnit: { cuid } }) as unknown as DashboardWorkflowComputingUnit;
+
+  beforeEach(() => {
+    const managingStub = {
+      listComputingUnits: () => of([]),
+      getComputingUnit: (cuid: number) => of(mockUnit(cuid)),
+      terminateComputingUnit: () => of(undefined),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        ComputingUnitStatusService,
+        WorkflowWebsocketService,
+        WorkflowStatusService,
+        { provide: WorkflowComputingUnitManagingService, useValue: managingStub },
+        { provide: UserService, useClass: StubUserService },
+        { provide: AuthService, useClass: StubAuthService },
+        ...commonTestProviders,
+      ],
+    });
+
+    service = TestBed.inject(ComputingUnitStatusService);
+    websocketService = TestBed.inject(WorkflowWebsocketService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("reconnects when re-selecting the same workflow after disconnect (regression #3120)", () => {
+    const openSpy = vi.spyOn(websocketService, "openWebsocket").mockImplementation(() => {});
+    const closeSpy = vi.spyOn(websocketService, "closeWebsocket");
+    (service as any).allComputingUnitsSubject.next([mockUnit(7)]);
+
+    // Enter workflow 5 on computing unit 7 → opens the websocket once.
+    service.selectComputingUnit(5, 7);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    // User returns to the dashboard.
+    service.disconnect();
+    expect(closeSpy).toHaveBeenCalled();
+
+    // Re-enter the SAME workflow (the `wid -> null -> wid` pattern). Without
+    // cleanup the retained currentConnectedWid/Cuid would suppress the reconnect
+    // and the stale socket would be reused; after disconnect it must reconnect.
+    service.selectComputingUnit(5, 7);
+    expect(openSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("disconnect() clears the selected computing unit", () => {
+    vi.spyOn(websocketService, "openWebsocket").mockImplementation(() => {});
+    (service as any).allComputingUnitsSubject.next([mockUnit(7)]);
+    service.selectComputingUnit(5, 7);
+
+    let latest: DashboardWorkflowComputingUnit | null = mockUnit(7);
+    service.getSelectedComputingUnit().subscribe(unit => (latest = unit));
+    expect(latest).not.toBeNull();
+
+    service.disconnect();
+    expect(latest).toBeNull();
+  });
+});

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
@@ -62,8 +62,7 @@ describe("ComputingUnitStatusService", () => {
   });
 
   afterEach(() => {
-    // selectComputingUnit() starts an RxJS interval poll; tear the service down so
-    // the timer doesn't outlive the test and make the suite hang/flap.
+    // tear down the interval poll started by selectComputingUnit() so it can't outlive the test
     service.ngOnDestroy();
   });
 
@@ -140,8 +139,7 @@ describe("ComputingUnitStatusService", () => {
     service.selectComputingUnit(5, 7);
     expect(resetCount).toBe(0);
 
-    // Switch units while the socket is already disconnected: stale state from
-    // unit 7 must still be cleared, so the signal fires regardless of isConnected.
+    // Switch units while disconnected: unit 7's stale state must still be cleared.
     service.selectComputingUnit(5, 8);
     expect(resetCount).toBe(1);
   });

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
@@ -78,9 +78,8 @@ describe("ComputingUnitStatusService", () => {
     service.disconnect();
     expect(closeSpy).toHaveBeenCalled();
 
-    // Re-enter the SAME workflow (the `wid -> null -> wid` pattern). Without
-    // cleanup the retained currentConnectedWid/Cuid would suppress the reconnect
-    // and the stale socket would be reused; after disconnect it must reconnect.
+    // Re-enter the SAME workflow (the `wid -> null -> wid` pattern): without the
+    // cleanup, the retained currentConnectedWid/Cuid would suppress the reconnect.
     service.selectComputingUnit(5, 7);
     expect(openSpy).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
@@ -48,7 +48,7 @@ export class ComputingUnitStatusService implements OnDestroy {
   private readonly refreshComputingUnitListSignal = new Subject<void>();
 
   // Emits when the active connection is torn down to switch computing units, so
-  // session consumers can clear their websocket-derived state (#3120).
+  // session consumers can clear their websocket-derived state.
   private readonly connectionResetSubject = new Subject<void>();
 
   // Refresh interval in milliseconds
@@ -165,7 +165,7 @@ export class ComputingUnitStatusService implements OnDestroy {
         if (this.workflowWebsocketService.isConnected) {
           this.workflowWebsocketService.closeWebsocket();
           this.workflowStatusService.clearStatus();
-          // switching units: signal consumers to clear their stale state (#3120)
+          // switching units: signal consumers to clear their stale state
           this.connectionResetSubject.next();
         }
 
@@ -233,7 +233,7 @@ export class ComputingUnitStatusService implements OnDestroy {
 
   /**
    * Emits when the connection is reset to switch computing units. Consumers
-   * subscribe to clear their websocket-derived session state (#3120).
+   * subscribe to clear their websocket-derived session state.
    */
   public getConnectionResetStream(): Observable<void> {
     return this.connectionResetSubject.asObservable();
@@ -242,7 +242,7 @@ export class ComputingUnitStatusService implements OnDestroy {
   /**
    * Tear down all websocket connection state when leaving the workspace, so
    * re-entering a workflow starts from a clean connection instead of reusing
-   * the previous one (#3120).
+   * the previous one.
    */
   public disconnect(): void {
     this.workflowWebsocketService.closeWebsocket();

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
@@ -162,8 +162,14 @@ export class ComputingUnitStatusService implements OnDestroy {
       // open websocket if needed
       const shouldReconnect = this.currentConnectedCuid !== cuid || this.currentConnectedWid !== wid;
       if (isDefined(wid) && shouldReconnect) {
+        // A previous connection attempt means websocket-derived state may be
+        // lingering even if the socket has since dropped (e.g. the prior unit was
+        // terminated), so tear it down regardless of the current isConnected flag.
+        const hadPreviousConnection = isDefined(this.currentConnectedWid) || isDefined(this.currentConnectedCuid);
         if (this.workflowWebsocketService.isConnected) {
           this.workflowWebsocketService.closeWebsocket();
+        }
+        if (hadPreviousConnection) {
           this.workflowStatusService.clearStatus();
           // switching units: signal consumers to clear their stale state
           this.connectionResetSubject.next();

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
@@ -162,9 +162,8 @@ export class ComputingUnitStatusService implements OnDestroy {
       // open websocket if needed
       const shouldReconnect = this.currentConnectedCuid !== cuid || this.currentConnectedWid !== wid;
       if (isDefined(wid) && shouldReconnect) {
-        // A previous connection attempt means websocket-derived state may be
-        // lingering even if the socket has since dropped (e.g. the prior unit was
-        // terminated), so tear it down regardless of the current isConnected flag.
+        // Tear down stale state on switch even if the socket already dropped
+        // (e.g. the prior unit was terminated), not just while still connected.
         const hadPreviousConnection = isDefined(this.currentConnectedWid) || isDefined(this.currentConnectedCuid);
         if (this.workflowWebsocketService.isConnected) {
           this.workflowWebsocketService.closeWebsocket();

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
@@ -225,6 +225,22 @@ export class ComputingUnitStatusService implements OnDestroy {
     );
   }
 
+  /**
+   * Tear down all websocket-related connection state. Called when the user
+   * leaves the workspace (e.g. returns to the dashboard) so that re-entering a
+   * workflow — even the same wid, which arrives as a `wid -> null -> wid`
+   * sequence — starts from a clean connection instead of reusing the previous
+   * one. See issue #3120.
+   */
+  public disconnect(): void {
+    this.workflowWebsocketService.closeWebsocket();
+    this.workflowStatusService.clearStatus();
+    this.stopPollingSelectedUnit();
+    this.currentConnectedCuid = undefined;
+    this.currentConnectedWid = undefined;
+    this.selectedUnitSubject.next(null);
+  }
+
   // Clean up on service destroy
   ngOnDestroy(): void {
     this.refreshSubscription?.unsubscribe();

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
@@ -47,9 +47,8 @@ export class ComputingUnitStatusService implements OnDestroy {
 
   private readonly refreshComputingUnitListSignal = new Subject<void>();
 
-  // Emits when an active websocket connection is torn down to switch to a
-  // different computing unit, so session-scoped consumers (execution status,
-  // console, results) can clear their websocket-derived state. See issue #3120.
+  // Emits when the active connection is torn down to switch computing units, so
+  // session consumers can clear their websocket-derived state (#3120).
   private readonly connectionResetSubject = new Subject<void>();
 
   // Refresh interval in milliseconds
@@ -166,9 +165,7 @@ export class ComputingUnitStatusService implements OnDestroy {
         if (this.workflowWebsocketService.isConnected) {
           this.workflowWebsocketService.closeWebsocket();
           this.workflowStatusService.clearStatus();
-          // We are tearing down an active connection to switch to a different
-          // unit; tell session consumers to clear their stale execution,
-          // console, and result state so the new unit starts fresh (#3120).
+          // switching units: signal consumers to clear their stale state (#3120)
           this.connectionResetSubject.next();
         }
 
@@ -235,21 +232,17 @@ export class ComputingUnitStatusService implements OnDestroy {
   }
 
   /**
-   * Emits whenever an active connection is reset to switch to a different
-   * computing unit. Consumers that hold websocket-derived session state (e.g.
-   * execution status, console output, results) subscribe to this to clear that
-   * state so the new unit starts fresh. See issue #3120.
+   * Emits when the connection is reset to switch computing units. Consumers
+   * subscribe to clear their websocket-derived session state (#3120).
    */
   public getConnectionResetStream(): Observable<void> {
     return this.connectionResetSubject.asObservable();
   }
 
   /**
-   * Tear down all websocket-related connection state. Called when the user
-   * leaves the workspace (e.g. returns to the dashboard) so that re-entering a
-   * workflow — even the same wid, which arrives as a `wid -> null -> wid`
-   * sequence — starts from a clean connection instead of reusing the previous
-   * one. See issue #3120.
+   * Tear down all websocket connection state when leaving the workspace, so
+   * re-entering a workflow starts from a clean connection instead of reusing
+   * the previous one (#3120).
    */
   public disconnect(): void {
     this.workflowWebsocketService.closeWebsocket();

--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.ts
@@ -47,6 +47,11 @@ export class ComputingUnitStatusService implements OnDestroy {
 
   private readonly refreshComputingUnitListSignal = new Subject<void>();
 
+  // Emits when an active websocket connection is torn down to switch to a
+  // different computing unit, so session-scoped consumers (execution status,
+  // console, results) can clear their websocket-derived state. See issue #3120.
+  private readonly connectionResetSubject = new Subject<void>();
+
   // Refresh interval in milliseconds
   private readonly REFRESH_INTERVAL_MS = 2000;
   private refreshSubscription: Subscription | null = null;
@@ -161,6 +166,10 @@ export class ComputingUnitStatusService implements OnDestroy {
         if (this.workflowWebsocketService.isConnected) {
           this.workflowWebsocketService.closeWebsocket();
           this.workflowStatusService.clearStatus();
+          // We are tearing down an active connection to switch to a different
+          // unit; tell session consumers to clear their stale execution,
+          // console, and result state so the new unit starts fresh (#3120).
+          this.connectionResetSubject.next();
         }
 
         this.workflowWebsocketService.openWebsocket(wid, this.userService.getCurrentUser()?.uid, cuid);
@@ -226,6 +235,16 @@ export class ComputingUnitStatusService implements OnDestroy {
   }
 
   /**
+   * Emits whenever an active connection is reset to switch to a different
+   * computing unit. Consumers that hold websocket-derived session state (e.g.
+   * execution status, console output, results) subscribe to this to clear that
+   * state so the new unit starts fresh. See issue #3120.
+   */
+  public getConnectionResetStream(): Observable<void> {
+    return this.connectionResetSubject.asObservable();
+  }
+
+  /**
    * Tear down all websocket-related connection state. Called when the user
    * leaves the workspace (e.g. returns to the dashboard) so that re-entering a
    * workflow — even the same wid, which arrives as a `wid -> null -> wid`
@@ -248,6 +267,7 @@ export class ComputingUnitStatusService implements OnDestroy {
 
     this.selectedUnitSubject.complete();
     this.allComputingUnitsSubject.complete();
+    this.connectionResetSubject.complete();
   }
 
   /**

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -21,6 +21,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 
 import { ResultPanelComponent } from "./result-panel.component";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
+import { WorkflowResultService } from "../../service/workflow-result/workflow-result.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
 import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
@@ -38,6 +39,7 @@ describe("ResultPanelComponent", () => {
   let fixture: ComponentFixture<ResultPanelComponent>;
   let executeWorkflowService: ExecuteWorkflowService;
   let workflowActionService: WorkflowActionService;
+  let workflowResultService: WorkflowResultService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -60,6 +62,7 @@ describe("ResultPanelComponent", () => {
     component = fixture.componentInstance;
     executeWorkflowService = TestBed.inject(ExecuteWorkflowService);
     workflowActionService = TestBed.inject(WorkflowActionService);
+    workflowResultService = TestBed.inject(WorkflowResultService);
     fixture.detectChanges();
   });
 
@@ -81,5 +84,23 @@ describe("ResultPanelComponent", () => {
     const resultPanelDiv = fixture.debugElement.query(By.css("#result-container"));
     const resultPanelHtmlElement: HTMLElement = resultPanelDiv.nativeElement;
     expect(resultPanelHtmlElement).toBeTruthy();
+  });
+
+  it("wipes the panel and operator selection when results are cleared, e.g. on a computing-unit switch (#3120)", () => {
+    // Simulate a result frame on screen for a currently-highlighted operator.
+    // ResultPanelComponent stands in as a throwaway frame component; it's cleared before it renders.
+    component.currentOperatorId = "op1";
+    component.operatorTitle = "Operator 1";
+    component.frameComponentConfigs.set("Result", { component: ResultPanelComponent, componentInputs: {} });
+    expect(component.frameComponentConfigs.size).toBe(1);
+
+    // A unit switch drops the cached results and emits on the cleared stream. The operator
+    // stays highlighted, so the normal rerender path won't tear the frame down — only this
+    // handler does, which is the part that actually fixes the lingering-stale-frame bug.
+    workflowResultService.clearResults();
+
+    expect(component.frameComponentConfigs.size).toBe(0);
+    expect(component.currentOperatorId).toBeUndefined();
+    expect(component.operatorTitle).toBe("");
   });
 });

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -136,6 +136,7 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
     this.updateReturnPosition(DEFAULT_HEIGHT, this.height);
     this.registerAutoRerenderResultPanel();
     this.registerAutoOpenResultPanel();
+    this.registerResultClearedHandler();
     this.handleResultPanelForVersionPreview();
     this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => this.closePanel());
     this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => {
@@ -215,6 +216,24 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
             }
           }
         }
+      });
+  }
+
+  /**
+   * When all session results are dropped (e.g. switching computing units or
+   * leaving the workspace), wipe the panel. Clearing the result caches alone does
+   * not re-render an operator that stays highlighted, so the previous unit's
+   * result/console frames would otherwise linger on screen.
+   */
+  registerResultClearedHandler() {
+    this.workflowResultService
+      .getResultClearedStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.clearResultPanel();
+        this.currentOperatorId = undefined;
+        this.operatorTitle = "";
+        this.changeDetectorRef.detectChanges();
       });
   }
 

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -220,10 +220,8 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * When all session results are dropped (e.g. switching computing units or
-   * leaving the workspace), wipe the panel. Clearing the result caches alone does
-   * not re-render an operator that stays highlighted, so the previous unit's
-   * result/console frames would otherwise linger on screen.
+   * Wipe the panel when results are dropped (e.g. switching computing units): a
+   * still-highlighted operator isn't re-rendered, so its stale frames would linger.
    */
   registerResultClearedHandler() {
     this.workflowResultService

--- a/frontend/src/app/workspace/component/workspace.component.spec.ts
+++ b/frontend/src/app/workspace/component/workspace.component.spec.ts
@@ -40,8 +40,11 @@ import { WorkflowCompilingService } from "../service/compile-workflow/workflow-c
 import { OperatorMetadataService } from "../service/operator-metadata/operator-metadata.service";
 import { UndoRedoService } from "../service/undo-redo/undo-redo.service";
 import { WorkflowConsoleService } from "../service/workflow-console/workflow-console.service";
+import { ExecuteWorkflowService } from "../service/execute-workflow/execute-workflow.service";
+import { WorkflowResultService } from "../service/workflow-result/workflow-result.service";
 import { WorkflowActionService } from "../service/workflow-graph/model/workflow-action.service";
 import { OperatorReuseCacheStatusService } from "../service/workflow-status/operator-reuse-cache-status.service";
+import { ComputingUnitStatusService } from "../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
 import { EntityType, HubService } from "../../hub/service/hub.service";
 import { commonTestProviders } from "../../common/testing/test-utils";
 import { WorkspaceComponent } from "./workspace.component";
@@ -62,6 +65,10 @@ describe("WorkspaceComponent", () => {
   let messageService: any;
   let routerMock: any;
   let locationMock: any;
+  let computingUnitStatusService: any;
+  let executeWorkflowService: any;
+  let workflowConsoleService: any;
+  let workflowResultService: any;
   let metadataChangedSubject: Subject<void>;
   let stubGraph: { triggerCenterEvent: ReturnType<typeof vi.fn>; hasElementWithID: ReturnType<typeof vi.fn> };
 
@@ -136,6 +143,10 @@ describe("WorkspaceComponent", () => {
 
     routerMock = { navigate: vi.fn() };
     locationMock = { go: vi.fn() };
+    computingUnitStatusService = { disconnect: vi.fn() };
+    executeWorkflowService = { resetState: vi.fn() };
+    workflowConsoleService = { clearConsoleMessages: vi.fn() };
+    workflowResultService = { clearResults: vi.fn() };
 
     // Drop the standalone component's child imports and allow unknown elements via
     // CUSTOM_ELEMENTS_SCHEMA. The template still renders, so `<ng-template #codeEditor>`
@@ -167,8 +178,11 @@ describe("WorkspaceComponent", () => {
         // The three services listed in the constructor only to force their
         // initialization aren't exercised by any test here; provide stubs.
         { provide: WorkflowCompilingService, useValue: {} },
-        { provide: WorkflowConsoleService, useValue: {} },
+        { provide: WorkflowConsoleService, useValue: workflowConsoleService },
         { provide: OperatorReuseCacheStatusService, useValue: {} },
+        { provide: ComputingUnitStatusService, useValue: computingUnitStatusService },
+        { provide: ExecuteWorkflowService, useValue: executeWorkflowService },
+        { provide: WorkflowResultService, useValue: workflowResultService },
         ...commonTestProviders,
       ],
       schemas: [NO_ERRORS_SCHEMA],
@@ -414,6 +428,16 @@ describe("WorkspaceComponent", () => {
       expect(workflowPersistService.persistWorkflow).not.toHaveBeenCalled();
       // Cleanup of the workflow state still happens regardless.
       expect(workflowActionService.clearWorkflow).toHaveBeenCalled();
+    });
+
+    it("tears down every piece of websocket-derived state when leaving the workspace (issue #3120)", async () => {
+      await createFixture();
+      fixture.detectChanges();
+      component.ngOnDestroy();
+      expect(computingUnitStatusService.disconnect).toHaveBeenCalled();
+      expect(executeWorkflowService.resetState).toHaveBeenCalled();
+      expect(workflowConsoleService.clearConsoleMessages).toHaveBeenCalled();
+      expect(workflowResultService.clearResults).toHaveBeenCalled();
     });
   });
 

--- a/frontend/src/app/workspace/component/workspace.component.spec.ts
+++ b/frontend/src/app/workspace/component/workspace.component.spec.ts
@@ -69,6 +69,7 @@ describe("WorkspaceComponent", () => {
   let executeWorkflowService: any;
   let workflowConsoleService: any;
   let workflowResultService: any;
+  let connectionResetSubject: Subject<void>;
   let metadataChangedSubject: Subject<void>;
   let stubGraph: { triggerCenterEvent: ReturnType<typeof vi.fn>; hasElementWithID: ReturnType<typeof vi.fn> };
 
@@ -143,8 +144,12 @@ describe("WorkspaceComponent", () => {
 
     routerMock = { navigate: vi.fn() };
     locationMock = { go: vi.fn() };
-    computingUnitStatusService = { disconnect: vi.fn() };
-    executeWorkflowService = { resetState: vi.fn() };
+    connectionResetSubject = new Subject<void>();
+    computingUnitStatusService = {
+      disconnect: vi.fn(),
+      getConnectionResetStream: () => connectionResetSubject.asObservable(),
+    };
+    executeWorkflowService = { resetExecutionAndWorkers: vi.fn() };
     workflowConsoleService = { clearConsoleMessages: vi.fn() };
     workflowResultService = { clearResults: vi.fn() };
 
@@ -435,7 +440,17 @@ describe("WorkspaceComponent", () => {
       fixture.detectChanges();
       component.ngOnDestroy();
       expect(computingUnitStatusService.disconnect).toHaveBeenCalled();
-      expect(executeWorkflowService.resetState).toHaveBeenCalled();
+      expect(executeWorkflowService.resetExecutionAndWorkers).toHaveBeenCalled();
+      expect(workflowConsoleService.clearConsoleMessages).toHaveBeenCalled();
+      expect(workflowResultService.clearResults).toHaveBeenCalled();
+    });
+
+    it("clears the workflow session state when the computing unit is switched in-canvas (issue #3120)", async () => {
+      await createFixture();
+      fixture.detectChanges();
+      // Switching to a different unit emits on the connection-reset stream.
+      connectionResetSubject.next();
+      expect(executeWorkflowService.resetExecutionAndWorkers).toHaveBeenCalled();
       expect(workflowConsoleService.clearConsoleMessages).toHaveBeenCalled();
       expect(workflowResultService.clearResults).toHaveBeenCalled();
     });

--- a/frontend/src/app/workspace/component/workspace.component.ts
+++ b/frontend/src/app/workspace/component/workspace.component.ts
@@ -150,9 +150,8 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     this.pid = parseInt(this.route.snapshot.queryParams.pid) || undefined;
     this.workflowActionService.setHighlightingEnabled(true);
-    // When the user switches computing units without leaving the workspace, the
-    // socket reconnects to the new unit; clear the previous unit's session state
-    // (execution status, console, results) so it does not linger (issue #3120).
+    // Clear session state when the user switches computing units in-canvas, so
+    // the previous unit's status/console/results don't linger (#3120).
     this.computingUnitStatusService
       .getConnectionResetStream()
       .pipe(untilDestroyed(this))
@@ -197,19 +196,15 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
 
     this.codeEditorViewRef.clear();
     this.workflowActionService.clearWorkflow();
-    // Tear down every piece of websocket-derived state so that re-entering a
-    // workflow starts from a clean session instead of reusing the previous one
-    // (issue #3120): the connection itself, plus the session state that is
-    // populated from websocket events.
+    // Tear down the connection and all websocket-derived session state so a
+    // re-entered workflow starts clean instead of reusing the previous one (#3120).
     this.computingUnitStatusService.disconnect();
     this.resetWorkflowSessionState();
   }
 
   /**
-   * Clear the websocket-derived session state (execution status, console
-   * output, result caches) so a fresh workflow session does not inherit the
-   * previous one. Shared by workspace teardown (returning to the dashboard) and
-   * in-canvas computing-unit switches (issue #3120).
+   * Clear websocket-derived session state (execution status, console, results).
+   * Shared by workspace teardown and in-canvas unit switches (#3120).
    */
   private resetWorkflowSessionState(): void {
     this.executeWorkflowService.resetExecutionAndWorkers();

--- a/frontend/src/app/workspace/component/workspace.component.ts
+++ b/frontend/src/app/workspace/component/workspace.component.ts
@@ -150,6 +150,13 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
      */
     this.pid = parseInt(this.route.snapshot.queryParams.pid) || undefined;
     this.workflowActionService.setHighlightingEnabled(true);
+    // When the user switches computing units without leaving the workspace, the
+    // socket reconnects to the new unit; clear the previous unit's session state
+    // (execution status, console, results) so it does not linger (issue #3120).
+    this.computingUnitStatusService
+      .getConnectionResetStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => this.resetWorkflowSessionState());
   }
 
   ngAfterViewInit(): void {
@@ -192,10 +199,20 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
     this.workflowActionService.clearWorkflow();
     // Tear down every piece of websocket-derived state so that re-entering a
     // workflow starts from a clean session instead of reusing the previous one
-    // (issue #3120): the connection itself, plus the execution status, console
-    // output, and result caches that are populated from websocket events.
+    // (issue #3120): the connection itself, plus the session state that is
+    // populated from websocket events.
     this.computingUnitStatusService.disconnect();
-    this.executeWorkflowService.resetState();
+    this.resetWorkflowSessionState();
+  }
+
+  /**
+   * Clear the websocket-derived session state (execution status, console
+   * output, result caches) so a fresh workflow session does not inherit the
+   * previous one. Shared by workspace teardown (returning to the dashboard) and
+   * in-canvas computing-unit switches (issue #3120).
+   */
+  private resetWorkflowSessionState(): void {
+    this.executeWorkflowService.resetExecutionAndWorkers();
     this.workflowConsoleService.clearConsoleMessages();
     this.workflowResultService.clearResults();
   }

--- a/frontend/src/app/workspace/component/workspace.component.ts
+++ b/frontend/src/app/workspace/component/workspace.component.ts
@@ -51,6 +51,9 @@ import { THROTTLE_TIME_MS } from "../../hub/component/workflow/detail/hub-workfl
 import { WorkflowCompilingService } from "../service/compile-workflow/workflow-compiling.service";
 import { USER_WORKSPACE } from "../../app-routing.constant";
 import { GuiConfigService } from "../../common/service/gui-config.service";
+import { ComputingUnitStatusService } from "../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
+import { ExecuteWorkflowService } from "../service/execute-workflow/execute-workflow.service";
+import { WorkflowResultService } from "../service/workflow-result/workflow-result.service";
 import { checkIfWorkflowBroken } from "../../common/util/workflow-check";
 import { NzSpinComponent } from "ng-zorro-antd/spin";
 import { ResultPanelComponent } from "./result-panel/result-panel.component";
@@ -126,7 +129,10 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
     private hubService: HubService,
     private codeEditorService: CodeEditorService,
     private config: GuiConfigService,
-    private changeDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef,
+    private computingUnitStatusService: ComputingUnitStatusService,
+    private executeWorkflowService: ExecuteWorkflowService,
+    private workflowResultService: WorkflowResultService
   ) {}
 
   ngOnInit() {
@@ -184,6 +190,14 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
 
     this.codeEditorViewRef.clear();
     this.workflowActionService.clearWorkflow();
+    // Tear down every piece of websocket-derived state so that re-entering a
+    // workflow starts from a clean session instead of reusing the previous one
+    // (issue #3120): the connection itself, plus the execution status, console
+    // output, and result caches that are populated from websocket events.
+    this.computingUnitStatusService.disconnect();
+    this.executeWorkflowService.resetState();
+    this.workflowConsoleService.clearConsoleMessages();
+    this.workflowResultService.clearResults();
   }
 
   registerAutoPersistWorkflow(): void {

--- a/frontend/src/app/workspace/component/workspace.component.ts
+++ b/frontend/src/app/workspace/component/workspace.component.ts
@@ -151,7 +151,7 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
     this.pid = parseInt(this.route.snapshot.queryParams.pid) || undefined;
     this.workflowActionService.setHighlightingEnabled(true);
     // Clear session state when the user switches computing units in-canvas, so
-    // the previous unit's status/console/results don't linger (#3120).
+    // the previous unit's status/console/results don't linger.
     this.computingUnitStatusService
       .getConnectionResetStream()
       .pipe(untilDestroyed(this))
@@ -197,14 +197,14 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
     this.codeEditorViewRef.clear();
     this.workflowActionService.clearWorkflow();
     // Tear down the connection and all websocket-derived session state so a
-    // re-entered workflow starts clean instead of reusing the previous one (#3120).
+    // re-entered workflow starts clean instead of reusing the previous one.
     this.computingUnitStatusService.disconnect();
     this.resetWorkflowSessionState();
   }
 
   /**
    * Clear websocket-derived session state (execution status, console, results).
-   * Shared by workspace teardown and in-canvas unit switches (#3120).
+   * Shared by workspace teardown and in-canvas unit switches.
    */
   private resetWorkflowSessionState(): void {
     this.executeWorkflowService.resetExecutionAndWorkers();

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -90,10 +90,15 @@ describe("ExecuteWorkflowService", () => {
     (service as any).currentState = { state: ExecutionState.Running };
     (service as any).assignedWorkerIds.set("op1", ["w1", "w2"]);
 
+    const emittedStates: ExecutionState[] = [];
+    service.getExecutionStateStream().subscribe(event => emittedStates.push(event.current.state));
+
     service.resetExecutionAndWorkers();
 
     expect(service.getExecutionState().state).toBe(ExecutionState.Uninitialized);
     expect(service.getWorkerIds("op1")).toEqual([]);
+    // must broadcast on the stream so subscribers (menu, result panel) drop stale status
+    expect(emittedStates).toContain(ExecutionState.Uninitialized);
   });
 
   it("should generate a logical plan request based on the workflow graph that is passed to the function", () => {

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -86,6 +86,16 @@ describe("ExecuteWorkflowService", () => {
     expect(injectedService).toBeTruthy();
   }));
 
+  it("resetState() clears the execution state and worker assignments", () => {
+    (service as any).currentState = { state: ExecutionState.Running };
+    (service as any).assignedWorkerIds.set("op1", ["w1", "w2"]);
+
+    service.resetState();
+
+    expect(service.getExecutionState().state).toBe(ExecutionState.Uninitialized);
+    expect(service.getWorkerIds("op1")).toEqual([]);
+  });
+
   it("should generate a logical plan request based on the workflow graph that is passed to the function", () => {
     const newLogicalPlan: LogicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(mockWorkflowPlan_scan_result);
     expect(newLogicalPlan).toEqual(mockLogicalPlan_scan_result);

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -86,11 +86,11 @@ describe("ExecuteWorkflowService", () => {
     expect(injectedService).toBeTruthy();
   }));
 
-  it("resetState() clears the execution state and worker assignments", () => {
+  it("resetExecutionAndWorkers() clears the execution state and worker assignments", () => {
     (service as any).currentState = { state: ExecutionState.Running };
     (service as any).assignedWorkerIds.set("op1", ["w1", "w2"]);
 
-    service.resetState();
+    service.resetExecutionAndWorkers();
 
     expect(service.getExecutionState().state).toBe(ExecutionState.Uninitialized);
     expect(service.getWorkerIds("op1")).toEqual([]);

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -355,11 +355,12 @@ export class ExecuteWorkflowService {
   }
 
   /**
-   * Reset all websocket-derived execution state. Called when leaving the
-   * workspace so a re-entered workflow does not inherit the previous
-   * execution's status or worker assignments (issue #3120).
+   * Reset all websocket-derived execution state. Unlike resetExecutionState(),
+   * which only resets the current execution status, this also clears the worker
+   * assignments. Called when leaving the workspace so a re-entered workflow does
+   * not inherit the previous execution's status or worker assignments (issue #3120).
    */
-  public resetState(): void {
+  public resetExecutionAndWorkers(): void {
     this.resetExecutionState();
     this.assignedWorkerIds.clear();
   }

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -356,7 +356,7 @@ export class ExecuteWorkflowService {
 
   /**
    * Reset execution status and worker assignments. Unlike resetExecutionState(),
-   * which resets only the status, this also clears the worker assignments (#3120).
+   * which resets only the status, this also clears the worker assignments.
    */
   public resetExecutionAndWorkers(): void {
     this.resetExecutionState();

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -355,10 +355,8 @@ export class ExecuteWorkflowService {
   }
 
   /**
-   * Reset all websocket-derived execution state. Unlike resetExecutionState(),
-   * which only resets the current execution status, this also clears the worker
-   * assignments. Called when leaving the workspace so a re-entered workflow does
-   * not inherit the previous execution's status or worker assignments (issue #3120).
+   * Reset execution status and worker assignments. Unlike resetExecutionState(),
+   * which resets only the status, this also clears the worker assignments (#3120).
    */
   public resetExecutionAndWorkers(): void {
     this.resetExecutionState();

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -354,6 +354,16 @@ export class ExecuteWorkflowService {
     };
   }
 
+  /**
+   * Reset all websocket-derived execution state. Called when leaving the
+   * workspace so a re-entered workflow does not inherit the previous
+   * execution's status or worker assignments (issue #3120).
+   */
+  public resetState(): void {
+    this.resetExecutionState();
+    this.assignedWorkerIds.clear();
+  }
+
   private updateExecutionState(stateInfo: ExecutionStateInfo): void {
     if (isEqual(this.currentState, stateInfo)) {
       return;

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -357,9 +357,14 @@ export class ExecuteWorkflowService {
   /**
    * Reset execution status and worker assignments. Unlike resetExecutionState(),
    * which resets only the status, this also clears the worker assignments.
+   *
+   * Goes through updateExecutionState() (rather than resetExecutionState()) so the
+   * change is broadcast on executionStateStream; otherwise subscribers such as
+   * MenuComponent and ResultPanelComponent would keep showing the previous unit's
+   * execution status after a computing-unit switch.
    */
   public resetExecutionAndWorkers(): void {
-    this.resetExecutionState();
+    this.updateExecutionState({ state: ExecutionState.Uninitialized });
     this.assignedWorkerIds.clear();
   }
 

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -356,12 +356,8 @@ export class ExecuteWorkflowService {
 
   /**
    * Reset execution status and worker assignments. Unlike resetExecutionState(),
-   * which resets only the status, this also clears the worker assignments.
-   *
-   * Goes through updateExecutionState() (rather than resetExecutionState()) so the
-   * change is broadcast on executionStateStream; otherwise subscribers such as
-   * MenuComponent and ResultPanelComponent would keep showing the previous unit's
-   * execution status after a computing-unit switch.
+   * this also clears worker assignments and broadcasts the reset on
+   * executionStateStream so subscribers drop the previous unit's status.
    */
   public resetExecutionAndWorkers(): void {
     this.updateExecutionState({ state: ExecutionState.Uninitialized });

--- a/frontend/src/app/workspace/service/workflow-console/workflow-console.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-console/workflow-console.service.spec.ts
@@ -34,4 +34,17 @@ describe("WorkflowConsoleService", () => {
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
+
+  it("clearConsoleMessages() removes all messages and notifies subscribers", () => {
+    (service as any).consoleMessages.set("op1", []);
+    expect(service.hasConsoleMessages("op1")).toBe(true);
+
+    let notified = false;
+    service.getConsoleMessageUpdateStream().subscribe(() => (notified = true));
+
+    service.clearConsoleMessages();
+
+    expect(service.hasConsoleMessages("op1")).toBe(false);
+    expect(notified).toBe(true);
+  });
 });

--- a/frontend/src/app/workspace/service/workflow-console/workflow-console.service.ts
+++ b/frontend/src/app/workspace/service/workflow-console/workflow-console.service.ts
@@ -76,7 +76,7 @@ export class WorkflowConsoleService {
 
   /**
    * Clear all console messages so a re-entered workflow doesn't show the
-   * previous session's output (#3120).
+   * previous session's output.
    */
   public clearConsoleMessages(): void {
     this.consoleMessages.clear();

--- a/frontend/src/app/workspace/service/workflow-console/workflow-console.service.ts
+++ b/frontend/src/app/workspace/service/workflow-console/workflow-console.service.ts
@@ -73,4 +73,14 @@ export class WorkflowConsoleService {
   getConsoleMessageUpdateStream(): Observable<void> {
     return this.consoleMessagesUpdateStream.asObservable();
   }
+
+  /**
+   * Clear all console messages. Called when leaving the workspace so a
+   * re-entered workflow does not show the previous session's console output
+   * (issue #3120).
+   */
+  public clearConsoleMessages(): void {
+    this.consoleMessages.clear();
+    this.consoleMessagesUpdateStream.next();
+  }
 }

--- a/frontend/src/app/workspace/service/workflow-console/workflow-console.service.ts
+++ b/frontend/src/app/workspace/service/workflow-console/workflow-console.service.ts
@@ -75,9 +75,8 @@ export class WorkflowConsoleService {
   }
 
   /**
-   * Clear all console messages. Called when leaving the workspace so a
-   * re-entered workflow does not show the previous session's console output
-   * (issue #3120).
+   * Clear all console messages so a re-entered workflow doesn't show the
+   * previous session's output (#3120).
    */
   public clearConsoleMessages(): void {
     this.consoleMessages.clear();

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
@@ -57,6 +57,13 @@ describe("WorkflowResultService", () => {
     service.clearResults();
     expect(pairs[pairs.length - 1][1]).toEqual({});
   });
+
+  it("clearResults() emits on the cleared stream so the UI tears down stale frames", () => {
+    let clearedCount = 0;
+    service.getResultClearedStream().subscribe(() => clearedCount++);
+    service.clearResults();
+    expect(clearedCount).toBe(1);
+  });
 });
 
 describe("OperatorPaginationResultService", () => {

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
@@ -37,6 +37,26 @@ describe("WorkflowResultService", () => {
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
+
+  it("clearResults() drops cached operator results", () => {
+    (service as any).operatorResultServices.set("op1", {});
+    (service as any).paginatedResultServices.set("op2", {});
+    expect(service.hasAnyResult("op1")).toBe(true);
+    expect(service.hasAnyResult("op2")).toBe(true);
+
+    service.clearResults();
+
+    expect(service.hasAnyResult("op1")).toBe(false);
+    expect(service.hasAnyResult("op2")).toBe(false);
+  });
+
+  it("clearResults() resets table stats to empty for subscribers", () => {
+    const pairs: [unknown, unknown][] = [];
+    service.getResultTableStats().subscribe(p => pairs.push(p));
+    (service as any).resultTableStats.next({ op1: {} });
+    service.clearResults();
+    expect(pairs[pairs.length - 1][1]).toEqual({});
+  });
 });
 
 describe("OperatorPaginationResultService", () => {

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -49,6 +49,8 @@ export class WorkflowResultService {
   private resultUpdateStream = new Subject<Record<string, WebResultUpdate | undefined>>();
   private resultTableStats = new ReplaySubject<Record<string, Record<string, Record<string, number>>>>(1);
   private resultInitiateStream = new Subject<string>();
+  // emits when all cached results are dropped, so the UI can tear down stale result frames
+  private resultClearedStream = new Subject<void>();
 
   constructor(private wsService: WorkflowWebsocketService) {
     this.wsService.subscribeToEvent("WebResultUpdateEvent").subscribe(event => {
@@ -87,6 +89,15 @@ export class WorkflowResultService {
     return this.resultInitiateStream.asObservable();
   }
 
+  /**
+   * Emits when clearResults() drops all cached results. Consumers (e.g.
+   * ResultPanelComponent) subscribe to tear down stale result frames, since
+   * clearing the caches alone does not re-render an already-displayed operator.
+   */
+  public getResultClearedStream(): Observable<void> {
+    return this.resultClearedStream.asObservable();
+  }
+
   public getPaginatedResultService(operatorID: string): OperatorPaginationResultService | undefined {
     return this.paginatedResultServices.get(operatorID);
   }
@@ -99,11 +110,14 @@ export class WorkflowResultService {
    * Drop cached operator results and reset table stats so a re-entered workflow
    * doesn't show stale results. resultTableStats is a ReplaySubject, so
    * reset it to an empty snapshot to avoid replaying stale stats to subscribers.
+   * Emits on resultClearedStream so subscribers tear down already-displayed
+   * result frames instead of leaving them on screen.
    */
   public clearResults(): void {
     this.operatorResultServices.clear();
     this.paginatedResultServices.clear();
     this.resultTableStats.next({});
+    this.resultClearedStream.next();
   }
 
   private handleCleanResultCache(event: WorkflowAvailableResultEvent): void {

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -95,6 +95,18 @@ export class WorkflowResultService {
     return this.operatorResultServices.get(operatorID);
   }
 
+  /**
+   * Drop all cached operator results and reset table stats. Called when leaving
+   * the workspace so a re-entered workflow does not show the previous session's
+   * results (issue #3120). resultTableStats is a ReplaySubject, so it is reset
+   * to an empty snapshot to avoid replaying stale stats to new subscribers.
+   */
+  public clearResults(): void {
+    this.operatorResultServices.clear();
+    this.paginatedResultServices.clear();
+    this.resultTableStats.next({});
+  }
+
   private handleCleanResultCache(event: WorkflowAvailableResultEvent): void {
     const removedOrInvalidatedOperators = new Set<string>();
     // remove operators that no longer have results

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -96,10 +96,9 @@ export class WorkflowResultService {
   }
 
   /**
-   * Drop all cached operator results and reset table stats. Called when leaving
-   * the workspace so a re-entered workflow does not show the previous session's
-   * results (issue #3120). resultTableStats is a ReplaySubject, so it is reset
-   * to an empty snapshot to avoid replaying stale stats to new subscribers.
+   * Drop cached operator results and reset table stats so a re-entered workflow
+   * doesn't show stale results (#3120). resultTableStats is a ReplaySubject, so
+   * reset it to an empty snapshot to avoid replaying stale stats to subscribers.
    */
   public clearResults(): void {
     this.operatorResultServices.clear();

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -97,7 +97,7 @@ export class WorkflowResultService {
 
   /**
    * Drop cached operator results and reset table stats so a re-entered workflow
-   * doesn't show stale results (#3120). resultTableStats is a ReplaySubject, so
+   * doesn't show stale results. resultTableStats is a ReplaySubject, so
    * reset it to an empty snapshot to avoid replaying stale stats to subscribers.
    */
   public clearResults(): void {

--- a/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/frontend/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -49,7 +49,7 @@ export class WorkflowResultService {
   private resultUpdateStream = new Subject<Record<string, WebResultUpdate | undefined>>();
   private resultTableStats = new ReplaySubject<Record<string, Record<string, Record<string, number>>>>(1);
   private resultInitiateStream = new Subject<string>();
-  // emits when all cached results are dropped, so the UI can tear down stale result frames
+  // emits when clearResults() drops cached results, so the UI can drop stale frames
   private resultClearedStream = new Subject<void>();
 
   constructor(private wsService: WorkflowWebsocketService) {
@@ -90,9 +90,8 @@ export class WorkflowResultService {
   }
 
   /**
-   * Emits when clearResults() drops all cached results. Consumers (e.g.
-   * ResultPanelComponent) subscribe to tear down stale result frames, since
-   * clearing the caches alone does not re-render an already-displayed operator.
+   * Emits when clearResults() drops cached results, so consumers can tear down
+   * stale frames (clearing the caches alone won't re-render a displayed operator).
    */
   public getResultClearedStream(): Observable<void> {
     return this.resultClearedStream.asObservable();
@@ -107,11 +106,9 @@ export class WorkflowResultService {
   }
 
   /**
-   * Drop cached operator results and reset table stats so a re-entered workflow
-   * doesn't show stale results. resultTableStats is a ReplaySubject, so
-   * reset it to an empty snapshot to avoid replaying stale stats to subscribers.
-   * Emits on resultClearedStream so subscribers tear down already-displayed
-   * result frames instead of leaving them on screen.
+   * Drop cached results and reset table stats so a re-entered workflow doesn't show
+   * stale results (resultTableStats is a ReplaySubject, so push an empty snapshot).
+   * Emits resultClearedStream so subscribers tear down already-displayed frames.
    */
   public clearResults(): void {
     this.operatorResultServices.clear();

--- a/frontend/src/app/workspace/service/workflow-websocket/workflow-websocket.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-websocket/workflow-websocket.service.spec.ts
@@ -94,4 +94,12 @@ describe("WorkflowWebsocketService", () => {
       window.WebSocket = originalWebSocket;
     }
   });
+
+  it("should reset the cached worker count when the websocket is closed", () => {
+    // numWorkers is populated from ClusterStatusUpdateEvent on the live connection;
+    // once the socket is closed the count is stale and must reset (see issue #3120).
+    service.numWorkers = 5;
+    service.closeWebsocket();
+    expect(service.numWorkers).toBe(-1);
+  });
 });

--- a/frontend/src/app/workspace/service/workflow-websocket/workflow-websocket.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-websocket/workflow-websocket.service.spec.ts
@@ -97,7 +97,7 @@ describe("WorkflowWebsocketService", () => {
 
   it("should reset the cached worker count when the websocket is closed", () => {
     // numWorkers is populated from ClusterStatusUpdateEvent on the live connection;
-    // once the socket is closed the count is stale and must reset (see issue #3120).
+    // once the socket is closed the count is stale and must reset.
     service.numWorkers = 5;
     service.closeWebsocket();
     expect(service.numWorkers).toBe(-1);

--- a/frontend/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
+++ b/frontend/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
@@ -93,6 +93,8 @@ export class WorkflowWebsocketService {
     this.wsWithReconnectSubscription?.unsubscribe();
     this.statusUpdateSubscription?.unsubscribe();
     this.websocket?.complete();
+    // the worker count comes from the live connection; reset it once the socket is gone
+    this.numWorkers = -1;
     this.updateConnectionStatus(false);
   }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Websocket-derived front-end state (the connection itself, plus the execution status, console output, and results built from its events) lives in singletons outside the workspace. It was never torn down in two cases, so stale state carried over:

1. **Returning to the dashboard** and re-entering a workflow reused the previous socket. The connection-tracking fields (`currentConnectedWid` / `currentConnectedCuid`) also survived, so the reconnect guard saw them unchanged, skipped reconnecting, and reused the stale socket. (#3120 — the case #3093 did not cover.)
2. **Switching computing units** inside the workspace left the previous unit's console, results, and execution status on screen.

This PR clears that state at both points.

**Workspace exit**: `WorkspaceComponent.ngOnDestroy()` now tears everything down:

| Call *(new)* | Resets |
| --- | --- |
| `ComputingUnitStatusService.disconnect()` | closes the socket, clears operator status, stops the unit poll, resets the connection-tracking fields and the selected unit |
| `ExecuteWorkflowService.resetExecutionAndWorkers()` | execution status and worker assignments |
| `WorkflowConsoleService.clearConsoleMessages()` | console output |
| `WorkflowResultService.clearResults()` | result caches and table stats |

**Unit switch**: `ComputingUnitStatusService` emits a reset signal when it reconnects to a different unit, and `WorkspaceComponent` clears the same execution / console / result state in response. As a result, switching units now discards the previous unit's results and console instead of leaving them on screen.

The remaining websocket-event consumers need no teardown: `OperatorReuseCacheStatusService` is stateless, and `udf-debug.service`'s state lives in the `TexeraGraph`, already reset by `clearWorkflow()`.

### Any related issues, documentation, discussions?

Closes #3120. Related: #3093 (earlier partial fix for the in-canvas socket re-open).

### How was this PR tested?

Test with this workflow
[Untitled workflow (14).json](https://github.com/user-attachments/files/28696700/Untitled.workflow.14.json)

https://github.com/user-attachments/assets/060fe1ac-39cf-45e5-b423-5aa27fe17aed



### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
