### PR TITLE
test(frontend): add ConflictingFileModalContentComponent unit tests

### DIFF
--- a/frontend/src/app/dashboard/component/user/files-uploader/conflicting-file-modal-content/conflicting-file-modal-content.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/files-uploader/conflicting-file-modal-content/conflicting-file-modal-content.component.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { ConflictingFileModalContentComponent } from "./conflicting-file-modal-content.component";
+
+describe("ConflictingFileModalContentComponent", () => {
+  let component: ConflictingFileModalContentComponent;
+  let fixture: ComponentFixture<ConflictingFileModalContentComponent>;
+
+  const modalData = { fileName: "a.csv", path: "/a.csv", size: "1 KB" };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConflictingFileModalContentComponent],
+      providers: [{ provide: NZ_MODAL_DATA, useValue: modalData }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConflictingFileModalContentComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should expose injected modal data", () => {
+    expect(component.data).toEqual(modalData);
+  });
+});


### PR DESCRIPTION
## Purpose of the PR

Closes #5465

This PR adds frontend unit tests for `ConflictingFileModalContentComponent` to improve test coverage and verify correct handling of injected modal data.

## Summary of Changes

- Added `conflicting-file-modal-content.component.spec.ts`
- Added a test to verify the component is created successfully
- Added a test to verify the component correctly exposes the injected `NZ_MODAL_DATA` payload

## Design Proposal

N/A — this PR only adds unit tests for existing functionality and does not introduce behavioral changes.

## Technical Design Diagram/Description

The tests validate that the component initializes correctly and that modal data provided through Angular dependency injection is exposed as expected by the component.

## GIFs/Screenshots

N/A — test-only change.

## Testing

Executed locally:

```bash
yarn test --include='**/conflicting-file-modal-content.component.spec.ts'
yarn lint
```

Both commands completed successfully.