### PR TITLE
test(workflow-operator): fill uncovered branches in filter, reader, and dual-port UDF classes

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/FilterPredicateSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/FilterPredicateSpec.scala
@@ -24,6 +24,8 @@ import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.sql.Timestamp
+
 class FilterPredicateSpec extends AnyFlatSpec with Matchers {
 
   private val intSchema = Schema().add(new Attribute("age", AttributeType.INTEGER))
@@ -74,5 +76,73 @@ class FilterPredicateSpec extends AnyFlatSpec with Matchers {
     node.get("condition").asText shouldBe ">="
     node.get("value").asText shouldBe "18"
     objectMapper.readValue(json, classOf[FilterPredicate]) shouldBe p
+  }
+
+  private def singleFieldTuple(attributeType: AttributeType, field: Any): Tuple = {
+    val schema = Schema().add(new Attribute("col", attributeType))
+    Tuple.builder(schema).add("col", attributeType, field).build()
+  }
+
+  "FilterPredicate.evaluate" should "apply the remaining comparison operators" in {
+    new FilterPredicate("age", ComparisonType.GREATER_THAN_OR_EQUAL_TO, "18")
+      .evaluate(ageTuple(18)) shouldBe true
+    new FilterPredicate("age", ComparisonType.GREATER_THAN_OR_EQUAL_TO, "18")
+      .evaluate(ageTuple(17)) shouldBe false
+    new FilterPredicate("age", ComparisonType.LESS_THAN, "18").evaluate(ageTuple(10)) shouldBe true
+    new FilterPredicate("age", ComparisonType.EQUAL_TO, "18").evaluate(ageTuple(18)) shouldBe true
+  }
+
+  it should "return false for non-null-check conditions when the field is null" in {
+    new FilterPredicate("age", ComparisonType.EQUAL_TO, "1").evaluate(ageTuple(null)) shouldBe false
+  }
+
+  it should "evaluate IS_NULL against null and non-null fields" in {
+    new FilterPredicate("age", ComparisonType.IS_NULL, null).evaluate(ageTuple(null)) shouldBe true
+    new FilterPredicate("age", ComparisonType.IS_NULL, null).evaluate(ageTuple(5)) shouldBe false
+    new FilterPredicate("age", ComparisonType.IS_NOT_NULL, null)
+      .evaluate(ageTuple(null)) shouldBe false
+  }
+
+  it should "compare boolean fields case-insensitively against the value" in {
+    val t = singleFieldTuple(AttributeType.BOOLEAN, java.lang.Boolean.TRUE)
+    new FilterPredicate("col", ComparisonType.EQUAL_TO, "TRUE").evaluate(t) shouldBe true
+    new FilterPredicate("col", ComparisonType.EQUAL_TO, "false").evaluate(t) shouldBe false
+    new FilterPredicate("col", ComparisonType.NOT_EQUAL_TO, "false").evaluate(t) shouldBe true
+  }
+
+  it should "compare double fields numerically" in {
+    val t = singleFieldTuple(AttributeType.DOUBLE, java.lang.Double.valueOf(3.5))
+    new FilterPredicate("col", ComparisonType.GREATER_THAN, "3.0").evaluate(t) shouldBe true
+    new FilterPredicate("col", ComparisonType.LESS_THAN_OR_EQUAL_TO, "3.5")
+      .evaluate(t) shouldBe true
+  }
+
+  it should "compare long fields numerically" in {
+    val t = singleFieldTuple(AttributeType.LONG, java.lang.Long.valueOf(100L))
+    new FilterPredicate("col", ComparisonType.LESS_THAN_OR_EQUAL_TO, "100")
+      .evaluate(t) shouldBe true
+    new FilterPredicate("col", ComparisonType.GREATER_THAN, "99").evaluate(t) shouldBe true
+  }
+
+  it should "compare timestamp fields against parsed timestamp values" in {
+    val t =
+      singleFieldTuple(AttributeType.TIMESTAMP, Timestamp.valueOf("2020-01-01 00:00:00"))
+    new FilterPredicate("col", ComparisonType.EQUAL_TO, "2020-01-01 00:00:00")
+      .evaluate(t) shouldBe true
+    new FilterPredicate("col", ComparisonType.GREATER_THAN, "2019-01-01 00:00:00")
+      .evaluate(t) shouldBe true
+  }
+
+  it should "compare numeric strings numerically before falling back to string comparison" in {
+    val t = singleFieldTuple(AttributeType.STRING, "10")
+    // string comparison would put "10" before "9"; the numeric path compares 10 > 9
+    new FilterPredicate("col", ComparisonType.GREATER_THAN, "9").evaluate(t) shouldBe true
+  }
+
+  "FilterPredicate.equals" should "treat the same instance as equal and reject other types" in {
+    val p = new FilterPredicate("age", ComparisonType.EQUAL_TO, "1")
+    p.equals(p) shouldBe true
+    p.equals(null) shouldBe false
+    p.equals("not a predicate") shouldBe false
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/BufferedBlockReaderSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/BufferedBlockReaderSpec.scala
@@ -29,15 +29,22 @@ class BufferedBlockReaderSpec extends AnyFlatSpec {
 
   // The reader only ever calls read(byte[]) and close(); each chunk arrives
   // as one read so buffer-boundary paths can be forced without 4 KB inputs.
+  // Reads are bounded by the buffer length, carrying any chunk remainder
+  // into the next call per the InputStream contract.
   private class ChunkedInputStream(chunks: Seq[String]) extends java.io.InputStream {
     private val iterator = chunks.iterator
+    private var pending: Array[Byte] = Array.emptyByteArray
     override def read(): Int = -1
-    override def read(buffer: Array[Byte]): Int =
-      if (iterator.hasNext) {
-        val chunk = iterator.next().getBytes("UTF-8")
-        System.arraycopy(chunk, 0, buffer, 0, chunk.length)
-        chunk.length
-      } else -1
+    override def read(buffer: Array[Byte]): Int = {
+      if (pending.isEmpty) {
+        if (!iterator.hasNext) return -1
+        pending = iterator.next().getBytes("UTF-8")
+      }
+      val length = math.min(pending.length, buffer.length)
+      System.arraycopy(pending, 0, buffer, 0, length)
+      pending = pending.drop(length)
+      length
+    }
   }
 
   // ----- readLine: splitting -----

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/BufferedBlockReaderSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/BufferedBlockReaderSpec.scala
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.source
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.io.ByteArrayInputStream
+
+class BufferedBlockReaderSpec extends AnyFlatSpec {
+
+  private def bais(s: String) = new ByteArrayInputStream(s.getBytes("UTF-8"))
+
+  // The reader only ever calls read(byte[]) and close(); each chunk arrives
+  // as one read so buffer-boundary paths can be forced without 4 KB inputs.
+  private class ChunkedInputStream(chunks: Seq[String]) extends java.io.InputStream {
+    private val iterator = chunks.iterator
+    override def read(): Int = -1
+    override def read(buffer: Array[Byte]): Int =
+      if (iterator.hasNext) {
+        val chunk = iterator.next().getBytes("UTF-8")
+        System.arraycopy(chunk, 0, buffer, 0, chunk.length)
+        chunk.length
+      } else -1
+  }
+
+  // ----- readLine: splitting -----
+
+  "readLine" should "split a line into fields by the delimiter" in {
+    val reader = new BufferedBlockReader(bais("a,b,c\n"), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("a", "b", "c"))
+  }
+
+  it should "return consecutive lines and then null at end of stream" in {
+    val reader = new BufferedBlockReader(bais("a,b\nc,d\n"), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("a", "b"))
+    assert(reader.readLine().toSeq == Seq("c", "d"))
+    assert(reader.readLine() == null)
+  }
+
+  it should "return null for an empty stream" in {
+    val reader = new BufferedBlockReader(bais(""), 100L, ',', null)
+    assert(reader.readLine() == null)
+  }
+
+  it should "flush the trailing field at end of stream without a newline" in {
+    val reader = new BufferedBlockReader(bais("a,b"), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("a", "b"))
+  }
+
+  it should "flush the trailing field even when it is filtered out by kept" in {
+    val reader = new BufferedBlockReader(bais("a,bcd"), 100L, ',', Array(0))
+    assert(reader.readLine().toSeq == Seq("a", "bcd"))
+  }
+
+  it should "treat carriage returns as line terminators" in {
+    val reader = new BufferedBlockReader(bais("x\ry\r"), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("x"))
+    assert(reader.readLine().toSeq == Seq("y"))
+  }
+
+  it should "emit a single-null line between the CR and LF of a CRLF terminator" in {
+    val reader = new BufferedBlockReader(bais("a\r\nb\n"), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("a"))
+    val crlfArtifact = reader.readLine()
+    assert(crlfArtifact.length == 1 && crlfArtifact(0) == null)
+    assert(reader.readLine().toSeq == Seq("b"))
+  }
+
+  it should "map empty fields to null" in {
+    val reader = new BufferedBlockReader(bais("a,,c\n"), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("a", null, "c"))
+    val trailing = new BufferedBlockReader(bais("a,\n"), 100L, ',', null)
+    assert(trailing.readLine().toSeq == Seq("a", null))
+  }
+
+  // ----- readLine: buffer boundaries -----
+
+  it should "concatenate a field that spans buffer reads" in {
+    val reader = new BufferedBlockReader(new ChunkedInputStream(Seq("a", "b\n")), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("ab"))
+  }
+
+  it should "close a carried field when the next buffer starts with a delimiter" in {
+    val reader =
+      new BufferedBlockReader(new ChunkedInputStream(Seq("ab", ",x\n")), 100L, ',', null)
+    assert(reader.readLine().toSeq == Seq("ab", "x"))
+  }
+
+  // ----- readLine: kept filter -----
+
+  it should "keep only the requested field indices" in {
+    val reader = new BufferedBlockReader(bais("a,b,c\n"), 100L, ',', Array(0, 2))
+    assert(reader.readLine().toSeq == Seq("a", "c"))
+  }
+
+  it should "return an empty line when every field is filtered out" in {
+    val reader = new BufferedBlockReader(bais("a,b\n"), 100L, ',', Array(5))
+    assert(reader.readLine().length == 0)
+  }
+
+  // ----- hasNext -----
+
+  "hasNext" should "hold until the reader passes the block boundary or hits end of stream" in {
+    val fresh = new BufferedBlockReader(bais("ab,c\n"), 5L, ',', null)
+    assert(fresh.hasNext)
+
+    // the reader intentionally reads one line past the block boundary
+    val pastBoundary = new BufferedBlockReader(bais("ab,c\n"), 4L, ',', null)
+    pastBoundary.readLine()
+    assert(!pastBoundary.hasNext)
+
+    val atEof = new BufferedBlockReader(bais("a\n"), 100L, ',', null)
+    assert(atEof.readLine().toSeq == Seq("a"))
+    assert(atEof.hasNext)
+    assert(atEof.readLine() == null)
+    assert(!atEof.hasNext)
+  }
+
+  // ----- close -----
+
+  "close" should "close the underlying stream" in {
+    var closed = false
+    val input = new ByteArrayInputStream("x".getBytes("UTF-8")) {
+      override def close(): Unit = {
+        closed = true
+        super.close()
+      }
+    }
+    new BufferedBlockReader(input, 10L, ',', null).close()
+    assert(closed)
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2Spec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2Spec.scala
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.udf.python
+
+import org.apache.texera.amber.core.executor.OpExecWithCode
+import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import org.apache.texera.amber.core.workflow.{PortIdentity, UnknownPartition}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DualInputPortsPythonUDFOpDescV2Spec extends AnyFlatSpec with Matchers {
+
+  private val workflowId = WorkflowIdentity(1L)
+  private val executionId = ExecutionIdentity(1L)
+
+  private def twoPortSchemas(dataSchema: Schema): Map[PortIdentity, Schema] =
+    Map(
+      PortIdentity() -> Schema().add(new Attribute("model", AttributeType.STRING)),
+      PortIdentity(1) -> dataSchema
+    )
+
+  "DualInputPortsPythonUDFOpDescV2.operatorInfo" should
+    "advertise the 2-in Python UDF with a model port and a dependent tuples port" in {
+    val info = (new DualInputPortsPythonUDFOpDescV2).operatorInfo
+    info.userFriendlyName shouldBe "2-in Python UDF"
+    info.operatorGroupName shouldBe OperatorGroupConstants.PYTHON_GROUP
+    info.inputPorts should have length 2
+    info.inputPorts.head.displayName shouldBe "model"
+    info.inputPorts(1).displayName shouldBe "tuples"
+    info.inputPorts(1).id shouldBe PortIdentity(1)
+    info.inputPorts(1).dependencies shouldBe List(PortIdentity(0))
+    info.outputPorts should have length 1
+  }
+
+  "DualInputPortsPythonUDFOpDescV2.getPhysicalOp" should "reject a non-positive worker count" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.workers = 0
+    intercept[IllegalArgumentException] {
+      d.getPhysicalOp(workflowId, executionId)
+    }
+  }
+
+  it should "wire a single-worker op with the default environment and unknown partition" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.code = "yield t"
+    val physical = d.getPhysicalOp(workflowId, executionId)
+    physical.opExecInitInfo match {
+      case OpExecWithCode(code, language) =>
+        language shouldBe "python"
+        code shouldBe "yield t"
+      case other => fail(s"expected OpExecWithCode, got $other")
+    }
+    physical.parallelizable shouldBe false
+    physical.suggestedWorkerNum shouldBe None
+    physical.pveName shouldBe ""
+    physical.inputPorts.keySet shouldBe d.operatorInfo.inputPorts.map(_.id).toSet
+    physical.outputPorts.keySet shouldBe d.operatorInfo.outputPorts.map(_.id).toSet
+    physical.derivePartition(List.empty) shouldBe UnknownPartition()
+  }
+
+  it should "wire a parallelizable op with the suggested worker count when workers > 1" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.workers = 2
+    val physical = d.getPhysicalOp(workflowId, executionId)
+    physical.parallelizable shouldBe true
+    physical.suggestedWorkerNum shouldBe Some(2)
+  }
+
+  it should "reject a blank virtual-environment name when the default env is disabled" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.defaultEnv = false
+    d.envName = "   "
+    val ex = intercept[RuntimeException] {
+      d.getPhysicalOp(workflowId, executionId)
+    }
+    ex.getMessage shouldBe
+      "Virtual Environment name is required when not using the default Python environment."
+  }
+
+  it should "trim and carry a custom virtual-environment name" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.defaultEnv = false
+    d.envName = "  myenv  "
+    d.getPhysicalOp(workflowId, executionId).pveName shouldBe "myenv"
+  }
+
+  "DualInputPortsPythonUDFOpDescV2 schema propagation" should
+    "emit only the output columns when input columns are not retained (default)" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.outputColumns = List(new Attribute("res", AttributeType.INTEGER))
+    val out = d.getExternalOutputSchemas(
+      twoPortSchemas(Schema().add(new Attribute("in", AttributeType.STRING)))
+    )
+    out shouldBe Map(
+      d.operatorInfo.outputPorts.head.id -> Schema().add(
+        new Attribute("res", AttributeType.INTEGER)
+      )
+    )
+  }
+
+  it should "retain the tuples-port columns (not the model port) when retaining input" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.retainInputColumns = true
+    d.outputColumns = List(new Attribute("res", AttributeType.INTEGER))
+    val out = d.getExternalOutputSchemas(
+      twoPortSchemas(Schema().add(new Attribute("in", AttributeType.STRING)))
+    )
+    out shouldBe Map(
+      d.operatorInfo.outputPorts.head.id -> Schema()
+        .add(new Attribute("in", AttributeType.STRING))
+        .add(new Attribute("res", AttributeType.INTEGER))
+    )
+  }
+
+  it should "reject an output column that collides with a retained input column" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.retainInputColumns = true
+    d.outputColumns = List(new Attribute("dup", AttributeType.INTEGER))
+    val ex = intercept[RuntimeException] {
+      d.getExternalOutputSchemas(
+        twoPortSchemas(Schema().add(new Attribute("dup", AttributeType.STRING)))
+      )
+    }
+    ex.getMessage shouldBe "Column name dup already exists!"
+  }
+
+  "DualInputPortsPythonUDFOpDescV2" should
+    "round-trip its config fields through the polymorphic base" in {
+    val d = new DualInputPortsPythonUDFOpDescV2
+    d.code = "print(1)"
+    d.workers = 3
+    d.retainInputColumns = true
+    d.defaultEnv = false
+    d.envName = "myenv"
+    d.outputColumns = List(new Attribute("res", AttributeType.INTEGER))
+    val restored = objectMapper.readValue(objectMapper.writeValueAsString(d), classOf[LogicalOp])
+    restored shouldBe a[DualInputPortsPythonUDFOpDescV2]
+    val r = restored.asInstanceOf[DualInputPortsPythonUDFOpDescV2]
+    r.code shouldBe "print(1)"
+    r.workers shouldBe 3
+    r.retainInputColumns shouldBe true
+    r.defaultEnv shouldBe false
+    r.envName shouldBe "myenv"
+    r.outputColumns shouldBe List(new Attribute("res", AttributeType.INTEGER))
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2Spec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2Spec.scala
@@ -106,7 +106,7 @@ class DualInputPortsPythonUDFOpDescV2Spec extends AnyFlatSpec with Matchers {
   }
 
   "DualInputPortsPythonUDFOpDescV2 schema propagation" should
-    "emit only the output columns when input columns are not retained (default)" in {
+    "emit only the output columns when input columns are not retained" in {
     val d = new DualInputPortsPythonUDFOpDescV2
     d.outputColumns = List(new Attribute("res", AttributeType.INTEGER))
     val out = d.getExternalOutputSchemas(


### PR DESCRIPTION
### What changes were proposed in this PR?

Fill uncovered code paths in three `workflow-operator` classes, selected from the Codecov report. No production-code changes.

| File | Codecov before | Missed lines targeted |
| --- | --- | --- |
| `FilterPredicate.java` | 40.0% | 26 — the remaining `evaluate` branches: GE/LT operators, null-field short-circuit, IS_NULL both ways, boolean (case-insensitive), double, long, and timestamp evaluators, the numeric-string fast path, and the `equals` identity/null/other-type branches |
| `BufferedBlockReader.java` | 0% | 51 (whole class) — delimiter splitting, EOF flush (incl. kept-filter bypass), CR terminators and the CRLF single-null artifact, empty fields → null, fields spanning buffer reads, delimiter-at-buffer-start carry, kept-index filtering, `hasNext` block-boundary semantics, `close` |
| `DualInputPortsPythonUDFOpDescV2.scala` | 40.0% | 27 — the entire `getPhysicalOp`: worker precondition, env-name resolution (default/blank-reject/trim), single vs parallel wiring, unknown-partition derivation, and the port-1-drives-output schema propagation incl. the duplicate-column rejection |

Extends the existing `FilterPredicateSpec` and adds `BufferedBlockReaderSpec` (with a chunked-stream stub to force buffer-boundary paths) and `DualInputPortsPythonUDFOpDescV2Spec`.

### Any related issues, documentation, discussions?

Follow-up to the review feedback on #6043: prioritize tests that fill uncovered code paths.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *FilterPredicateSpec *BufferedBlockReaderSpec *DualInputPortsPythonUDFOpDescV2Spec"` — 39 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean
- CI + Codecov delta to confirm

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
