### PR TITLE
fix(pyamber): use monotonic_ns to prevent negative elapsed times in statistics_manager

### DIFF
--- a/amber/src/main/python/core/architecture/managers/statistics_manager.py
+++ b/amber/src/main/python/core/architecture/managers/statistics_manager.py
@@ -77,12 +77,22 @@ class StatisticsManager:
 
     def increase_data_processing_time(self, time: int) -> None:
         if time < 0:
-            raise ValueError("Time must be non-negative")
+            logger.warning(
+                f"increase_data_processing_time called with negative elapsed time "
+                f"({time}ns); ignoring. Use time.monotonic_ns() at call sites to "
+                "prevent clock-skew from producing negative durations."
+            )
+            return
         self._data_processing_time += time
 
     def increase_control_processing_time(self, time: int) -> None:
         if time < 0:
-            raise ValueError("Time must be non-negative")
+            logger.warning(
+                f"increase_control_processing_time called with negative elapsed time "
+                f"({time}ns); ignoring. Use time.monotonic_ns() at call sites to "
+                "prevent clock-skew from producing negative durations."
+            )
+            return
         self._control_processing_time += time
 
     def update_total_execution_time(self, time: int) -> None:

--- a/amber/src/main/python/core/runnables/main_loop.py
+++ b/amber/src/main/python/core/runnables/main_loop.py
@@ -98,7 +98,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
         # stop the data processing thread
         self.data_processor.stop()
         self.context.state_manager.transit_to(WorkerState.COMPLETED)
-        self.context.statistics_manager.update_total_execution_time(time.time_ns())
+        self.context.statistics_manager.update_total_execution_time(time.monotonic_ns())
         controller_interface = self._async_rpc_client.controller_stub()
         controller_interface.worker_execution_completed(EmptyRequest())
         self.context.close()
@@ -130,7 +130,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
     def pre_start(self) -> None:
         self.context.state_manager.assert_state(WorkerState.UNINITIALIZED)
         self.context.state_manager.transit_to(WorkerState.READY)
-        self.context.statistics_manager.initialize_worker_start_time(time.time_ns())
+        self.context.statistics_manager.initialize_worker_start_time(time.monotonic_ns())
 
     @overrides
     def receive(self, next_entry: QueueElement) -> None:
@@ -226,7 +226,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
 
         :param dcm_element: DirectControlMessageElement to be handled.
         """
-        start_time = time.time_ns()
+        start_time = time.monotonic_ns()
         match(
             (dcm_element.tag, get_one_of(dcm_element.payload, sealed=False)),
             typing.Tuple[ChannelIdentity, ControlInvocation],
@@ -234,7 +234,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
             typing.Tuple[ChannelIdentity, ReturnInvocation],
             self._async_rpc_client.receive,
         )
-        end_time = time.time_ns()
+        end_time = time.monotonic_ns()
         self.context.statistics_manager.increase_control_processing_time(
             end_time - start_time
         )
@@ -431,12 +431,12 @@ class MainLoop(StoppableQueueBlockingRunnable):
         """
         Notify the DataProcessor thread and wait here until being switched back.
         """
-        start_time = time.time_ns()
+        start_time = time.monotonic_ns()
         with self.context.tuple_processing_manager.context_switch_condition:
             self.context.tuple_processing_manager.context_switch_condition.notify()
             self.context.tuple_processing_manager.context_switch_condition.wait()
         self._post_switch_context_checks()
-        end_time = time.time_ns()
+        end_time = time.monotonic_ns()
         self.context.statistics_manager.increase_data_processing_time(
             end_time - start_time
         )

--- a/amber/src/test/python/core/architecture/managers/test_statistics_manager.py
+++ b/amber/src/test/python/core/architecture/managers/test_statistics_manager.py
@@ -101,13 +101,20 @@ class TestStatisticsManagerProcessingTime:
         assert stats.control_processing_time == 0
 
     @pytest.mark.parametrize(
-        "method",
-        ["increase_data_processing_time", "increase_control_processing_time"],
+        "method, attr",
+        [
+            ("increase_data_processing_time", "_data_processing_time"),
+            ("increase_control_processing_time", "_control_processing_time"),
+        ],
     )
-    def test_negative_time_raises(self, method):
+    def test_negative_time_is_clamped_to_zero(self, method, attr):
+        # Negative elapsed times can arise from non-monotonic wall-clock reads
+        # (e.g. NTP adjustment). The manager should absorb them silently rather
+        # than raise and potentially hang the worker thread.
         mgr = StatisticsManager()
-        with pytest.raises(ValueError, match="Time must be non-negative"):
-            getattr(mgr, method)(-1)
+        getattr(mgr, method)(100)  # prime the accumulator
+        getattr(mgr, method)(-1)   # must not raise
+        assert getattr(mgr, attr) == 100  # accumulator unchanged
 
 
 class TestStatisticsManagerExecutionTime:


### PR DESCRIPTION
### What changes were proposed in this PR?

**Root cause:** `time.time_ns()` is a wall-clock call that can go backward during NTP adjustments or inside VMs/containers.  In `MainLoop._switch_context` and `_process_dcm`, elapsed time is computed as `end_time - start_time` where both values come from `time.time_ns()`.  When the clock steps backward between the two calls, the difference is negative.  Passing a negative value to `StatisticsManager.increase_data_processing_time` raised `ValueError: Time must be non-negative`, which propagated into the DataProcessor thread and left the worker in a deadlocked wait.

**Before → After**

```
Before:
  start_time = time.time_ns()   # wall clock — can go backward
  ...
  end_time   = time.time_ns()   # can be < start_time after NTP step
  statistics_manager.increase_data_processing_time(end_time - start_time)
  #  → ValueError: Time must be non-negative
  #  → worker thread hangs (unhandled exception)

After:
  start_time = time.monotonic_ns()   # guaranteed non-decreasing
  ...
  end_time   = time.monotonic_ns()   # always ≥ start_time
  statistics_manager.increase_data_processing_time(end_time - start_time)
  #  → always ≥ 0, no exception
```

**Changes (3 files):**

| File | Change |
|------|--------|
| `core/runnables/main_loop.py` | Replace all 6 `time.time_ns()` calls with `time.monotonic_ns()` |
| `core/architecture/managers/statistics_manager.py` | Defense-in-depth: log a warning and return early for negative elapsed times instead of raising `ValueError` |
| `test/python/core/architecture/managers/test_statistics_manager.py` | Update `test_negative_time_raises` → `test_negative_time_is_clamped_to_zero` to match new behavior |

### Any related issues, documentation, discussions?

Closes #3768

### How was this PR tested?

```bash
cd amber && pytest src/test/python/core/architecture/managers/test_statistics_manager.py -v
```

(Requires `bin/python-proto-gen.sh` to have been run first, as in CI.)

All existing `TestStatisticsManager*` tests pass.  The updated test `test_negative_time_is_clamped_to_zero` replaces `test_negative_time_raises` and covers the new clamp-and-warn behavior.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Sonnet 4.6