### PR TITLE
chore(licensing): refresh transitive versions in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -246,7 +246,7 @@ Python packages:
   - aioitertools==0.13.0
   - annotated-doc==0.0.4
   - annotated-types==0.7.0
-  - anyio==4.14.0
+  - anyio==4.14.1
   - appdirs==1.4.4
   - asn1crypto==1.5.1
   - attrs==26.1.0


### PR DESCRIPTION
### What changes were proposed in this PR?

Refresh one transitive Python dependency version in `amber/LICENSE-binary-python` to match the bundled wheel, as reported by the License Binary Checker on `release/v1.2` ([run](https://github.com/apache/texera/actions/runs/28133400596)):

- anyio 4.14.0 → 4.14.1

Version-only refresh; license groupings unchanged. The file is identical on `main` and `release/v1.2`, so this PR fixes both via the `release/v1.2` backport label.

### Any related issues, documentation, discussions?

Resolves #5943

### How was this PR tested?

License Binary Checker CI on this PR.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)