### PR TITLE
chore: upgrade ng-zorro-antd to 21.3.1

### DIFF
--- a/frontend/LICENSE-binary
+++ b/frontend/LICENSE-binary
@@ -295,7 +295,7 @@ Angular / npm packages:
   - monaco-breakpoints@0.2.0
   - monaco-editor-wrapper@5.5.3
   - monaco-languageclient@8.8.3
-  - ng-zorro-antd@21.2.2
+  - ng-zorro-antd@21.3.1
   - ngx-color-picker@12.0.1
   - ngx-file-drop@16.0.0
   - ngx-json-viewer@3.2.1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -56,7 +56,7 @@
     "monaco-editor": "npm:@codingame/monaco-vscode-editor-api@8.0.4",
     "monaco-editor-wrapper": "5.5.3",
     "monaco-languageclient": "8.8.3",
-    "ng-zorro-antd": "21.2.2",
+    "ng-zorro-antd": "21.3.1",
     "ngx-color-picker": "12.0.1",
     "ngx-file-drop": "16.0.0",
     "ngx-json-viewer": "3.2.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -10702,7 +10702,7 @@ __metadata:
     monaco-editor: "npm:@codingame/monaco-vscode-editor-api@8.0.4"
     monaco-editor-wrapper: "npm:5.5.3"
     monaco-languageclient: "npm:8.8.3"
-    ng-zorro-antd: "npm:21.2.2"
+    ng-zorro-antd: "npm:21.3.1"
     ngx-color-picker: "npm:12.0.1"
     ngx-file-drop: "npm:16.0.0"
     ngx-json-viewer: "npm:3.2.1"
@@ -13167,9 +13167,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ng-zorro-antd@npm:21.2.2":
-  version: 21.2.2
-  resolution: "ng-zorro-antd@npm:21.2.2"
+"ng-zorro-antd@npm:21.3.1":
+  version: 21.3.1
+  resolution: "ng-zorro-antd@npm:21.3.1"
   dependencies:
     "@angular/cdk": "npm:^21.0.0"
     "@ant-design/icons-angular": "npm:^21.0.0"
@@ -13182,7 +13182,7 @@ __metadata:
     "@angular/forms": ^21.0.0
     "@angular/platform-browser": ^21.0.0
     "@angular/router": ^21.0.0
-  checksum: 10c0/bbc68d56cde3b3ae65b4d32e70daff71e6318343d88f1f8cdb0aeaa557014e050cbd5c27a79b4998f3b38fb640293ce317f8b7ad7112f351613176534cb36437
+  checksum: 10c0/ecb07144ffacd7c42bf5a2bbc0e1cbabccf0d4dc371082e3629e738d8907a858163a72193fce428554e37e0ea41f7c440b64bba2101deed84968c4d7d857c428
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes were proposed in this PR?
Upgrades the ng-zorro-antd dependency in the frontend from 21.2.2 to 21.3.1 (frontend/package.json + frontend/yarn.lock).

Motivation: 21.2.2 has a bug in nz-input-number where the mouse-wheel handler (onWheel) guards on the raw nzDisabled() input instead of the computed finalDisabled() state. When a form control is disabled via the form group, as the operator property panel does while a workflow is running, the field greys out and blocks typing, but scrolling the mouse wheel over it still changes the value, bypassing the disabled state.

This was fixed upstream in [NG-ZORRO/ng-zorro-antd#9785](https://github.com/NG-ZORRO/ng-zorro-antd/pull/9785), which guards on finalDisabled() || nzReadOnly(). The fix first shipped in 21.3.0; 21.3.1 is the latest stable. This is a minor-version bump within the same major (21.x) with no breaking changes in the [21.3.0/21.3.1 changelogs](https://github.com/NG-ZORRO/ng-zorro-antd/releases).

The greyed out number input fields are now not affected by the mouse-wheel scroll during a workflow's execution as shown in the below video:

https://github.com/user-attachments/assets/15bb5c1d-8ae2-4fc6-b5c9-934f58509fa9

### Any related issues, documentation, discussions?
Closes #5879.
Closes #5848.
Related bug: #5848.
Upstream fix: NG-ZORRO/ng-zorro-antd#9785.

### How was this PR tested?
Tested with existing test cases. Additionally verified manually:

- yarn install succeeds; confirmed the installed nz-input-number onWheel handler now guards on finalDisabled() || nzReadOnly().
- Ran the app, started a workflow, and confirmed that greyed-out number fields in the operator property panel (e.g. Python UDF "Worker count") no longer change value on mouse-wheel scroll during execution.

No new automated tests were added, as this is a dependency version bump with no source-code changes; the fix lives in the upstream library.

### Was this PR authored or co-authored using generative AI tooling?
This PR was co-authored by Claude Opus 4.7, in compliance with ASF.