### PR TITLE
test(workflow-operator): add unit test coverage for filter/dictionary predicate types

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/dictionary/MatchingTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/dictionary/MatchingTypeSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.dictionary
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MatchingTypeSpec extends AnyFlatSpec with Matchers {
+
+  "MatchingType" should "map each constant to its wire name via getName" in {
+    MatchingType.SCANBASED.getName shouldBe "Scan"
+    MatchingType.SUBSTRING.getName shouldBe "Substring"
+    MatchingType.CONJUNCTION_INDEXBASED.getName shouldBe "Conjunction"
+    MatchingType.values() should have length 3
+  }
+
+  "MatchingType" should "round-trip through Jackson using its wire name" in {
+    objectMapper.writeValueAsString(MatchingType.SUBSTRING) shouldBe "\"Substring\""
+    objectMapper.readValue("\"Conjunction\"", classOf[MatchingType]) shouldBe
+      MatchingType.CONJUNCTION_INDEXBASED
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/ComparisonTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/ComparisonTypeSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.filter
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ComparisonTypeSpec extends AnyFlatSpec with Matchers {
+
+  "ComparisonType" should "map each constant to its wire symbol via getName" in {
+    ComparisonType.EQUAL_TO.getName shouldBe "="
+    ComparisonType.GREATER_THAN.getName shouldBe ">"
+    ComparisonType.GREATER_THAN_OR_EQUAL_TO.getName shouldBe ">="
+    ComparisonType.LESS_THAN.getName shouldBe "<"
+    ComparisonType.LESS_THAN_OR_EQUAL_TO.getName shouldBe "<="
+    ComparisonType.NOT_EQUAL_TO.getName shouldBe "!="
+    ComparisonType.IS_NULL.getName shouldBe "is null"
+    ComparisonType.IS_NOT_NULL.getName shouldBe "is not null"
+    ComparisonType.values() should have length 8
+  }
+
+  "ComparisonType.fromString" should "resolve symbols case-insensitively" in {
+    ComparisonType.fromString(">=") shouldBe ComparisonType.GREATER_THAN_OR_EQUAL_TO
+    ComparisonType.fromString("IS NULL") shouldBe ComparisonType.IS_NULL
+    ComparisonType.fromString("is not null") shouldBe ComparisonType.IS_NOT_NULL
+  }
+
+  it should "reject an unknown symbol" in {
+    intercept[IllegalArgumentException](ComparisonType.fromString("≈"))
+  }
+
+  "ComparisonType" should "round-trip through Jackson using its symbol" in {
+    objectMapper.writeValueAsString(ComparisonType.GREATER_THAN) shouldBe "\">\""
+    objectMapper.readValue("\"is null\"", classOf[ComparisonType]) shouldBe ComparisonType.IS_NULL
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/FilterPredicateSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/FilterPredicateSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.filter
+
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema, Tuple}
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FilterPredicateSpec extends AnyFlatSpec with Matchers {
+
+  private val intSchema = Schema().add(new Attribute("age", AttributeType.INTEGER))
+  private def ageTuple(age: Integer): Tuple =
+    Tuple.builder(intSchema).add(new Attribute("age", AttributeType.INTEGER), age).build()
+
+  "FilterPredicate" should "expose its constructor-supplied fields" in {
+    val p = new FilterPredicate("age", ComparisonType.GREATER_THAN, "18")
+    p.attribute shouldBe "age"
+    p.condition shouldBe ComparisonType.GREATER_THAN
+    p.value shouldBe "18"
+  }
+
+  "FilterPredicate.evaluate" should "apply numeric comparisons against the tuple field" in {
+    new FilterPredicate("age", ComparisonType.GREATER_THAN, "18")
+      .evaluate(ageTuple(30)) shouldBe true
+    new FilterPredicate("age", ComparisonType.GREATER_THAN, "18")
+      .evaluate(ageTuple(10)) shouldBe false
+    new FilterPredicate("age", ComparisonType.LESS_THAN_OR_EQUAL_TO, "18")
+      .evaluate(ageTuple(18)) shouldBe true
+  }
+
+  it should "handle the null-check conditions without parsing the value" in {
+    new FilterPredicate("age", ComparisonType.IS_NOT_NULL, null).evaluate(ageTuple(5)) shouldBe true
+  }
+
+  it should "compare string fields when the value is non-numeric" in {
+    val schema = Schema().add(new Attribute("name", AttributeType.STRING))
+    val t = Tuple.builder(schema).add(new Attribute("name", AttributeType.STRING), "bob").build()
+    new FilterPredicate("name", ComparisonType.EQUAL_TO, "bob").evaluate(t) shouldBe true
+    new FilterPredicate("name", ComparisonType.NOT_EQUAL_TO, "bob").evaluate(t) shouldBe false
+  }
+
+  "FilterPredicate" should "honor equals/hashCode by its three fields" in {
+    val a = new FilterPredicate("age", ComparisonType.EQUAL_TO, "1")
+    val b = new FilterPredicate("age", ComparisonType.EQUAL_TO, "1")
+    val c = new FilterPredicate("age", ComparisonType.EQUAL_TO, "2")
+    a shouldBe b
+    a.hashCode shouldBe b.hashCode
+    a should not be c
+  }
+
+  "FilterPredicate" should "round-trip through Jackson (condition as its symbol)" in {
+    val p = new FilterPredicate("age", ComparisonType.GREATER_THAN_OR_EQUAL_TO, "18")
+    val json = objectMapper.writeValueAsString(p)
+    json should include("\"condition\":\">=\"")
+    objectMapper.readValue(json, classOf[FilterPredicate]) shouldBe p
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/FilterPredicateSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/FilterPredicateSpec.scala
@@ -28,7 +28,7 @@ class FilterPredicateSpec extends AnyFlatSpec with Matchers {
 
   private val intSchema = Schema().add(new Attribute("age", AttributeType.INTEGER))
   private def ageTuple(age: Integer): Tuple =
-    Tuple.builder(intSchema).add(new Attribute("age", AttributeType.INTEGER), age).build()
+    Tuple.builder(intSchema).add("age", AttributeType.INTEGER, age).build()
 
   "FilterPredicate" should "expose its constructor-supplied fields" in {
     val p = new FilterPredicate("age", ComparisonType.GREATER_THAN, "18")
@@ -52,7 +52,7 @@ class FilterPredicateSpec extends AnyFlatSpec with Matchers {
 
   it should "compare string fields when the value is non-numeric" in {
     val schema = Schema().add(new Attribute("name", AttributeType.STRING))
-    val t = Tuple.builder(schema).add(new Attribute("name", AttributeType.STRING), "bob").build()
+    val t = Tuple.builder(schema).add("name", AttributeType.STRING, "bob").build()
     new FilterPredicate("name", ComparisonType.EQUAL_TO, "bob").evaluate(t) shouldBe true
     new FilterPredicate("name", ComparisonType.NOT_EQUAL_TO, "bob").evaluate(t) shouldBe false
   }
@@ -69,7 +69,10 @@ class FilterPredicateSpec extends AnyFlatSpec with Matchers {
   "FilterPredicate" should "round-trip through Jackson (condition as its symbol)" in {
     val p = new FilterPredicate("age", ComparisonType.GREATER_THAN_OR_EQUAL_TO, "18")
     val json = objectMapper.writeValueAsString(p)
-    json should include("\"condition\":\">=\"")
+    val node = objectMapper.readTree(json)
+    node.get("attribute").asText shouldBe "age"
+    node.get("condition").asText shouldBe ">="
+    node.get("value").asText shouldBe "18"
     objectMapper.readValue(json, classOf[FilterPredicate]) shouldBe p
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of three previously-untested filter/dictionary value & enum types in `common/workflow-operator`. No production-code changes.

| Spec | Source class | Tests |
| --- | --- | --- |
| `ComparisonTypeSpec` | `ComparisonType` | 4 |
| `MatchingTypeSpec` | `MatchingType` | 2 |
| `FilterPredicateSpec` | `FilterPredicate` | 6 |

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| `ComparisonType` | the 8 constants → wire symbols (`=`, `>`, `>=`, `<`, `<=`, `!=`, `is null`, `is not null`); `fromString` case-insensitive + unknown-symbol rejection; Jackson `@JsonValue` round-trip |
| `MatchingType` | the 3 constants → `Scan`/`Substring`/`Conjunction`; Jackson round-trip |
| `FilterPredicate` | constructor fields; `equals`/`hashCode`; Jackson round-trip (`condition` as its symbol); `evaluate` over numeric, string, and null-check conditions against a `Tuple` |

### Any related issues, documentation, discussions?

Resolves #6020. Part of the ongoing `workflow-operator` unit-test coverage effort.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *ComparisonTypeSpec *MatchingTypeSpec *FilterPredicateSpec"` — 12 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])