### PR TITLE
docs(local-dev): fix stale comment claiming infra is unmanaged

### DIFF
--- a/bin/local-dev/main.sh
+++ b/bin/local-dev/main.sh
@@ -60,9 +60,10 @@
 #   agent-service                  :3001  Bun --watch (cd agent-service && bun run dev)
 #   frontend                       :4200  ng serve via cd frontend && yarn start
 #
-# Docker infra (postgres / minio / lakefs / lakekeeper / litellm) is NOT managed
-# here -- bring those up yourself before `up`. The script will warn if expected
-# ports are unreachable.
+# Docker infra (postgres / minio / lakefs / lakekeeper / litellm) IS managed
+# here: `up` brings it up via `docker compose` (project texera-local-dev) and
+# `down` tears down any docker targets. The script warns if expected ports are
+# unreachable.
 #
 # Logs and pid book-keeping live under: ${TEXERA_LOCAL_DEV_DIR:-/tmp/texera-local-dev}
 


### PR DESCRIPTION
### What changes were proposed in this PR?

The usage banner in `bin/local-dev/main.sh` claimed Docker infra is **not**
managed by the script and that you must bring it up yourself before `up`. That
contradicts the actual code: `cmd_up` calls `infra_up` (which runs `docker
compose up -d` against project `texera-local-dev`) and `cmd_down` calls
`infra_down` for any docker targets.

```
Before:  comment says "infra is NOT managed here -- bring those up yourself"
After:   comment says "infra IS managed: `up` brings it up, `down` tears it down"
```

Comment-only change; no behavior change.

### Any related issues, documentation, discussions?

Related to #5960 (introduced `bin/local-dev` and this banner) and #6007 (wired
`infra_up` into `up`/`auto`, which is what made the banner stale). No dedicated
issue — documentation/comment-only fix (issue-first is excepted for docs). The
sibling `bin/local-dev/README.md` already documents the correct behavior
("infra in docker, JVM + frontend native"); this just realigns the script's
own banner.

### How was this PR tested?

No tests — comment-only change. Verified the described behavior by reading
`cmd_up` → `infra_up` (`docker compose up -d`, project `texera-local-dev`) and
`cmd_down` → `infra_down`, and by running `bin/local-dev.sh up`, which brought
up postgres/minio/lakefs/lakekeeper/litellm automatically (14/14 services
healthy) with no manual `docker compose` step.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
