### PR TITLE
test(common-auth): add HeaderFieldSpec for header-name constants

### DIFF
--- a/common/auth/src/test/scala/org/apache/texera/auth/util/HeaderFieldSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/util/HeaderFieldSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.auth.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HeaderFieldSpec extends AnyFlatSpec with Matchers {
+
+  "HeaderField.UserComputingUnitAccess" should "equal \"x-user-computing-unit-access\"" in {
+    HeaderField.UserComputingUnitAccess shouldBe "x-user-computing-unit-access"
+  }
+
+  "HeaderField.UserId" should "equal \"x-user-id\"" in {
+    HeaderField.UserId shouldBe "x-user-id"
+  }
+
+  "HeaderField.UserName" should "equal \"x-user-name\"" in {
+    HeaderField.UserName shouldBe "x-user-name"
+  }
+
+  "HeaderField.UserEmail" should "equal \"x-user-email\"" in {
+    HeaderField.UserEmail shouldBe "x-user-email"
+  }
+
+  "HeaderField constants" should "all match the x-user-* namespace in lowercase-hyphen format" in {
+    val rfcPattern = "^x-user-[a-z]+(?:-[a-z]+)*$".r
+    val allConstants = Seq(
+      HeaderField.UserComputingUnitAccess,
+      HeaderField.UserId,
+      HeaderField.UserName,
+      HeaderField.UserEmail
+    )
+    allConstants.foreach { value =>
+      rfcPattern.matches(value) shouldBe true
+    }
+  }
+
+  it should "all be distinct (no accidental aliasing)" in {
+    val allConstants = Seq(
+      HeaderField.UserComputingUnitAccess,
+      HeaderField.UserId,
+      HeaderField.UserName,
+      HeaderField.UserEmail
+    )
+    allConstants.distinct should have size allConstants.size
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `HeaderFieldSpec.scala` — a dedicated unit spec for `HeaderField` in `common/auth/src/main/scala/org/apache/texera/auth/util/`.

`HeaderField` holds the canonical HTTP header names the auth layer reads from every request. Without a spec, accidental renames silently break header-based authentication. This PR pins three contracts:

| Contract | Tests |
|---|---|
| Exact value | Each constant equals its expected string literal |
| RFC-7230 format | Every constant matches `x-user-*` lowercase-hyphen namespace |
| Distinctness | No two constants share the same value (no accidental aliasing) |

No production-code changes.

### Any related issues, documentation, discussions?

Closes #5662

### How was this PR tested?

New spec file: `HeaderFieldSpec.scala` (~50 lines, no build changes needed — ScalaTest is already a `% Test` dependency in `common/auth`).

```
sbt "Auth/testOnly org.apache.texera.auth.util.HeaderFieldSpec"
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6