### PR TITLE
chore(frontend): migrate Sass @import to @use

### DIFF
--- a/frontend/src/app/dashboard/component/user/filters/filters.component.scss
+++ b/frontend/src/app/dashboard/component/user/filters/filters.component.scss
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-@import "../user-workflow/user-workflow.component.scss";
+@use "../user-workflow/user-workflow.component.scss" as *;

--- a/frontend/src/app/dashboard/component/user/search-results/search-results.component.scss
+++ b/frontend/src/app/dashboard/component/user/search-results/search-results.component.scss
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@import "../../section-style";
+@use "../../section-style" as *;
 
 .load-more {
   text-align: center;

--- a/frontend/src/app/dashboard/component/user/sort-button/sort-button.component.scss
+++ b/frontend/src/app/dashboard/component/user/sort-button/sort-button.component.scss
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-@import "../user-workflow/user-workflow.component.scss";
+@use "../user-workflow/user-workflow.component.scss" as *;

--- a/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit-list-item/user-computing-unit-list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit-list-item/user-computing-unit-list-item.component.scss
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-@import "../../../section-style";
-@import "../../../dashboard.component.scss";
+@use "../../../section-style" as *;
+@use "../../../dashboard.component.scss" as *;
 
 .computing-unit-list-item-card {
   padding: 3px;

--- a/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-computing-unit/user-computing-unit.component.scss
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-@import "../../dashboard.component.scss";
-@import "../../section-style";
-@import "../../button-style";
+@use "../../dashboard.component.scss" as *;
+@use "../../section-style" as *;
+@use "../../button-style" as *;
 
 .subsection-grid-container {
   min-width: 100%;

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-list-item/user-dataset-list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-list-item/user-dataset-list-item.component.scss
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-@import "../../../section-style";
-@import "../../../dashboard.component.scss";
+@use "../../../section-style" as *;
+@use "../../../dashboard.component.scss" as *;
 
 /**
   * css for project label, shared by workflow section and file section

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.scss
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-@import "../../dashboard.component";
-@import "../../section-style";
-@import "../../button-style";
+@use "../../dashboard.component" as *;
+@use "../../section-style" as *;
+@use "../../button-style" as *;
 
 .dataset-menu-bar {
   height: 55px;

--- a/frontend/src/app/dashboard/component/user/user-project/user-project-list-item/user-project-list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-project/user-project-list-item/user-project-list-item.component.scss
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@import "../../../dashboard.component.scss";
+@use "../../../dashboard.component.scss" as *;
 
 .project-name {
   font-size: 20px;

--- a/frontend/src/app/dashboard/component/user/user-project/user-project.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-project/user-project.component.scss
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@import "../../section-style";
+@use "../../section-style" as *;
 
 button {
   border-radius: 5px;

--- a/frontend/src/app/dashboard/component/user/user-venv/user-venv.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-venv/user-venv.component.scss
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-@import "../../section-style";
-@import "../../button-style";
+@use "../../section-style" as *;
+@use "../../button-style" as *;
 
 .subsection-grid-container {
   min-width: 100%;

--- a/frontend/src/app/dashboard/component/user/user-workflow/user-workflow-list-item/user-workflow-list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-workflow/user-workflow-list-item/user-workflow-list-item.component.scss
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-@import "../../../section-style";
-@import "../../../dashboard.component.scss";
+@use "../../../section-style" as *;
+@use "../../../dashboard.component.scss" as *;
 
 /**
   * css for project label, shared by workflow section and file section

--- a/frontend/src/app/dashboard/component/user/user-workflow/user-workflow.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-workflow/user-workflow.component.scss
@@ -17,9 +17,9 @@
  * under the License.
  */
 
-@import "../../dashboard.component.scss";
-@import "../../section-style";
-@import "../../button-style";
+@use "../../dashboard.component.scss" as *;
+@use "../../section-style" as *;
+@use "../../button-style" as *;
 
 ::ng-deep .ant-badge-dot {
   right: 8px;

--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.scss
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.scss
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-@import "../../../dashboard/component/user/search/search.component";
+@use "../../../dashboard/component/user/search/search.component" as *;
 
 .filter {
   flex: 1;


### PR DESCRIPTION
### What changes were proposed in this PR?

Dart Sass deprecated `@import` (to be removed in Dart Sass 3.0); the frontend build emitted **29** `Sass @import rules are deprecated` warnings across 13 dashboard/hub component stylesheets.

These `@import`s only pull shared CSS rules from sibling stylesheets (`section-style`, `button-style`, `dashboard.component`, and a few sibling `*.component.scss`); no Sass variables, mixins, or functions are referenced across files (the only declared variables live inside `section-style.scss` and are used only there). So this is a mechanical migration: each `@import "X"` becomes `@use "X" as *`, which emits the same CSS in the same order while clearing the deprecation.

`as *` is used (rather than the default namespace) because Sass auto-derives the namespace from the filename, which is invalid for the dotted names here (e.g. `dashboard.component`). Since no members are referenced cross-file, `as *` is safe — there are no member collisions.

The plain CSS `@import` in `styles.scss` (`angular-tree-component.css`) is intentionally left as-is: it is a CSS import, not a Sass one, and is not affected by the deprecation.

### Any related issues, documentation, discussions?

Closes #5986

### How was this PR tested?

Ran `ng build` with these changes: Sass compiles cleanly, the **29** `@import` deprecation warnings drop to **0**, and the bundle is produced normally. CSS output ordering is preserved because the `@import`s were already at the top of each file (right after the license header), matching `@use` semantics.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)