### PR TITLE
test(frontend): add unit tests for DatasetFileSelectorComponent

### DIFF
--- a/frontend/src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.spec.ts
+++ b/frontend/src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormControl } from "@angular/forms";
+import { FieldTypeConfig } from "@ngx-formly/core";
+import { of } from "rxjs";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { DatasetFileSelectorComponent } from "./dataset-file-selector.component";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { GuiConfigService } from "../../../common/service/gui-config.service";
+
+describe("DatasetFileSelectorComponent", () => {
+  let component: DatasetFileSelectorComponent;
+  let fixture: ComponentFixture<DatasetFileSelectorComponent>;
+  // Minimal NzModalService stub: only `create` is used, and the component only
+  // reads `afterClose` off the returned modal ref. Each test overrides what
+  // `afterClose` emits via `mockReturnValue`.
+  let modalServiceSpy: { create: ReturnType<typeof vi.fn> };
+
+  // Attach a fresh FormControl with a known starting value, since the component
+  // extends FieldType and reads/writes through `this.formControl`.
+  function setFormControl(initialValue: string): FormControl {
+    const formControl = new FormControl(initialValue);
+    component.field = { formControl } as FieldTypeConfig;
+    return formControl;
+  }
+
+  beforeEach(async () => {
+    modalServiceSpy = { create: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [DatasetFileSelectorComponent],
+      providers: [
+        { provide: NzModalService, useValue: modalServiceSpy },
+        { provide: WorkflowActionService, useValue: {} },
+        { provide: GuiConfigService, useValue: { env: { selectingFilesFromDatasetsEnabled: true } } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DatasetFileSelectorComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("opens the dataset selection modal once when clicked", () => {
+    modalServiceSpy.create.mockReturnValue({ afterClose: of(undefined) });
+    setFormControl("");
+
+    component.onClickOpenFileSelectionModal();
+
+    expect(modalServiceSpy.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes the chosen path back into the form control when a path is selected", () => {
+    const formControl = setFormControl("");
+    modalServiceSpy.create.mockReturnValue({ afterClose: of("/dataset/data.csv") });
+
+    component.onClickOpenFileSelectionModal();
+
+    expect(formControl.value).toBe("/dataset/data.csv");
+  });
+
+  it("leaves the form control unchanged when the modal is dismissed without a path", () => {
+    const formControl = setFormControl("/existing/path.csv");
+    modalServiceSpy.create.mockReturnValue({ afterClose: of("") });
+
+    component.onClickOpenFileSelectionModal();
+
+    expect(formControl.value).toBe("/existing/path.csv");
+  });
+
+  it("exposes isFileSelectionEnabled from the GUI config", () => {
+    expect(component.isFileSelectionEnabled).toBe(true);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
Adds a unit test spec for DatasetFileSelectorComponent, which previously had no *.spec.ts. The component is a Formly field type whose onClickOpenFileSelectionModal() opens a dataset-selection modal and writes the chosen path back into the form control when the modal closes with a value.

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Closes #5471

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
New unit tests added in dataset-file-selector.component.spec.ts, run via `ng test` (Vitest). They cover:
- component creation
- onClickOpenFileSelectionModal() opens the dataset selection modal exactly once
- a selected path is written back into the form control
- the form control is left unchanged when the modal is dismissed without a path
- isFileSelectionEnabled reflects the GUI config

All 5 tests pass; eslint and prettier checks are clean.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code