### PR TITLE
test(workflow-operator): add unit test coverage for visualization option enums

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/boxViolinPlot/BoxViolinPlotQuartileFunctionSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/boxViolinPlot/BoxViolinPlotQuartileFunctionSpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.boxViolinPlot
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class BoxViolinPlotQuartileFunctionSpec extends AnyFlatSpec with Matchers {
+
+  "BoxViolinPlotQuartileFunction" should "map each constant to its wire value" in {
+    BoxViolinPlotQuartileFunction.LINEAR.getQuartiletype shouldBe "linear"
+    BoxViolinPlotQuartileFunction.INCLUSIVE.getQuartiletype shouldBe "inclusive"
+    BoxViolinPlotQuartileFunction.EXCLUSIVE.getQuartiletype shouldBe "exclusive"
+    BoxViolinPlotQuartileFunction.values() should have length 3
+  }
+
+  "BoxViolinPlotQuartileFunction" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(
+      BoxViolinPlotQuartileFunction.INCLUSIVE
+    ) shouldBe "\"inclusive\""
+    objectMapper.readValue(
+      "\"inclusive\"",
+      classOf[BoxViolinPlotQuartileFunction]
+    ) shouldBe BoxViolinPlotQuartileFunction.INCLUSIVE
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/contourPlot/ContourPlotColoringFunctionSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/contourPlot/ContourPlotColoringFunctionSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.contourPlot
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ContourPlotColoringFunctionSpec extends AnyFlatSpec with Matchers {
+
+  "ContourPlotColoringFunction" should "map each constant to its wire value" in {
+    ContourPlotColoringFunction.HEATMAP.getColoringMethod shouldBe "heatmap"
+    ContourPlotColoringFunction.LINES.getColoringMethod shouldBe "lines"
+    ContourPlotColoringFunction.NONE.getColoringMethod shouldBe "none"
+    ContourPlotColoringFunction.values() should have length 3
+  }
+
+  "ContourPlotColoringFunction" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(ContourPlotColoringFunction.LINES) shouldBe "\"lines\""
+    objectMapper.readValue(
+      "\"lines\"",
+      classOf[ContourPlotColoringFunction]
+    ) shouldBe ContourPlotColoringFunction.LINES
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/hierarchychart/HierarchyChartTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/hierarchychart/HierarchyChartTypeSpec.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.hierarchychart
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HierarchyChartTypeSpec extends AnyFlatSpec with Matchers {
+
+  "HierarchyChartType" should "map each constant to its wire value" in {
+    HierarchyChartType.TREEMAP.getPlotlyExpressApiName shouldBe "treemap"
+    HierarchyChartType.SUNBURSTCHART.getPlotlyExpressApiName shouldBe "sunburst"
+    HierarchyChartType.values() should have length 2
+  }
+
+  "HierarchyChartType" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(HierarchyChartType.SUNBURSTCHART) shouldBe "\"sunburst\""
+    objectMapper.readValue(
+      "\"sunburst\"",
+      classOf[HierarchyChartType]
+    ) shouldBe HierarchyChartType.SUNBURSTCHART
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/histogram2d/NormalizationTypeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/histogram2d/NormalizationTypeSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.histogram2d
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class NormalizationTypeSpec extends AnyFlatSpec with Matchers {
+
+  "NormalizationType" should "map each constant to its wire value" in {
+    NormalizationType.DENSITY.getValue shouldBe "density"
+    NormalizationType.PROBABILITY.getValue shouldBe "probability"
+    NormalizationType.PERCENT.getValue shouldBe "percent"
+    NormalizationType.values() should have length 3
+  }
+
+  "NormalizationType" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(NormalizationType.PERCENT) shouldBe "\"percent\""
+    objectMapper.readValue(
+      "\"percent\"",
+      classOf[NormalizationType]
+    ) shouldBe NormalizationType.PERCENT
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/lineChart/LineModeSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/lineChart/LineModeSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.lineChart
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LineModeSpec extends AnyFlatSpec with Matchers {
+
+  "LineMode" should "map each constant to its wire mode" in {
+    LineMode.LINE.getMode shouldBe "line"
+    LineMode.DOTS.getMode shouldBe "dots"
+    LineMode.LINE_WITH_DOTS.getMode shouldBe "line with dots"
+    LineMode.values() should have length 3
+  }
+
+  "LineMode.getModeInPlotly" should "translate to the Plotly mode string" in {
+    LineMode.LINE.getModeInPlotly shouldBe "lines"
+    LineMode.DOTS.getModeInPlotly shouldBe "markers"
+    LineMode.LINE_WITH_DOTS.getModeInPlotly shouldBe "lines+markers"
+  }
+
+  "LineMode.fromString" should "resolve wire modes case-insensitively and reject unknowns" in {
+    LineMode.fromString("line with dots") shouldBe LineMode.LINE_WITH_DOTS
+    LineMode.fromString("DOTS") shouldBe LineMode.DOTS
+    intercept[IllegalArgumentException](LineMode.fromString("zigzag"))
+  }
+
+  "LineMode" should "round-trip through Jackson using its wire mode" in {
+    objectMapper.writeValueAsString(LineMode.LINE_WITH_DOTS) shouldBe "\"line with dots\""
+    objectMapper.readValue("\"dots\"", classOf[LineMode]) shouldBe LineMode.DOTS
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/radarPlot/RadarPlotLinePatternSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/radarPlot/RadarPlotLinePatternSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.radarPlot
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RadarPlotLinePatternSpec extends AnyFlatSpec with Matchers {
+
+  "RadarPlotLinePattern" should "map each constant to its wire value" in {
+    RadarPlotLinePattern.SOLID.getLinePattern shouldBe "solid"
+    RadarPlotLinePattern.DASH.getLinePattern shouldBe "dash"
+    RadarPlotLinePattern.DOT.getLinePattern shouldBe "dot"
+    RadarPlotLinePattern.values() should have length 3
+  }
+
+  "RadarPlotLinePattern" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(RadarPlotLinePattern.DASH) shouldBe "\"dash\""
+    objectMapper.readValue(
+      "\"dash\"",
+      classOf[RadarPlotLinePattern]
+    ) shouldBe RadarPlotLinePattern.DASH
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/rangeSlider/RangeSliderHandleDuplicateFunctionSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/rangeSlider/RangeSliderHandleDuplicateFunctionSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.visualization.rangeSlider
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class RangeSliderHandleDuplicateFunctionSpec extends AnyFlatSpec with Matchers {
+
+  "RangeSliderHandleDuplicateFunction" should "map each constant to its wire value" in {
+    RangeSliderHandleDuplicateFunction.NOTHING.getFunctionType shouldBe "Nothing"
+    RangeSliderHandleDuplicateFunction.MEAN.getFunctionType shouldBe "Mean"
+    RangeSliderHandleDuplicateFunction.SUM.getFunctionType shouldBe "Sum"
+    RangeSliderHandleDuplicateFunction.values() should have length 3
+  }
+
+  "RangeSliderHandleDuplicateFunction" should "round-trip through Jackson using its wire value" in {
+    objectMapper.writeValueAsString(RangeSliderHandleDuplicateFunction.MEAN) shouldBe "\"Mean\""
+    objectMapper.readValue(
+      "\"Mean\"",
+      classOf[RangeSliderHandleDuplicateFunction]
+    ) shouldBe RangeSliderHandleDuplicateFunction.MEAN
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Pin behavior of seven previously-untested visualization option enums in `common/workflow-operator`. No production-code changes.

| Spec | Source enum | Tests |
| --- | --- | --- |
| `RadarPlotLinePatternSpec` | `RadarPlotLinePattern` | 2 |
| `LineModeSpec` | `LineMode` | 4 |
| `HierarchyChartTypeSpec` | `HierarchyChartType` | 2 |
| `NormalizationTypeSpec` | `NormalizationType` | 2 |
| `RangeSliderHandleDuplicateFunctionSpec` | `RangeSliderHandleDuplicateFunction` | 2 |
| `ContourPlotColoringFunctionSpec` | `ContourPlotColoringFunction` | 2 |
| `BoxViolinPlotQuartileFunctionSpec` | `BoxViolinPlotQuartileFunction` | 2 |

**Behavior pinned**

| Surface | Contract |
| --- | --- |
| wire mapping | each constant's `@JsonValue` string + constant counts |
| `LineMode` extras | `getModeInPlotly` (`lines`/`markers`/`lines+markers`); `@JsonCreator fromString` case-insensitive + unknown-value rejection |
| Jackson round-trip | serialize + deserialize back to the constant |

### Any related issues, documentation, discussions?

Part of the ongoing `workflow-operator` unit-test coverage effort.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *RadarPlotLinePatternSpec *LineModeSpec *HierarchyChartTypeSpec *NormalizationTypeSpec *RangeSliderHandleDuplicateFunctionSpec *ContourPlotColoringFunctionSpec *BoxViolinPlotQuartileFunctionSpec"` — 16 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
