### PR TITLE
test(frontend): add spec for AdminGuardService

### DIFF
--- a/frontend/src/app/dashboard/service/admin/guard/admin-guard.service.spec.ts
+++ b/frontend/src/app/dashboard/service/admin/guard/admin-guard.service.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { Router } from "@angular/router";
+
+import { AdminGuardService } from "./admin-guard.service";
+import { UserService } from "../../../../common/service/user/user.service";
+import { MOCK_USER, StubUserService } from "../../../../common/service/user/stub-user.service";
+import { Role } from "../../../../common/type/user";
+import { USER_WORKFLOW } from "../../../../app-routing.constant";
+import { commonTestProviders } from "../../../../common/testing/test-utils";
+
+describe("AdminGuardService", () => {
+  let guard: AdminGuardService;
+  let userService: StubUserService;
+  let routerSpy: { navigate: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    routerSpy = { navigate: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [
+        AdminGuardService,
+        { provide: UserService, useClass: StubUserService },
+        { provide: Router, useValue: routerSpy },
+        ...commonTestProviders,
+      ],
+    });
+    guard = TestBed.inject(AdminGuardService);
+    userService = TestBed.inject(UserService) as unknown as StubUserService;
+  });
+
+  it("allows navigation and does not redirect when the user is an admin", () => {
+    userService.user = { ...MOCK_USER, role: Role.ADMIN };
+
+    expect(guard.canActivate()).toBe(true);
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it("blocks navigation and redirects to USER_WORKFLOW when the user is a regular (non-admin) user", () => {
+    userService.user = { ...MOCK_USER, role: Role.REGULAR };
+
+    expect(guard.canActivate()).toBe(false);
+    expect(routerSpy.navigate).toHaveBeenCalledWith([USER_WORKFLOW]);
+  });
+
+  it("blocks navigation and redirects to USER_WORKFLOW when there is no signed-in user", () => {
+    userService.user = undefined;
+
+    expect(guard.canActivate()).toBe(false);
+    expect(routerSpy.navigate).toHaveBeenCalledWith([USER_WORKFLOW]);
+  });
+});


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->



### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->

Adds a behavior-focused unit test spec for `AdminGuardService`. Tests cover:
- Admin user: `canActivate()` returns `true`, `Router.navigate` is NOT called
- Non-admin user: `canActivate()` returns `false`, `Router.navigate` is called with `[USER_WORKFLOW]`
- No signed-in user: `canActivate()` returns `false`, `Router.navigate` is called with `[USER_WORKFLOW]`

Mirrors the existing `auth-guard.service.spec.ts` pattern.

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

closes  #5780

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->

Spec verified with `npx ng test --watch=false --include='**/admin-guard.service.spec.ts'`. 3 tests passing.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Co-Authored: Claude Code (Anthropic)