### PR TITLE
ci: skip benchmark comment when artifact is missing

### DIFF
--- a/.github/workflows/benchmarks-pr-comment.yml
+++ b/.github/workflows/benchmarks-pr-comment.yml
@@ -60,6 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download bench-results artifact
+        id: artifact
         uses: actions/github-script@v8
         with:
           script: |
@@ -74,6 +75,7 @@ jobs:
             const match = data.artifacts.find((a) => a.name.startsWith("bench-results-"));
             if (!match) {
               core.warning(`no bench-results-* artifact on run ${runId}; nothing to comment.`);
+              core.setOutput("found", "false");
               return;
             }
             const zip = await github.rest.actions.downloadArtifact({
@@ -84,15 +86,18 @@ jobs:
             });
             fs.mkdirSync("bench-results-zip", { recursive: true });
             fs.writeFileSync(path.join("bench-results-zip", "artifact.zip"), Buffer.from(zip.data));
+            core.setOutput("found", "true");
             core.info(`downloaded artifact ${match.name} (${match.size_in_bytes} bytes)`);
 
       - name: Unzip artifact
+        if: steps.artifact.outputs.found == 'true'
         run: |
           mkdir -p bench-results
           unzip -o bench-results-zip/artifact.zip -d bench-results
           ls -la bench-results/
 
       - name: Read PR number from artifact
+        if: steps.artifact.outputs.found == 'true'
         id: pr
         # Read + strictly validate (digits only) before using in API calls.
         # The artifact comes from a fork-triggered workflow whose contents


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR prevents the `Benchmarks PR Comment` workflow from failing when the upstream `Benchmarks` workflow run has no `bench-results-*` artifact.

The artifact download step now records whether an artifact was found. The unzip and PR-number steps only run when that artifact exists, so a missing artifact exits the comment workflow cleanly after emitting the existing warning instead of failing at `unzip`.

### Any related issues, documentation, discussions?

Closes #5755.

### How was this PR tested?

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/benchmarks-pr-comment.yml"); puts "yaml ok"'
```

Fork workflow-run test:

- Merged this workflow change into `kz930/texera:main` through fork PR https://github.com/kz930/texera/pull/1 so the updated `workflow_run` file was present on the fork default branch.
- Opened fork-to-fork test PR https://github.com/kz930/texera/pull/2.
- The fork `Benchmarks` workflow ran from the pull request event and completed successfully: https://github.com/kz930/texera/actions/runs/27729684035.
- The downstream `Benchmarks PR Comment` workflow then triggered from `workflow_run`, downloaded the `bench-results-*` artifact, unzipped it, read `pr-number.txt`, and created the benchmark comment on the fork PR: https://github.com/kz930/texera/actions/runs/27729974324 and https://github.com/kz930/texera/pull/2#issuecomment-4736897569.
- The logs show the guarded artifact path setting `found=true`; the unzip, PR-number, and comment steps ran only after the artifact was found.

Note: the fork has no `gh-pages` branch, so the benchmark action emitted non-fatal `gh-pages` baseline warnings, but the `Benchmarks` job and downstream comment workflow both completed successfully.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
