### PR TITLE
feat(workflow-operator): add column summary statistics operator

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/LogicalOp.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/LogicalOp.scala
@@ -65,6 +65,7 @@ import org.apache.texera.amber.operator.projection.ProjectionOpDesc
 import org.apache.texera.amber.operator.randomksampling.RandomKSamplingOpDesc
 import org.apache.texera.amber.operator.regex.RegexOpDesc
 import org.apache.texera.amber.operator.reservoirsampling.ReservoirSamplingOpDesc
+import org.apache.texera.amber.operator.statistics.columnsummary.ColumnSummaryStatisticsOpDesc
 import org.apache.texera.amber.operator.sklearn._
 import org.apache.texera.amber.operator.sklearn.training._
 import org.apache.texera.amber.operator.sleep.SleepOpDesc
@@ -196,6 +197,7 @@ trait StateTransferFunc
     new Type(value = classOf[KeywordSearchOpDesc], name = "KeywordSearch"),
     new Type(value = classOf[SubstringSearchOpDesc], name = "SubstringSearch"),
     new Type(value = classOf[AggregateOpDesc], name = "Aggregate"),
+    new Type(value = classOf[ColumnSummaryStatisticsOpDesc], name = "ColumnSummaryStatistics"),
     new Type(value = classOf[LineChartOpDesc], name = "LineChart"),
     new Type(value = classOf[WaterfallChartOpDesc], name = "WaterfallChart"),
     new Type(value = classOf[WindRoseChartOpDesc], name = "WindRoseChart"),

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpDesc.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.statistics.columnsummary
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.core.workflow.{
+  InputPort,
+  OutputPort,
+  PhysicalOp,
+  SchemaPropagationFunc
+}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+
+class ColumnSummaryStatisticsOpDesc extends LogicalOp {
+
+  override def operatorInfo: OperatorInfo =
+    OperatorInfo(
+      "Column Summary Statistics",
+      "Computes per-column row count, null count, non-null count, min, max, and mean.",
+      OperatorGroupConstants.AGGREGATE_GROUP,
+      inputPorts = List(InputPort()),
+      outputPorts = List(OutputPort(blocking = true))
+    )
+
+  override def getPhysicalOp(
+      workflowId: WorkflowIdentity,
+      executionId: ExecutionIdentity
+  ): PhysicalOp = {
+    PhysicalOp
+      .oneToOnePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        OpExecWithClassName(
+          "org.apache.texera.amber.operator.statistics.columnsummary.ColumnSummaryStatisticsOpExec",
+          objectMapper.writeValueAsString(ColumnSummaryStatisticsOpExecConfig())
+        )
+      )
+      .withInputPorts(operatorInfo.inputPorts)
+      .withOutputPorts(operatorInfo.outputPorts)
+      .withParallelizable(false)
+      .withPropagateSchema(
+        SchemaPropagationFunc(_ => Map(operatorInfo.outputPorts.head.id -> outputSchema))
+      )
+  }
+
+  private def outputSchema: Schema =
+    Schema(
+      List(
+        new Attribute("columnName", AttributeType.STRING),
+        new Attribute("dataType", AttributeType.STRING),
+        new Attribute("rowCount", AttributeType.INTEGER),
+        new Attribute("nullCount", AttributeType.INTEGER),
+        new Attribute("nonNullCount", AttributeType.INTEGER),
+        new Attribute("minValue", AttributeType.STRING),
+        new Attribute("maxValue", AttributeType.STRING),
+        new Attribute("meanValue", AttributeType.DOUBLE)
+      )
+    )
+}

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExec.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.statistics.columnsummary
+
+import org.apache.texera.amber.core.executor.OperatorExecutor
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Tuple, TupleLike}
+
+import scala.collection.mutable
+
+class ColumnSummaryStatisticsOpExec(descString: String) extends OperatorExecutor {
+
+  private case class ColumnStats(
+      columnName: String,
+      dataType: AttributeType,
+      var rowCount: Int = 0,
+      var nullCount: Int = 0,
+      var nonNullCount: Int = 0,
+      var minValue: Option[Double] = None,
+      var maxValue: Option[Double] = None,
+      var sum: Double = 0.0,
+      var numericCount: Int = 0
+  )
+
+  private val statsByColumn = mutable.LinkedHashMap[String, ColumnStats]()
+
+  override def open(): Unit = {
+    statsByColumn.clear()
+  }
+
+  override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+    initializeStatsIfNeeded(tuple)
+
+    tuple.getSchema.getAttributes.foreach { attribute =>
+      val columnName = attribute.getName
+      val stats = statsByColumn(columnName)
+      val value = tuple.getField[Any](columnName)
+
+      stats.rowCount += 1
+
+      if (value == null) {
+        stats.nullCount += 1
+      } else {
+        stats.nonNullCount += 1
+
+        toDoubleIfNumeric(value).foreach { numericValue =>
+          stats.numericCount += 1
+          stats.sum += numericValue
+          stats.minValue = Some(stats.minValue.fold(numericValue)(Math.min(_, numericValue)))
+          stats.maxValue = Some(stats.maxValue.fold(numericValue)(Math.max(_, numericValue)))
+        }
+      }
+    }
+
+    Iterator.empty
+  }
+
+  override def onFinish(port: Int): Iterator[TupleLike] = {
+    statsByColumn.valuesIterator.map { stats =>
+      val meanValue =
+        if (stats.numericCount > 0) {
+          Double.box(stats.sum / stats.numericCount)
+        } else {
+          null
+        }
+
+      TupleLike(
+        "columnName" -> stats.columnName,
+        "dataType" -> stats.dataType.name(),
+        "rowCount" -> Int.box(stats.rowCount),
+        "nullCount" -> Int.box(stats.nullCount),
+        "nonNullCount" -> Int.box(stats.nonNullCount),
+        "minValue" -> stats.minValue.map(_.toString).orNull,
+        "maxValue" -> stats.maxValue.map(_.toString).orNull,
+        "meanValue" -> meanValue
+      )
+    }
+  }
+
+  override def close(): Unit = {
+    statsByColumn.clear()
+  }
+
+  private def initializeStatsIfNeeded(tuple: Tuple): Unit = {
+    if (statsByColumn.nonEmpty) {
+      return
+    }
+
+    tuple.getSchema.getAttributes.foreach { attribute: Attribute =>
+      statsByColumn.put(
+        attribute.getName,
+        ColumnStats(
+          columnName = attribute.getName,
+          dataType = attribute.getType
+        )
+      )
+    }
+  }
+
+  private def toDoubleIfNumeric(value: Any): Option[Double] = {
+    value match {
+      case v: java.lang.Byte    => Some(v.doubleValue())
+      case v: java.lang.Short   => Some(v.doubleValue())
+      case v: java.lang.Integer => Some(v.doubleValue())
+      case v: java.lang.Long    => Some(v.doubleValue())
+      case v: java.lang.Float   => Some(v.doubleValue())
+      case v: java.lang.Double  => Some(v.doubleValue())
+      case v: Byte              => Some(v.toDouble)
+      case v: Short             => Some(v.toDouble)
+      case v: Int               => Some(v.toDouble)
+      case v: Long              => Some(v.toDouble)
+      case v: Float             => Some(v.toDouble)
+      case v: Double            => Some(v)
+      case _                    => None
+    }
+  }
+}

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExecConfig.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExecConfig.scala
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.statistics.columnsummary
+
+case class ColumnSummaryStatisticsOpExecConfig()

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExecSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExecSpec.scala
@@ -1,0 +1,165 @@
+/*
+
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+  */
+
+package org.apache.texera.amber.operator.statistics.columnsummary
+
+import org.apache.texera.amber.core.tuple.{
+  Attribute,
+  AttributeType,
+  Schema,
+  SchemaEnforceable,
+  Tuple,
+  TupleLike}
+import org.scalatest.funsuite.AnyFunSuite
+
+class ColumnSummaryStatisticsOpExecSpec extends AnyFunSuite {
+
+  private def makeSchema(fields: (String, AttributeType)*): Schema =
+    Schema(fields.map { case (name, attributeType) =>
+      new Attribute(name, attributeType)
+    }.toList)
+
+  private def makeTuple(schema: Schema, values: Any*): Tuple =
+    Tuple(schema, values.toArray)
+
+  private val outputSchema: Schema =
+    Schema(
+      List(
+        new Attribute("columnName", AttributeType.STRING),
+        new Attribute("dataType", AttributeType.STRING),
+        new Attribute("rowCount", AttributeType.INTEGER),
+        new Attribute("nullCount", AttributeType.INTEGER),
+        new Attribute("nonNullCount", AttributeType.INTEGER),
+        new Attribute("minValue", AttributeType.STRING),
+        new Attribute("maxValue", AttributeType.STRING),
+        new Attribute("meanValue", AttributeType.DOUBLE)
+      )
+    )
+
+  private def executeOperator(tuples: Seq[Tuple]): List[TupleLike] = {
+    val exec = new ColumnSummaryStatisticsOpExec("")
+    exec.open()
+    tuples.foreach(tuple => exec.processTuple(tuple, 0))
+    val results = exec.onFinish(0).toList
+    exec.close()
+    results
+  }
+
+  private def rowsByColumn(results: List[TupleLike]): Map[String, Tuple] =
+    results
+      .map(_.asInstanceOf[SchemaEnforceable].enforceSchema(outputSchema))
+      .map(row => row.getField[String]("columnName") -> row)
+      .toMap
+
+  test("computes min, max, mean, and null counts for an integer column") {
+    val schema = makeSchema("score" -> AttributeType.INTEGER)
+
+    val results = executeOperator(
+      Seq(
+        makeTuple(schema, 10),
+        makeTuple(schema, null),
+        makeTuple(schema, 30)
+      )
+    )
+
+    assert(results.size == 1)
+
+    val score = rowsByColumn(results)("score")
+
+    assert(score.getField[String]("columnName") == "score")
+    assert(score.getField[String]("dataType") == AttributeType.INTEGER.name())
+    assert(score.getField[Int]("rowCount") == 3)
+    assert(score.getField[Int]("nullCount") == 1)
+    assert(score.getField[Int]("nonNullCount") == 2)
+    assert(score.getField[String]("minValue") == "10.0")
+    assert(score.getField[String]("maxValue") == "30.0")
+    assert(math.abs(score.getField[Double]("meanValue") - 20.0) < 1e-6)
+
+  }
+
+  test("computes numeric statistics while leaving non-numeric statistics null") {
+    val schema = makeSchema(
+      "price" -> AttributeType.DOUBLE,
+      "category" -> AttributeType.STRING
+    )
+
+    val results = executeOperator(
+      Seq(
+        makeTuple(schema, 1.5, "book"),
+        makeTuple(schema, 2.5, null),
+        makeTuple(schema, null, "game")
+      )
+    )
+
+    assert(results.size == 2)
+
+    val rows = rowsByColumn(results)
+    val price = rows("price")
+    val category = rows("category")
+
+    assert(price.getField[String]("dataType") == AttributeType.DOUBLE.name())
+    assert(price.getField[Int]("rowCount") == 3)
+    assert(price.getField[Int]("nullCount") == 1)
+    assert(price.getField[Int]("nonNullCount") == 2)
+    assert(price.getField[String]("minValue") == "1.5")
+    assert(price.getField[String]("maxValue") == "2.5")
+    assert(math.abs(price.getField[Double]("meanValue") - 2.0) < 1e-6)
+
+    assert(category.getField[String]("dataType") == AttributeType.STRING.name())
+    assert(category.getField[Int]("rowCount") == 3)
+    assert(category.getField[Int]("nullCount") == 1)
+    assert(category.getField[Int]("nonNullCount") == 2)
+    assert(category.getField[String]("minValue") == null)
+    assert(category.getField[String]("maxValue") == null)
+    assert(category.getField[Any]("meanValue") == null)
+  }
+
+  test("returns one summary row for each input column") {
+    val schema = makeSchema(
+      "id" -> AttributeType.INTEGER,
+      "name" -> AttributeType.STRING,
+      "amount" -> AttributeType.DOUBLE
+    )
+
+    val results = executeOperator(
+      Seq(
+        makeTuple(schema, 1, "alpha", 10.0),
+        makeTuple(schema, 2, "beta", 20.0)
+      )
+    )
+
+    val rows = rowsByColumn(results)
+
+    assert(results.size == 3)
+    assert(rows.keySet == Set("id", "name", "amount"))
+
+    assert(rows("id").getField[Int]("rowCount") == 2)
+    assert(rows("name").getField[Int]("rowCount") == 2)
+    assert(rows("amount").getField[Int]("rowCount") == 2)
+
+  }
+
+  test("returns no rows when no input tuples are processed") {
+    val results = executeOperator(Seq.empty)
+
+    assert(results.isEmpty)
+
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR adds a new **Column Summary Statistics** workflow operator.

The operator takes one input table and outputs one summary row per input column. The output includes:

* `columnName`
* `dataType`
* `rowCount`
* `nullCount`
* `nonNullCount`
* `minValue`
* `maxValue`
* `meanValue`

For numeric columns, the operator computes `minValue`, `maxValue`, and `meanValue` in addition to row/null/non-null counts.

For non-numeric columns, the operator reports row/null/non-null counts and leaves numeric summary fields as `null`.

This PR includes:

* A new `ColumnSummaryStatisticsOpDesc`
* A new `ColumnSummaryStatisticsOpExec`
* A new `ColumnSummaryStatisticsOpExecConfig`
* Operator registration in `LogicalOp`
* Unit tests covering numeric, string, null, mixed-column, and empty-input behavior

The operator is intentionally scoped as a workflow operator for basic per-column summary statistics.

### Any related issues, documentation, discussions?

Closes https://github.com/apache/texera/issues/5693

### How was this PR tested?

Added unit tests in:

`common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/statistics/columnsummary/ColumnSummaryStatisticsOpExecSpec.scala`

The tests cover:

* Computing min, max, mean, row count, null count, and non-null count for an integer column
* Computing numeric statistics while leaving non-numeric statistics as `null`
* Returning one summary row for each input column
* Returning no rows when no input tuples are processed

Test command run locally:

`sbt "WorkflowOperator / testOnly org.apache.texera.amber.operator.statistics.columnsummary.ColumnSummaryStatisticsOpExecSpec"`

Result:

`Tests: succeeded 4, failed 0`

`All tests passed.`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: ChatGPT (GPT-5.5 Thinking)