### PR TITLE
test(common/auth): add spec for SessionUser

### DIFF
--- a/common/auth/src/test/scala/org/apache/texera/auth/SessionUserSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/SessionUserSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.auth
+
+import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
+import org.apache.texera.dao.jooq.generated.tables.pojos.User
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SessionUserSpec extends AnyFlatSpec with Matchers {
+
+  private def buildUser(role: UserRoleEnum = UserRoleEnum.REGULAR): User = {
+    val user = new User
+    user.setUid(42)
+    user.setName("alice")
+    user.setEmail("alice@example.com")
+    user.setGoogleId("g-123")
+    user.setRole(role)
+    user
+  }
+
+  "SessionUser" should "expose the underlying User's name via getName" in {
+    val user = buildUser()
+    val session = new SessionUser(user)
+    session.getName shouldBe user.getName
+  }
+
+  it should "expose the underlying User's uid via getUid" in {
+    val user = buildUser()
+    val session = new SessionUser(user)
+    session.getUid shouldBe user.getUid
+  }
+
+  it should "expose the underlying User's email via getEmail" in {
+    val user = buildUser()
+    val session = new SessionUser(user)
+    session.getEmail shouldBe user.getEmail
+  }
+
+  it should "expose the underlying User's googleId via getGoogleId" in {
+    val user = buildUser()
+    val session = new SessionUser(user)
+    session.getGoogleId shouldBe user.getGoogleId
+  }
+
+  it should "return the same User instance via getUser" in {
+    val user = buildUser()
+    val session = new SessionUser(user)
+    session.getUser should be theSameInstanceAs user
+  }
+
+  "SessionUser.isRoleOf" should "return true when the user's role matches" in {
+    val session = new SessionUser(buildUser(UserRoleEnum.ADMIN))
+    session.isRoleOf(UserRoleEnum.ADMIN) shouldBe true
+  }
+
+  it should "return false when the user's role does not match" in {
+    val session = new SessionUser(buildUser(UserRoleEnum.REGULAR))
+    session.isRoleOf(UserRoleEnum.ADMIN) shouldBe false
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->


Adds a unit test spec for `SessionUser`. Tests cover:
- `getName` returns the wrapped `user.getName` (Principal contract)
- `getUid`, `getEmail`, `getGoogleId` delegate to the wrapped User
- `getUser` returns the same User instance
- `isRoleOf(ADMIN)` returns `true` when role is ADMIN
- `isRoleOf(ADMIN)` returns `false` when role is REGULAR
Mirrors the existing `JwtParserSpec.scala` style (AnyFlatSpec with Matchers).

### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->

Closes: #5779

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->

Spec verified with `sbt "common-auth/testOnly *SessionUserSpec"`. 7 tests passing.

### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Coauthored-by: Claude Code (Anthropic)