### PR TITLE
test(workflow-operator): add unit test coverage for operator function/type enums

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/aggregate/AggregationFunctionSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/aggregate/AggregationFunctionSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.aggregate
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class AggregationFunctionSpec extends AnyFlatSpec with Matchers {
+
+  "AggregationFunction" should "map each constant to its wire name via getName" in {
+    AggregationFunction.SUM.getName shouldBe "sum"
+    AggregationFunction.COUNT.getName shouldBe "count"
+    AggregationFunction.AVERAGE.getName shouldBe "average"
+    AggregationFunction.MIN.getName shouldBe "min"
+    AggregationFunction.MAX.getName shouldBe "max"
+    AggregationFunction.CONCAT.getName shouldBe "concat"
+    AggregationFunction.values() should have length 6
+  }
+
+  "AggregationFunction" should "round-trip through Jackson using its wire name" in {
+    objectMapper.writeValueAsString(AggregationFunction.AVERAGE) shouldBe "\"average\""
+    objectMapper.readValue("\"concat\"", classOf[AggregationFunction]) shouldBe
+      AggregationFunction.CONCAT
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/hashJoin/JoinTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/hashJoin/JoinTypeSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.hashJoin
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class JoinTypeSpec extends AnyFlatSpec with Matchers {
+
+  "JoinType" should "map each constant to its wire value via getJoinType" in {
+    JoinType.INNER.getJoinType shouldBe "inner"
+    JoinType.LEFT_OUTER.getJoinType shouldBe "left outer"
+    JoinType.RIGHT_OUTER.getJoinType shouldBe "right outer"
+    JoinType.FULL_OUTER.getJoinType shouldBe "full outer"
+    JoinType.values() should have length 4
+  }
+
+  "JoinType" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(JoinType.LEFT_OUTER) shouldBe "\"left outer\""
+    objectMapper.readValue("\"full outer\"", classOf[JoinType]) shouldBe JoinType.FULL_OUTER
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/intervalJoin/TimeIntervalTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/intervalJoin/TimeIntervalTypeSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.intervalJoin
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TimeIntervalTypeSpec extends AnyFlatSpec with Matchers {
+
+  "TimeIntervalType" should "map each constant to its wire name (also its toString)" in {
+    TimeIntervalType.YEAR.getName shouldBe "year"
+    TimeIntervalType.MONTH.getName shouldBe "month"
+    TimeIntervalType.DAY.getName shouldBe "day"
+    TimeIntervalType.HOUR.getName shouldBe "hour"
+    TimeIntervalType.MINUTE.getName shouldBe "minute"
+    TimeIntervalType.SECOND.getName shouldBe "second"
+    TimeIntervalType.values() should have length 6
+    TimeIntervalType.DAY.toString shouldBe "day"
+  }
+
+  "TimeIntervalType" should "round-trip through Jackson using its wire name" in {
+    objectMapper.writeValueAsString(TimeIntervalType.HOUR) shouldBe "\"hour\""
+    objectMapper.readValue("\"minute\"", classOf[TimeIntervalType]) shouldBe TimeIntervalType.MINUTE
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of three previously-untested operator function/type enums in `common/workflow-operator`. No production-code changes.

| Spec | Source class | Tests |
| --- | --- | --- |
| `AggregationFunctionSpec` | `AggregationFunction` | 2 |
| `JoinTypeSpec` | `JoinType` | 2 |
| `TimeIntervalTypeSpec` | `TimeIntervalType` | 2 |

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| `AggregationFunction` | the 6 constants → `sum`/`count`/`average`/`min`/`max`/`concat`; Jackson `@JsonValue` round-trip |
| `JoinType` | the 4 constants → `inner`/`left outer`/`right outer`/`full outer`; Jackson round-trip |
| `TimeIntervalType` | the 6 constants → `year`…`second` (also `toString`); Jackson round-trip |

### Any related issues, documentation, discussions?

Resolves #6018. Part of the ongoing `workflow-operator` unit-test coverage effort.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *AggregationFunctionSpec *JoinTypeSpec *TimeIntervalTypeSpec"` — 6 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])