### PR TITLE
chore(ci): collapse dev label into infra and widen infra to bin/**

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -108,21 +108,12 @@ ci:
           - '.asf.yaml'
           - 'codecov.yml'
 
-dev:
+infra:
+  # Anything under bin/ — project-tooling scripts, Dockerfiles, k8s
+  # manifests, license / deploy / dev-loop tooling.
   - changed-files:
       - any-glob-to-any-file:
           - 'bin/**'
-
-infra:
-  # Project-tooling scripts under bin/* that aren't tied to a specific
-  # service. The CI's `infra` job picks up everything labelled here and
-  # runs each subdirectory's unit / smoke tests in one consolidated job.
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'bin/local-dev.sh'
-          - 'bin/local-dev-tui.py'
-          - 'bin/local-dev/**'
-          - 'bin/licensing/**'
 
 dependencies:
   - changed-files:

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -45,13 +45,13 @@ concurrency:
 jobs:
   # Precheck decides which downstream jobs run for this event:
   #   - On PR events, wait for the Pull Request Labeler workflow to finish so
-  #     the labels it applies (frontend, docs, dev, ...) are available, then
+  #     the labels it applies (frontend, docs, infra, ...) are available, then
   #     gate run_* outputs on those labels.
   #   - run_frontend / run_amber / run_platform / run_pyamber /
   #     run_agent_service: gate the main build stacks. Each labeler-applied
   #     label maps to the stacks it requires (LABEL_STACKS below); the run
   #     set is the union across all PR labels. Empty union (e.g. docs-only
-  #     / dev-only PRs) skips every stack. Push and workflow_dispatch
+  #     PRs) skips every stack. Push and workflow_dispatch
   #     events run every stack.
   #   - backport_targets: JSON array of release/* labels currently on the PR.
   #     Drives the backport matrix; empty array means no backport runs.
@@ -132,8 +132,8 @@ jobs:
             //                                                                             config)
             //   ddl-change        |          |   x   |      x      |    x     |         |
             //   ci                |    x     |   x   |      x      |    x     |    x    |     x
-            //   docs / dev /      |          |       |             |          |         |
-            //   deps / release/   |          |       |             |          |         |
+            //   docs / deps /     |          |       |             |          |         |
+            //   release/*         |          |       |             |          |         |
             //   * / branch        |          |       |             |          |         |
             //
             // amber-integration runs the Scala tests tagged


### PR DESCRIPTION
### What changes were proposed in this PR?

Collapse the labeler's two overlapping `bin/`-related labels into one.

```yaml
# Before
dev:   bin/**                                            ← no CI (informational only)
infra: bin/local-dev*, bin/local-dev/**, bin/licensing   ← drives infra CI stack

# After
infra: bin/**                                            ← drives infra CI stack
```

`dev` never triggered a CI job (not in `LABEL_STACKS`). The split meant PRs touching `bin/` outside the narrow infra glob (e.g. recent dead-code cleanup #5971 / #5973 deleting `bin/deploy-*`, `bin/server.sh`, the per-service wrappers) shipped without any of the lightweight infra smoke / unit tests running. PRs touching `bin/local-dev*` got both labels — `dev` was redundant.

After this PR every change under `bin/` lights up the `infra` job, which is already cheap: no docker, no sbt, no live stack — just `find bin/**/test_*.sh` + `pytest bin/`. As more tooling test suites land under `bin/<svc>/tests/` they pick up automatically.

Also drops the two prose `dev` references in `required-checks.yml` (the precheck comment + the label/stack matrix's `docs / dev / deps / release/*` row).

### Any related issues, documentation, discussions?

Closes #5977.

### How was this PR tested?

Static. Confirmed:

* `grep -rn` for the `dev` label across `.github/` returns nothing label-related — the remaining hits are `dev/bench` (benchmark data path) and `dev@texera.apache.org` (mailing list).
* The labeler's only other `bin/` glob (`infra:`) is now the canonical one.
* `required-checks.yml`'s `LABEL_STACKS` already had `infra: ["infra"]` from #5961, so no map change needed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic, Claude Opus 4.7).
