### PR TITLE
chore(licensing): refresh transitive versions in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -218,7 +218,7 @@ Python packages:
   - botocore==1.40.53
   - frozenlist==1.8.0
   - hf-xet==1.5.1
-  - huggingface-hub==1.19.0
+  - huggingface-hub==1.20.1
   - multidict==6.7.1
   - overrides==7.4.0
   - packaging==26.2
@@ -246,7 +246,7 @@ Python packages:
   - aioitertools==0.13.0
   - annotated-doc==0.0.4
   - annotated-types==0.7.0
-  - anyio==4.13.0
+  - anyio==4.14.0
   - appdirs==1.4.4
   - asn1crypto==1.5.1
   - attrs==26.1.0
@@ -257,10 +257,10 @@ Python packages:
   - filelock==3.29.4
   - fonttools==4.63.0
   - fs==2.4.16
-  - greenlet==3.5.1
+  - greenlet==3.5.2
   - h11==0.16.0
   - h2==4.3.0
-  - hpack==4.1.0
+  - hpack==4.2.0
   - hyperframe==6.1.0
   - jmespath==1.1.0
   - loguru==0.7.0
@@ -278,7 +278,7 @@ Python packages:
   - readerwriterlock==1.0.9
   - rich==14.3.4
   - ruff==0.14.7
-  - scramp==1.4.8
+  - scramp==1.4.9
   - six==1.17.0
   - sqlalchemy==2.0.37
   - strictyaml==1.7.3
@@ -295,7 +295,7 @@ Dependencies under the BSD 3-Clause License
 
 Python packages:
   - cached-property==1.5.2
-  - click==8.4.1
+  - click==8.4.2
   - contourpy==1.3.3
   - cycler==0.12.1
   - fsspec==2025.9.0
@@ -318,7 +318,7 @@ Python packages:
   - s3fs==2025.9.0
   - scikit-image==0.25.2
   - scikit-learn==1.5.0
-  - scipy==1.17.1
+  - scipy==1.18.0
   - sympy==1.14.0
   - threadpoolctl==3.6.0
   - tifffile==2026.6.1
@@ -351,8 +351,8 @@ Dependencies under the Mozilla Public License, Version 2.0
 
 Python packages:
   - bidict==0.22.0
-  - certifi==2026.5.20
-  - tqdm==4.68.2
+  - certifi==2026.6.17
+  - tqdm==4.68.3
 
 --------------------------------------------------------------------------------
 Dependencies under the Python Software Foundation License


### PR DESCRIPTION
### What changes were proposed in this PR?

Refresh nine transitive Python dependency versions in `amber/LICENSE-binary-python` to match the bundled wheels, as reported by the License Binary Checker on `release/v1.2` ([run](https://github.com/apache/texera/actions/runs/28120669638)):

- anyio 4.13.0 → 4.14.0
- certifi 2026.5.20 → 2026.6.17
- click 8.4.1 → 8.4.2
- greenlet 3.5.1 → 3.5.2
- hpack 4.1.0 → 4.2.0
- huggingface-hub 1.19.0 → 1.20.1
- scipy 1.17.1 → 1.18.0
- scramp 1.4.8 → 1.4.9
- tqdm 4.68.2 → 4.68.3

Version-only refresh to match bundled wheels; license groupings unchanged. The file is identical on `main` and `release/v1.2`, so this PR fixes both via the `release/v1.2` backport label.

### Any related issues, documentation, discussions?

Resolves #5936

### How was this PR tested?

License Binary Checker CI on this PR.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)