### PR TITLE
ci: suggest reviewers on PRs without auto-pinging

### DIFF
--- a/.github/workflows/suggest-reviewers.yml
+++ b/.github/workflows/suggest-reviewers.yml
@@ -1,0 +1,226 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Suggest reviewers on a PR WITHOUT pinging anyone.
+#
+# When a PR is opened or updated, this posts (and keeps updating) a
+# single comment listing people who recently touched the changed files,
+# flagging which of them are committers. It never requests a review on
+# its own: the author stays in control and opts in explicitly via
+# `/request-review @user` (handled by `comment-commands.yml`).
+#
+# Why this shape (see the discussion in the PR that introduced it):
+#   - Auto-requesting a reviewer can ping a past contributor who no
+#     longer wants review requests (e.g. someone who touched a file
+#     years ago). So we only *suggest*; the author decides.
+#   - Suggested logins are rendered inside code spans (`@user`), which
+#     GitHub does NOT turn into notifications. Nobody is bothered by the
+#     suggestion itself; only the author's explicit /request-review (or
+#     a manual cc) actually reaches out.
+#   - GitHub only lets you formally request review from collaborators,
+#     so we mark committers: those are the names /request-review can act
+#     on. Non-committers are still listed (they have context) with a
+#     note to cc them instead.
+#
+# Why API-only (no checkout): repos.listCommits returns the GitHub
+# *login* per commit, sidestepping unreliable git-email-to-login
+# mapping; and pull_request_target grants a token that can comment on
+# fork PRs without ever running fork code.
+name: Suggest reviewers
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  suggest:
+    # Skip drafts (still noisy mid-work) and bot-opened/-pushed PRs.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.sender.type != 'Bot'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.pull_request;
+            const pull_number = pr.number;
+            const author = pr.user.login;
+            const base = pr.base.ref;
+            const { owner, repo } = context.repo;
+
+            const MARKER = '<!-- texera:suggested-reviewers -->';
+
+            // Bound the API budget on large PRs / long histories.
+            const MAX_FILES = 50;        // changed files we mine for history
+            const COMMITS_PER_FILE = 30; // recent commits scanned per file
+            const MAX_SUGGESTIONS = 6;   // names shown to the author
+
+            // 1. Changed files (cap to MAX_FILES; ignore pure deletions:
+            //    history of a removed path isn't a useful review signal).
+            let files = [];
+            try {
+              files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number, per_page: 100,
+              });
+            } catch (e) {
+              core.warning(`listFiles on #${pull_number} failed: ${e.message}`);
+              return;
+            }
+            const paths = files
+              .filter((f) => f.status !== 'removed')
+              .map((f) => f.filename)
+              .slice(0, MAX_FILES);
+            if (!paths.length) {
+              core.info(`No non-deleted files on #${pull_number}; skipping.`);
+              return;
+            }
+
+            // 2. Score logins by how many recent base-branch commits to
+            //    those files they authored. listCommits hands us the
+            //    GitHub login directly, so no email-to-login guessing.
+            const score = new Map();
+            for (const path of paths) {
+              try {
+                const { data } = await github.rest.repos.listCommits({
+                  owner, repo, sha: base, path, per_page: COMMITS_PER_FILE,
+                });
+                for (const c of data) {
+                  const login = c.author && c.author.login;
+                  if (!login) continue; // anonymous / unmapped author
+                  score.set(login, (score.get(login) || 0) + 1);
+                }
+              } catch (e) {
+                core.info(`listCommits for ${path} failed: ${e.message}`);
+              }
+            }
+
+            // 3. Drop the PR author and bots, rank by score, take top N.
+            const ranked = [...score.entries()]
+              .filter(([login]) =>
+                login.toLowerCase() !== author.toLowerCase() &&
+                !login.endsWith('[bot]'))
+              .sort((a, b) => b[1] - a[1])
+              .slice(0, MAX_SUGGESTIONS)
+              .map(([login]) => login);
+
+            // 4. Flag committers (write/maintain/admin): the only people
+            //    GitHub will let the author actually /request-review.
+            const isCommitter = {};
+            for (const login of ranked) {
+              try {
+                const { data } =
+                  await github.rest.repos.getCollaboratorPermissionLevel({
+                    owner, repo, username: login,
+                  });
+                isCommitter[login] =
+                  ['write', 'maintain', 'admin'].includes(data.permission);
+              } catch (e) {
+                isCommitter[login] = false; // unknown: treat as non-committer
+              }
+            }
+            const committers = ranked.filter((l) => isCommitter[l]);
+            const others = ranked.filter((l) => !isCommitter[l]);
+
+            // 5. Build the comment. Every login sits in a code span so the
+            //    suggestion never notifies it; the author opts in by
+            //    copying the /request-review line into a real comment.
+            const tag = (l) => '`@' + l + '`';
+            const cmd = (xs) =>
+              '`/request-review ' + xs.map((l) => '@' + l).join(' ') + '`';
+            const lines = [MARKER, `### Suggested reviewers`, ``];
+            if (!ranked.length) {
+              lines.push(
+                `Nobody stood out from the recent history of the changed ` +
+                  `files. You can still request a committer with ` +
+                  '`/request-review @committer`.',
+              );
+            } else {
+              lines.push(
+                `Based on recent commit history of the files this PR ` +
+                  `changes (most relevant first):`,
+                ``,
+              );
+              for (const l of ranked) {
+                lines.push(`- ${tag(l)}${isCommitter[l] ? ' (committer)' : ''}`);
+              }
+              lines.push(``);
+              lines.push(
+                committers.length
+                  ? `**Author:** request a committer's review by commenting ` +
+                      `${cmd(committers)} (trim or extend the list as you like).`
+                  : `**Author:** none of these are committers, so they can't ` +
+                      `be formally requested. Comment ` +
+                      '`/request-review @committer`' +
+                      ` to ping a committer you know.`,
+              );
+              if (others.length) {
+                lines.push(
+                  ``,
+                  `GitHub only lets you request review from committers. The ` +
+                    `non-committers above know this code too: to loop them ` +
+                    `in for context, mention them in a normal comment ` +
+                    `(e.g. \`cc ${others.map((l) => '@' + l).join(' ')}\`).`,
+                );
+              }
+            }
+            lines.push(
+              ``,
+              `<sub>Auto-generated suggestion. Updates as the PR changes and ` +
+                `never sends a review request on its own.</sub>`,
+            );
+            const body = lines.join('\n');
+
+            // 6. Upsert: reuse our marker comment if present, else create.
+            //    Skip entirely when there's nothing to say and no prior
+            //    comment, so empty PRs don't get noise.
+            let prior;
+            try {
+              const existing = await github.paginate(
+                github.rest.issues.listComments,
+                { owner, repo, issue_number: pull_number, per_page: 100 },
+              );
+              prior = existing.find((c) => (c.body || '').includes(MARKER));
+            } catch (e) {
+              core.warning(`listComments on #${pull_number} failed: ${e.message}`);
+              // Fall through: we may create a (possibly duplicate) comment,
+              // preferable to silently dropping the suggestion.
+            }
+            if (!ranked.length && !prior) {
+              core.info(`No suggestions and no existing comment; skipping.`);
+              return;
+            }
+            try {
+              if (prior) {
+                await github.rest.issues.updateComment({
+                  owner, repo, comment_id: prior.id, body,
+                });
+                core.info(`Updated suggestion comment on #${pull_number}`);
+              } else {
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: pull_number, body,
+                });
+                core.info(`Posted suggestion comment on #${pull_number}`);
+              }
+            } catch (e) {
+              core.warning(
+                `Upserting suggestion on #${pull_number} failed: ${e.message}`,
+              );
+            }


### PR DESCRIPTION
### What changes were proposed in this PR?
- Adds a `Suggest reviewers` GitHub Actions workflow (`.github/workflows/suggest-reviewers.yml`) that posts and keeps updating a single comment suggesting reviewers when a PR is opened or updated, and never requests a review automatically.
- Candidates come from the recent commit history of the changed files via `repos.listCommits` per file (which returns the GitHub login directly, avoiding unreliable git-email-to-login mapping); the PR author and bots are excluded and the list is ranked by recent-commit count.
- Committers (write/maintain/admin) are flagged, since GitHub only lets the author formally request review from collaborators; non-committers are still listed for context with a note to `cc` them.
- Suggested logins are rendered inside code spans so the comment never notifies anyone; only the author's explicit `/request-review` (see `comment-commands.yml`) or a manual `cc` reaches out.
- Uses `pull_request_target` so fork PRs get a writable token without checking out or running fork code, with a bounded API budget (50 files, 30 commits/file, 6 suggestions).
### Any related issues, documentation, or discussions?
Closes: #5591
### How was this PR tested?
- Confirm the workflow parses: run `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/suggest-reviewers.yml'))"`, expect no error.
- Confirm the embedded script is valid: extract the `script:` block, wrap it in `async function f(){ ... }`, run `node --check`, expect no syntax error.
- End-to-end behavior (comment content, committer flagging, idempotent update) cannot run locally; it only executes on GitHub for real PR events once the workflow is on the default branch, since `pull_request_target` runs from the base branch. After merge, open a scratch PR and confirm a single "Suggested reviewers" comment appears and is edited (not duplicated) on each push.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF
