### PR TITLE
test(workflow-operator): cover operator utilities

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/PortDescriptorSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/PortDescriptorSpec.scala
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import org.apache.texera.amber.core.workflow.HashPartition
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PortDescriptorSpec extends AnyFlatSpec {
+
+  private class TestPortDescriptor extends PortDescriptor
+
+  private val inputPort = PortDescription(
+    portID = "input-0",
+    displayName = "Input",
+    disallowMultiInputs = true,
+    isDynamicPort = false,
+    partitionRequirement = HashPartition(List("city")),
+    dependencies = List(1, 2)
+  )
+
+  private val outputPort = PortDescription(
+    portID = "output-0",
+    displayName = "Output",
+    disallowMultiInputs = false,
+    isDynamicPort = true,
+    partitionRequirement = HashPartition(),
+    dependencies = List.empty
+  )
+
+  "PortDescriptor" should "default inputPorts and outputPorts to null" in {
+    val descriptor = new TestPortDescriptor
+
+    assert(descriptor.inputPorts == null)
+    assert(descriptor.outputPorts == null)
+  }
+
+  it should "allow inputPorts and outputPorts to be assigned after construction" in {
+    val descriptor = new TestPortDescriptor
+
+    descriptor.inputPorts = List(inputPort)
+    descriptor.outputPorts = List(outputPort)
+
+    assert(descriptor.inputPorts == List(inputPort))
+    assert(descriptor.outputPorts == List(outputPort))
+  }
+
+  "PortDescription" should "preserve every constructor field" in {
+    assert(inputPort.portID == "input-0")
+    assert(inputPort.displayName == "Input")
+    assert(inputPort.disallowMultiInputs)
+    assert(!inputPort.isDynamicPort)
+    assert(inputPort.partitionRequirement == HashPartition(List("city")))
+    assert(inputPort.dependencies == List(1, 2))
+  }
+
+  it should "support case-class equality and copy semantics" in {
+    val copied = inputPort.copy(displayName = "Renamed")
+
+    assert(inputPort == inputPort.copy())
+    assert(copied.portID == inputPort.portID)
+    assert(copied.displayName == "Renamed")
+    assert(copied != inputPort)
+  }
+
+  it should "carry the allowMultiInputs Jackson ignore-property shim" in {
+    val annotation = classOf[PortDescription].getAnnotation(classOf[JsonIgnoreProperties])
+
+    assert(annotation != null)
+    assert(annotation.value().contains("allowMultiInputs"))
+  }
+
+  it should "round-trip through JSON while preserving every field" in {
+    val json = objectMapper.writeValueAsString(inputPort)
+    val restored = objectMapper.readValue(json, classOf[PortDescription])
+
+    assert(restored == inputPort)
+  }
+
+  it should "ignore the legacy allowMultiInputs JSON field during deserialization" in {
+    val json =
+      """
+        |{
+        |  "portID": "input-0",
+        |  "displayName": "Input",
+        |  "disallowMultiInputs": true,
+        |  "allowMultiInputs": false,
+        |  "isDynamicPort": false,
+        |  "partitionRequirement": {
+        |    "type": "hash",
+        |    "hashAttributeNames": ["city"]
+        |  },
+        |  "dependencies": [1, 2]
+        |}
+        |""".stripMargin
+
+    assert(objectMapper.readValue(json, classOf[PortDescription]) == inputPort)
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/PropertyNameConstantsSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/PropertyNameConstantsSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.metadata
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class PropertyNameConstantsSpec extends AnyFlatSpec {
+
+  private val logicalPlanKeys = Map(
+    "OPERATOR_ID" -> PropertyNameConstants.OPERATOR_ID,
+    "OPERATOR_TYPE" -> PropertyNameConstants.OPERATOR_TYPE,
+    "OPERATOR_LIST" -> PropertyNameConstants.OPERATOR_LIST,
+    "OPERATOR_LINK_LIST" -> PropertyNameConstants.OPERATOR_LINK_LIST,
+    "OPERATOR_VERSION" -> PropertyNameConstants.OPERATOR_VERSION,
+    "ORIGIN_OPERATOR_ID" -> PropertyNameConstants.ORIGIN_OPERATOR_ID,
+    "DESTINATION_OPERATOR_ID" -> PropertyNameConstants.DESTINATION_OPERATOR_ID
+  )
+
+  private val commonOperatorKeys = Map(
+    "ATTRIBUTE_NAMES" -> PropertyNameConstants.ATTRIBUTE_NAMES,
+    "ATTRIBUTE_NAME" -> PropertyNameConstants.ATTRIBUTE_NAME,
+    "RESULT_ATTRIBUTE_NAME" -> PropertyNameConstants.RESULT_ATTRIBUTE_NAME,
+    "SPAN_LIST_NAME" -> PropertyNameConstants.SPAN_LIST_NAME,
+    "TABLE_NAME" -> PropertyNameConstants.TABLE_NAME
+  )
+
+  private val physicalPlanKeys = Map(
+    "WORKFLOW_ID" -> PropertyNameConstants.WORKFLOW_ID,
+    "EXECUTION_ID" -> PropertyNameConstants.EXECUTION_ID,
+    "PARALLELIZABLE" -> PropertyNameConstants.PARALLELIZABLE,
+    "LOCATION_PREFERENCE" -> PropertyNameConstants.LOCATION_PREFERENCE,
+    "PARTITION_REQUIREMENT" -> PropertyNameConstants.PARTITION_REQUIREMENT,
+    "INPUT_PORTS" -> PropertyNameConstants.INPUT_PORTS,
+    "OUTPUT_PORTS" -> PropertyNameConstants.OUTPUT_PORTS,
+    "IS_ONE_TO_MANY_OP" -> PropertyNameConstants.IS_ONE_TO_MANY_OP,
+    "SUGGESTED_WORKER_NUM" -> PropertyNameConstants.SUGGESTED_WORKER_NUM
+  )
+
+  "PropertyNameConstants" should "pin logical-plan key values" in {
+    assert(
+      logicalPlanKeys == Map(
+        "OPERATOR_ID" -> "operatorID",
+        "OPERATOR_TYPE" -> "operatorType",
+        "OPERATOR_LIST" -> "operators",
+        "OPERATOR_LINK_LIST" -> "links",
+        "OPERATOR_VERSION" -> "operatorVersion",
+        "ORIGIN_OPERATOR_ID" -> "origin",
+        "DESTINATION_OPERATOR_ID" -> "destination"
+      )
+    )
+  }
+
+  it should "pin common operator key values" in {
+    assert(
+      commonOperatorKeys == Map(
+        "ATTRIBUTE_NAMES" -> "attributes",
+        "ATTRIBUTE_NAME" -> "attribute",
+        "RESULT_ATTRIBUTE_NAME" -> "resultAttribute",
+        "SPAN_LIST_NAME" -> "spanListName",
+        "TABLE_NAME" -> "tableName"
+      )
+    )
+  }
+
+  it should "pin physical-plan key values" in {
+    assert(
+      physicalPlanKeys == Map(
+        "WORKFLOW_ID" -> "workflowID",
+        "EXECUTION_ID" -> "executionID",
+        "PARALLELIZABLE" -> "parallelizable",
+        "LOCATION_PREFERENCE" -> "locationPreference",
+        "PARTITION_REQUIREMENT" -> "partitionRequirement",
+        "INPUT_PORTS" -> "inputPorts",
+        "OUTPUT_PORTS" -> "outputPorts",
+        "IS_ONE_TO_MANY_OP" -> "isOneToManyOp",
+        "SUGGESTED_WORKER_NUM" -> "suggestedWorkerNum"
+      )
+    )
+  }
+
+  it should "keep all constant values distinct" in {
+    val allValues = (logicalPlanKeys ++ commonOperatorKeys ++ physicalPlanKeys).values.toList
+
+    assert(allValues.distinct.size == allValues.size)
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/util/OperatorDescriptorUtilsSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/util/OperatorDescriptorUtilsSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.util
+
+class OperatorDescriptorUtilsSpec extends AnyFlatSpec {
+
+  "OperatorDescriptorUtils.equallyPartitionGoal" should "split an exactly divisible goal evenly" in {
+    val partitions = OperatorDescriptorUtils.equallyPartitionGoal(goal = 12, totalNumWorkers = 4)
+
+    assert(partitions == List(3, 3, 3, 3))
+    assert(partitions.length == 4)
+    assert(partitions.sum == 12)
+  }
+
+  it should "assign remainder units to the first workers" in {
+    val partitions = OperatorDescriptorUtils.equallyPartitionGoal(goal = 10, totalNumWorkers = 4)
+
+    assert(partitions == List(3, 3, 2, 2))
+    assert(partitions.length == 4)
+    assert(partitions.sum == 10)
+  }
+
+  it should "return all zeroes for a zero goal" in {
+    val partitions = OperatorDescriptorUtils.equallyPartitionGoal(goal = 0, totalNumWorkers = 3)
+
+    assert(partitions == List(0, 0, 0))
+    assert(partitions.sum == 0)
+  }
+
+  it should "return the whole goal for a single worker" in {
+    assert(OperatorDescriptorUtils.equallyPartitionGoal(goal = 7, totalNumWorkers = 1) == List(7))
+  }
+
+  it should "fail when asked to partition across zero workers" in {
+    assertThrows[ArithmeticException] {
+      OperatorDescriptorUtils.equallyPartitionGoal(goal = 7, totalNumWorkers = 0)
+    }
+  }
+
+  "OperatorDescriptorUtils.toImmutableMap" should "convert an empty java map to an empty Scala map" in {
+    val javaMap = new util.LinkedHashMap[String, Int]()
+
+    assert(OperatorDescriptorUtils.toImmutableMap(javaMap).isEmpty)
+  }
+
+  it should "copy all entries from a populated java map" in {
+    val javaMap = new util.LinkedHashMap[String, Int]()
+    javaMap.put("first", 1)
+    javaMap.put("second", 2)
+
+    assert(OperatorDescriptorUtils.toImmutableMap(javaMap) == Map("first" -> 1, "second" -> 2))
+  }
+
+  it should "not reflect later mutations to the source java map" in {
+    val javaMap = new util.LinkedHashMap[String, Int]()
+    javaMap.put("original", 1)
+
+    val immutableMap = OperatorDescriptorUtils.toImmutableMap(javaMap)
+    javaMap.put("later", 2)
+
+    assert(immutableMap == Map("original" -> 1))
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR adds dedicated unit coverage for small `common/workflow-operator` utility and contract classes:

- `OperatorDescriptorUtilsSpec` covers goal partitioning and Java-map copying behavior.
- `PropertyNameConstantsSpec` pins logical-plan, common-operator, and physical-plan key strings, and verifies the constant values stay distinct.
- `PortDescriptorSpec` covers default/mutable port-list behavior, `PortDescription` constructor/case-class semantics, the `allowMultiInputs` Jackson compatibility shim, and JSON deserialization/round-trip behavior.

No production code is changed.

### Any related issues, documentation, discussions?

Closes #5735.

### How was this PR tested?

```bash
sbt "PyBuilder / clean" "WorkflowCore / clean" "WorkflowOperator / clean" "WorkflowOperator / testOnly org.apache.texera.amber.operator.util.OperatorDescriptorUtilsSpec org.apache.texera.amber.operator.metadata.PropertyNameConstantsSpec org.apache.texera.amber.operator.PortDescriptorSpec"
```

```bash
sbt "WorkflowOperator / scalafmtCheck" "WorkflowOperator / Test / scalafmtCheck"
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)