### PR TITLE
fix(workflow-core): paginate S3 deleteDirectory deletions

### DIFF
--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/LargeBinaryManager.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/LargeBinaryManager.scala
@@ -75,8 +75,8 @@ object LargeBinaryManager extends LazyLogging {
   }
 
   /**
-    * Deletes all large binaries for one execution. Uses deleteDirectory, which paginates over
-    * every object under the prefix (no per-page limit), so all binaries for the execution are removed.
+    * Deletes all large binaries for one execution via deleteDirectory, which removes every object
+    * under the prefix.
     *
     * @param executionId the execution whose large binaries should be removed
     */

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/LargeBinaryManager.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/LargeBinaryManager.scala
@@ -75,8 +75,8 @@ object LargeBinaryManager extends LazyLogging {
   }
 
   /**
-    * Deletes all large binaries for one execution. Uses deleteDirectory, which removes one
-    * listing page (<= 1000 objects) — enough for expected counts; more needs a paginated delete.
+    * Deletes all large binaries for one execution. Uses deleteDirectory, which paginates over
+    * every object under the prefix (no per-page limit), so all binaries for the execution are removed.
     *
     * @param executionId the execution whose large binaries should be removed
     */

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
@@ -27,7 +27,6 @@ import software.amazon.awssdk.services.s3.{S3Client, S3Configuration}
 import software.amazon.awssdk.core.sync.RequestBody
 
 import java.io.InputStream
-import java.security.MessageDigest
 import scala.jdk.CollectionConverters._
 
 /**
@@ -40,6 +39,9 @@ object S3StorageClient {
   val MAXIMUM_NUM_OF_MULTIPART_S3_PARTS = 10_000
   //Keep on sync with LakeFS https://github.com/treeverse/lakeFS/pull/10180
   val PHYSICAL_ADDRESS_EXPIRATION_TIME_HRS = 24
+  // AWS S3 DeleteObjects accepts at most 1000 keys per request (listObjectsV2 also
+  // returns at most 1000 keys per page).
+  val MAX_KEYS_PER_DELETE_REQUEST = 1000
 
   // Initialize MinIO-compatible S3 Client
   private lazy val s3Client: S3Client = {
@@ -106,41 +108,42 @@ object S3StorageClient {
     // Ensure the directory prefix ends with `/` to avoid accidental deletions
     val prefix = if (directoryPrefix.endsWith("/")) directoryPrefix else directoryPrefix + "/"
 
-    // List objects under the given prefix
-    val listRequest = ListObjectsV2Request
-      .builder()
-      .bucket(bucketName)
-      .prefix(prefix)
-      .build()
+    val listRequest = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build()
 
-    val listResponse = s3Client.listObjectsV2(listRequest)
+    // listObjectsV2Paginator transparently follows the continuation token across all
+    // pages (listObjectsV2 returns at most 1000 keys per page). Keys are grouped into
+    // batches of at most MAX_KEYS_PER_DELETE_REQUEST, the DeleteObjects per-request limit.
+    s3Client
+      .listObjectsV2Paginator(listRequest)
+      .contents()
+      .asScala
+      .iterator
+      .map(obj => ObjectIdentifier.builder().key(obj.key()).build())
+      .grouped(MAX_KEYS_PER_DELETE_REQUEST)
+      .foreach { batch =>
+        val response = s3Client.deleteObjects(
+          DeleteObjectsRequest
+            .builder()
+            .bucket(bucketName)
+            .delete(Delete.builder().objects(batch.asJava).build())
+            .build()
+        )
+        throwOnDeleteErrors(prefix, response)
+      }
+  }
 
-    // Extract object keys
-    val objectKeys = listResponse.contents().asScala.map(_.key())
-
-    if (objectKeys.nonEmpty) {
-      val objectsToDelete =
-        objectKeys.map(key => ObjectIdentifier.builder().key(key).build()).asJava
-
-      val deleteRequest = Delete
-        .builder()
-        .objects(objectsToDelete)
-        .build()
-
-      // Compute MD5 checksum for MinIO if required
-      val md5Hash = MessageDigest
-        .getInstance("MD5")
-        .digest(deleteRequest.toString.getBytes("UTF-8"))
-
-      // Convert object keys to S3 DeleteObjectsRequest format
-      val deleteObjectsRequest = DeleteObjectsRequest
-        .builder()
-        .bucket(bucketName)
-        .delete(deleteRequest)
-        .build()
-
-      // Perform batch deletion
-      s3Client.deleteObjects(deleteObjectsRequest)
+  /**
+    * The DeleteObjects API reports per-key failures in its response instead of throwing,
+    * so an unchecked response can silently leave objects behind. Raise if any key in the
+    * batch failed to delete.
+    */
+  private[util] def throwOnDeleteErrors(prefix: String, response: DeleteObjectsResponse): Unit = {
+    val failed = response.errors().asScala
+    if (failed.nonEmpty) {
+      throw new RuntimeException(
+        s"Failed to delete ${failed.size} object(s) under prefix '$prefix': " +
+          failed.map(error => s"${error.key()} (${error.code()})").mkString(", ")
+      )
     }
   }
 

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
@@ -100,15 +100,14 @@ object S3StorageClient {
   }
 
   /**
-    * Deletes a "directory" from a bucket — every object whose key begins with the given prefix.
+    * Deletes every object whose key begins with `directoryPrefix`. S3 keys are a flat namespace
+    * with no real directories, so a "directory" is just a shared key prefix.
     *
-    * S3 keys are a flat namespace with no real directories; a "directory" is just a shared key
-    * prefix. A trailing `/` is appended when missing so the prefix only matches on a path
-    * boundary: prefix `a/b` deletes `a/b/file` but not the unrelated `a/bc/file`.
+    * A trailing `/` is added when missing so the prefix matches on a path boundary (`a/b` deletes
+    * `a/b/file` but not `a/bc/file`). An empty prefix would match the whole bucket and is rejected.
     *
     * @param bucketName Target S3/MinIO bucket.
-    * @param directoryPrefix The directory (key prefix) to delete. Must be non-empty: an empty
-    *                        prefix matches the whole bucket, so it is rejected as a safeguard.
+    * @param directoryPrefix Non-empty key prefix to delete.
     */
   def deleteDirectory(bucketName: String, directoryPrefix: String): Unit = {
     require(directoryPrefix.nonEmpty, "directoryPrefix must not be empty")
@@ -116,11 +115,9 @@ object S3StorageClient {
 
     val listRequest = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build()
 
-    // Paginate across all listing pages and delete in batches within the per-request key limit.
-    // Every batch is attempted before raising, so one undeletable key doesn't strand the keys
-    // behind it — DatasetResource can't retry (its LakeFS repo is already gone), so each attempt
-    // must make as much progress as possible. `quiet(true)` trims each response down to just the
-    // failures, which is all we inspect.
+    // Delete in batches capped at the per-request key limit. Attempt every batch before raising,
+    // so one undeletable key can't strand the rest; `quiet(true)` keeps each response to just the
+    // failures.
     val errors = s3Client
       .listObjectsV2Paginator(listRequest)
       .contents()
@@ -145,10 +142,7 @@ object S3StorageClient {
     throwOnDeleteErrors(prefix, errors)
   }
 
-  /**
-    * DeleteObjects reports per-key failures in its response instead of throwing. Raise if any key
-    * failed across the batches, listing up to `MAX_LISTED_DELETE_ERRORS` of them.
-    */
+  /** Raise if any object failed to delete, listing up to `MAX_LISTED_DELETE_ERRORS` keys. */
   private[util] def throwOnDeleteErrors(prefix: String, errors: Seq[S3Error]): Unit = {
     if (errors.nonEmpty) {
       val listed = errors.take(MAX_LISTED_DELETE_ERRORS).map(e => s"${e.key()} (${e.code()})")

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
@@ -42,6 +42,10 @@ object S3StorageClient {
   // AWS S3 DeleteObjects accepts at most 1000 keys per request (listObjectsV2 also
   // returns at most 1000 keys per page).
   val MAX_KEYS_PER_DELETE_REQUEST = 1000
+  // A failed DeleteObjects batch can report up to MAX_KEYS_PER_DELETE_REQUEST per-key
+  // errors; only enumerate this many in the exception message and summarize the rest so
+  // the message stays bounded.
+  private[util] val MAX_LISTED_DELETE_ERRORS = 10
 
   // Initialize MinIO-compatible S3 Client
   private lazy val s3Client: S3Client = {
@@ -140,9 +144,14 @@ object S3StorageClient {
   private[util] def throwOnDeleteErrors(prefix: String, response: DeleteObjectsResponse): Unit = {
     val failed = response.errors().asScala
     if (failed.nonEmpty) {
+      val listed = failed.take(MAX_LISTED_DELETE_ERRORS).map(e => s"${e.key()} (${e.code()})")
+      val summary =
+        if (failed.size > MAX_LISTED_DELETE_ERRORS)
+          s" (and ${failed.size - MAX_LISTED_DELETE_ERRORS} more)"
+        else ""
       throw new RuntimeException(
         s"Failed to delete ${failed.size} object(s) under prefix '$prefix': " +
-          failed.map(error => s"${error.key()} (${error.code()})").mkString(", ")
+          listed.mkString(", ") + summary
       )
     }
   }

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
@@ -39,12 +39,9 @@ object S3StorageClient {
   val MAXIMUM_NUM_OF_MULTIPART_S3_PARTS = 10_000
   //Keep on sync with LakeFS https://github.com/treeverse/lakeFS/pull/10180
   val PHYSICAL_ADDRESS_EXPIRATION_TIME_HRS = 24
-  // AWS S3 DeleteObjects accepts at most 1000 keys per request (listObjectsV2 also
-  // returns at most 1000 keys per page).
+  // S3 DeleteObjects accepts at most 1000 keys per request.
   val MAX_KEYS_PER_DELETE_REQUEST = 1000
-  // A failed DeleteObjects batch can report up to MAX_KEYS_PER_DELETE_REQUEST per-key
-  // errors; only enumerate this many in the exception message and summarize the rest so
-  // the message stays bounded.
+  // Cap how many failed keys are listed in the error message.
   private[util] val MAX_LISTED_DELETE_ERRORS = 10
 
   // Initialize MinIO-compatible S3 Client
@@ -114,9 +111,7 @@ object S3StorageClient {
 
     val listRequest = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build()
 
-    // listObjectsV2Paginator transparently follows the continuation token across all
-    // pages (listObjectsV2 returns at most 1000 keys per page). Keys are grouped into
-    // batches of at most MAX_KEYS_PER_DELETE_REQUEST, the DeleteObjects per-request limit.
+    // Paginate across all pages, then delete in batches within the per-request key limit.
     s3Client
       .listObjectsV2Paginator(listRequest)
       .contents()
@@ -137,9 +132,8 @@ object S3StorageClient {
   }
 
   /**
-    * The DeleteObjects API reports per-key failures in its response instead of throwing,
-    * so an unchecked response can silently leave objects behind. Raise if any key in the
-    * batch failed to delete.
+    * DeleteObjects reports per-key failures in its response instead of throwing;
+    * raise if any key failed.
     */
   private[util] def throwOnDeleteErrors(prefix: String, response: DeleteObjectsResponse): Unit = {
     val failed = response.errors().asScala

--- a/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/service/util/S3StorageClient.scala
@@ -100,51 +100,64 @@ object S3StorageClient {
   }
 
   /**
-    * Deletes a directory (all objects under a given prefix) from a bucket.
+    * Deletes a "directory" from a bucket — every object whose key begins with the given prefix.
+    *
+    * S3 keys are a flat namespace with no real directories; a "directory" is just a shared key
+    * prefix. A trailing `/` is appended when missing so the prefix only matches on a path
+    * boundary: prefix `a/b` deletes `a/b/file` but not the unrelated `a/bc/file`.
     *
     * @param bucketName Target S3/MinIO bucket.
-    * @param directoryPrefix The directory to delete (must end with `/`).
+    * @param directoryPrefix The directory (key prefix) to delete. Must be non-empty: an empty
+    *                        prefix matches the whole bucket, so it is rejected as a safeguard.
     */
   def deleteDirectory(bucketName: String, directoryPrefix: String): Unit = {
-    // Ensure the directory prefix ends with `/` to avoid accidental deletions
+    require(directoryPrefix.nonEmpty, "directoryPrefix must not be empty")
     val prefix = if (directoryPrefix.endsWith("/")) directoryPrefix else directoryPrefix + "/"
 
     val listRequest = ListObjectsV2Request.builder().bucket(bucketName).prefix(prefix).build()
 
-    // Paginate across all pages, then delete in batches within the per-request key limit.
-    s3Client
+    // Paginate across all listing pages and delete in batches within the per-request key limit.
+    // Every batch is attempted before raising, so one undeletable key doesn't strand the keys
+    // behind it — DatasetResource can't retry (its LakeFS repo is already gone), so each attempt
+    // must make as much progress as possible. `quiet(true)` trims each response down to just the
+    // failures, which is all we inspect.
+    val errors = s3Client
       .listObjectsV2Paginator(listRequest)
       .contents()
       .asScala
       .iterator
       .map(obj => ObjectIdentifier.builder().key(obj.key()).build())
       .grouped(MAX_KEYS_PER_DELETE_REQUEST)
-      .foreach { batch =>
-        val response = s3Client.deleteObjects(
-          DeleteObjectsRequest
-            .builder()
-            .bucket(bucketName)
-            .delete(Delete.builder().objects(batch.asJava).build())
-            .build()
-        )
-        throwOnDeleteErrors(prefix, response)
+      .flatMap { batch =>
+        s3Client
+          .deleteObjects(
+            DeleteObjectsRequest
+              .builder()
+              .bucket(bucketName)
+              .delete(Delete.builder().objects(batch.asJava).quiet(true).build())
+              .build()
+          )
+          .errors()
+          .asScala
       }
+      .toList
+
+    throwOnDeleteErrors(prefix, errors)
   }
 
   /**
-    * DeleteObjects reports per-key failures in its response instead of throwing;
-    * raise if any key failed.
+    * DeleteObjects reports per-key failures in its response instead of throwing. Raise if any key
+    * failed across the batches, listing up to `MAX_LISTED_DELETE_ERRORS` of them.
     */
-  private[util] def throwOnDeleteErrors(prefix: String, response: DeleteObjectsResponse): Unit = {
-    val failed = response.errors().asScala
-    if (failed.nonEmpty) {
-      val listed = failed.take(MAX_LISTED_DELETE_ERRORS).map(e => s"${e.key()} (${e.code()})")
+  private[util] def throwOnDeleteErrors(prefix: String, errors: Seq[S3Error]): Unit = {
+    if (errors.nonEmpty) {
+      val listed = errors.take(MAX_LISTED_DELETE_ERRORS).map(e => s"${e.key()} (${e.code()})")
       val summary =
-        if (failed.size > MAX_LISTED_DELETE_ERRORS)
-          s" (and ${failed.size - MAX_LISTED_DELETE_ERRORS} more)"
+        if (errors.size > MAX_LISTED_DELETE_ERRORS)
+          s" (and ${errors.size - MAX_LISTED_DELETE_ERRORS} more)"
         else ""
       throw new RuntimeException(
-        s"Failed to delete ${failed.size} object(s) under prefix '$prefix': " +
+        s"Failed to delete ${errors.size} object(s) under prefix '$prefix': " +
           listed.mkString(", ") + summary
       )
     }

--- a/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
@@ -358,10 +358,7 @@ class S3StorageClientSpec
   }
 
   test("deleteDirectory should delete more than 1000 objects under a prefix") {
-    // listObjectsV2 returns at most 1000 keys per page and DeleteObjects accepts at
-    // most 1000 keys per request. Exceeding 1000 objects exercises both the
-    // continuation-token pagination loop and the batching of deletions; without them
-    // only the first 1000 objects are removed and the rest are silently orphaned.
+    // >1000 objects exercises pagination and delete batching; without them the tail is orphaned.
     val prefix = "delete-dir/large"
     val objectCount = 1001
 
@@ -391,15 +388,12 @@ class S3StorageClientSpec
   }
 
   test("deleteDirectory should not throw for a prefix with no objects") {
-    // Nothing to delete: the listing is empty, so no DeleteObjects request is issued.
+    // Empty listing: no DeleteObjects request is issued.
     S3StorageClient.deleteDirectory(testBucketName, "delete-dir/non-existent")
   }
 
   test("deleteDirectory should surface per-key delete failures rather than swallow them") {
-    // DeleteObjects returns failed keys in its response instead of throwing, so the
-    // client must inspect them; otherwise partial deletions become silent storage leaks.
-    // (Provoking a real per-key failure needs object-lock/retention setup, so the
-    // response-handling is verified directly here.)
+    // A real per-key failure needs object-lock setup, so verify response handling directly.
     val responseWithError = DeleteObjectsResponse
       .builder()
       .errors(S3Error.builder().key("delete-dir/locked.txt").code("AccessDenied").build())
@@ -414,8 +408,7 @@ class S3StorageClientSpec
     // A response with no errors must not throw.
     S3StorageClient.throwOnDeleteErrors("delete-dir/", DeleteObjectsResponse.builder().build())
 
-    // When many keys fail, the message reports the true total but only enumerates the first
-    // MAX_LISTED_DELETE_ERRORS keys and summarizes the rest, so it stays bounded.
+    // Many failures: message reports the true total but only lists up to the cap.
     val cap = S3StorageClient.MAX_LISTED_DELETE_ERRORS
     val errorCount = cap + 5
     val manyErrors = (0 until errorCount).map(i =>

--- a/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
@@ -43,8 +43,7 @@ class S3StorageClientSpec
   }
 
   override def afterAll(): Unit = {
-    // Best-effort cleanup of the prefixes these tests write under. (deleteDirectory rejects an
-    // empty prefix, so a whole-bucket sweep isn't available — and isn't needed here.)
+    // Best-effort cleanup of the prefixes these tests use (deleteDirectory rejects an empty prefix).
     try {
       Seq("test", "delete-dir").foreach(S3StorageClient.deleteDirectory(testBucketName, _))
     } catch {
@@ -359,8 +358,8 @@ class S3StorageClientSpec
   }
 
   test("deleteDirectory should not delete siblings that merely share the prefix string") {
-    // Deleting "delete-dir/small" must not touch "delete-dir/small-sibling.txt": the trailing-slash
-    // normalization makes the prefix "delete-dir/small/", which is not a prefix of the sibling key.
+    // The trailing-slash guard: deleting "delete-dir/small" (→ "delete-dir/small/") must leave the
+    // sibling "delete-dir/small-sibling.txt" untouched.
     val prefix = "delete-dir/small"
     S3StorageClient.uploadObject(testBucketName, s"$prefix/object.txt", createInputStream("data"))
     val sibling = "delete-dir/small-sibling.txt"
@@ -410,8 +409,7 @@ class S3StorageClientSpec
     S3StorageClient.deleteDirectory(testBucketName, "delete-dir/non-existent")
   }
 
-  // A real per-key delete failure needs object-lock setup, so exercise throwOnDeleteErrors
-  // directly — it's the helper that decides whether deleteDirectory raises.
+  // A real per-key failure needs object-lock setup, so test throwOnDeleteErrors directly.
 
   test("throwOnDeleteErrors should raise on a per-key delete failure") {
     val errors = Seq(S3Error.builder().key("delete-dir/locked.txt").code("AccessDenied").build())

--- a/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
@@ -21,8 +21,12 @@ package org.apache.texera.service.util
 
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
+import software.amazon.awssdk.services.s3.model.{DeleteObjectsResponse, S3Error}
 
 import java.io.ByteArrayInputStream
+import java.util.concurrent.Executors
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.Random
 
 class S3StorageClientSpec
@@ -333,5 +337,81 @@ class S3StorageClientSpec
     assert(downloadedData == testData)
 
     S3StorageClient.deleteObject(testBucketName, objectKey)
+  }
+
+  // ========================================
+  // deleteDirectory Tests
+  // ========================================
+
+  test("deleteDirectory should delete all objects under a prefix") {
+    val prefix = "delete-dir/small"
+    val keys = (0 until 5).map(i => s"$prefix/object-$i.txt")
+    keys.foreach(key =>
+      S3StorageClient.uploadObject(testBucketName, key, createInputStream("data"))
+    )
+
+    assert(S3StorageClient.directoryExists(testBucketName, prefix))
+
+    S3StorageClient.deleteDirectory(testBucketName, prefix)
+
+    assert(!S3StorageClient.directoryExists(testBucketName, prefix))
+  }
+
+  test("deleteDirectory should delete more than 1000 objects under a prefix") {
+    // listObjectsV2 returns at most 1000 keys per page and DeleteObjects accepts at
+    // most 1000 keys per request. Exceeding 1000 objects exercises both the
+    // continuation-token pagination loop and the batching of deletions; without them
+    // only the first 1000 objects are removed and the rest are silently orphaned.
+    val prefix = "delete-dir/large"
+    val objectCount = 1001
+
+    // Upload concurrently to keep the test reasonably fast.
+    val pool = Executors.newFixedThreadPool(16)
+    implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(pool)
+    try {
+      val uploads = (0 until objectCount).map { i =>
+        Future {
+          S3StorageClient.uploadObject(
+            testBucketName,
+            f"$prefix/object-$i%05d.txt",
+            createInputStream("")
+          )
+        }
+      }
+      Await.result(Future.sequence(uploads), 5.minutes)
+    } finally {
+      pool.shutdown()
+    }
+
+    assert(S3StorageClient.directoryExists(testBucketName, prefix))
+
+    S3StorageClient.deleteDirectory(testBucketName, prefix)
+
+    assert(!S3StorageClient.directoryExists(testBucketName, prefix))
+  }
+
+  test("deleteDirectory should not throw for a prefix with no objects") {
+    // Nothing to delete: the listing is empty, so no DeleteObjects request is issued.
+    S3StorageClient.deleteDirectory(testBucketName, "delete-dir/non-existent")
+  }
+
+  test("deleteDirectory should surface per-key delete failures rather than swallow them") {
+    // DeleteObjects returns failed keys in its response instead of throwing, so the
+    // client must inspect them; otherwise partial deletions become silent storage leaks.
+    // (Provoking a real per-key failure needs object-lock/retention setup, so the
+    // response-handling is verified directly here.)
+    val responseWithError = DeleteObjectsResponse
+      .builder()
+      .errors(S3Error.builder().key("delete-dir/locked.txt").code("AccessDenied").build())
+      .build()
+
+    val thrown = intercept[RuntimeException] {
+      S3StorageClient.throwOnDeleteErrors("delete-dir/", responseWithError)
+    }
+    assert(thrown.getMessage.contains("delete-dir/locked.txt"))
+    assert(thrown.getMessage.contains("AccessDenied"))
+
+    // A response with no errors must not throw.
+    S3StorageClient.throwOnDeleteErrors("delete-dir/", DeleteObjectsResponse.builder().build())
   }
 }

--- a/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
@@ -413,5 +413,23 @@ class S3StorageClientSpec
 
     // A response with no errors must not throw.
     S3StorageClient.throwOnDeleteErrors("delete-dir/", DeleteObjectsResponse.builder().build())
+
+    // When many keys fail, the message reports the true total but only enumerates the first
+    // MAX_LISTED_DELETE_ERRORS keys and summarizes the rest, so it stays bounded.
+    val cap = S3StorageClient.MAX_LISTED_DELETE_ERRORS
+    val errorCount = cap + 5
+    val manyErrors = (0 until errorCount).map(i =>
+      S3Error.builder().key(f"delete-dir/locked-$i%02d.txt").code("AccessDenied").build()
+    )
+    val thrownMany = intercept[RuntimeException] {
+      S3StorageClient.throwOnDeleteErrors(
+        "delete-dir/",
+        DeleteObjectsResponse.builder().errors(manyErrors: _*).build()
+      )
+    }
+    assert(thrownMany.getMessage.contains(s"$errorCount object(s)"))
+    assert(thrownMany.getMessage.contains(f"delete-dir/locked-00.txt")) // first key is listed
+    assert(!thrownMany.getMessage.contains(f"delete-dir/locked-$cap%02d.txt")) // capped key is not
+    assert(thrownMany.getMessage.contains(s"and ${errorCount - cap} more"))
   }
 }

--- a/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageClientSpec.scala
@@ -21,7 +21,7 @@ package org.apache.texera.service.util
 
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.funsuite.AnyFunSuite
-import software.amazon.awssdk.services.s3.model.{DeleteObjectsResponse, S3Error}
+import software.amazon.awssdk.services.s3.model.S3Error
 
 import java.io.ByteArrayInputStream
 import java.util.concurrent.Executors
@@ -43,9 +43,10 @@ class S3StorageClientSpec
   }
 
   override def afterAll(): Unit = {
-    // Clean up test bucket
+    // Best-effort cleanup of the prefixes these tests write under. (deleteDirectory rejects an
+    // empty prefix, so a whole-bucket sweep isn't available — and isn't needed here.)
     try {
-      S3StorageClient.deleteDirectory(testBucketName, "")
+      Seq("test", "delete-dir").foreach(S3StorageClient.deleteDirectory(testBucketName, _))
     } catch {
       case _: Exception => // Ignore cleanup errors
     }
@@ -357,6 +358,23 @@ class S3StorageClientSpec
     assert(!S3StorageClient.directoryExists(testBucketName, prefix))
   }
 
+  test("deleteDirectory should not delete siblings that merely share the prefix string") {
+    // Deleting "delete-dir/small" must not touch "delete-dir/small-sibling.txt": the trailing-slash
+    // normalization makes the prefix "delete-dir/small/", which is not a prefix of the sibling key.
+    val prefix = "delete-dir/small"
+    S3StorageClient.uploadObject(testBucketName, s"$prefix/object.txt", createInputStream("data"))
+    val sibling = "delete-dir/small-sibling.txt"
+    S3StorageClient.uploadObject(testBucketName, sibling, createInputStream("keep me"))
+
+    S3StorageClient.deleteDirectory(testBucketName, prefix)
+
+    assert(!S3StorageClient.directoryExists(testBucketName, prefix))
+    val survivor = S3StorageClient.downloadObject(testBucketName, sibling)
+    assert(new String(readInputStream(survivor)) == "keep me")
+    survivor.close()
+    S3StorageClient.deleteObject(testBucketName, sibling)
+  }
+
   test("deleteDirectory should delete more than 1000 objects under a prefix") {
     // >1000 objects exercises pagination and delete batching; without them the tail is orphaned.
     val prefix = "delete-dir/large"
@@ -392,37 +410,34 @@ class S3StorageClientSpec
     S3StorageClient.deleteDirectory(testBucketName, "delete-dir/non-existent")
   }
 
-  test("deleteDirectory should surface per-key delete failures rather than swallow them") {
-    // A real per-key failure needs object-lock setup, so verify response handling directly.
-    val responseWithError = DeleteObjectsResponse
-      .builder()
-      .errors(S3Error.builder().key("delete-dir/locked.txt").code("AccessDenied").build())
-      .build()
+  // A real per-key delete failure needs object-lock setup, so exercise throwOnDeleteErrors
+  // directly — it's the helper that decides whether deleteDirectory raises.
 
+  test("throwOnDeleteErrors should raise on a per-key delete failure") {
+    val errors = Seq(S3Error.builder().key("delete-dir/locked.txt").code("AccessDenied").build())
     val thrown = intercept[RuntimeException] {
-      S3StorageClient.throwOnDeleteErrors("delete-dir/", responseWithError)
+      S3StorageClient.throwOnDeleteErrors("delete-dir/", errors)
     }
     assert(thrown.getMessage.contains("delete-dir/locked.txt"))
     assert(thrown.getMessage.contains("AccessDenied"))
+  }
 
-    // A response with no errors must not throw.
-    S3StorageClient.throwOnDeleteErrors("delete-dir/", DeleteObjectsResponse.builder().build())
+  test("throwOnDeleteErrors should not throw when there are no errors") {
+    S3StorageClient.throwOnDeleteErrors("delete-dir/", Seq.empty[S3Error])
+  }
 
-    // Many failures: message reports the true total but only lists up to the cap.
+  test("throwOnDeleteErrors should report the true total but list at most the cap") {
     val cap = S3StorageClient.MAX_LISTED_DELETE_ERRORS
     val errorCount = cap + 5
-    val manyErrors = (0 until errorCount).map(i =>
+    val errors = (0 until errorCount).map(i =>
       S3Error.builder().key(f"delete-dir/locked-$i%02d.txt").code("AccessDenied").build()
     )
-    val thrownMany = intercept[RuntimeException] {
-      S3StorageClient.throwOnDeleteErrors(
-        "delete-dir/",
-        DeleteObjectsResponse.builder().errors(manyErrors: _*).build()
-      )
+    val thrown = intercept[RuntimeException] {
+      S3StorageClient.throwOnDeleteErrors("delete-dir/", errors)
     }
-    assert(thrownMany.getMessage.contains(s"$errorCount object(s)"))
-    assert(thrownMany.getMessage.contains(f"delete-dir/locked-00.txt")) // first key is listed
-    assert(!thrownMany.getMessage.contains(f"delete-dir/locked-$cap%02d.txt")) // capped key is not
-    assert(thrownMany.getMessage.contains(s"and ${errorCount - cap} more"))
+    assert(thrown.getMessage.contains(s"$errorCount object(s)"))
+    assert(thrown.getMessage.contains("delete-dir/locked-00.txt")) // first key is listed
+    assert(!thrown.getMessage.contains(f"delete-dir/locked-$cap%02d.txt")) // capped key is not
+    assert(thrown.getMessage.contains(s"and ${errorCount - cap} more"))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

`S3StorageClient.deleteDirectory` listed objects with a single `listObjectsV2` call and issued one `deleteObjects` batch. Both S3 APIs cap at 1000 keys per call, so for any prefix holding more than 1000 objects only the first 1000 were deleted and the rest causes a storage leak. This affects dataset deletion (`DatasetResource`) and per-execution cleanup (`LargeBinaryManager`), either of which can exceed 1000 objects under one prefix.

This PR:
- Lists via `listObjectsV2Paginator`, which follows the continuation token across all pages, and deletes in batches of at most 1000 keys. Keys are streamed so memory stays bounded to a single batch.
- Inspects each `DeleteObjects` response and throws if any key failed.

### Any related issues, documentation, discussions?

Closes #5281

### How was this PR tested?

1. Create more than 1000 files `for i in {1..1100}; do printf 'x' > "file_$i.txt"; done`
2. Upload them in a dataset. (There is a frontend memory issue when you upload all 1100 files at the same time. Try to upload batch-by-batch)
3. Delete the dataset.
4. Check if all the files are removed in the minio console. (Before this fix, some files remain)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
