### PR TITLE
fix(build): download protoc matching target arch in image builds

### DIFF
--- a/bin/computing-unit-master.dockerfile
+++ b/bin/computing-unit-master.dockerfile
@@ -55,7 +55,12 @@ RUN apt-get update && apt-get install -y \
 COPY bin/protoc-version.txt bin/protoc-version.txt
 COPY bin/python-proto-gen.sh bin/python-proto-gen.sh
 RUN PROTOC_VERSION=$(cat bin/protoc-version.txt) \
-    && curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && case "$(uname -m)" in \
+         x86_64 | amd64) PROTOC_ARCH=x86_64 ;; \
+         aarch64 | arm64) PROTOC_ARCH=aarch_64 ;; \
+         *) echo "Unsupported architecture: $(uname -m)" >&2 && exit 1 ;; \
+       esac \
+    && curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" \
     && unzip -o /tmp/protoc.zip -d /usr/local \
     && chmod +x /usr/local/bin/protoc \
     && rm /tmp/protoc.zip \

--- a/bin/computing-unit-worker.dockerfile
+++ b/bin/computing-unit-worker.dockerfile
@@ -55,7 +55,12 @@ RUN apt-get update && apt-get install -y \
 COPY bin/protoc-version.txt bin/protoc-version.txt
 COPY bin/python-proto-gen.sh bin/python-proto-gen.sh
 RUN PROTOC_VERSION=$(cat bin/protoc-version.txt) \
-    && curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && case "$(uname -m)" in \
+         x86_64 | amd64) PROTOC_ARCH=x86_64 ;; \
+         aarch64 | arm64) PROTOC_ARCH=aarch_64 ;; \
+         *) echo "Unsupported architecture: $(uname -m)" >&2 && exit 1 ;; \
+       esac \
+    && curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" \
     && unzip -o /tmp/protoc.zip -d /usr/local \
     && chmod +x /usr/local/bin/protoc \
     && rm /tmp/protoc.zip \

--- a/bin/texera-web-application.dockerfile
+++ b/bin/texera-web-application.dockerfile
@@ -70,7 +70,12 @@ RUN apt-get update && apt-get install -y \
 COPY bin/protoc-version.txt bin/protoc-version.txt
 COPY bin/python-proto-gen.sh bin/python-proto-gen.sh
 RUN PROTOC_VERSION=$(cat bin/protoc-version.txt) \
-    && curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip" \
+    && case "$(uname -m)" in \
+         x86_64 | amd64) PROTOC_ARCH=x86_64 ;; \
+         aarch64 | arm64) PROTOC_ARCH=aarch_64 ;; \
+         *) echo "Unsupported architecture: $(uname -m)" >&2 && exit 1 ;; \
+       esac \
+    && curl -fsSL -o /tmp/protoc.zip "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-${PROTOC_ARCH}.zip" \
     && unzip -o /tmp/protoc.zip -d /usr/local \
     && chmod +x /usr/local/bin/protoc \
     && rm /tmp/protoc.zip \


### PR DESCRIPTION
### What changes were proposed in this PR?

The three service Dockerfiles (`texera-web-application`, `computing-unit-master`, `computing-unit-worker`) always downloaded the `linux-x86_64` `protoc` release, so the build-time Python proto regeneration failed on ARM64 image builds with `protoc: No such file or directory` (exit 127). This selects the `protoc` asset by architecture from `uname -m` (`x86_64`/`amd64` → `x86_64`, `aarch64`/`arm64` → `aarch_64`, unknown → fail fast), so both platforms build.

### Any related issues, documentation, discussions?

Closes #5571

### How was this PR tested?

- Confirmed protoc 3.19.4 publishes a `linux-aarch_64` asset and that the URL the fix builds resolves (HTTP 200).
- Confirmed the `case` selection under `/bin/sh` maps `x86_64`/`amd64` → `x86_64`, `aarch64`/`arm64` → `aarch_64`, and exits non-zero on an unknown architecture.
- The original failure was isolated to this single download line (the AMD64 image already builds), so the targeted fix addresses the failing step on ARM64.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8 (1M context)
