### PR TITLE
chore(deps): bump ws from 6.2.3 to 6.2.4 in /frontend [release/v1.2 backport]

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -18153,11 +18153,11 @@ __metadata:
   linkType: hard
 
 "ws@npm:^6.2.1":
-  version: 6.2.3
-  resolution: "ws@npm:6.2.3"
+  version: 6.2.4
+  resolution: "ws@npm:6.2.4"
   dependencies:
     async-limiter: "npm:~1.0.0"
-  checksum: 10c0/56a35b9799993cea7ce2260197e7879f21bbbb194a967f31acbbda6f7f46ecda4365951966fb062044c95197e19fb2f053be6f65c172435455186835f494de41
+  checksum: 10c0/5c2b9474164f9cb68c7776a1d10b0461c186f3a69bffb1028fca33eba5ab7206a09173fb0b311d6c5a81c8cf148406f8deb0b7d899542ab8ca67407d99717dad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5803 to `release/v1.2`: bump ws from 6.2.3 to 6.2.4 in /frontend.

Clean cherry-pick of the squash commit (yarn.lock only).

**Risk:** 🟢 Patch — **security** fix (ws DoS). Lowest-risk, highest-value backport in this set.

### Any related issues, documentation, discussions?

Backports apache/texera#5803 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5803); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

Built the frontend and confirmed websocket-backed features (workflow execution status, console output) still stream. `yarn install --immutable` + `yarn build` succeed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])