### PR TITLE
test(workflow-operator): add unit test coverage for column-transform operator descriptors

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDescSpec.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.filter
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SpecializedFilterOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  "SpecializedFilterOpDesc.operatorInfo" should
+    "advertise the name, Cleaning group, and reconfiguration support" in {
+    val info = (new SpecializedFilterOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Filter"
+    info.operatorGroupName shouldBe OperatorGroupConstants.CLEANING_GROUP
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+    info.supportReconfiguration shouldBe true
+  }
+
+  "SpecializedFilterOpDesc.predicates" should "default to an empty list" in {
+    (new SpecializedFilterOpDesc).predicates shouldBe empty
+  }
+
+  "SpecializedFilterOpDesc.getPhysicalOp" should
+    "wire SpecializedFilterOpExec and carry port identities" in {
+    val op = new SpecializedFilterOpDesc
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.filter.SpecializedFilterOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
+  }
+
+  "SpecializedFilterOpDesc" should
+    "round-trip (default empty predicates) through the polymorphic base" in {
+    val restored =
+      objectMapper.readValue(
+        objectMapper.writeValueAsString(new SpecializedFilterOpDesc),
+        classOf[LogicalOp]
+      )
+    restored shouldBe a[SpecializedFilterOpDesc]
+    restored.asInstanceOf[SpecializedFilterOpDesc].predicates shouldBe empty
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingOpDescSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.typecasting
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.core.workflow.PortIdentity
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TypeCastingOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def castUnit(attr: String, to: AttributeType): TypeCastingUnit = {
+    val u = new TypeCastingUnit()
+    u.attribute = attr
+    u.resultType = to
+    u
+  }
+
+  "TypeCastingOpDesc.operatorInfo" should "advertise the name and Cleaning group" in {
+    val info = (new TypeCastingOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Type Casting"
+    info.operatorGroupName shouldBe OperatorGroupConstants.CLEANING_GROUP
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+  }
+
+  "TypeCastingOpDesc.getPhysicalOp" should "wire TypeCastingOpExec and carry port identities" in {
+    val op = new TypeCastingOpDesc
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.typecasting.TypeCastingOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
+  }
+
+  "TypeCastingOpDesc schema propagation" should
+    "leave the schema unchanged when there are no casting units" in {
+    val input = Schema().add(new Attribute("n", AttributeType.INTEGER))
+    val out =
+      (new TypeCastingOpDesc).getExternalOutputSchemas(Map(PortIdentity() -> input)).values.head
+    out shouldBe input
+  }
+
+  it should "change the target column's type for a casting unit" in {
+    val op = new TypeCastingOpDesc
+    op.typeCastingUnits = List(castUnit("n", AttributeType.STRING))
+    val input = Schema().add(new Attribute("n", AttributeType.INTEGER))
+    val out = op.getExternalOutputSchemas(Map(PortIdentity() -> input)).values.head
+    out shouldBe Schema().add(new Attribute("n", AttributeType.STRING))
+  }
+
+  "TypeCastingOpDesc" should "round-trip its casting units through the polymorphic base" in {
+    val op = new TypeCastingOpDesc
+    op.typeCastingUnits = List(castUnit("n", AttributeType.STRING))
+    val restored =
+      objectMapper.readValue(objectMapper.writeValueAsString(op), classOf[LogicalOp])
+    restored shouldBe a[TypeCastingOpDesc]
+    val tc = restored.asInstanceOf[TypeCastingOpDesc]
+    tc.typeCastingUnits should have size 1
+    tc.typeCastingUnits.head.attribute shouldBe "n"
+    tc.typeCastingUnits.head.resultType shouldBe AttributeType.STRING
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingOpDescSpec.scala
@@ -22,7 +22,6 @@ package org.apache.texera.amber.operator.typecasting
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import org.apache.texera.amber.core.workflow.PortIdentity
 import org.apache.texera.amber.operator.LogicalOp
 import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
 import org.apache.texera.amber.util.JSONUtils.objectMapper
@@ -64,18 +63,20 @@ class TypeCastingOpDescSpec extends AnyFlatSpec with Matchers {
 
   "TypeCastingOpDesc schema propagation" should
     "leave the schema unchanged when there are no casting units" in {
+    val op = new TypeCastingOpDesc
     val input = Schema().add(new Attribute("n", AttributeType.INTEGER))
-    val out =
-      (new TypeCastingOpDesc).getExternalOutputSchemas(Map(PortIdentity() -> input)).values.head
-    out shouldBe input
+    val out = op.getExternalOutputSchemas(Map(op.operatorInfo.inputPorts.head.id -> input))
+    out shouldBe Map(op.operatorInfo.outputPorts.head.id -> input)
   }
 
   it should "change the target column's type for a casting unit" in {
     val op = new TypeCastingOpDesc
     op.typeCastingUnits = List(castUnit("n", AttributeType.STRING))
     val input = Schema().add(new Attribute("n", AttributeType.INTEGER))
-    val out = op.getExternalOutputSchemas(Map(PortIdentity() -> input)).values.head
-    out shouldBe Schema().add(new Attribute("n", AttributeType.STRING))
+    val out = op.getExternalOutputSchemas(Map(op.operatorInfo.inputPorts.head.id -> input))
+    out shouldBe Map(
+      op.operatorInfo.outputPorts.head.id -> Schema().add(new Attribute("n", AttributeType.STRING))
+    )
   }
 
   "TypeCastingOpDesc" should "round-trip its casting units through the polymorphic base" in {

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/unneststring/UnnestStringOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/unneststring/UnnestStringOpDescSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.unneststring
+
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.core.workflow.PortIdentity
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UnnestStringOpDescSpec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def newDesc(delim: String, attr: String, result: String): UnnestStringOpDesc = {
+    val d = new UnnestStringOpDesc
+    d.delimiter = delim
+    d.attribute = attr
+    d.resultAttribute = result
+    d
+  }
+
+  "UnnestStringOpDesc.operatorInfo" should "advertise the name and Utility group" in {
+    val info = (new UnnestStringOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Unnest String"
+    info.operatorGroupName shouldBe OperatorGroupConstants.UTILITY_GROUP
+    info.inputPorts should have length 1
+    info.outputPorts should have length 1
+  }
+
+  "UnnestStringOpDesc.getPhysicalOp" should "wire UnnestStringOpExec and carry port identities" in {
+    val op = newDesc(",", "tags", "tag")
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        className shouldBe "org.apache.texera.amber.operator.unneststring.UnnestStringOpExec"
+        descString should not be empty
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    physical.inputPorts.keySet shouldBe op.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe op.operatorInfo.outputPorts.map(_.id).toSet
+  }
+
+  "UnnestStringOpDesc schema propagation" should
+    "append a STRING column named by resultAttribute" in {
+    val op = newDesc(",", "tags", "tag")
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    val input = Schema().add(new Attribute("tags", AttributeType.STRING))
+    val out = physical.propagateSchema.func(Map(PortIdentity() -> input)).values.head
+    out shouldBe input.add(new Attribute("tag", AttributeType.STRING))
+  }
+
+  it should "throw when resultAttribute is blank" in {
+    val op = newDesc(",", "tags", "")
+    val physical = op.getPhysicalOp(workflowId, executionId)
+    val input = Schema().add(new Attribute("tags", AttributeType.STRING))
+    intercept[RuntimeException] {
+      physical.propagateSchema.func(Map(PortIdentity() -> input))
+    }
+  }
+
+  "UnnestStringOpDesc" should "round-trip its fields through the polymorphic base" in {
+    val restored =
+      objectMapper.readValue(
+        objectMapper.writeValueAsString(newDesc(";", "csv", "item")),
+        classOf[LogicalOp]
+      )
+    restored shouldBe a[UnnestStringOpDesc]
+    val u = restored.asInstanceOf[UnnestStringOpDesc]
+    u.delimiter shouldBe ";"
+    u.attribute shouldBe "csv"
+    u.resultAttribute shouldBe "item"
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/unneststring/UnnestStringOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/unneststring/UnnestStringOpDescSpec.scala
@@ -22,7 +22,6 @@ package org.apache.texera.amber.operator.unneststring
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import org.apache.texera.amber.core.workflow.PortIdentity
 import org.apache.texera.amber.operator.LogicalOp
 import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
 import org.apache.texera.amber.util.JSONUtils.objectMapper
@@ -68,8 +67,10 @@ class UnnestStringOpDescSpec extends AnyFlatSpec with Matchers {
     val op = newDesc(",", "tags", "tag")
     val physical = op.getPhysicalOp(workflowId, executionId)
     val input = Schema().add(new Attribute("tags", AttributeType.STRING))
-    val out = physical.propagateSchema.func(Map(PortIdentity() -> input)).values.head
-    out shouldBe input.add(new Attribute("tag", AttributeType.STRING))
+    val out = physical.propagateSchema.func(Map(op.operatorInfo.inputPorts.head.id -> input))
+    out shouldBe Map(
+      op.operatorInfo.outputPorts.head.id -> input.add(new Attribute("tag", AttributeType.STRING))
+    )
   }
 
   it should "throw when resultAttribute is blank" in {
@@ -77,7 +78,7 @@ class UnnestStringOpDescSpec extends AnyFlatSpec with Matchers {
     val physical = op.getPhysicalOp(workflowId, executionId)
     val input = Schema().add(new Attribute("tags", AttributeType.STRING))
     intercept[RuntimeException] {
-      physical.propagateSchema.func(Map(PortIdentity() -> input))
+      physical.propagateSchema.func(Map(op.operatorInfo.inputPorts.head.id -> input))
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of three previously-untested single-input transform descriptors in `common/workflow-operator/`. No production-code changes.

| Spec | Source class | Tests |
| --- | --- | --- |
| `TypeCastingOpDescSpec` | `TypeCastingOpDesc` | 5 |
| `UnnestStringOpDescSpec` | `UnnestStringOpDesc` | 5 |
| `SpecializedFilterOpDescSpec` | `SpecializedFilterOpDesc` | 4 |

All three spec files follow the `<srcClassName>Spec.scala` one-to-one convention.

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| `operatorInfo` | exact name + group (`Type Casting`/`Unnest String`/`Filter`); `Filter` advertises `supportReconfiguration` |
| `getPhysicalOp` wiring | `OpExecWithClassName` with the exact executor FQCN; port **identities** carried forward (`keySet`) |
| `TypeCasting` schema propagation | empty units = identity; a cast unit changes the target column's type; casting-unit round-trip |
| `UnnestString` schema propagation | non-blank `resultAttribute` appends a STRING column; blank `resultAttribute` throws |
| `SpecializedFilter` | `predicates` default empty; round-trip |

### Any related issues, documentation, discussions?

Closes #5823.

### How was this PR tested?

Pure unit-test additions; verified locally with:

- `sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.typecasting.TypeCastingOpDescSpec org.apache.texera.amber.operator.unneststring.UnnestStringOpDescSpec org.apache.texera.amber.operator.filter.SpecializedFilterOpDescSpec"` — 14 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/Test/scalafix --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])