### PR TITLE
chore(deps): bump tar from 7.5.13 to 7.5.16 in /frontend [release/v1.2 backport]

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -16753,15 +16753,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.4.3, tar@npm:^7.5.4":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+  version: 7.5.16
+  resolution: "tar@npm:7.5.16"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5802 to `release/v1.2`: bump tar from 7.5.13 to 7.5.16 in /frontend.

Clean cherry-pick (transitive dep, yarn.lock only).

**Risk:** 🟢 Patch (transitive build dependency).

### Any related issues, documentation, discussions?

Backports apache/texera#5802 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5802); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`yarn install --immutable` + `yarn build` succeed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])