### PR TITLE
fix(storage): close Files.walk stream in deleteRepo to stop leak

### DIFF
--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/util/dataset/GitVersionControlLocalFileStorage.java
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/util/dataset/GitVersionControlLocalFileStorage.java
@@ -78,10 +78,12 @@ public class GitVersionControlLocalFileStorage {
    * @throws IOException If an I/O error occurs.
    */
   public static void deleteRepo(Path directoryPath) throws IOException {
-    Files.walk(directoryPath)
-        .sorted(Comparator.reverseOrder())
-        .map(Path::toFile)
-        .forEach(File::delete);
+    try (var stream = Files.walk(directoryPath)) {
+      stream
+          .sorted(Comparator.reverseOrder())
+          .map(Path::toFile)
+          .forEach(File::delete);
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #5548 

Close Files.walk stream so directory handle is released immediately instead of leaking.
