### PR TITLE
fix: close Files.walk stream in GitVersionControlLocalFileStorage.del…

### DIFF
--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/util/dataset/GitVersionControlLocalFileStorage.java
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/util/dataset/GitVersionControlLocalFileStorage.java
@@ -78,11 +78,13 @@ public class GitVersionControlLocalFileStorage {
    * @throws IOException If an I/O error occurs.
    */
   public static void deleteRepo(Path directoryPath) throws IOException {
-    Files.walk(directoryPath)
-        .sorted(Comparator.reverseOrder())
-        .map(Path::toFile)
-        .forEach(File::delete);
-  }
+    try (var stream = Files.walk(directoryPath)) {
+        stream
+            .sorted(Comparator.reverseOrder())
+            .map(Path::toFile)
+            .forEach(File::delete);
+    }
+}
 
   /**
    * Initializes a new repository for version control at the specified path.


### PR DESCRIPTION
### What changes were proposed in this PR?

`GitVersionControlLocalFileStorage.deleteRepo` called `Files.walk(...)` without closing the returned stream. `Files.walk` returns a closeable `Stream` backed by an open directory handle, so the handle leaked until GC — which can flake temp-dir deletion on Windows and leak file descriptors on long-lived JVMs.

This PR wraps the walk in a try-with-resources block so the stream (and its underlying directory handle) is always closed, even if iteration throws. No behavior change for callers.

### Any related issues, documentation, discussions?

Closes #5548

### How was this PR tested?

No new tests added. This is a stream-lifecycle fix with no behavior change; existing dataset deletion paths already exercise `deleteRepo`.

### Was this PR authored or co-authored using generative AI tooling?

The code change was taken from the fix described in issue #5548. The PR description was drafted with assistance from Claude (Anthropic).
Generated-by: Claude (Anthropic)