### PR TITLE
fix(frontend): reuse operator validation result

### DIFF
--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -22,7 +22,7 @@ import { UndoRedoService } from "../../service/undo-redo/undo-redo.service";
 import { DragDropService } from "../../service/drag-drop/drag-drop.service";
 import { WorkflowUtilService } from "../../service/workflow-graph/util/workflow-util.service";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
+import { Validation, ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
 import { WorkflowEditorComponent } from "./workflow-editor.component";
 import { workflowEditorTestImports, workflowEditorTestProviders } from "./workflow-editor.test-utils";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
@@ -909,6 +909,19 @@ describe("WorkflowEditorComponent", () => {
         fixture.detectChanges();
 
         expect(getStroke(mockScanPredicate.operatorID)).toBe("red");
+      });
+
+      it("uses the supplied validation without recomputing the operator validation", () => {
+        const suppliedValidation: Validation = { isValid: false, messages: {} };
+        const validateOperatorSpy = vi
+          .spyOn(validationWorkflowService, "validateOperator")
+          .mockReturnValue({ isValid: true });
+        const changeOperatorColorSpy = vi.spyOn(jointUIService, "changeOperatorColor").mockImplementation(() => {});
+
+        component["applyOperatorBorder"](mockScanPredicate.operatorID, suppliedValidation);
+
+        expect(validateOperatorSpy).not.toHaveBeenCalled();
+        expect(changeOperatorColorSpy).toHaveBeenCalledWith(component.paper, mockScanPredicate.operatorID, false);
       });
     });
   });

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -25,7 +25,7 @@ import { DragDropService } from "../../service/drag-drop/drag-drop.service";
 import { DynamicSchemaService } from "../../service/dynamic-schema/dynamic-schema.service";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
 import { fromJointPaperEvent, JointUIService, linkPathStrokeColor } from "../../service/joint-ui/joint-ui.service";
-import { ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
+import { Validation, ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowStatusService } from "../../service/workflow-status/workflow-status.service";
 import { ExecutionState, OperatorState } from "../../types/execute-workflow.interface";
@@ -398,8 +398,8 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
    * overwrites a state-derived stroke (or vice versa) for an operator that
    * is both invalid and has a cached execution status.
    */
-  private applyOperatorBorder(operatorID: string): void {
-    const validation = this.validationWorkflowService.validateOperator(operatorID);
+  private applyOperatorBorder(operatorID: string, validation?: Validation): void {
+    validation ??= this.validationWorkflowService.validateOperator(operatorID);
     if (!validation.isValid) {
       this.jointUIService.changeOperatorColor(this.paper, operatorID, false);
       return;
@@ -1025,7 +1025,7 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
     this.validationWorkflowService
       .getOperatorValidationStream()
       .pipe(untilDestroyed(this))
-      .subscribe(value => this.applyOperatorBorder(value.operatorID));
+      .subscribe(value => this.applyOperatorBorder(value.operatorID, value.validation));
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR avoids a redundant operator validation recomputation in `WorkflowEditorComponent.applyOperatorBorder`.

The helper now accepts an optional `Validation` result. The operator validation stream passes along the validation value it already emitted, while callers without a validation result, such as the operator-add stream, still fall back to `validateOperator(operatorID)`.

### Any related issues, documentation, discussions?

Closes #5683.

### How was this PR tested?

```bash
yarn ng test --include src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts --watch=false
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)