### PR TITLE
fix(infra): start postgres before sbt build in local-dev up/auto

### DIFF
--- a/bin/local-dev/main.sh
+++ b/bin/local-dev/main.sh
@@ -1149,6 +1149,27 @@ infra_ensure_db_schema() {
     fi
 }
 
+# Build precondition: ensure ONLY the postgres container is up + schema
+# bootstrapped. common/dao's jooqGenerate sourceGenerator connects to
+# postgres via JDBC at sbt-compile time; if postgres isn't reachable the
+# catch block in common/dao/build.sbt logs "Continuing compilation with
+# existing generated files..." but the generated dir is not git-tracked,
+# so fresh checkouts have nothing to fall back on and the downstream
+# Scala compile fails on missing Tables/Keys/etc. (#6007)
+#
+# Used by cmd_auto, which only wants to touch what its scan said is
+# dirty. cmd_up uses the heavier infra_up + infra_ensure_db_schema pair
+# instead so minio/lakefs/litellm warm up in parallel with the build.
+ensure_postgres_for_build() {
+    if [[ "$(docker_svc_state postgres)" != "running" ]]; then
+        tui_step "postgres: starting (required for jOOQ codegen at build time)"
+        local files=($(docker_compose_files))
+        docker compose --progress auto -p "$DOCKER_PROJECT" --env-file "$DOCKER_ENV_FILE" "${files[@]}" \
+            up -d postgres >/dev/null 2>&1 || true
+    fi
+    infra_ensure_db_schema
+}
+
 svc_running_pid() {
     listen_pid_for_port "$(amap_get SVC_PORT "$1")"
 }
@@ -1898,6 +1919,32 @@ cmd_up() {
         fi
     fi
 
+    # ── Infra (must precede Build) ────────────────────────────────────────
+    # common/dao's jooqGenerate sourceGenerator runs at sbt-compile time
+    # and connects to postgres via JDBC; if postgres isn't reachable the
+    # generator returns Seq.empty and the downstream Scala compile fails
+    # on missing Tables/Keys/etc (the generated dir is not git-tracked).
+    # Bring infra up first so postgres is ready when the build fires.
+    # As a bonus minio/lakefs/litellm warm up while sbt runs. (#6007)
+    local svc=""
+    local has_docker_targets=false
+    for svc in "${SERVICES[@]}"; do
+        [[ "$(amap_get SVC_TYPE "$svc")" == "docker" ]] || continue
+        is_skipped "$svc" && continue
+        has_docker_targets=true
+        break
+    done
+    if $has_docker_targets; then
+        tui_section "Infra"
+        case "$(infra_state)" in
+            running)    tui_ok "infra: already running" ;;
+            external:*) tui_err "infra: ports taken by non-script containers"
+                        printf "  ${DIM}docker compose -p texera-dev down${RESET}\n" ;;
+            *)          infra_up || true ;;
+        esac
+        infra_ensure_db_schema
+    fi
+
     if [[ "$BUILD" != "no" ]]; then
         tui_section "Build"
         build_all
@@ -1907,38 +1954,16 @@ cmd_up() {
         tui_skip "build: --no-build (using existing artifacts)"
     fi
 
-    # ▸ Services -- docker compose has its own TTY panel; native services we
-    # kick off silently in the background, then a single redrawing panel below
-    # shows progress for ALL of them.
+    # ▸ Services -- native services only; docker rows were handled by the
+    # Infra section above. We kick each one off silently in the background
+    # and a single redrawing panel below shows progress for ALL of them.
     tui_section "Services  ${DIM}(launching)${RESET}"
-    local svc="" cwd="" log="" type="" launcher=""
-
-    # One project-level `docker compose up -d` for every non-skipped docker
-    # row — much faster than five separate calls.
-    local has_docker_targets=false
-    for svc in "${SERVICES[@]}"; do
-        [[ "$(amap_get SVC_TYPE "$svc")" == "docker" ]] || continue
-        is_skipped "$svc" && continue
-        has_docker_targets=true
-        break
-    done
-    if $has_docker_targets; then
-        case "$(infra_state)" in
-            running)    tui_ok "infra: already running" ;;
-            external:*) tui_err "infra: ports taken by non-script containers"
-                        printf "  ${DIM}docker compose -p texera-dev down${RESET}\n" ;;
-            *)          infra_up || true ;;
-        esac
-        # Whether infra is fresh or already up, make sure the texera_db
-        # schema is current — JVMs about to start expect it (jOOQ + Iceberg
-        # both need real tables).
-        infra_ensure_db_schema
-    fi
+    local cwd="" log="" type="" launcher=""
 
     for svc in "${SERVICES[@]}"; do
         is_skipped "$svc" && { tui_skip "$svc: --skip"; continue; }
         type=$(amap_get SVC_TYPE "$svc")
-        [[ "$type" == "docker" ]] && continue   # already handled by infra_up
+        [[ "$type" == "docker" ]] && continue   # handled by Infra section above
         if [[ -n "$(svc_running_pid "$svc")" ]]; then
             tui_ok "$svc: already running ${DIM}(PID $(svc_running_pid "$svc"))${RESET}"
             continue
@@ -2050,6 +2075,11 @@ cmd_auto() {
     # get pre-bounced just because the build ran.
     if (( ${#dirty_jvms[@]} > 0 )); then
         tui_section "Build  ${DIM}(${#dirty_jvms[@]} JVM service(s) dirty)${RESET}"
+        # sbt build precondition: common/dao's jooqGenerate connects to
+        # postgres at compile time; a `down` + `auto` sequence on a
+        # fresh-ish checkout otherwise fails before any service launches.
+        # See #6007.
+        ensure_postgres_for_build
         # Mark each dirty service as "building" so the TUI shows the
         # animation across the whole sbt window (~30s+). Without this the
         # dashboard stays on the prior STATE during the slow build.

--- a/bin/local-dev/tests/test_local_dev_sh.sh
+++ b/bin/local-dev/tests/test_local_dev_sh.sh
@@ -193,5 +193,42 @@ else
         "naked-glob unzip count=$n_naked  picker count=$n_picker  (expected naked=0, picker>=2)"
 fi
 
+# 11) Regression: jOOQ codegen runs at sbt-build time and connects to
+#     postgres (common/dao's jooqGenerate sourceGenerator). On a fresh
+#     checkout the generated dir is empty (not git-tracked), so if
+#     postgres isn't reachable when sbt runs, the build fails. Both
+#     cmd_up and cmd_auto must run a postgres-ready step BEFORE the
+#     sbt build is launched. Closes #6007.
+MAIN_SH="$REPO_ROOT/bin/local-dev/main.sh"
+for fn in cmd_up cmd_auto; do
+    result=$(awk -v fn="$fn" '
+        BEGIN { in_fn = 0; depth = 0; schema_at = 0; build_at = 0 }
+        !in_fn && index($0, fn "()") == 1 { in_fn = 1; depth = 1; next }
+        in_fn {
+            for (i = 1; i <= length($0); i++) {
+                c = substr($0, i, 1)
+                if (c == "{") depth++
+                else if (c == "}") depth--
+            }
+            if (schema_at == 0 && match($0, /infra_ensure_db_schema|ensure_postgres_for_build/))
+                schema_at = NR
+            if (build_at == 0 && match($0, /build_all|sbt[[:space:]]+-no-colors[[:space:]]+dist/))
+                build_at = NR
+            if (depth == 0) {
+                printf "schema=%d build=%d", schema_at, build_at
+                exit
+            }
+        }
+    ' "$MAIN_SH")
+    schema_at=$(echo "$result" | sed -n 's/.*schema=\([0-9]*\).*/\1/p')
+    build_at=$(echo "$result" | sed -n 's/.*build=\([0-9]*\).*/\1/p')
+    if (( schema_at > 0 )) && (( build_at > 0 )) && (( schema_at < build_at )); then
+        _pass "$fn: postgres readiness check precedes sbt build (regression for #6007)"
+    else
+        _fail "$fn: postgres readiness must precede sbt build (regression for #6007)" \
+            "schema_at=$schema_at  build_at=$build_at"
+    fi
+done
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
### What changes were proposed in this PR?

`bin/local-dev.sh up` / `auto` were running `sbt dist` before postgres was reachable. `common/dao`'s `jooqGenerate` sourceGenerator connects to postgres via JDBC at compile time; with no postgres the catch block in [`common/dao/build.sbt`](common/dao/build.sbt) logs `Continuing compilation with existing generated files...` and returns `Seq.empty`. Because the generated jOOQ dir is not git-tracked, fresh checkouts have no fallback and the downstream Scala compile fails on missing `Tables` / `Keys` / etc.

| Path | Before | After |
| --- | --- | --- |
| `cmd_up` | Build → Infra (`infra_up` + `infra_ensure_db_schema`) → Services | **Infra → Build → Services** (minio/lakefs/litellm warm up in parallel with the build) |
| `cmd_auto` | Scan → Build (no postgres precondition) → Bounce | Scan → Build (calls new `ensure_postgres_for_build`) → Bounce |

`ensure_postgres_for_build` is a new helper that starts only the `postgres` container (if it isn't already running) and applies the schema — minimal blast radius for `cmd_auto`, which by contract only touches what its scan flagged dirty.

### Any related issues, documentation, discussions?

Closes #6007.

### How was this PR tested?

- `bash bin/local-dev/tests/test_local_dev_sh.sh` — 12/12 pass; added a static regression assertion #11 that scans `cmd_up` and `cmd_auto` and fails if any postgres-ready step (`infra_ensure_db_schema` / `ensure_postgres_for_build`) does not precede the first `build_all` / `sbt -no-colors dist` invocation. Verified red-then-green: before the source change the new assertion reports `schema_at=1935 build_at=1903` for `cmd_up` and `schema_at=0 build_at=2062` for `cmd_auto`.
- `bash -n bin/local-dev/main.sh` — clean.
- `bin/local-dev.sh --help` — unchanged usage.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7