### PR TITLE
chore: enable dev static pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -24,6 +24,8 @@ meta:
 github:
   description: "Human-AI Collaborative Data Science Using Visual Workflows"
   homepage: https://texera.apache.org/
+  ghp_branch: gh-pages
+  ghp_path: /
   labels:
     - human-ai-collaboration
     - ai-agents


### PR DESCRIPTION
### What changes were proposed in this PR?
Enable GitHub Pages publishing through `.asf.yaml` by setting `github.ghp_branch` to `gh-pages` and `github.ghp_path` to `/`.

This is intended to make dev-facing static pages under the `gh-pages` branch viewable in a browser. The first page this unlocks is the benchmark dashboard generated under `dev/bench`, so benchmark results can be inspected at a stable web URL instead of only through short-lived GitHub Actions artifacts.

The root Pages path is set explicitly because ASF `.asf.yaml` defaults `ghp_path` to `/docs` when it is omitted, while the existing dashboard files are generated at `gh-pages:/dev/bench`.

### Any related issues, documentation, discussions?
Closes #5636

### How was this PR tested?
Configuration-only change; no unit tests were added.

```bash
ruby -e "require %q(yaml); YAML.load_file(%q(.asf.yaml)); puts %q(YAML OK)"
git diff --check
```

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Codex (GPT-5)