### PR TITLE
ci: add sync check between requirements.txt and system-requirements-lock.txt

### DIFF
--- a/.github/scripts/check_requirements_lock_sync.py
+++ b/.github/scripts/check_requirements_lock_sync.py
@@ -1,0 +1,107 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify that requirements.txt and system-requirements-lock.txt stay in sync.
+
+For every pinned package in requirements.txt, the lock file must contain the
+same package pinned to the same version. The lock file is a superset: it also
+pins transitive dependencies, so packages that appear only in the lock file are
+allowed. The script exits non-zero and prints a report when a requirement is
+missing from the lock file or pinned to a different version.
+
+Usage:
+    python .github/scripts/check_requirements_lock_sync.py [requirements] [lock]
+
+Both paths are optional and default to amber/requirements.txt and
+amber/system-requirements-lock.txt.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_REQUIREMENTS = "amber/requirements.txt"
+DEFAULT_LOCK = "amber/system-requirements-lock.txt"
+
+
+def normalize_name(name: str) -> str:
+    """Normalize a package name per PEP 503 so e.g. ``typing_extensions`` and
+    ``typing-extensions`` compare equal."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def parse_pinned(path: str) -> dict[str, tuple[str, str]]:
+    """Parse ``name==version`` lines from a requirements/lock file.
+
+    Returns a mapping of normalized name -> (original name, version). Comment
+    and blank lines are ignored, as are any lines that are not exact pins.
+    """
+    packages: dict[str, tuple[str, str]] = {}
+    for raw_line in Path(path).read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "==" not in line:
+            continue
+        name, version = line.split("==", 1)
+        packages[normalize_name(name)] = (name.strip(), version.strip())
+    return packages
+
+
+def find_sync_errors(requirements: dict, lock: dict) -> tuple[list[str], list[str]]:
+    """Return (missing, mismatched) lists describing how requirements drifts from lock."""
+    missing: list[str] = []
+    mismatched: list[str] = []
+    for key, (name, version) in sorted(requirements.items()):
+        if key not in lock:
+            missing.append(f"{name}=={version}")
+        elif lock[key][1] != version:
+            mismatched.append(f"{name}: requirements pins {version}, lock pins {lock[key][1]}")
+    return missing, mismatched
+
+
+def main(argv: list[str]) -> int:
+    req_path = argv[1] if len(argv) > 1 else DEFAULT_REQUIREMENTS
+    lock_path = argv[2] if len(argv) > 2 else DEFAULT_LOCK
+
+    requirements = parse_pinned(req_path)
+    lock = parse_pinned(lock_path)
+
+    missing, mismatched = find_sync_errors(requirements, lock)
+
+    if not missing and not mismatched:
+        print(
+            f"OK: all {len(requirements)} packages in {req_path} are present "
+            f"in {lock_path} with matching versions."
+        )
+        return 0
+
+    print(f"ERROR: {req_path} and {lock_path} are out of sync.")
+    if missing:
+        print("\nMissing from the lock file:")
+        for entry in missing:
+            print(f"  - {entry}")
+    if mismatched:
+        print("\nVersion mismatches:")
+        for entry in mismatched:
+            print(f"  - {entry}")
+    print(
+        f"\nRegenerate {lock_path} so every package in {req_path} is present "
+        "at the same version."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/workflows/check-requirements-lock-sync.yml
+++ b/.github/workflows/check-requirements-lock-sync.yml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Requirements Lock Sync
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check requirements / lock sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Verify requirements.txt and system-requirements-lock.txt are in sync
+        run: python .github/scripts/check_requirements_lock_sync.py


### PR DESCRIPTION

<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
Adds a CI check that verifies amber/requirements.txt and amber/system-requirements-lock.txt stay in sync, so editing one without the other can't silently drift.

- .github/scripts/check_requirements_lock_sync.py: for every pinned package in requirements.txt, asserts the lock file contains it at the same version (PEP 503 name normalization). The lock file may contain extra transitive deps; those are allowed. Exits non-zero with a clear report on any missing package or version mismatch.
- .github/workflows/check-requirements-lock-sync.yml: runs the script on pull_request / push / merge_group via setup-python 3.12.

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Closes #5034

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
- Ran the script against the current files: passes (all 33 requirements packages present in the lock at matching versions).
- Verified it fails (exit 1) with a clear message when a version is mismatched and when a package is missing from the lock, using temporary inputs via the script's optional path arguments.
- Validated the workflow YAML parses and is structurally correct.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Claude Opus 4.8)