### PR TITLE
chore(licensing): refresh Python license-binary drift

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -254,7 +254,7 @@ Python packages:
   - cachetools==6.2.6
   - charset-normalizer==3.4.7
   - deprecated==1.2.14
-  - filelock==3.29.3
+  - filelock==3.29.4
   - fonttools==4.63.0
   - fs==2.4.16
   - greenlet==3.5.1


### PR DESCRIPTION
### What changes were proposed in this PR?

Refresh `amber/LICENSE-binary-python` so the recorded `filelock` version matches the Python packages installed by the pyamber CI job.

### Any related issues, documentation, discussions?

Closes #5725

### How was this PR tested?

```bash
/tmp/texera-license-venv/bin/python bin/licensing/check_binary_deps.py --ignore-transitive-version python /tmp/pip-licenses-linux-like.csv
```

This uses the same licensing checker with the local package snapshot adjusted for the Linux-only `greenlet==3.5.1` package from the failing Ubuntu job. It verifies the `filelock` drift is resolved; unrelated local transitive version drift is reported as informational.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
