### PR TITLE
chore(licensing): refresh transitive versions in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -212,13 +212,13 @@ Dependencies under the Apache License, Version 2.0
 
 Python packages:
   - aiobotocore==2.25.1
-  - aiohttp==3.13.5
+  - aiohttp==3.14.1
   - aiosignal==1.4.0
   - boto3==1.40.53
   - botocore==1.40.53
   - frozenlist==1.8.0
-  - hf-xet==1.5.0
-  - huggingface-hub==1.16.1
+  - hf-xet==1.5.1
+  - huggingface-hub==1.18.0
   - multidict==6.7.1
   - overrides==7.4.0
   - packaging==26.2
@@ -230,7 +230,7 @@ Python packages:
   - regex==2026.5.9
   - requests==2.34.2
   - s3transfer==0.14.0
-  - safetensors==0.7.0
+  - safetensors==0.8.0
   - tenacity==8.5.0
   - tokenizers==0.22.2
   - transformers==5.0.0rc3
@@ -254,7 +254,7 @@ Python packages:
   - cachetools==6.2.6
   - charset-normalizer==3.4.7
   - deprecated==1.2.14
-  - filelock==3.29.0
+  - filelock==3.29.1
   - fonttools==4.63.0
   - fs==2.4.16
   - greenlet==3.5.1
@@ -307,7 +307,7 @@ Python packages:
   - grpclib==0.4.9
   - httpcore==1.0.9
   - httpx==0.28.1
-  - idna==3.16
+  - idna==3.18
   - jinja2==3.1.6
   - joblib==1.5.3
   - kiwisolver==1.5.0
@@ -326,7 +326,7 @@ Python packages:
   - scipy==1.17.1
   - sympy==1.14.0
   - threadpoolctl==3.6.0
-  - tifffile==2026.5.15
+  - tifffile==2026.6.1
   - torch==2.8.0
   - zstandard==0.25.0
 
@@ -340,7 +340,7 @@ Python packages:
   - prawcore==2.4.0
   - pybase64==1.3.2
   - pygments==2.20.0
-  - update-checker==0.18.0
+  - update-checker==1.0.0
   - wrapt==1.17.3
 
 --------------------------------------------------------------------------------
@@ -357,7 +357,7 @@ Dependencies under the Mozilla Public License, Version 2.0
 Python packages:
   - bidict==0.22.0
   - certifi==2026.5.20
-  - tqdm==4.67.3
+  - tqdm==4.68.2
 
 --------------------------------------------------------------------------------
 Dependencies under the Python Software Foundation License


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR refreshes `amber/LICENSE-binary-python` to match the currently-bundled
transitive Python dependency versions. These are calver/semver bumps of
already-declared deps — the licenses are unchanged, only the recorded version
strings had drifted behind upstream:

- aiohttp 3.13.5 → 3.14.1
- filelock 3.29.0 → 3.29.1
- hf-xet 1.5.0 → 1.5.1
- huggingface-hub 1.16.1 → 1.18.0
- idna 3.16 → 3.18
- safetensors 0.7.0 → 0.8.0
- tifffile 2026.5.15 → 2026.6.1
- tqdm 4.67.3 → 4.68.2
- update-checker 0.18.0 → 1.0.0

This clears the License Binary Checker drift on both `main` and `release/v1.2`
(they share an identical `amber/LICENSE-binary-python`).

### Any related issues, documentation, discussions?

Closes #5297. Closes #5588. To be backported to `release/v1.2` via the
`release/v1.2` label.

### How was this PR tested?

License Binary Checker (build.yml strict mode) passes against the bundled wheels.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code
