### PR TITLE
chore(deps): bump js-yaml from 4.1.1 to 4.2.0 in /frontend [release/v1.2 backport]

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11667,13 +11667,13 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/561c7d7088c40a9bb53cc75becbfb1df6ae49b34b5e6e5a81744b14ae8667ec564ad2527709d1a6e7d5e5fa6d483aa0f373a50ad98d42fde368ec4a190d4fae7
+  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5812 to `release/v1.2`: bump js-yaml from 4.1.1 to 4.2.0 in /frontend.

Clean cherry-pick (transitive dep, yarn.lock only).

**Risk:** 🟢 Minor (transitive).

### Any related issues, documentation, discussions?

Backports apache/texera#5812 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5812); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`yarn install --immutable` + `yarn build` succeed; YAML import/export paths exercised.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])