### PR TITLE
chore(deps): bump typescript from 5.9.3 to 6.0.3 in /agent-service [release/v1.2 backport]

### DIFF
--- a/agent-service/LICENSE-binary
+++ b/agent-service/LICENSE-binary
@@ -219,7 +219,7 @@ Agent service npm packages:
   - @vercel/oidc@3.0.5
   - ai@5.0.108
   - rxjs@7.8.2
-  - typescript@5.9.3
+  - typescript@6.0.3
 
 --------------------------------------------------------------------------------
 Dependencies under the MIT License

--- a/agent-service/bun.lock
+++ b/agent-service/bun.lock
@@ -21,7 +21,7 @@
         "pino-pretty": "13.1.3",
         "prettier": "3.4.2",
         "tsx": "4.21.0",
-        "typescript": "5.9.3",
+        "typescript": "6.0.3",
       },
     },
   },
@@ -224,7 +224,7 @@
 
     "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 

--- a/agent-service/package.json
+++ b/agent-service/package.json
@@ -31,7 +31,7 @@
     "pino-pretty": "13.1.3",
     "prettier": "3.4.2",
     "tsx": "4.21.0",
-    "typescript": "5.9.3"
+    "typescript": "6.0.3"
   },
   "packageManager": "yarn@4.5.1+sha512.341db9396b6e289fecc30cd7ab3af65060e05ebff4b3b47547b278b9e67b08f485ecd8c79006b405446262142c7a38154445ef7f17c1d5d1de7d90bf9ce7054d"
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5818 to `release/v1.2`: bump typescript from 5.9.3 to 6.0.3 in /agent-service.

Clean cherry-pick (package.json + bun.lock + LICENSE-binary).

**Risk:** 🔴 **MAJOR** (5→6) compiler; dev/build only.

### Any related issues, documentation, discussions?

Backports apache/texera#5818 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5818); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

`tsc`/`bun run build` of agent-service passes under TypeScript 6.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])