### PR TITLE
fix(frontend): align dashboard dividers

### DIFF
--- a/frontend/src/app/dashboard/component/dashboard.component.scss
+++ b/frontend/src/app/dashboard/component/dashboard.component.scss
@@ -54,6 +54,8 @@ button {
 
 .page-content-layout {
   border-left: 1px solid #f0f0f0;
+  height: 100%;
+  min-height: 0;
 }
 
 .ant-layout-sider-has-trigger {
@@ -92,6 +94,8 @@ nz-content {
 .page-container {
   display: flex;
   flex-direction: column;
+  flex: 1;
+  min-width: 0;
   width: 100%;
 }
 

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -253,7 +253,6 @@
   <nz-sider
     *ngIf="!isRightBarCollapsed"
     nzTheme="light"
-    style="float: right; height: 100%"
     [nzWidth]="siderWidth"
     nz-resizable
     [nzMinWidth]="MIN_SIDER_WIDTH"

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.scss
@@ -62,6 +62,9 @@ body {
 }
 
 .sider-resize-line {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   height: 100%;
   width: 5px;
   border-right: 1px solid #e8e8e8;
@@ -74,7 +77,6 @@ body {
   font-size: 12px;
   height: 20px;
   line-height: 20px;
-  margin-top: 400px;
 }
 
 .file-renderer {


### PR DESCRIPTION
 ### What changes were proposed in this PR?

  Fix the dashboard and dataset-detail sidebar dividers so they span the full panel height consistently.

  The dashboard sidebar divider is now rendered as a full-height overlay on the sidebar itself. The dataset detail right panel uses the same approach and avoids drawing a
  duplicate divider from the resize handle.

  ### Any related issues, documentation, discussions?

  Closes #3741

  ### How was this PR tested?

  ```bash
  ./node_modules/.bin/prettier-eslint --list-different src/app/dashboard/component/dashboard.component.html src/app/dashboard/component/dashboard.component.scss src/app/
  dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-
  detail.component.scss
  ./node_modules/.bin/eslint src/app/dashboard/component/dashboard.component.html src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-
  detail.component.html
  git diff --check -- frontend/src/app/dashboard/component/dashboard.component.html frontend/src/app/dashboard/component/dashboard.component.scss frontend/src/app/
  dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/
  dataset-detail.component.scss
  ```

 Manually verified at http://localhost:4200/ that the sidebar divider spans the full height, including the email/admin page.
<img width="1706" height="986" alt="Screenshot 2026-06-17 at 3 50 59 PM" src="https://github.com/user-attachments/assets/462ea367-09c5-4315-a4e1-89909e67cf1a" />
<img width="1709" height="985" alt="Screenshot 2026-06-17 at 3 51 16 PM" src="https://github.com/user-attachments/assets/3f3e9f73-0f7d-4c65-afa6-727874e05a46" />


  ### Was this PR authored or co-authored using generative AI tooling?

  Generated-by: Codex (GPT-5)