### PR TITLE
feat(operator): Add Case Sensitivity to Keyword Search Operator

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/keywordSearch/CaseSensitiveAnalyzer.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/keywordSearch/CaseSensitiveAnalyzer.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.texera.amber.operator.keywordSearch
+
+import org.apache.lucene.analysis.{Analyzer, TokenStream}
+import org.apache.lucene.analysis.core.WhitespaceTokenizer
+import org.apache.lucene.analysis.CharArraySet
+import org.apache.lucene.analysis.StopFilter
+import org.apache.lucene.analysis.Analyzer.TokenStreamComponents
+
+// Achieves case sensitivity by skipping the lowercasing and normalization
+// pipeline used in StandardAnalyzer.
+class CaseSensitiveAnalyzer extends Analyzer {
+  override protected def createComponents(fieldName: String): TokenStreamComponents = {
+    val tokenizer = new WhitespaceTokenizer()
+    val stream: TokenStream = new StopFilter(tokenizer, CharArraySet.EMPTY_SET)
+    new TokenStreamComponents(tokenizer, stream)
+  }
+}

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpDesc.scala
@@ -43,6 +43,11 @@ class KeywordSearchOpDesc extends FilterOpDesc {
   @JsonSchemaInject(json = """{"minLength": 1}""")
   var keyword: String = _
 
+  @JsonProperty(required = true, defaultValue = "false")
+  @JsonSchemaTitle("Case Sensitive")
+  @JsonPropertyDescription("Whether the keyword is case sensitive or not")
+  var isCaseSensitive: Boolean = false
+
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpExec.scala
@@ -26,6 +26,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.index.memory.MemoryIndex
 import org.apache.lucene.queryparser.classic.QueryParser
 import org.apache.lucene.search.Query
+import org.apache.lucene.analysis.Analyzer
 
 class KeywordSearchOpExec(descString: String) extends FilterOpExec {
   private val desc: KeywordSearchOpDesc =
@@ -33,7 +34,11 @@ class KeywordSearchOpExec(descString: String) extends FilterOpExec {
 
   // We chose StandardAnalyzer because it provides more comprehensive tokenization, retaining numeric tokens and handling a broader range of characters.
   // This ensures that search functionality can include standalone numbers (e.g., "3") and complex queries while offering robust performance for most use cases.
-  @transient private lazy val analyzer = new StandardAnalyzer()
+
+  @transient private lazy val analyzer: Analyzer = {
+    if (desc.isCaseSensitive) new CaseSensitiveAnalyzer() else new StandardAnalyzer()
+  }
+
   @transient lazy val query: Query = new QueryParser(desc.attribute, analyzer).parse(desc.keyword)
   @transient private lazy val memoryIndex: MemoryIndex = new MemoryIndex()
 

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpExecSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpExecSpec.scala
@@ -213,4 +213,29 @@ class KeywordSearchOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(results.isEmpty)
     opExec.close()
   }
+
+  it should "not match 'twitter' against 'Twitter' when case-sensitive" in {
+    opDesc.attribute = "text"
+    opDesc.keyword = "twitter"
+    opDesc.isCaseSensitive = true
+    val opExec = new KeywordSearchOpExec(objectMapper.writeValueAsString(opDesc))
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.isEmpty)
+    opExec.close()
+    opDesc.isCaseSensitive = false
+  }
+
+  it should "match 'Twitter' against 'Twitter' when case-sensitive" in {
+    opDesc.attribute = "text"
+    opDesc.keyword = "Twitter"
+    opDesc.isCaseSensitive = true
+    val opExec = new KeywordSearchOpExec(objectMapper.writeValueAsString(opDesc))
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "Twitter")
+    opExec.close()
+    opDesc.isCaseSensitive = false
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->

Supersedes #3510. Since the PR is old and the repository structure has changed, this PR reapplies the relevant changes on top of the current master branch.

This PR adds an option for case sensitivity to the keyword search operator. Users can now use a checkbox to specify whether their search should be case sensitive or case insensitive. This functionality is enabled through the addition of a CaseSensitiveAnalyzer that extends the base Lucene Analyzer for case sensitive searches, while the original StandardAnalyzer is used for case insensitive searches.

<img width="2574" height="1366" alt="image" src="https://github.com/user-attachments/assets/5e2d6686-642a-49e4-8ad5-3d052d616f68" />
<img width="2564" height="1350" alt="image" src="https://github.com/user-attachments/assets/1d766f3e-993e-4229-84ce-c41b72bf1f46" />
<img width="2572" height="1350" alt="image" src="https://github.com/user-attachments/assets/f254761f-ceaa-4c30-ada9-89b63f9347fa" />


### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

Closes #3045. 


### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->

Tested Manually. 


### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Co-authored using: Claude Code