### PR TITLE
ci: bump runners from ubuntu-22.04 to ubuntu-latest

### DIFF
--- a/.github/workflows/benchmarks-pr-comment.yml
+++ b/.github/workflows/benchmarks-pr-comment.yml
@@ -57,7 +57,7 @@ jobs:
     # Only act when the upstream Benchmarks run was triggered by a PR.
     # push-to-main / schedule / dispatch produce no PR to comment on.
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Download bench-results artifact
         uses: actions/github-script@v8

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -173,7 +173,7 @@ jobs:
     name: Bench
     needs: precheck
     if: ${{ needs.precheck.outputs.run_bench == 'true' }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
       JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
     if: ${{ inputs.run_amber }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
         java-version: [17]
     runs-on: ${{ matrix.os }}
     env:
@@ -323,7 +323,7 @@ jobs:
       # the docker image, macOS uses brew + the upstream
       # aarch64-apple-darwin lakekeeper tarball.
       matrix:
-        os: [ubuntu-22.04, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         java-version: [17]
     runs-on: ${{ matrix.os }}
     env:
@@ -622,7 +622,7 @@ jobs:
     # cover every module in the amber job above, so this matrix skips them.
     if: ${{ inputs.run_platform }}
     name: ${{ format('platform{0} ({1})', inputs.job_name_suffix, matrix.service) }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### What changes were proposed in this PR?

Bump five `ubuntu-22.04` pins to `ubuntu-latest` so the remaining CI
jobs match the rest of the workflows.

| File | Job(s) |
| --- | --- |
| `.github/workflows/build.yml` | `amber`, `amber-integration` (Linux leg), `platform` |
| `.github/workflows/benchmarks.yml` | `bench` |
| `.github/workflows/benchmarks-pr-comment.yml` | bench PR comment |

The pin came from #3194 (Jan 2025) when the 24.04 image temporarily
dropped sbt and broke libncurses. Both causes are gone: sbt is now
installed explicitly via `sbt/setup-sbt@v1.1.22`, and 24.04 has been
stable for over a year.

### Any related issues, documentation, discussions?

Closes #5723. Reverses the temporary workaround in #3194.

### How was this PR tested?

CI on this PR exercises every bumped job — `Required Checks` covers
`amber`, `amber-integration`, and `platform`; Benchmarks covers `bench`;
`benchmarks-pr-comment` runs on the artifact hand-off after Benchmarks.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.7)