### PR TITLE
chore(deps): bump pyarrow from 21.0.0 to 23.0.1 in /amber [release/v1.2 backport]

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -223,7 +223,7 @@ Python packages:
   - overrides==7.4.0
   - packaging==26.2
   - propcache==0.5.2
-  - pyarrow==21.0.0
+  - pyarrow==23.0.1
   - pyiceberg==0.11.1
   - pympler==1.1
   - python-dateutil==2.8.2

--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -21,7 +21,7 @@ pandas==2.2.3
 ruff==0.14.7
 iniconfig==1.1.1
 loguru==0.7.0
-pyarrow==21.0.0
+pyarrow==23.0.1
 pytest==7.4.0
 python-dateutil==2.8.2
 pytest-timeout==2.2.0


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#5800 to `release/v1.2`: bump pyarrow from 21.0.0 to 23.0.1 in /amber.

Manual re-apply: the upstream PR sits on a main-only reorg that moved test deps into dev-requirements.txt, so requirements.txt context diverges. Bumped pyarrow in requirements.txt and the matching LICENSE-binary-python entry; pyarrow 21→23 adds no transitive packages.

**Risk:** 🔴 **MAJOR** (21→23); core Arrow data path.

### Any related issues, documentation, discussions?

Backports apache/texera#5800 (merged to `main`). No `release/*` label is added — this PR *is* the backport, and a release label would trigger a backport-of-a-backport precheck. CI stacks auto-select from the file-based labels.

### How was this PR tested?

Mirrors the change already merged and CI-validated on `main` (apache/texera#5800); verified the backport diff equals the original bump and applies onto `release/v1.2`. Manual verification:

Installed requirements and ran a workflow exchanging Arrow data between Python operators and to/from Iceberg.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])