### PR TITLE
test(workflow-operator): add unit test coverage for attribute-transform units

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/AttributeUnitSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/AttributeUnitSpec.scala
@@ -41,14 +41,15 @@ class AttributeUnitSpec extends AnyFlatSpec with Matchers {
     val b = new AttributeUnit("col", "x")
     a shouldBe b
     a.hashCode shouldBe b.hashCode
-    a should not be new AttributeUnit("col", "y")
+    a should not be new AttributeUnit("col", "y") // differs by alias
+    a should not be new AttributeUnit("other", "x") // differs by original attribute
   }
 
   "AttributeUnit" should "round-trip through Jackson" in {
     val u = new AttributeUnit("col", "renamed")
-    val json = objectMapper.writeValueAsString(u)
-    json should include("\"originalAttribute\":\"col\"")
-    json should include("\"alias\":\"renamed\"")
-    objectMapper.readValue(json, classOf[AttributeUnit]) shouldBe u
+    val node = objectMapper.readTree(objectMapper.writeValueAsString(u))
+    node.get("originalAttribute").asText shouldBe "col"
+    node.get("alias").asText shouldBe "renamed"
+    objectMapper.readValue(objectMapper.writeValueAsString(u), classOf[AttributeUnit]) shouldBe u
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/AttributeUnitSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/AttributeUnitSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.projection
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AttributeUnitSpec extends AnyFlatSpec with Matchers {
+
+  "AttributeUnit.getAlias" should "return the alias when one is provided" in {
+    new AttributeUnit("col", "renamed").getAlias shouldBe "renamed"
+    new AttributeUnit("col", "renamed").getOriginalAttribute shouldBe "col"
+  }
+
+  it should "fall back to the original attribute when the alias is blank" in {
+    new AttributeUnit("col", "").getAlias shouldBe "col"
+    new AttributeUnit("col", "   ").getAlias shouldBe "col"
+    new AttributeUnit("col", null).getAlias shouldBe "col"
+  }
+
+  "AttributeUnit" should "honor equals/hashCode by original attribute and alias" in {
+    val a = new AttributeUnit("col", "x")
+    val b = new AttributeUnit("col", "x")
+    a shouldBe b
+    a.hashCode shouldBe b.hashCode
+    a should not be new AttributeUnit("col", "y")
+  }
+
+  "AttributeUnit" should "round-trip through Jackson" in {
+    val u = new AttributeUnit("col", "renamed")
+    val json = objectMapper.writeValueAsString(u)
+    json should include("\"originalAttribute\":\"col\"")
+    json should include("\"alias\":\"renamed\"")
+    objectMapper.readValue(json, classOf[AttributeUnit]) shouldBe u
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingUnitSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingUnitSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.typecasting
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TypeCastingUnitSpec extends AnyFlatSpec with Matchers {
+
+  "TypeCastingUnit" should "expose its attribute and result-type fields" in {
+    val u = new TypeCastingUnit
+    u.attribute = "amount"
+    u.resultType = AttributeType.DOUBLE
+    u.attribute shouldBe "amount"
+    u.resultType shouldBe AttributeType.DOUBLE
+  }
+
+  "TypeCastingUnit" should "round-trip its fields through Jackson" in {
+    val u = new TypeCastingUnit
+    u.attribute = "amount"
+    u.resultType = AttributeType.INTEGER
+    val json = objectMapper.writeValueAsString(u)
+    json should include("\"attribute\":\"amount\"")
+    val restored = objectMapper.readValue(json, classOf[TypeCastingUnit])
+    restored.attribute shouldBe "amount"
+    restored.resultType shouldBe AttributeType.INTEGER
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingUnitSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/typecasting/TypeCastingUnitSpec.scala
@@ -39,7 +39,9 @@ class TypeCastingUnitSpec extends AnyFlatSpec with Matchers {
     u.attribute = "amount"
     u.resultType = AttributeType.INTEGER
     val json = objectMapper.writeValueAsString(u)
-    json should include("\"attribute\":\"amount\"")
+    val node = objectMapper.readTree(json)
+    node.get("attribute").asText shouldBe "amount"
+    node.get("resultType").asText shouldBe "integer"
     val restored = objectMapper.readValue(json, classOf[TypeCastingUnit])
     restored.attribute shouldBe "amount"
     restored.resultType shouldBe AttributeType.INTEGER

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/LambdaAttributeUnitSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/LambdaAttributeUnitSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.udf.python
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LambdaAttributeUnitSpec extends AnyFlatSpec with Matchers {
+
+  "LambdaAttributeUnit" should "expose its constructor-supplied fields" in {
+    val u = new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.INTEGER)
+    u.attributeName shouldBe "score"
+    u.expression shouldBe "1 + 1"
+    u.newAttributeName shouldBe "scoreOut"
+    u.attributeType shouldBe AttributeType.INTEGER
+  }
+
+  "LambdaAttributeUnit" should "honor equals/hashCode by all four fields" in {
+    val a = new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.INTEGER)
+    val b = new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.INTEGER)
+    a shouldBe b
+    a.hashCode shouldBe b.hashCode
+    a should not be new LambdaAttributeUnit("score", "1 + 2", "scoreOut", AttributeType.INTEGER)
+  }
+
+  "LambdaAttributeUnit" should "round-trip through Jackson" in {
+    val u = new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.INTEGER)
+    val json = objectMapper.writeValueAsString(u)
+    json should include("\"attributeName\":\"score\"")
+    json should include("\"expression\":\"1 + 1\"")
+    objectMapper.readValue(json, classOf[LambdaAttributeUnit]) shouldBe u
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/LambdaAttributeUnitSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/LambdaAttributeUnitSpec.scala
@@ -39,14 +39,20 @@ class LambdaAttributeUnitSpec extends AnyFlatSpec with Matchers {
     val b = new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.INTEGER)
     a shouldBe b
     a.hashCode shouldBe b.hashCode
+    a should not be new LambdaAttributeUnit("other", "1 + 1", "scoreOut", AttributeType.INTEGER)
     a should not be new LambdaAttributeUnit("score", "1 + 2", "scoreOut", AttributeType.INTEGER)
+    a should not be new LambdaAttributeUnit("score", "1 + 1", "renamed", AttributeType.INTEGER)
+    a should not be new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.DOUBLE)
   }
 
   "LambdaAttributeUnit" should "round-trip through Jackson" in {
     val u = new LambdaAttributeUnit("score", "1 + 1", "scoreOut", AttributeType.INTEGER)
     val json = objectMapper.writeValueAsString(u)
-    json should include("\"attributeName\":\"score\"")
-    json should include("\"expression\":\"1 + 1\"")
+    val node = objectMapper.readTree(json)
+    node.get("attributeName").asText shouldBe "score"
+    node.get("expression").asText shouldBe "1 + 1"
+    node.get("newAttributeName").asText shouldBe "scoreOut"
+    node.get("attributeType").asText shouldBe "integer"
     objectMapper.readValue(json, classOf[LambdaAttributeUnit]) shouldBe u
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of three previously-untested attribute-transform value classes in `common/workflow-operator`. No production-code changes.

| Spec | Source class | Tests |
| --- | --- | --- |
| `AttributeUnitSpec` | `AttributeUnit` | 4 |
| `TypeCastingUnitSpec` | `TypeCastingUnit` | 2 |
| `LambdaAttributeUnitSpec` | `LambdaAttributeUnit` | 3 |

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| `AttributeUnit` | `getAlias` falls back to the original attribute when the alias is blank/null; `equals`/`hashCode`; Jackson round-trip |
| `TypeCastingUnit` | `attribute`/`resultType` fields; Jackson round-trip (no `equals` override, so fields are asserted directly) |
| `LambdaAttributeUnit` | constructor fields; `equals`/`hashCode` over all four fields; Jackson round-trip |

### Any related issues, documentation, discussions?

Resolves #6019. Part of the ongoing `workflow-operator` unit-test coverage effort.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *AttributeUnitSpec *TypeCastingUnitSpec *LambdaAttributeUnitSpec"` — 9 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])