### PR TITLE
chore(licensing): refresh transitive versions in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -218,7 +218,7 @@ Python packages:
   - botocore==1.40.53
   - frozenlist==1.8.0
   - hf-xet==1.5.1
-  - huggingface-hub==1.18.0
+  - huggingface-hub==1.19.0
   - multidict==6.7.1
   - overrides==7.4.0
   - packaging==26.2
@@ -254,7 +254,7 @@ Python packages:
   - cachetools==6.2.6
   - charset-normalizer==3.4.7
   - deprecated==1.2.14
-  - filelock==3.29.1
+  - filelock==3.29.3
   - fonttools==4.63.0
   - fs==2.4.16
   - greenlet==3.5.1
@@ -365,7 +365,7 @@ Dependencies under the Python Software Foundation License
 
 Python packages:
   - aiohappyeyeballs==2.6.2
-  - matplotlib==3.10.9
+  - matplotlib==3.11.0
   - typing-extensions==4.14.1
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this PR?

Refresh three transitive Python dependency versions in `amber/LICENSE-binary-python` to match the bundled wheels, as reported by the License Binary Checker ([release run](https://github.com/apache/texera/actions/runs/27444261750) and this PR's CI):

- filelock 3.29.1 → 3.29.3
- huggingface-hub 1.18.0 → 1.19.0
- matplotlib 3.10.9 → 3.11.0

Version-only refresh; license groupings unchanged. The file is identical on `main` and `release/v1.2`, so this PR fixes both via the `release/v1.2` backport label.

### Any related issues, documentation, discussions?

Resolves #5649

### How was this PR tested?

License Binary Checker CI on this PR.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)