### PR TITLE
test(frontend): add RegistrationRequestModalComponent unit tests

### DIFF
--- a/frontend/src/app/common/service/user/registration-request-modal/registration-request-modal.component.spec.ts
+++ b/frontend/src/app/common/service/user/registration-request-modal/registration-request-modal.component.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { RegistrationRequestModalComponent } from "./registration-request-modal.component";
+
+describe("RegistrationRequestModalComponent", () => {
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  function setup(data: any): RegistrationRequestModalComponent {
+    TestBed.configureTestingModule({
+      imports: [RegistrationRequestModalComponent],
+      providers: [{ provide: NZ_MODAL_DATA, useValue: data }],
+    });
+    const fixture = TestBed.createComponent(RegistrationRequestModalComponent);
+    return fixture.componentInstance;
+  }
+
+  it("should create", () => {
+    const component = setup({ uid: 1, email: "a@b.c", name: "Ada" });
+    expect(component).toBeTruthy();
+  });
+
+  it("copies modal data in the constructor", () => {
+    const component = setup({ uid: 1, email: "a@b.c", name: "Ada" });
+    expect(component.name).toBe("Ada");
+    expect(component.email).toBe("a@b.c");
+  });
+
+  it("handles null modal data gracefully", () => {
+    const component = setup(null);
+    expect(component.name).toBe("");
+    expect(component.email).toBe("");
+  });
+
+  it("getValues() trims whitespace", () => {
+    const component = setup({ uid: 1, email: "a@b.c", name: "Ada" });
+    component.affiliation = "  UCI  ";
+    component.reason = "  hi ";
+    expect(component.getValues()).toEqual({ affiliation: "UCI", reason: "hi" });
+  });
+});


### PR DESCRIPTION
## Purpose of the PR

Closes #5467

This PR adds frontend unit tests for `RegistrationRequestModalComponent` to improve coverage of modal initialization and value processing behavior.

## Summary of Changes

- Added `registration-request-modal.component.spec.ts`
- Added a test to verify the component is created successfully
- Added a test to verify modal data correctly seeds name and email fields
- Added a test to verify null modal data falls back to empty strings
- Added a test to verify `getValues()` trims whitespace from affiliation and reason fields

## Design Proposal

N/A — this PR only adds unit tests for existing functionality and does not modify production behavior.

## Technical Design Diagram/Description

The tests validate component initialization under different modal data conditions and verify that user-entered values are normalized before being returned by the component.

## GIFs/Screenshots

N/A — test-only change.

## Testing

Executed locally:

```bash
yarn test --include='**/registration-request-modal.component.spec.ts'
yarn lint
```

Both commands completed successfully.