### PR TITLE
chore(ci): scope pyamber labeler globs to amber/ so bin/ changes only trigger infra

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -47,7 +47,7 @@ agent-service:
 engine:
   # Non-Python, non-integration parts of amber/. Pure Python changes
   # under amber/src/{main,test}/python/** intentionally fall through to
-  # the `pyamber` label (which the labeler also matches via **/*.py),
+  # the `pyamber` label (which the labeler also matches via amber/**/*.py),
   # so they only trigger the pyamber + amber-integration stacks rather
   # than the full Scala-only `amber` stack. Integration specs live
   # under amber/src/test/integration/** (added to sbt's Test sources
@@ -85,13 +85,14 @@ pyamber:
   # exercise the pyamber + amber-integration stacks. Without this a
   # bumped requirements.txt would only get `dependencies` (no stack
   # mapping) and silently skip CI for the very deps it's changing.
+  #
+  # Globs are scoped to amber/ so bin/ tooling Python (its own `infra`
+  # job) isn't dragged into the pyamber stack.
   - changed-files:
       - any-glob-to-any-file:
-          - 'amber/src/main/python/**'
-          - 'amber/src/test/python/**'
+          - 'amber/**/*.py'
           - 'amber/pyproject.toml'
-          - '**/*.py'
-          - '**/*requirements*.txt'
+          - 'amber/**/*requirements*.txt'
 
 docs:
   - changed-files:


### PR DESCRIPTION
### What changes were proposed in this PR?

The `pyamber` label in `.github/labeler.yml` used repo-wide catch-all globs (`**/*.py`, `**/*requirements*.txt`). These also matched the tooling Python under `bin/` (`bin/local-dev-tui.py`, `bin/licensing/*.py`, `bin/local-dev/tests/*.py`), which now has its own lightweight `infra` job. As a result, a `bin/`-only PR was labeled `pyamber` on top of `infra` and wrongly pulled in the heavy `pyamber` + `amber-integration` stacks (`LABEL_STACKS.pyamber = ["amber-integration", "pyamber"]` in `required-checks.yml`).

This PR scopes both globs to `amber/`:

```yaml
pyamber:
  - changed-files:
      - any-glob-to-any-file:
          - 'amber/**/*.py'
          - 'amber/pyproject.toml'
          - 'amber/**/*requirements*.txt'
```

Coverage is preserved exactly for amber:
- `amber/**/*.py` fully subsumes the old `amber/src/{main,test}/python/**` globs — those dirs contain only `.py` files (0 non-`.py` files) — and it still catches `amber/src/main/scala/.../aiassistant/*.py`, just like the old `**/*.py` did.
- All three `requirements*.txt` files live under `amber/`, so `amber/**/*requirements*.txt` covers them.
- The only other Python in the repo (`.github/scripts/*.py`) is already covered by the `ci` label, which triggers every stack.

Net effect: `bin/` changes now trigger only the `infra` job, not `pyamber` / `amber-integration`. The stale `**/*.py` reference in the `engine` label comment is updated to `amber/**/*.py`.

A repo-wide `!bin/**` negation was deliberately avoided: with labeler's `all-globs-to-all-files`, a PR touching both amber and bin Python would have the `pyamber` label wrongly suppressed. Scoping to `amber/` has no such edge case.

### Any related issues, documentation, discussions?

Fixes #5999. Follow-up to #5978 (collapse dev label into infra and widen infra to `bin/**`), which added the `infra` job/label.

### How was this PR tested?

This is a labeler-config-only change with no runtime code. Validated `.github/labeler.yml` parses as valid YAML, and manually traced the glob set against every tracked `*.py` / `*requirements*.txt` path in the repo to confirm amber coverage is unchanged and `bin/` no longer matches `pyamber`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.8 (1M context)