### PR TITLE
refactor(frontend): remove unused FormlyRepeatDndComponent imports

### DIFF
--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -188,7 +188,6 @@ import { NzProgressModule } from "ng-zorro-antd/progress";
 import { ComputingUnitSelectionComponent } from "./workspace/component/power-button/computing-unit-selection.component";
 import { NzSliderModule } from "ng-zorro-antd/slider";
 import { AdminSettingsComponent } from "./dashboard/component/admin/settings/admin-settings.component";
-import { FormlyRepeatDndComponent } from "./common/formly/repeat-dnd/repeat-dnd.component";
 import { NzInputNumberModule } from "ng-zorro-antd/input-number";
 import { NzGridModule } from "ng-zorro-antd/grid";
 import { NzCheckboxModule } from "ng-zorro-antd/checkbox";
@@ -270,7 +269,6 @@ registerLocaleData(en);
     NzCheckboxModule,
     NzGridModule,
     ScrollingModule,
-    FormlyRepeatDndComponent,
     UiUdfParametersComponent,
     AdminGmailComponent,
     PublicProjectComponent,

--- a/frontend/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
+++ b/frontend/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
@@ -40,7 +40,6 @@ import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { MarkdownDescriptionComponent } from "../../../../dashboard/component/user/markdown-description/markdown-description.component";
 import { WorkflowEditorComponent } from "../../../../workspace/component/workflow-editor/workflow-editor.component";
 import { MiniMapComponent } from "../../../../workspace/component/workflow-editor/mini-map/mini-map.component";
-import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/repeat-dnd.component";
 import { formatCount } from "../../../../common/util/format.util";
 
 export const THROTTLE_TIME_MS = 1000;
@@ -61,7 +60,6 @@ export const THROTTLE_TIME_MS = 1000;
     MarkdownDescriptionComponent,
     WorkflowEditorComponent,
     MiniMapComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy, OnInit {

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.ts
@@ -36,7 +36,6 @@ import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
 import { NzTabsComponent, NzTabBarExtraContentDirective, NzTabComponent, NzTabDirective } from "ng-zorro-antd/tabs";
 import { AgentRegistrationComponent } from "./agent-registration/agent-registration.component";
 import { AgentChatComponent } from "./agent-chat/agent-chat.component";
-import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 @UntilDestroy()
 @Component({
@@ -65,7 +64,6 @@ import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/r
     NgFor,
     AgentChatComponent,
     NzResizeHandlesComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class AgentPanelComponent implements OnInit, OnDestroy, OnChanges {

--- a/frontend/src/app/workspace/component/code-editor-dialog/breakpoint-condition-input/breakpoint-condition-input.component.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/breakpoint-condition-input/breakpoint-condition-input.component.ts
@@ -23,7 +23,6 @@ import { UdfDebugService } from "../../../service/operator-debug/udf-debug.servi
 import { isDefined } from "../../../../common/util/predicate";
 import { NgIf, NgStyle } from "@angular/common";
 import { FormsModule } from "@angular/forms";
-import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 type MonacoEditor = editor.IStandaloneCodeEditor;
 
@@ -34,7 +33,7 @@ type MonacoEditor = editor.IStandaloneCodeEditor;
   selector: "texera-breakpoint-condition-input",
   templateUrl: "./breakpoint-condition-input.component.html",
   styleUrls: ["./breakpoint-condition-input.component.scss"],
-  imports: [NgIf, NgStyle, FormsModule, FormlyRepeatDndComponent],
+  imports: [NgIf, NgStyle, FormsModule],
 })
 export class BreakpointConditionInputComponent implements OnChanges {
   constructor(private udfDebugService: UdfDebugService) {}

--- a/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -57,7 +57,6 @@ import { NzButtonComponent } from "ng-zorro-antd/button";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NgFor, NgComponentOutlet, NgIf } from "@angular/common";
-import { FormlyRepeatDndComponent } from "../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 type MonacoEditor = monaco.editor.IStandaloneCodeEditor;
 
@@ -87,7 +86,6 @@ export const LANGUAGE_SERVER_CONNECTION_TIMEOUT_MS = 1000;
     NgComponentOutlet,
     NgIf,
     AnnotationSuggestionComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy {

--- a/frontend/src/app/workspace/component/left-panel/left-panel.component.ts
+++ b/frontend/src/app/workspace/component/left-panel/left-panel.component.ts
@@ -36,7 +36,6 @@ import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
-import { FormlyRepeatDndComponent } from "../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 @UntilDestroy()
 @Component({
@@ -61,7 +60,6 @@ import { FormlyRepeatDndComponent } from "../../../common/formly/repeat-dnd/repe
     CdkDragHandle,
     NgComponentOutlet,
     NzResizeHandlesComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class LeftPanelComponent implements OnDestroy, OnInit, AfterViewInit {

--- a/frontend/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/frontend/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -44,7 +44,6 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { CdkDrag, CdkDragHandle } from "@angular/cdk/drag-drop";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
-import { FormlyRepeatDndComponent } from "../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 /**
  * PropertyEditorComponent is the panel that allows user to edit operator properties.
@@ -73,7 +72,6 @@ import { FormlyRepeatDndComponent } from "../../../common/formly/repeat-dnd/repe
     CdkDragHandle,
     NgComponentOutlet,
     NzResizeHandlesComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class PropertyEditorComponent implements OnInit, OnDestroy {

--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -58,7 +58,6 @@ import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzTabsComponent, NzTabComponent } from "ng-zorro-antd/tabs";
-import { FormlyRepeatDndComponent } from "../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 export const DEFAULT_WIDTH = 800;
 export const DEFAULT_HEIGHT = 500;
@@ -90,7 +89,6 @@ export const DEFAULT_HEIGHT = 500;
     NgFor,
     NgComponentOutlet,
     NzResizeHandlesComponent,
-    FormlyRepeatDndComponent,
     KeyValuePipe,
   ],
 })

--- a/frontend/src/app/workspace/component/workflow-editor/comment-box-modal/nz-modal-comment-box.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/comment-box-modal/nz-modal-comment-box.component.ts
@@ -42,7 +42,6 @@ import { FormsModule } from "@angular/forms";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { NzIconDirective } from "ng-zorro-antd/icon";
-import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 @UntilDestroy()
 @Component({
@@ -68,7 +67,6 @@ import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/r
     NzIconDirective,
     NzListItemActionsComponent,
     NzListItemActionComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class NzModalCommentBoxComponent {

--- a/frontend/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
@@ -30,7 +30,6 @@ import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzIconDirective } from "ng-zorro-antd/icon";
-import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/repeat-dnd.component";
 
 @UntilDestroy()
 @Component({
@@ -44,7 +43,6 @@ import { FormlyRepeatDndComponent } from "../../../../common/formly/repeat-dnd/r
     ɵNzTransitionPatchDirective,
     NzIconDirective,
     CdkDrag,
-    FormlyRepeatDndComponent,
   ],
 })
 export class MiniMapComponent implements AfterViewInit, OnDestroy {

--- a/frontend/src/app/workspace/component/workspace.component.ts
+++ b/frontend/src/app/workspace/component/workspace.component.ts
@@ -63,7 +63,6 @@ import { MiniMapComponent } from "./workflow-editor/mini-map/mini-map.component"
 import { LeftPanelComponent } from "./left-panel/left-panel.component";
 import { AgentPanelComponent } from "./agent/agent-panel/agent-panel.component";
 import { PropertyEditorComponent } from "./property-editor/property-editor.component";
-import { FormlyRepeatDndComponent } from "../../common/formly/repeat-dnd/repeat-dnd.component";
 
 export const SAVE_DEBOUNCE_TIME_IN_MS = 5000;
 
@@ -86,7 +85,6 @@ export const SAVE_DEBOUNCE_TIME_IN_MS = 5000;
     NgIf,
     AgentPanelComponent,
     PropertyEditorComponent,
-    FormlyRepeatDndComponent,
   ],
 })
 export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {


### PR DESCRIPTION
### What changes were proposed in this PR?

`FormlyRepeatDndComponent` is a Formly custom field type, registered as `repeat-section-dnd` in `formly-config.ts` and instantiated dynamically by Formly at runtime. Its selector `texera-formly-repeat-section-dnd` never appears in any template, so listing it in a standalone component's `imports` array is redundant — and the Angular compiler emits one warning per component:

```
NG8113: FormlyRepeatDndComponent is not used within the template of <Component>
```

This PR removes the redundant import (the `import` statement and the `imports`-array entry) from the 10 standalone components that listed it, plus the matching NgModule import in `app.module.ts`.

The class is still imported and registered via `formly-config.ts`, which is the bundling anchor, so Formly continues to render `repeat-section-dnd` fields at runtime — no behavior change.

I also audited the other Formly dynamically-instantiated types/wrappers (`CodeareaCustomTemplateComponent`, `UiUdfParametersComponent`, `PresetWrapperComponent`, `CollabWrapperComponent`, etc.); `FormlyRepeatDndComponent` was the only one with stray standalone imports. `PresetWrapperComponent` is imported in `operator-property-edit-frame` but legitimately used via its static `setupFieldConfig` (not in the `imports` array), so it is left untouched.

### Any related issues, documentation, discussions?

Closes #5974

### How was this PR tested?

Static change only — removal of confirmed-unused imports. Verified the selector `texera-formly-repeat-section-dnd` is not referenced in any template and the symbol had no other usage in the affected files. Covered by existing build/CI.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)