### PR TITLE
fix(infra): select newest dist zip in bin/local-dev.sh unzip step

### DIFF
--- a/bin/local-dev.sh
+++ b/bin/local-dev.sh
@@ -1715,7 +1715,9 @@ build_all() {
             continue
         fi
         # shellcheck disable=SC2086
-        if unzip -oq ${zip_glob} -d "${unzip_dest}" 2>/dev/null; then
+        local zip_file=""
+        zip_file=$(ls -t ${zip_glob} 2>/dev/null | head -1)
+        if [[ -n "$zip_file" ]] && unzip -oq "$zip_file" -d "${unzip_dest}" 2>/dev/null; then
             svc_source_hash "$svc" > "$BUILD_STAMP_DIR/$svc"
         else
             tui_warn "${zip_glob} not produced"
@@ -2123,7 +2125,9 @@ cmd_auto() {
             fi
             phase_set "$svc" building
             # shellcheck disable=SC2086
-            if unzip -oq ${zip_glob} -d "${unzip_dest}" 2>/dev/null; then
+            local zip_file=""
+            zip_file=$(ls -t ${zip_glob} 2>/dev/null | head -1)
+            if [[ -n "$zip_file" ]] && unzip -oq "$zip_file" -d "${unzip_dest}" 2>/dev/null; then
                 svc_source_hash "$svc" > "$BUILD_STAMP_DIR/$svc"
                 n_rebuilt=$((n_rebuilt+1))
             else

--- a/bin/local-dev/tests/test_local_dev_sh.sh
+++ b/bin/local-dev/tests/test_local_dev_sh.sh
@@ -163,5 +163,22 @@ else
     _pass "skip: 'script' not on PATH"
 fi
 
+# 10) Regression: dual-zip selection in target/universal/. Closes #5991.
+#     Leftover `<svc>-1.2.0-incubating.zip` next to a fresh
+#     `<svc>-1.3.0-incubating-SNAPSHOT.zip` used to break `unzip -oq <glob>`:
+#     the shell expanded the unquoted glob to two filenames, unzip read the
+#     second as a member to extract from the first, exit 11, and the script
+#     silently logged "not produced — skipping". Both call sites
+#     (`build_all` + `cmd_auto`) must now pick the newest match via
+#     `ls -t <glob> | head -1` and feed unzip a single file.
+n_naked=$(grep -cE '^[[:space:]]*if unzip -oq \$\{zip_glob\}' "$SCRIPT" 2>/dev/null || true)
+n_picker=$(grep -cE 'ls -t \$\{?zip_glob\}?.*head -1' "$SCRIPT" 2>/dev/null || true)
+if (( n_naked == 0 )) && (( n_picker >= 2 )); then
+    _pass "unzip step picks newest dist zip (regression for #5991)"
+else
+    _fail "unzip step is missing the newest-zip picker" \
+        "naked-glob unzip count=$n_naked  picker count=$n_picker  (expected naked=0, picker>=2)"
+fi
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
### What changes were proposed in this PR?

`bin/local-dev.sh auto` / `up` silently skipped every JVM service when `target/universal/` had two zips (e.g. a leftover `<svc>-1.2.0-incubating.zip` next to the fresh `<svc>-1.3.0-incubating-SNAPSHOT.zip`):

```
⚠  config-service: config-service/target/universal/config-service-*.zip not produced — skipping
✓ auto bounce done: 0 rebuilt, 6 bounced
```

Stamps never updated, dirty indicator never cleared, and the auto pass stopped previously-running services without relaunching them.

**Root cause.** Both unzip call sites used `unzip -oq ${zip_glob} -d "${dest}"` with the glob unquoted. The shell expanded `<svc>-*.zip` to two filenames; `unzip` read the second as a member to extract from the first archive (`unzip [archive] [members…]`), returned exit 11, and the script logged "not produced":

```
$ unzip -oq config-service/target/universal/config-service-*.zip
caution: filename not matched: ...-1.3.0-incubating-SNAPSHOT.zip
$ echo $?
11
```

**Fix.** Pick the newest matching zip via `ls -t <glob> | head -1` and feed unzip a single file. Both `build_all` (line 1718) and `cmd_auto` (line 2128) updated identically.

### Any related issues, documentation, discussions?

Closes #5991.

### How was this PR tested?

* **Regression test** added to `bin/local-dev/tests/test_local_dev_sh.sh` (the existing infra-CI bash smoke suite). It greps `bin/local-dev.sh` to assert no call site still feeds `unzip -oq` an unquoted glob, and that the `ls -t <glob> | head -1` picker is present in both call sites. Verified the test fails (`9 passed, 1 failed`) when either site is reverted to the pre-fix shape, and passes (`10 passed, 0 failed`) on the fix. Runs automatically in the `infra` CI job.
* **Manual repro** on a main checkout with both `<svc>-1.2.0-incubating.zip` and `<svc>-1.3.0-incubating-SNAPSHOT.zip` in every service's `target/universal/`:
  * Before fix: `./bin/local-dev.sh auto` → `0 rebuilt, 6 bounced`, every JVM service ended `stopped`, dirty indicator stayed.
  * After fix: same dual-zip state → `6 rebuilt, 0 bounced`, all 6 stamps refreshed to current source hash, dirty cleared.

Bash 3.2 syntax-checked (`bash -n bin/local-dev.sh`). No new external commands — `ls -t` and `head -1` are POSIX-portable and already used elsewhere in the script.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Anthropic, Claude Opus 4.7).