### PR TITLE
chore(deps): bump prettier from 3.4.2 to 3.8.4 in /agent-service [release/v1.2 backport]

### DIFF
--- a/agent-service/bun.lock
+++ b/agent-service/bun.lock
@@ -19,7 +19,7 @@
         "@types/bun": "1.3.3",
         "@types/dagre": "0.7.54",
         "pino-pretty": "13.1.3",
-        "prettier": "3.4.2",
+        "prettier": "3.8.4",
         "tsx": "4.21.0",
         "typescript": "5.9.3",
       },
@@ -188,7 +188,7 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
-    "prettier": ["prettier@3.4.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ=="],
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 

--- a/agent-service/package.json
+++ b/agent-service/package.json
@@ -29,7 +29,7 @@
     "@types/bun": "1.3.3",
     "@types/dagre": "0.7.54",
     "pino-pretty": "13.1.3",
-    "prettier": "3.4.2",
+    "prettier": "3.8.4",
     "tsx": "4.21.0",
     "typescript": "5.9.3"
   },


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5819 to `release/v1.2`: bump prettier from 3.4.2 to 3.8.4 in /agent-service.

Clean cherry-pick (package.json + bun.lock).

**Risk:** 🟢 Minor (dev tool).

### Any related issues, documentation, discussions?

Backports apache/texera#5819 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5819); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`bun run format:check` runs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])