### PR TITLE
test(workflow-operator): add unit test coverage for source operator enums

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/apis/reddit/RedditSourceOperatorFunctionSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/apis/reddit/RedditSourceOperatorFunctionSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.source.apis.reddit
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RedditSourceOperatorFunctionSpec extends AnyFlatSpec with Matchers {
+
+  "RedditSourceOperatorFunction" should "map each constant to its wire value" in {
+    RedditSourceOperatorFunction.None.getName shouldBe "none"
+    RedditSourceOperatorFunction.Controversial.getName shouldBe "controversial"
+    RedditSourceOperatorFunction.Gilded.getName shouldBe "gilded"
+    RedditSourceOperatorFunction.Hot.getName shouldBe "hot"
+    RedditSourceOperatorFunction.New.getName shouldBe "new"
+    RedditSourceOperatorFunction.Rising.getName shouldBe "rising"
+    RedditSourceOperatorFunction.Top.getName shouldBe "top"
+    RedditSourceOperatorFunction.values() should have length 7
+  }
+
+  "RedditSourceOperatorFunction" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(RedditSourceOperatorFunction.Hot) shouldBe "\"hot\""
+    objectMapper.readValue(
+      "\"hot\"",
+      classOf[RedditSourceOperatorFunction]
+    ) shouldBe RedditSourceOperatorFunction.Hot
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/fetcher/DecodingMethodSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/fetcher/DecodingMethodSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.source.fetcher
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DecodingMethodSpec extends AnyFlatSpec with Matchers {
+
+  "DecodingMethod" should "map each constant to its wire value" in {
+    DecodingMethod.UTF_8.getName shouldBe "UTF-8"
+    DecodingMethod.RAW_BYTES.getName shouldBe "RAW BYTES"
+    DecodingMethod.values() should have length 2
+  }
+
+  "DecodingMethod" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(DecodingMethod.RAW_BYTES) shouldBe "\"RAW BYTES\""
+    objectMapper.readValue(
+      "\"RAW BYTES\"",
+      classOf[DecodingMethod]
+    ) shouldBe DecodingMethod.RAW_BYTES
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/FileAttributeTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/FileAttributeTypeSpec.scala
@@ -37,7 +37,7 @@ class FileAttributeTypeSpec extends AnyFlatSpec with Matchers {
     FileAttributeType.BINARY.getName shouldBe "binary"
     FileAttributeType.LARGE_BINARY.getName shouldBe "large binary"
     FileAttributeType.values() should have length 9
-    FileAttributeType.SINGLE_STRING.toString shouldBe "single string"
+    FileAttributeType.values().foreach(t => t.toString shouldBe t.getName)
   }
 
   "FileAttributeType.getType" should "map to the corresponding core AttributeType" in {

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/FileAttributeTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/FileAttributeTypeSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.source.scan
+
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FileAttributeTypeSpec extends AnyFlatSpec with Matchers {
+
+  "FileAttributeType" should "map each constant to its wire name (also its toString)" in {
+    FileAttributeType.STRING.getName shouldBe "string"
+    FileAttributeType.SINGLE_STRING.getName shouldBe "single string"
+    FileAttributeType.INTEGER.getName shouldBe "integer"
+    FileAttributeType.LONG.getName shouldBe "long"
+    FileAttributeType.DOUBLE.getName shouldBe "double"
+    FileAttributeType.BOOLEAN.getName shouldBe "boolean"
+    FileAttributeType.TIMESTAMP.getName shouldBe "timestamp"
+    FileAttributeType.BINARY.getName shouldBe "binary"
+    FileAttributeType.LARGE_BINARY.getName shouldBe "large binary"
+    FileAttributeType.values() should have length 9
+    FileAttributeType.SINGLE_STRING.toString shouldBe "single string"
+  }
+
+  "FileAttributeType.getType" should "map to the corresponding core AttributeType" in {
+    FileAttributeType.STRING.getType shouldBe AttributeType.STRING
+    FileAttributeType.SINGLE_STRING.getType shouldBe AttributeType.STRING
+    FileAttributeType.INTEGER.getType shouldBe AttributeType.INTEGER
+    FileAttributeType.LONG.getType shouldBe AttributeType.LONG
+    FileAttributeType.DOUBLE.getType shouldBe AttributeType.DOUBLE
+    FileAttributeType.BOOLEAN.getType shouldBe AttributeType.BOOLEAN
+    FileAttributeType.TIMESTAMP.getType shouldBe AttributeType.TIMESTAMP
+    FileAttributeType.BINARY.getType shouldBe AttributeType.BINARY
+    FileAttributeType.LARGE_BINARY.getType shouldBe AttributeType.LARGE_BINARY
+  }
+
+  "FileAttributeType.isSingle" should "hold only for the single-value types" in {
+    FileAttributeType.SINGLE_STRING.isSingle shouldBe true
+    FileAttributeType.BINARY.isSingle shouldBe true
+    FileAttributeType.LARGE_BINARY.isSingle shouldBe true
+    FileAttributeType.STRING.isSingle shouldBe false
+    FileAttributeType.INTEGER.isSingle shouldBe false
+  }
+
+  "FileAttributeType" should "round-trip through Jackson using its wire name" in {
+    objectMapper.writeValueAsString(FileAttributeType.SINGLE_STRING) shouldBe "\"single string\""
+    objectMapper.readValue("\"large binary\"", classOf[FileAttributeType]) shouldBe
+      FileAttributeType.LARGE_BINARY
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/FileDecodingMethodSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/FileDecodingMethodSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.source.scan
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FileDecodingMethodSpec extends AnyFlatSpec with Matchers {
+
+  "FileDecodingMethod" should "map each constant to its wire value" in {
+    FileDecodingMethod.UTF_8.getName shouldBe "UTF_8"
+    FileDecodingMethod.UTF_16.getName shouldBe "UTF_16"
+    FileDecodingMethod.ASCII.getName shouldBe "US_ASCII"
+    FileDecodingMethod.values() should have length 3
+  }
+
+  "FileDecodingMethod" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(FileDecodingMethod.UTF_16) shouldBe "\"UTF_16\""
+    objectMapper.readValue(
+      "\"UTF_16\"",
+      classOf[FileDecodingMethod]
+    ) shouldBe FileDecodingMethod.UTF_16
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of four previously-untested source operator enums in `common/workflow-operator`. No production-code changes.

| Spec | Source enum | Tests |
| --- | --- | --- |
| `FileAttributeTypeSpec` | `FileAttributeType` | 4 |
| `FileDecodingMethodSpec` | `FileDecodingMethod` | 2 |
| `DecodingMethodSpec` | `DecodingMethod` | 2 |
| `RedditSourceOperatorFunctionSpec` | `RedditSourceOperatorFunction` | 2 |

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| wire mapping | each constant's `@JsonValue` string (e.g. `FileDecodingMethod.ASCII` → `US_ASCII`, `FileAttributeType.LARGE_BINARY` → `large binary`, `DecodingMethod.RAW_BYTES` → `RAW BYTES`) + constant counts |
| `FileAttributeType` extras | `getType` → core `AttributeType`; `isSingle` true only for `SINGLE_STRING`/`BINARY`/`LARGE_BINARY`; `toString` == wire name |
| Jackson round-trip | `@JsonValue` serialize + deserialize back to the constant |

### Any related issues, documentation, discussions?

Part of the ongoing `workflow-operator` unit-test coverage effort.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *FileAttributeTypeSpec *FileDecodingMethodSpec *DecodingMethodSpec *RedditSourceOperatorFunctionSpec"` — 10 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
