### PR TITLE
chore(deps): bump ws from 8.18.0 to 8.21.0 in /pyright-language-service [release/v1.2 backport]

### DIFF
--- a/pyright-language-service/package.json
+++ b/pyright-language-service/package.json
@@ -12,7 +12,7 @@
     "typescript": "5.5.4",
     "vscode-languageserver": "9.0.1",
     "vscode-ws-jsonrpc": "3.3.2",
-    "ws": "8.18.0"
+    "ws": "8.21.0"
   },
   "devDependencies": {
     "@types/express": "4.17.21",

--- a/pyright-language-service/yarn.lock
+++ b/pyright-language-service/yarn.lock
@@ -749,10 +749,10 @@ vscode-ws-jsonrpc@3.3.2:
   dependencies:
     vscode-jsonrpc "~8.2.1"
 
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@8.21.0:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5741 to `release/v1.2`: bump ws from 8.18.0 to 8.21.0 in /pyright-language-service.

Clean cherry-pick (package.json + yarn.lock).

**Risk:** 🟢 Minor — ws lib backing the pyright LSP bridge.

### Any related issues, documentation, discussions?

Backports apache/texera#5741 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5741); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`yarn install --immutable` + build succeed; opened a Python UDF editor and confirmed completions/diagnostics work.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])