### PR TITLE
docs: backport content updates from incubator-texera-site

### DIFF
--- a/docs/getting-started/installing-using-docker.md
+++ b/docs/getting-started/installing-using-docker.md
@@ -50,10 +50,10 @@ If either command produces output, that port is occupied by another process. You
 
 ---
 
+## Download Texera
 
-## Download the docker compose tarball from the release
+Download the [docker compose tarball](https://downloads.apache.org/incubator/texera/1.1.0-incubating/apache-texera-1.1.0-incubating-docker-compose.tar.gz) and extract it.
 
-Download by clicking [here](https://dist.apache.org/repos/dist/dev/incubator/texera/1.1.0-incubating-RC5/apache-texera-1.1.0-incubating-docker-compose.tar.gz) and extract it.
 
 ## Launch Texera
 
@@ -62,17 +62,11 @@ Enter the extracted directory and run the following command to start Texera:
 docker compose --profile examples up
 ```
 
-This command will start docker containers that host the  Texera services, and pre-create two example workflows and datasets. 
+This command will start docker containers that host the  Texera services, and pre-create two example workflows and datasets.
 
 If you don't want to have these examples pre-created, run the following command instead:
 ```bash
 docker compose up
-```
-
-To enable the AI copilot panel, also pass your LLM provider key inline. For example, with Anthropic:
-```bash
-export ANTHROPIC_API_KEY=<your-api-key>
-docker compose --profile examples up
 ```
 
 > If you see the error message like `unable to get image 'nginx:alpine': Cannot connect to the Docker daemon at unix:///Users/kunwoopark/.docker/run/docker.sock. Is the docker daemon running?`, please make sure Docker Desktop is installed and running
@@ -103,7 +97,7 @@ Press `Ctrl+C` in the terminal to stop Texera.
 
 If you already closed the terminal, you can go to the installation folder and run:
 ```bash
-docker compose stop
+docker compose --profile examples stop
 ```
 to stop Texera.
 
@@ -116,6 +110,28 @@ To remove Texera and all its data, go to the installation folder and run:
 docker compose --profile examples down -v
 ```
 > ⚠️ Warning: This will permanently delete all the data used by Texera.
+
+
+## Enable the Texera Agent
+
+The Texera agent is powered by a large language model (LLM). By default, Texera uses [Claude Haiku 4.5](https://www.anthropic.com/claude/haiku) as the LLM and queries it through [LiteLLM](https://docs.litellm.ai/). Without an API key, the Texera agent panel still appears but model calls will fail with a provider auth error.
+
+To enable it:
+
+1. [Stop Texera](#stop) if it is already running.
+2. Get an API key for the LLM. Since Claude Haiku 4.5 is enabled by default, you need an [Anthropic API key](https://console.anthropic.com/settings/keys).
+3. Export the key and restart Texera:
+   ```bash
+   export ANTHROPIC_API_KEY=sk-ant-...
+   docker compose --profile examples up
+   ```
+
+Once Texera is up, create a new workflow and open the Texera agent panel at the bottom right. Type a task like:
+
+> For /texera/popular-movies-of-imdb/v1/TMDb_updated.csv, visualize the top 10 most-voted movies.
+
+To switch providers or add more LLMs, see [Add more LLMs or providers](#add-more-llms-or-providers).
+
 
 
 ## Advanced Settings
@@ -160,6 +176,45 @@ $ docker compose up
 ? Volume "texera-single-node-release-1-1-0_workflow_result_data" exists but doesn't match configuration in compose file. Recreate (data will be lost)? (y/N)
 y // answer y to this prompt
 ```
+
+### Add more LLMs or providers
+Only Claude Haiku 4.5 is enabled by default. To add more LLMs, open `litellm-config.yaml` in the installation folder and append entries under `model_list`. Each entry follows this shape:
+```diff
+  model_list:
+    ...
++   - model_name: <name shown in Texera>
++     litellm_params:
++       model: <provider model id>
++       api_key: "os.environ/<API_KEY_ENV_VAR>"
+```
+For example, to add OpenAI's GPT-5.2 and Google's Gemini 2.5 Pro:
+```diff
+  model_list:
+    ...
++   - model_name: gpt-5.2
++     litellm_params:
++       model: gpt-5.2
++       api_key: "os.environ/OPENAI_API_KEY"
++
++   - model_name: gemini-2.5-pro
++     litellm_params:
++       model: gemini/gemini-2.5-pro
++       api_key: "os.environ/GEMINI_API_KEY"
+```
+Make sure to set the corresponding API key environment variable when you launch Texera (see [Enable the Texera Agent](#enable-the-texera-agent)). Get keys from each provider's console — for example, [OpenAI](https://platform.openai.com/api-keys) or [Google](https://aistudio.google.com/apikey).
+
+If your provider is not Anthropic, OpenAI, or Google, also pass its key into the LiteLLM container by editing `docker-compose.yml`:
+```diff
+  litellm:
+    ...
+    environment:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-}
++     <NEW_API_KEY>: ${<NEW_API_KEY>:-}
+```
+
+For the full list of supported providers and model IDs, see the [LiteLLM proxy config docs](https://docs.litellm.ai/docs/providers).
 
 ## Troubleshooting
 

--- a/docs/tutorials/migrate-jupyter-notebook.md
+++ b/docs/tutorials/migrate-jupyter-notebook.md
@@ -16,7 +16,7 @@ Migrating notebook code into Texera operators, then wiring those operators with 
 
 ## 2. Example: convert a "tweet analysis" notebook into a workflow
 
-> The [notebook](https://hub.texera.io/user/dataset/124), [dataset](https://hub.texera.io/user/dataset/124) and [workflow](https://hub.texera.io/user/workflow/1162) in this example are available on [TexeraHub](https://hub.texera.io/about).
+> The [notebook](https://hub.texera.io/dashboard/user/dataset/124), [dataset](https://hub.texera.io/dashboard/user/dataset/124) and [workflow](https://hub.texera.io/dashboard/user/workspace/1162) in this example are available on [TexeraHub](https://hub.texera.io/dashboard/about).
 
 ### Notebook Overview
 We will use a Tweet-Analysis notebook to demonstrate the migration process. The notebook has three cells:
@@ -174,17 +174,3 @@ Texera contains more than 110 built-in operators that cover data loading, cleani
 - **Identify the data dependencies in the Python code in order to connect operators**
 
 In Texera, data flows along links. Before wiring operators, review the notebook to understand which variables feed which; then reproduce those dependencies via links so the executions matches the original notebook.
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
### What changes were proposed in this PR?
- Backport doc content that was edited directly on the website (`apache/incubator-texera-site`, `content/docs/latest/`) back into this repo's `docs/` source, so `docs/` is the source of truth for the docs sync.
- `getting-started/installing-using-docker.md`: use the released download link instead of the RC5 dev-dist URL, add "Enable the Texera Agent" and "Add more LLMs or providers" sections, and fix the stop command to `docker compose --profile examples stop`.
- `tutorials/migrate-jupyter-notebook.md`: correct the `hub.texera.io/dashboard/...` URLs.
- Each file keeps its existing local front matter; website-only fields (`aliases`) and the `_index.md` `/docs/latest/` routing differences are intentionally not pulled, since they are site-specific.
### Any related issues, documentation, or discussions?
Closes: #5627
### How was this PR tested?
- Docs-only change, no code paths affected, so no automated tests apply.
- To verify content: open `docs/getting-started/installing-using-docker.md` and confirm the download link points to `downloads.apache.org/incubator/texera/1.1.0-incubating/...`, the "Enable the Texera Agent" and "Add more LLMs or providers" sections are present, and the stop command reads `docker compose --profile examples stop`.
- To verify content: open `docs/tutorials/migrate-jupyter-notebook.md` and confirm the example links use the `hub.texera.io/dashboard/...` paths.
- To confirm parity: diff `docs/` against the website's `content/docs/latest/` bodies and confirm the only remaining differences are website-only front matter and `_index.md` routing.
### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.8