### PR TITLE
test(workflow-operator): add unit test coverage for text search and match operator descriptors

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/dictionary/DictionaryMatcherOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/dictionary/DictionaryMatcherOpDescSpec.scala
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.dictionary
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.core.workflow.PortIdentity
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DictionaryMatcherOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def newDesc(
+      dict: String,
+      attr: String,
+      result: String,
+      mt: MatchingType
+  ): DictionaryMatcherOpDesc = {
+    val d = new DictionaryMatcherOpDesc
+    d.dictionary = dict
+    d.attribute = attr
+    d.resultAttribute = result
+    d.matchingType = mt
+    d
+  }
+
+  "DictionaryMatcherOpDesc.operatorInfo" should
+    "advertise the name, Search group, and reconfiguration support" in {
+    val info = (new DictionaryMatcherOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Dictionary matcher"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SEARCH_GROUP
+    info.operatorDescription.toLowerCase should include("dictionary")
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+    info.supportReconfiguration shouldBe true
+  }
+
+  "DictionaryMatcherOpDesc.getPhysicalOp" should "wire the DictionaryMatcherOpExec class name" in {
+    val physical =
+      newDesc("a,b,c", "word", "matched", MatchingType.SCANBASED)
+        .getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.dictionary.DictionaryMatcherOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+  }
+
+  "DictionaryMatcherOpDesc schema propagation" should
+    "append a BOOLEAN column named by resultAttribute to the input schema" in {
+    val desc = newDesc("a,b,c", "word", "matched", MatchingType.SCANBASED)
+    val inputSchema = Schema().add(new Attribute("word", AttributeType.STRING))
+    val out = desc.getExternalOutputSchemas(Map(PortIdentity() -> inputSchema)).values.head
+    out shouldBe inputSchema.add(new Attribute("matched", AttributeType.BOOLEAN))
+  }
+
+  "DictionaryMatcherOpDesc JSON round-trip" should
+    "preserve all fields including MatchingType via the polymorphic base" in {
+    val json = objectMapper.writeValueAsString(
+      newDesc("x,y", "col", "isMatch", MatchingType.CONJUNCTION_INDEXBASED)
+    )
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[DictionaryMatcherOpDesc]
+    val dm = restored.asInstanceOf[DictionaryMatcherOpDesc]
+    dm.dictionary shouldBe "x,y"
+    dm.attribute shouldBe "col"
+    dm.resultAttribute shouldBe "isMatch"
+    dm.matchingType shouldBe MatchingType.CONJUNCTION_INDEXBASED
+  }
+
+  it should "serialize MatchingType via its @JsonValue name (e.g. SCANBASED -> \"Scan\")" in {
+    val json = objectMapper.writeValueAsString(
+      newDesc("a", "col", "matched", MatchingType.SCANBASED)
+    )
+    val tree = objectMapper.readTree(json)
+    tree.get("Matching type").asText shouldBe "Scan"
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/dictionary/DictionaryMatcherOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/dictionary/DictionaryMatcherOpDescSpec.scala
@@ -59,16 +59,19 @@ class DictionaryMatcherOpDescSpec extends AnyFlatSpec with Matchers {
     info.supportReconfiguration shouldBe true
   }
 
-  "DictionaryMatcherOpDesc.getPhysicalOp" should "wire the DictionaryMatcherOpExec class name" in {
-    val physical =
-      newDesc("a,b,c", "word", "matched", MatchingType.SCANBASED)
-        .getPhysicalOp(workflowId, executionId)
+  "DictionaryMatcherOpDesc.getPhysicalOp" should
+    "wire the DictionaryMatcherOpExec class name and carry forward the operatorInfo port identities" in {
+    val op = newDesc("a,b,c", "word", "matched", MatchingType.SCANBASED)
+    val physical = op.getPhysicalOp(workflowId, executionId)
     physical.opExecInitInfo match {
       case OpExecWithClassName(className, descString) =>
         className shouldBe "org.apache.texera.amber.operator.dictionary.DictionaryMatcherOpExec"
         descString should not be empty
       case other => fail(s"expected OpExecWithClassName, got $other")
     }
+    // Pin the actual port identities (not just counts).
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
   }
 
   "DictionaryMatcherOpDesc schema propagation" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpDescSpec.scala
@@ -70,11 +70,13 @@ class KeywordSearchOpDescSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "carry forward the operatorInfo input/output ports" in {
+  it should "carry forward the operatorInfo input/output port identities" in {
     val op = newDesc("col", "needle", caseSensitive = false)
     val physical = op.getPhysicalOp(workflowId, executionId)
-    physical.inputPorts.size shouldBe op.operatorInfo.inputPorts.size
-    physical.outputPorts.size shouldBe op.operatorInfo.outputPorts.size
+    // Pin the actual port identities (not just counts), so a drift in port
+    // wiring is caught even when the number of ports is unchanged.
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
   }
 
   "KeywordSearchOpDesc JSON round-trip" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/keywordSearch/KeywordSearchOpDescSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.keywordSearch
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class KeywordSearchOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def newDesc(attr: String, kw: String, caseSensitive: Boolean): KeywordSearchOpDesc = {
+    val d = new KeywordSearchOpDesc
+    d.attribute = attr
+    d.keyword = kw
+    d.isCaseSensitive = caseSensitive
+    d
+  }
+
+  "KeywordSearchOpDesc.operatorInfo" should
+    "advertise the name, Search group, and reconfiguration support" in {
+    val info = (new KeywordSearchOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Keyword Search"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SEARCH_GROUP
+    info.operatorDescription.toLowerCase should include("keyword")
+    info.supportReconfiguration shouldBe true
+  }
+
+  it should "expose exactly one input port and one output port" in {
+    val info = (new KeywordSearchOpDesc).operatorInfo
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+  }
+
+  "KeywordSearchOpDesc.isCaseSensitive" should "default to false" in {
+    (new KeywordSearchOpDesc).isCaseSensitive shouldBe false
+  }
+
+  "KeywordSearchOpDesc.getPhysicalOp" should "wire the KeywordSearchOpExec class name" in {
+    val physical =
+      newDesc("col", "needle", caseSensitive = false).getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.keywordSearch.KeywordSearchOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+  }
+
+  it should "carry forward the operatorInfo input/output ports" in {
+    val op = newDesc("col", "needle", caseSensitive = false)
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    physical.inputPorts.size shouldBe op.operatorInfo.inputPorts.size
+    physical.outputPorts.size shouldBe op.operatorInfo.outputPorts.size
+  }
+
+  "KeywordSearchOpDesc JSON round-trip" should
+    "preserve attribute, keyword, and isCaseSensitive via the polymorphic base" in {
+    val json = objectMapper.writeValueAsString(newDesc("title", "apache", caseSensitive = true))
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[KeywordSearchOpDesc]
+    val kw = restored.asInstanceOf[KeywordSearchOpDesc]
+    kw.attribute shouldBe "title"
+    kw.keyword shouldBe "apache"
+    kw.isCaseSensitive shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/regex/RegexOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/regex/RegexOpDescSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.regex
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RegexOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def newDesc(attr: String, re: String, caseInsensitive: Boolean): RegexOpDesc = {
+    val d = new RegexOpDesc
+    d.attribute = attr
+    d.regex = re
+    d.caseInsensitive = caseInsensitive
+    d
+  }
+
+  "RegexOpDesc.operatorInfo" should
+    "advertise the name, Search group, and reconfiguration support" in {
+    val info = (new RegexOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Regular Expression"
+    info.operatorDescription.toLowerCase should include("regular expression")
+    info.operatorGroupName shouldBe OperatorGroupConstants.SEARCH_GROUP
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+    info.supportReconfiguration shouldBe true
+  }
+
+  "RegexOpDesc.getPhysicalOp" should "wire the RegexOpExec class name and carry ports" in {
+    val op = newDesc("col", ".*foo.*", caseInsensitive = false)
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.regex.RegexOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    physical.inputPorts.size shouldBe op.operatorInfo.inputPorts.size
+    physical.outputPorts.size shouldBe op.operatorInfo.outputPorts.size
+  }
+
+  "RegexOpDesc JSON round-trip" should
+    "preserve attribute, regex, and caseInsensitive via the polymorphic base" in {
+    val json = objectMapper.writeValueAsString(newDesc("url", "^https?://", caseInsensitive = true))
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[RegexOpDesc]
+    val re = restored.asInstanceOf[RegexOpDesc]
+    re.attribute shouldBe "url"
+    re.regex shouldBe "^https?://"
+    re.caseInsensitive shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/regex/RegexOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/regex/RegexOpDescSpec.scala
@@ -60,8 +60,9 @@ class RegexOpDescSpec extends AnyFlatSpec with Matchers {
         descString should not be empty
       case other => fail(s"expected OpExecWithClassName, got $other")
     }
-    physical.inputPorts.size shouldBe op.operatorInfo.inputPorts.size
-    physical.outputPorts.size shouldBe op.operatorInfo.outputPorts.size
+    // Pin the actual port identities (not just counts).
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
   }
 
   "RegexOpDesc JSON round-trip" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/substringSearch/SubstringSearchOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/substringSearch/SubstringSearchOpDescSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.substringSearch
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SubstringSearchOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def newDesc(attr: String, sub: String, caseSensitive: Boolean): SubstringSearchOpDesc = {
+    val d = new SubstringSearchOpDesc
+    d.attribute = attr
+    d.substring = sub
+    d.isCaseSensitive = caseSensitive
+    d
+  }
+
+  "SubstringSearchOpDesc.operatorInfo" should
+    "advertise the name, description, Search group, and reconfiguration support" in {
+    val info = (new SubstringSearchOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Substring Search"
+    info.operatorDescription shouldBe "Search for Substring(s) in a string column"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SEARCH_GROUP
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+    info.supportReconfiguration shouldBe true
+  }
+
+  "SubstringSearchOpDesc.isCaseSensitive" should "default to false" in {
+    (new SubstringSearchOpDesc).isCaseSensitive shouldBe false
+  }
+
+  "SubstringSearchOpDesc.getPhysicalOp" should "wire the SubstringSearchOpExec class name" in {
+    val physical =
+      newDesc("col", "ub", caseSensitive = false).getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.substringSearch.SubstringSearchOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    physical.inputPorts.size shouldBe 1
+    physical.outputPorts.size shouldBe 1
+  }
+
+  "SubstringSearchOpDesc JSON round-trip" should
+    "preserve attribute, substring, and isCaseSensitive via the polymorphic base" in {
+    val json = objectMapper.writeValueAsString(newDesc("body", "lo", caseSensitive = true))
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SubstringSearchOpDesc]
+    val ss = restored.asInstanceOf[SubstringSearchOpDesc]
+    ss.attribute shouldBe "body"
+    ss.substring shouldBe "lo"
+    ss.isCaseSensitive shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/substringSearch/SubstringSearchOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/substringSearch/SubstringSearchOpDescSpec.scala
@@ -55,17 +55,19 @@ class SubstringSearchOpDescSpec extends AnyFlatSpec with Matchers {
     (new SubstringSearchOpDesc).isCaseSensitive shouldBe false
   }
 
-  "SubstringSearchOpDesc.getPhysicalOp" should "wire the SubstringSearchOpExec class name" in {
-    val physical =
-      newDesc("col", "ub", caseSensitive = false).getPhysicalOp(workflowId, executionId)
+  "SubstringSearchOpDesc.getPhysicalOp" should
+    "wire the SubstringSearchOpExec class name and carry forward the operatorInfo port identities" in {
+    val op = newDesc("col", "ub", caseSensitive = false)
+    val physical = op.getPhysicalOp(workflowId, executionId)
     physical.opExecInitInfo match {
       case OpExecWithClassName(className, descString) =>
         className shouldBe "org.apache.texera.amber.operator.substringSearch.SubstringSearchOpExec"
         descString should not be empty
       case other => fail(s"expected OpExecWithClassName, got $other")
     }
-    physical.inputPorts.size shouldBe 1
-    physical.outputPorts.size shouldBe 1
+    // Pin the actual port identities (not just counts).
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
   }
 
   "SubstringSearchOpDesc JSON round-trip" should


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of four previously-untested text-search/match descriptors in `common/workflow-operator/`. They share the same shape — match/filter tuples by a string predicate on a column — and contribute operator metadata, physical-op wiring, and (for DictionaryMatcher) output-schema propagation. No production-code changes.

| Spec | Source class | Tests |
| --- | --- | --- |
| `KeywordSearchOpDescSpec` | `KeywordSearchOpDesc` | 6 |
| `SubstringSearchOpDescSpec` | `SubstringSearchOpDesc` | 4 |
| `RegexOpDescSpec` | `RegexOpDesc` | 3 |
| `DictionaryMatcherOpDescSpec` | `DictionaryMatcherOpDesc` | 5 |

All four spec files follow the `<srcClassName>Spec.scala` one-to-one convention.

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| `operatorInfo` | exact `userFriendlyName`; group `SEARCH_GROUP`; one input / one output port; `supportReconfiguration == true` |
| Field defaults | `KeywordSearch`/`Substring` `isCaseSensitive == false` |
| `getPhysicalOp` | `opExecInitInfo` pattern-matches `OpExecWithClassName(<FQCN>, descString)` with the exact executor class name and a non-empty payload; ports carried forward from `operatorInfo` |
| Polymorphic JSON round-trip | serialize → deserialize via `classOf[LogicalOp]` → correct subtype with fields preserved (pins the `@JsonTypeInfo` discriminator + `@JsonProperty` wire-keys) |
| `DictionaryMatcher` schema propagation | `getExternalOutputSchemas` appends a `BOOLEAN` column named by `resultAttribute` to the input schema |
| `DictionaryMatcher` MatchingType | serializes via its `@JsonValue` name (`SCANBASED` → `"Scan"`) and round-trips |

Mirrors the established `SleepOpDescSpec` / `SortOpDescSpec` patterns (AnyFlatSpec + Matchers; `OpExecWithClassName` match instead of brittle `toString`; polymorphic deserialize via `classOf[LogicalOp]`).

### Any related issues, documentation, discussions?

Closes #5806.

### How was this PR tested?

Pure unit-test additions; verified locally with:

- `sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.keywordSearch.KeywordSearchOpDescSpec org.apache.texera.amber.operator.substringSearch.SubstringSearchOpDescSpec org.apache.texera.amber.operator.regex.RegexOpDescSpec org.apache.texera.amber.operator.dictionary.DictionaryMatcherOpDescSpec"` — 18 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/Test/scalafix --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])