### PR TITLE
chore(deps): bump launch-editor from 2.13.2 to 2.14.1 in /frontend [release/v1.2 backport]

### DIFF
--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -11863,12 +11863,12 @@ __metadata:
   linkType: hard
 
 "launch-editor@npm:^2.6.1":
-  version: 2.13.2
-  resolution: "launch-editor@npm:2.13.2"
+  version: 2.14.1
+  resolution: "launch-editor@npm:2.14.1"
   dependencies:
     picocolors: "npm:^1.1.1"
-    shell-quote: "npm:^1.8.3"
-  checksum: 10c0/5057fc8d3d0b0a92055b09b99192ffb5860b3e8a3f8ba56ef9b7f252fd78650d6b4182b725f4a1dcb8b04e350fa053874d819bb84362f2cfd6c3e84f556066dd
+    shell-quote: "npm:^1.8.4"
+  checksum: 10c0/bb0ab182086afaf1c391abd38d6fc9d5391cb43d0c2da1d96176f79e9995635cdf34dcfd8df3f756bb82d7bbbb7d37014d5eb312f337350889c0cff92db53dab
   languageName: node
   linkType: hard
 
@@ -16190,10 +16190,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
+"shell-quote@npm:^1.7.3, shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5811 to `release/v1.2`: bump launch-editor from 2.13.2 to 2.14.1 in /frontend.

Cherry-pick with one conflict resolved: launch-editor 2.14.1 requires shell-quote ^1.8.4, so the shared shell-quote lock entry was advanced 1.8.3→1.8.4 (still satisfies the other ^1.7.3 consumer).

**Risk:** 🟢 Minor (transitive dev-server dep, not bundled).

### Any related issues, documentation, discussions?

Backports apache/texera#5811 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5811); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`yarn install --immutable` succeeds; dev server starts.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])