### PR TITLE
fix(ui): update computing unit status on /compute tab every second (#4612) [release/v1.2 backport]

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit.component.ts
@@ -39,6 +39,7 @@ import {
   getJvmMemorySliderConfig,
 } from "../../../../common/util/computing-unit.util";
 import { ComputingUnitActionsService } from "../../../../common/service/computing-unit/computing-unit-actions/computing-unit-actions.service";
+import { interval } from "rxjs";
 import { NzCardComponent } from "ng-zorro-antd/card";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
@@ -183,6 +184,12 @@ export class UserComputingUnitComponent implements OnInit {
       .subscribe(units => {
         this.allComputingUnits = units;
         this.entries = units.map(u => new DashboardEntry(u));
+      });
+
+    interval(1000)
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.computingUnitStatusService.refreshComputingUnitList();
       });
   }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #4612 to `release/v1.2`: the /compute tab now refreshes each computing unit's status every second, so the displayed status stays current instead of going stale until a manual refresh.

Clean `git cherry-pick -x` of the original squash commit (`891d2adbc`), +7/-0 in one file (`user-computing-unit.component.ts`), byte-identical to `main`.

### Any related issues, documentation, discussions?

Backports #4612

### How was this PR tested?

Covered by CI; the change is a small frontend polling addition that was verified on `main` as part of #4612.

### Was this PR authored or co-authored using generative AI tooling?

Backport prepared with Claude Code (Claude Opus 4.8).