### PR TITLE
chore(deps): bump @types/bun from 1.3.3 to 1.3.14 in /agent-service [release/v1.2 backport]

### DIFF
--- a/agent-service/LICENSE-binary
+++ b/agent-service/LICENSE-binary
@@ -233,11 +233,11 @@ Agent service npm packages:
   - @standard-schema/spec@1.0.0
   - @tokenizer/inflate@0.4.1
   - @tokenizer/token@0.3.0
-  - @types/bun@1.3.3
+  - @types/bun@1.3.14
   - @types/node@24.10.1
   - ajv@8.18.0
   - atomic-sleep@1.0.0
-  - bun-types@1.3.3
+  - bun-types@1.3.14
   - cookie@1.1.1
   - dagre@0.8.5
   - debug@4.4.3

--- a/agent-service/bun.lock
+++ b/agent-service/bun.lock
@@ -16,7 +16,7 @@
         "zod": "3.25.76",
       },
       "devDependencies": {
-        "@types/bun": "1.3.3",
+        "@types/bun": "1.3.14",
         "@types/dagre": "0.7.54",
         "pino-pretty": "13.1.3",
         "prettier": "3.4.2",
@@ -102,7 +102,7 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@types/bun": ["@types/bun@1.3.3", "", { "dependencies": { "bun-types": "1.3.3" } }, "sha512-ogrKbJ2X5N0kWLLFKeytG0eHDleBYtngtlbu9cyBKFtNL3cnpDZkNdQj8flVf6WTZUX5ulI9AY1oa7ljhSrp+g=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/dagre": ["@types/dagre@0.7.54", "", {}, "sha512-QjcRY+adGbYvBFS7cwv5txhVIwX1XXIUswWl+kSQTbI6NjgZydrZkEKX/etzVd7i+bCsCb40Z/xlBY5eoFuvWQ=="],
 
@@ -116,7 +116,7 @@
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
-    "bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
 

--- a/agent-service/package.json
+++ b/agent-service/package.json
@@ -26,7 +26,7 @@
     "zod": "3.25.76"
   },
   "devDependencies": {
-    "@types/bun": "1.3.3",
+    "@types/bun": "1.3.14",
     "@types/dagre": "0.7.54",
     "pino-pretty": "13.1.3",
     "prettier": "3.4.2",


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5817 to `release/v1.2`: bump @types/bun from 1.3.3 to 1.3.14 in /agent-service.

Clean cherry-pick (package.json + bun.lock + LICENSE-binary).

**Risk:** 🟢 Patch (dev types).

### Any related issues, documentation, discussions?

Backports apache/texera#5817 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5817); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`tsc --noEmit` typecheck passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])