### PR TITLE
chore(amber): drop duplicate praw from requirements.txt

### DIFF
--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -33,7 +33,6 @@ typing_extensions==4.14.1
 pytest-reraise==2.1.2
 Deprecated==1.2.14
 fs==2.4.16
-praw==7.6.1
 bidict==0.22.0
 cached_property==1.5.2
 psutil==5.9.0


### PR DESCRIPTION
### What changes were proposed in this PR?

`praw==7.6.1` was pinned in two requirements files:

| File | Role | Status |
| --- | --- | --- |
| `amber/requirements.txt` | engine / SDK deps | **drop** the duplicate `praw` line |
| `amber/operator-requirements.txt` | operator-specific deps (where praw belongs — only the Reddit Search operator uses it) | unchanged |

Both files are installed sequentially by `bin/computing-unit-master.dockerfile` and `bin/computing-unit-worker.dockerfile`, so removing the duplicate is a runtime no-op — pip resolves the single remaining pin from `operator-requirements.txt`. Lockfile (`amber/system-requirements-lock.txt`) and `LICENSE-binary-python` are untouched because praw is still pulled in by the operator file.

### Any related issues, documentation, discussions?

Closes #5687

(Supersedes #5688, which was wrongly scoped — that PR proposed to also delete the Reddit Search operator itself. Closed without merging.)

### How was this PR tested?

- `git diff upstream/main` — confirms only the single `praw==7.6.1` line is removed from `amber/requirements.txt`
- `grep -rn "praw" amber/` — confirms praw remains pinned in `operator-requirements.txt`, `system-requirements-lock.txt`, and `LICENSE-binary-python`
- No source code uses praw directly (only the Reddit Search operator's generated Python in `RedditSearchSourceOpDesc.scala`), so the operator continues to work as before with the single remaining pin

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.7 [1M context])