### PR TITLE
test(workflow-operator): add unit test coverage for Sklearn training SVM, neighbor & misc descriptors

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingDummyClassifierOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingDummyClassifierOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingDummyClassifierOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingDummyClassifierOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingDummyClassifierOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Dummy Classifier"
+    info.operatorDescription shouldBe "Sklearn Training: Dummy Classifier Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingDummyClassifierOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingDummyClassifierOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingDummyClassifierOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingDummyClassifierOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingDummyClassifierOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingDummyClassifierOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.dummy import DummyClassifier")
+    code should include("make_pipeline")
+    code should include("Training: Dummy Classifier")
+  }
+
+  "SklearnTrainingDummyClassifierOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingDummyClassifierOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingDummyClassifier\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingDummyClassifierOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingDummyClassifierOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingKNNOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingKNNOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingKNNOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingKNNOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingKNNOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: K-nearest Neighbors"
+    info.operatorDescription shouldBe "Sklearn Training: K-nearest Neighbors Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingKNNOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingKNNOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingKNNOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingKNNOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingKNNOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingKNNOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.neighbors import KNeighborsClassifier")
+    code should include("make_pipeline")
+    code should include("Training: K-nearest Neighbors")
+  }
+
+  "SklearnTrainingKNNOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingKNNOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingKNN\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingKNNOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingKNNOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLinearSVMOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLinearSVMOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingLinearSVMOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingLinearSVMOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingLinearSVMOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Linear Support Vector Machine"
+    info.operatorDescription shouldBe "Sklearn Training: Linear Support Vector Machine Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingLinearSVMOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingLinearSVMOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingLinearSVMOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingLinearSVMOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingLinearSVMOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingLinearSVMOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.svm import LinearSVC")
+    code should include("make_pipeline")
+    code should include("Training: Linear Support Vector Machine")
+  }
+
+  "SklearnTrainingLinearSVMOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingLinearSVMOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingLinearSVM\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingLinearSVMOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingLinearSVMOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingMultiLayerPerceptronOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingMultiLayerPerceptronOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingMultiLayerPerceptronOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingMultiLayerPerceptronOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingMultiLayerPerceptronOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Multi-layer Perceptron"
+    info.operatorDescription shouldBe "Sklearn Training: Multi-layer Perceptron Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingMultiLayerPerceptronOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingMultiLayerPerceptronOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingMultiLayerPerceptronOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingMultiLayerPerceptronOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingMultiLayerPerceptronOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingMultiLayerPerceptronOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.neural_network import MLPClassifier")
+    code should include("make_pipeline")
+    code should include("Training: Multi-layer Perceptron")
+  }
+
+  "SklearnTrainingMultiLayerPerceptronOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingMultiLayerPerceptronOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingMultiLayerPerceptron\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingMultiLayerPerceptronOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingMultiLayerPerceptronOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingNearestCentroidOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingNearestCentroidOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingNearestCentroidOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingNearestCentroidOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingNearestCentroidOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Nearest Centroid"
+    info.operatorDescription shouldBe "Sklearn Training: Nearest Centroid Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingNearestCentroidOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingNearestCentroidOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingNearestCentroidOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingNearestCentroidOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingNearestCentroidOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingNearestCentroidOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.neighbors import NearestCentroid")
+    code should include("make_pipeline")
+    code should include("Training: Nearest Centroid")
+  }
+
+  "SklearnTrainingNearestCentroidOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingNearestCentroidOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingNearestCentroid\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingNearestCentroidOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingNearestCentroidOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingProbabilityCalibrationOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingProbabilityCalibrationOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingProbabilityCalibrationOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingProbabilityCalibrationOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingProbabilityCalibrationOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Probability Calibration"
+    info.operatorDescription shouldBe "Sklearn Training: Probability Calibration Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingProbabilityCalibrationOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingProbabilityCalibrationOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingProbabilityCalibrationOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingProbabilityCalibrationOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingProbabilityCalibrationOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingProbabilityCalibrationOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.calibration import CalibratedClassifierCV")
+    code should include("make_pipeline")
+    code should include("Training: Probability Calibration")
+  }
+
+  "SklearnTrainingProbabilityCalibrationOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingProbabilityCalibrationOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingProbabilityCalibration\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingProbabilityCalibrationOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingProbabilityCalibrationOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeCVOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeCVOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingRidgeCVOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingRidgeCVOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingRidgeCVOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Ridge Regression Cross Validation"
+    info.operatorDescription shouldBe "Sklearn Training: Ridge Regression Cross Validation Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingRidgeCVOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingRidgeCVOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingRidgeCVOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingRidgeCVOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingRidgeCVOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingRidgeCVOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.linear_model import RidgeClassifierCV")
+    code should include("make_pipeline")
+    code should include("Training: Ridge Regression Cross Validation")
+  }
+
+  "SklearnTrainingRidgeCVOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingRidgeCVOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingRidgeCV\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingRidgeCVOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingRidgeCVOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingRidgeOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingRidgeOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingRidgeOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Ridge Regression"
+    info.operatorDescription shouldBe "Sklearn Training: Ridge Regression Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingRidgeOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingRidgeOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingRidgeOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingRidgeOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingRidgeOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingRidgeOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.linear_model import RidgeClassifier")
+    code should include("make_pipeline")
+    code should include("Training: Ridge Regression")
+  }
+
+  "SklearnTrainingRidgeOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingRidgeOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingRidge\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingRidgeOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingRidgeOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingSVMOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingSVMOpDescSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.sklearn.training
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SklearnTrainingSVMOpDescSpec extends AnyFlatSpec with Matchers {
+
+  "SklearnTrainingSVMOpDesc.operatorInfo" should
+    "advertise the model name, Sklearn Training group, and the single training port" in {
+    val info = (new SklearnTrainingSVMOpDesc).operatorInfo
+    info.userFriendlyName shouldBe "Training: Support Vector Machine"
+    info.operatorDescription shouldBe "Sklearn Training: Support Vector Machine Operator"
+    info.operatorGroupName shouldBe OperatorGroupConstants.SKLEARN_TRAINING_GROUP
+    info.inputPorts.map(_.displayName) shouldBe List("training")
+    info.outputPorts should have length 1
+    info.outputPorts.head.blocking shouldBe true
+  }
+
+  "SklearnTrainingSVMOpDesc" should "default its config fields" in {
+    val d = new SklearnTrainingSVMOpDesc
+    d.countVectorizer shouldBe false
+    d.tfidfTransformer shouldBe false
+    d.target shouldBe null
+    d.text shouldBe null
+  }
+
+  "SklearnTrainingSVMOpDesc.getOutputSchemas" should
+    "emit the model_name/model schema keyed by the declared output port" in {
+    val d = new SklearnTrainingSVMOpDesc
+    val schema = d.getOutputSchemas(Map.empty)(d.operatorInfo.outputPorts.head.id)
+    schema.getAttribute("model_name").getType shouldBe AttributeType.STRING
+    schema.getAttribute("model").getType shouldBe AttributeType.BINARY
+  }
+
+  "SklearnTrainingSVMOpDesc.generatePythonCode" should "import the configured sklearn estimator" in {
+    val d = new SklearnTrainingSVMOpDesc
+    d.target = "y"
+    val code = d.generatePythonCode()
+    code should include("from sklearn.svm import SVC")
+    code should include("make_pipeline")
+    code should include("Training: Support Vector Machine")
+  }
+
+  "SklearnTrainingSVMOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    val d = new SklearnTrainingSVMOpDesc
+    d.target = "label"
+    d.countVectorizer = true
+    val json = objectMapper.writeValueAsString(d)
+    json should include("\"operatorType\":\"SklearnTrainingSVM\"")
+    val restored = objectMapper.readValue(json, classOf[LogicalOp])
+    restored shouldBe a[SklearnTrainingSVMOpDesc]
+    val r = restored.asInstanceOf[SklearnTrainingSVMOpDesc]
+    r.target shouldBe "label"
+    r.countVectorizer shouldBe true
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of nine previously-untested Sklearn **training** operator descriptors in `common/workflow-operator`. No production-code changes.

| Spec | Source class |
| --- | --- |
| `SklearnTrainingSVMOpDescSpec` | `SklearnTrainingSVMOpDesc` |
| `SklearnTrainingLinearSVMOpDescSpec` | `SklearnTrainingLinearSVMOpDesc` |
| `SklearnTrainingKNNOpDescSpec` | `SklearnTrainingKNNOpDesc` |
| `SklearnTrainingNearestCentroidOpDescSpec` | `SklearnTrainingNearestCentroidOpDesc` |
| `SklearnTrainingRidgeOpDescSpec` | `SklearnTrainingRidgeOpDesc` |
| `SklearnTrainingRidgeCVOpDescSpec` | `SklearnTrainingRidgeCVOpDesc` |
| `SklearnTrainingDummyClassifierOpDescSpec` | `SklearnTrainingDummyClassifierOpDesc` |
| `SklearnTrainingMultiLayerPerceptronOpDescSpec` | `SklearnTrainingMultiLayerPerceptronOpDesc` |
| `SklearnTrainingProbabilityCalibrationOpDescSpec` | `SklearnTrainingProbabilityCalibrationOpDesc` |

**Behavior pinned** (shared `SklearnTrainingOpDesc` contract)

| Surface | Contract |
| --- | --- |
| `operatorInfo` | exact model name (`Training: <model>`) + `Sklearn <name> Operator` description; **Sklearn Training** group; single `training` input port; one blocking output |
| field defaults | `countVectorizer`/`tfidfTransformer` `false`; `target`/`text` `null` |
| `getOutputSchemas` | `model_name` (STRING) + `model` (BINARY) keyed by the declared output port |
| `generatePythonCode` | imports the matching sklearn estimator and builds the `make_pipeline(...).fit(X, Y)` training model |
| Round-trip | config fields preserved through the polymorphic `LogicalOp` base, with the correct `operatorType` discriminator |

### Any related issues, documentation, discussions?

Part of the ongoing `workflow-operator` unit-test coverage effort (the training-side counterpart to the Sklearn classifier coverage in #5925/#5939/#5940/#5941/#5945/#5946/#5951).

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.sklearn.training.*"` — 45 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
