### PR TITLE
test(frontend): add unit tests for CodeEditorService

### DIFF
--- a/frontend/src/app/workspace/service/code-editor/code-editor.service.spec.ts
+++ b/frontend/src/app/workspace/service/code-editor/code-editor.service.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CodeEditorService } from "./code-editor.service";
+
+describe("CodeEditorService", () => {
+  let service: CodeEditorService;
+
+  beforeEach(() => {
+    service = new CodeEditorService();
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should emit true after setEditorState is called with true", () => {
+    let value: boolean | undefined;
+    service.getEditorState("op1").subscribe(v => (value = v));
+    service.setEditorState("op1", true);
+    expect(value).toBe(true);
+  });
+
+  it("should emit false after setEditorState is called with false", () => {
+    let value: boolean | undefined;
+    service.getEditorState("op1").subscribe(v => (value = v));
+    service.setEditorState("op1", false);
+    expect(value).toBe(false);
+  });
+
+  it("should track state independently for different operator IDs", () => {
+    let valueA: boolean | undefined;
+    let valueB: boolean | undefined;
+    service.getEditorState("opA").subscribe(v => (valueA = v));
+    service.getEditorState("opB").subscribe(v => (valueB = v));
+    service.setEditorState("opA", true);
+    expect(valueA).toBe(true);
+    expect(valueB).toBe(false);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
Adds unit tests for CodeEditorService, which previously had no spec file. Covers service creation, `setEditorState`/`getEditorState` for true and false states, and independent state tracking across multiple operator IDs.

### Any related issues, documentation, discussions?
Closes #5502

### How was this PR tested?
New spec run via `yarn test -- code-editor.service` and `yarn lint`. 4 tests passing.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude (Claude Sonnet 4.6)