### PR TITLE
feat(dashboard): allow admins to impersonate users for debugging

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -19,12 +19,14 @@
 
 package org.apache.texera.web.resource.dashboard.admin.user
 
+import org.apache.texera.auth.JwtAuth.{TOKEN_EXPIRE_TIME_IN_MINUTES, jwtClaims, jwtToken}
 import org.apache.texera.dao.SqlServer
 import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
 import org.apache.texera.dao.jooq.generated.tables.User.USER
 import org.apache.texera.dao.jooq.generated.tables.UserLastActiveTime.USER_LAST_ACTIVE_TIME
 import org.apache.texera.dao.jooq.generated.tables.daos.UserDao
 import org.apache.texera.dao.jooq.generated.tables.pojos.User
+import org.apache.texera.web.model.http.response.TokenIssueResponse
 import org.apache.texera.web.resource.EmailTemplate.createRoleChangeTemplate
 import org.apache.texera.web.resource.GmailResource.sendEmail
 import org.apache.texera.web.resource.dashboard.admin.user.AdminUserResource.userDao
@@ -149,5 +151,31 @@ class AdminUserResource {
   @Path("/deleteCollection/{eid}")
   def deleteCollection(@PathParam("eid") eid: Integer): Unit = {
     deleteExecutionCollection(eid)
+  }
+
+  /**
+    * Issues a JWT for the target user so that an admin can log in as (impersonate)
+    * that user. The returned token is identical to one obtained via a normal login
+    * for the target user. This endpoint is restricted to admins by the class-level
+    * `@RolesAllowed("ADMIN")` guard.
+    *
+    * @param uid the uid of the user to impersonate
+    * @return a TokenIssueResponse wrapping the JWT minted for the target user
+    */
+  @POST
+  @Path("/impersonate/{uid}")
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def impersonate(@PathParam("uid") uid: Integer): TokenIssueResponse = {
+    val user = userDao.fetchOneByUid(uid)
+    if (user == null) {
+      throw new WebApplicationException("User not found", Response.Status.NOT_FOUND)
+    }
+    if (user.getRole == UserRoleEnum.INACTIVE) {
+      throw new WebApplicationException(
+        "Cannot impersonate an inactive user",
+        Response.Status.BAD_REQUEST
+      )
+    }
+    TokenIssueResponse(jwtToken(jwtClaims(user, TOKEN_EXPIRE_TIME_IN_MINUTES)))
   }
 }

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -157,7 +157,7 @@ class AdminUserResource {
     * Issues a JWT for the target user so that an admin can log in as (impersonate)
     * that user. The returned token is identical to one obtained via a normal login
     * for the target user. This endpoint is restricted to admins by the class-level
-    * `@RolesAllowed("ADMIN")` guard.
+    * `@RolesAllowed("ADMIN")` guard, and admins may not impersonate other admins.
     *
     * @param uid the uid of the user to impersonate
     * @return a TokenIssueResponse wrapping the JWT minted for the target user
@@ -174,6 +174,12 @@ class AdminUserResource {
       throw new WebApplicationException(
         "Cannot impersonate an inactive user",
         Response.Status.BAD_REQUEST
+      )
+    }
+    if (user.getRole == UserRoleEnum.ADMIN) {
+      throw new WebApplicationException(
+        "Cannot impersonate another admin",
+        Response.Status.FORBIDDEN
       )
     }
     TokenIssueResponse(jwtToken(jwtClaims(user, TOKEN_EXPIRE_TIME_IN_MINUTES)))

--- a/amber/src/test/scala/org/apache/texera/web/resource/AdminUserResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/AdminUserResourceSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.resource
+
+import org.apache.texera.auth.JwtParser
+import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
+import org.apache.texera.dao.jooq.generated.tables.daos.UserDao
+import org.apache.texera.dao.jooq.generated.tables.pojos.User
+import org.apache.texera.web.resource.dashboard.admin.user.AdminUserResource
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.util.UUID
+import javax.ws.rs.WebApplicationException
+import javax.ws.rs.core.Response
+
+class AdminUserResourceSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with MockTexeraDB {
+
+  private val regularUid = 9000 + scala.util.Random.nextInt(1000)
+  private val inactiveUid = regularUid + 1
+  private val missingUid = regularUid + 999
+  private val resource = new AdminUserResource
+
+  private def makeUser(uid: Int, name: String, role: UserRoleEnum): User = {
+    val user = new User
+    user.setUid(uid)
+    user.setName(name)
+    user.setEmail(s"user_${UUID.randomUUID()}@example.com")
+    user.setPassword("password")
+    user.setRole(role)
+    user
+  }
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+    val userDao = new UserDao(getDSLContext.configuration())
+    userDao.insert(makeUser(regularUid, "impersonate_spec_regular_user", UserRoleEnum.REGULAR))
+    userDao.insert(makeUser(inactiveUid, "impersonate_spec_inactive_user", UserRoleEnum.INACTIVE))
+  }
+
+  override protected def afterAll(): Unit = shutdownDB()
+
+  "impersonate" should "issue a token whose claims identify the target user" in {
+    val token = resource.impersonate(regularUid).accessToken
+
+    val parsed = JwtParser.parseToken(token)
+    parsed.isPresent shouldBe true
+    val user = parsed.get().getUser
+    user.getUid.intValue() shouldBe regularUid
+    user.getName shouldBe "impersonate_spec_regular_user"
+    user.getRole shouldBe UserRoleEnum.REGULAR
+  }
+
+  it should "reject impersonating a non-existent user with 404" in {
+    val thrown = the[WebApplicationException] thrownBy resource.impersonate(missingUid)
+    thrown.getResponse.getStatus shouldBe Response.Status.NOT_FOUND.getStatusCode
+  }
+
+  it should "reject impersonating an inactive user with 400" in {
+    val thrown = the[WebApplicationException] thrownBy resource.impersonate(inactiveUid)
+    thrown.getResponse.getStatus shouldBe Response.Status.BAD_REQUEST.getStatusCode
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/web/resource/AdminUserResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/AdminUserResourceSpec.scala
@@ -41,6 +41,7 @@ class AdminUserResourceSpec
 
   private val regularUid = 9000 + scala.util.Random.nextInt(1000)
   private val inactiveUid = regularUid + 1
+  private val adminUid = regularUid + 2
   private val missingUid = regularUid + 999
   private val resource = new AdminUserResource
 
@@ -59,6 +60,7 @@ class AdminUserResourceSpec
     val userDao = new UserDao(getDSLContext.configuration())
     userDao.insert(makeUser(regularUid, "impersonate_spec_regular_user", UserRoleEnum.REGULAR))
     userDao.insert(makeUser(inactiveUid, "impersonate_spec_inactive_user", UserRoleEnum.INACTIVE))
+    userDao.insert(makeUser(adminUid, "impersonate_spec_admin_user", UserRoleEnum.ADMIN))
   }
 
   override protected def afterAll(): Unit = shutdownDB()
@@ -82,5 +84,10 @@ class AdminUserResourceSpec
   it should "reject impersonating an inactive user with 400" in {
     val thrown = the[WebApplicationException] thrownBy resource.impersonate(inactiveUid)
     thrown.getResponse.getStatus shouldBe Response.Status.BAD_REQUEST.getStatusCode
+  }
+
+  it should "reject impersonating another admin with 403" in {
+    val thrown = the[WebApplicationException] thrownBy resource.impersonate(adminUid)
+    thrown.getResponse.getStatus shouldBe Response.Status.FORBIDDEN.getStatusCode
   }
 }

--- a/frontend/src/app/common/service/user/auth.service.ts
+++ b/frontend/src/app/common/service/user/auth.service.ts
@@ -31,6 +31,9 @@ import { NzModalService } from "ng-zorro-antd/modal";
 import { RegistrationRequestModalComponent } from "./registration-request-modal/registration-request-modal.component";
 
 export const TOKEN_KEY = "access_token";
+// When an admin impersonates another user, the admin's own token is stashed here
+// so the session can be restored on "Stop impersonating".
+export const IMPERSONATOR_TOKEN_KEY = "impersonator_access_token";
 
 /**
  * User Service contains the function of registering and logging the user.
@@ -110,6 +113,7 @@ export class AuthService {
    */
   public logout(): undefined {
     AuthService.removeAccessToken();
+    AuthService.removeImpersonatorToken();
     this.tokenExpirationSubscription?.unsubscribe();
     return undefined;
   }
@@ -193,6 +197,26 @@ export class AuthService {
 
   static removeAccessToken(): void {
     localStorage.removeItem(TOKEN_KEY);
+  }
+
+  static setImpersonatorToken(token: string): void {
+    localStorage.setItem(IMPERSONATOR_TOKEN_KEY, token);
+  }
+
+  static getImpersonatorToken(): string | null {
+    return localStorage.getItem(IMPERSONATOR_TOKEN_KEY);
+  }
+
+  static removeImpersonatorToken(): void {
+    localStorage.removeItem(IMPERSONATOR_TOKEN_KEY);
+  }
+
+  /**
+   * True when the current session is an admin impersonating another user, i.e.
+   * an impersonator token has been stashed and can be restored.
+   */
+  static isImpersonating(): boolean {
+    return localStorage.getItem(IMPERSONATOR_TOKEN_KEY) !== null;
   }
 
   /**

--- a/frontend/src/app/common/service/user/stub-user.service.ts
+++ b/frontend/src/app/common/service/user/stub-user.service.ts
@@ -75,6 +75,18 @@ export class StubUserService implements PublicInterfaceOf<UserService> {
     return of();
   }
 
+  startImpersonation(accessToken: string): Observable<void> {
+    return of(void 0);
+  }
+
+  stopImpersonation(): Observable<void> {
+    return of(void 0);
+  }
+
+  isImpersonating(): boolean {
+    return false;
+  }
+
   userChanged(): Observable<User | undefined> {
     return this.userChangeSubject.asObservable();
   }

--- a/frontend/src/app/common/service/user/user.service.spec.ts
+++ b/frontend/src/app/common/service/user/user.service.spec.ts
@@ -22,7 +22,7 @@ import "zone.js/testing";
 import { fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { UserService } from "./user.service";
 import { AuthService } from "./auth.service";
-import { StubAuthService } from "./stub-auth.service";
+import { MOCK_TOKEN, StubAuthService } from "./stub-auth.service";
 import { skip } from "rxjs/operators";
 import { firstValueFrom, Subject, throwError } from "rxjs";
 import { commonTestProviders } from "../../testing/test-utils";
@@ -169,5 +169,68 @@ describe("UserService", () => {
     vi.spyOn(config, "loadPostLogin").mockReturnValue(throwError(() => new Error("simulated 500")));
     await firstValueFrom(service.login("test", "password"));
     expect(service.isLogin()).toBe(true);
+  });
+
+  // ─── admin impersonation token stash / restore ────────────────────────────
+
+  describe("impersonation", () => {
+    // The stashed admin token must be a value the StubAuthService recognizes as a
+    // valid session (MOCK_TOKEN), so that restoring it logs the admin back in.
+    const ADMIN_TOKEN = MOCK_TOKEN.accessToken;
+    // Any other value stands in for the target user's freshly minted token.
+    const TARGET_TOKEN = "target-user-token";
+
+    beforeEach(() => {
+      AuthService.removeAccessToken();
+      AuthService.removeImpersonatorToken();
+    });
+
+    afterEach(() => {
+      AuthService.removeAccessToken();
+      AuthService.removeImpersonatorToken();
+    });
+
+    it("stashes the admin token and swaps to the target token on start", async () => {
+      AuthService.setAccessToken(ADMIN_TOKEN);
+
+      await firstValueFrom(service.startImpersonation(TARGET_TOKEN));
+
+      // Active session is now the target user's token; the admin token is stashed.
+      expect(AuthService.getAccessToken()).toBe(TARGET_TOKEN);
+      expect(AuthService.getImpersonatorToken()).toBe(ADMIN_TOKEN);
+      expect(service.isImpersonating()).toBe(true);
+    });
+
+    it("restores the stashed admin token and clears the stash on stop", async () => {
+      // Simulate an in-progress impersonation: target session active, admin stashed.
+      AuthService.setAccessToken(TARGET_TOKEN);
+      AuthService.setImpersonatorToken(ADMIN_TOKEN);
+
+      await firstValueFrom(service.stopImpersonation());
+
+      // The admin token is restored as the active session and the stash is cleared.
+      expect(AuthService.getAccessToken()).toBe(ADMIN_TOKEN);
+      expect(AuthService.getImpersonatorToken()).toBeNull();
+      expect(service.isImpersonating()).toBe(false);
+      expect(service.isLogin()).toBe(true);
+    });
+
+    it("is a no-op on stop when not impersonating", async () => {
+      AuthService.setAccessToken(TARGET_TOKEN);
+
+      await firstValueFrom(service.stopImpersonation());
+
+      // Nothing stashed, so the active token is left untouched.
+      expect(AuthService.getAccessToken()).toBe(TARGET_TOKEN);
+      expect(service.isImpersonating()).toBe(false);
+    });
+
+    it("reflects impersonation state via isImpersonating()", () => {
+      expect(service.isImpersonating()).toBe(false);
+      AuthService.setImpersonatorToken(ADMIN_TOKEN);
+      expect(service.isImpersonating()).toBe(true);
+      AuthService.removeImpersonatorToken();
+      expect(service.isImpersonating()).toBe(false);
+    });
   });
 });

--- a/frontend/src/app/common/service/user/user.service.ts
+++ b/frontend/src/app/common/service/user/user.service.ts
@@ -88,6 +88,37 @@ export class UserService {
   }
 
   /**
+   * Starts impersonating another user with a token issued for that user by the
+   * admin-only impersonate endpoint. The current (admin) token is stashed so the
+   * session can be restored later via stopImpersonation().
+   * @param accessToken the JWT minted for the target user
+   */
+  public startImpersonation(accessToken: string): Observable<void> {
+    const adminToken = AuthService.getAccessToken();
+    if (adminToken) {
+      AuthService.setImpersonatorToken(adminToken);
+    }
+    return this.handleAccessToken(accessToken);
+  }
+
+  /**
+   * Restores the admin session that was stashed when impersonation started. If no
+   * impersonator token exists, this is a no-op.
+   */
+  public stopImpersonation(): Observable<void> {
+    const adminToken = AuthService.getImpersonatorToken();
+    if (!adminToken) {
+      return of(undefined);
+    }
+    AuthService.removeImpersonatorToken();
+    return this.handleAccessToken(adminToken);
+  }
+
+  public isImpersonating(): boolean {
+    return AuthService.isImpersonating();
+  }
+
+  /**
    * changes the current user and triggers currentUserSubject
    * @param user
    */

--- a/frontend/src/app/dashboard/component/admin/user/admin-user.component.html
+++ b/frontend/src/app/dashboard/component/admin/user/admin-user.component.html
@@ -337,9 +337,9 @@
       <td>
         <button
           (click)="impersonateUser(user)"
-          [disabled]="currentUid===user.uid"
+          [disabled]="impersonateDisabled(user)"
           nz-button
-          [nz-tooltip]="currentUid===user.uid ? 'you cannot impersonate yourself' : 'log in as this user'"
+          [nz-tooltip]="impersonateTooltip(user)"
           type="button">
           <i
             nz-icon

--- a/frontend/src/app/dashboard/component/admin/user/admin-user.component.html
+++ b/frontend/src/app/dashboard/component/admin/user/admin-user.component.html
@@ -107,6 +107,7 @@
       </th>
       <th>Quota</th>
       <th>Feedbacks</th>
+      <th>Login As</th>
       <th
         [nzSortFn]="sortByAccountCreation"
         [nzSortDirections]="['ascend', 'descend']">
@@ -331,6 +332,19 @@
               nzTheme="outline"
               nzType="message"></i>
           </nz-badge>
+        </button>
+      </td>
+      <td>
+        <button
+          (click)="impersonateUser(user)"
+          [disabled]="currentUid===user.uid"
+          nz-button
+          [nz-tooltip]="currentUid===user.uid ? 'you cannot impersonate yourself' : 'log in as this user'"
+          type="button">
+          <i
+            nz-icon
+            nzTheme="outline"
+            nzType="reload"></i>
         </button>
       </td>
       <td>

--- a/frontend/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/frontend/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -19,6 +19,7 @@
 
 import { Component, ElementRef, OnInit, ViewChild } from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { switchMap } from "rxjs/operators";
 import {
   NzTableFilterFn,
   NzTableSortFn,
@@ -144,6 +145,36 @@ export class AdminUserComponent implements OnInit {
 
   getFeedbackCount(uid: number): number {
     return this.feedbackCounts.get(uid) ?? 0;
+  }
+
+  /**
+   * Logs the admin in as the given user (impersonation). Prompts for confirmation,
+   * requests a token for the target user, stashes the admin's own session, then does
+   * a full page reload as the target user. Return to the admin session via
+   * "Stop impersonating" in the account menu.
+   */
+  impersonateUser(user: User): void {
+    this.modalService.confirm({
+      nzTitle: `Log in as ${user.name}?`,
+      nzContent:
+        'You will be signed in as this user. Use "Stop impersonating" in the account menu to return to your admin session.',
+      nzOkText: "Log in as user",
+      nzOnOk: () =>
+        this.adminUserService
+          .impersonateUser(user.uid)
+          .pipe(
+            switchMap(({ accessToken }) => this.userService.startImpersonation(accessToken)),
+            untilDestroyed(this)
+          )
+          .subscribe({
+            // Full reload so the entire app re-initializes as the impersonated user.
+            next: () => (window.location.href = "/dashboard"),
+            error: (err: unknown) => {
+              const errorMessage = (err as any).error?.message || (err as Error).message;
+              this.messageService.error(errorMessage);
+            },
+          }),
+    });
   }
 
   clickToViewFeedbacks(uid: number): void {

--- a/frontend/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/frontend/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -177,6 +177,22 @@ export class AdminUserComponent implements OnInit {
     });
   }
 
+  // Admins may not impersonate themselves or another admin; the backend enforces
+  // the same rules and this only mirrors them in the UI.
+  impersonateDisabled(user: User): boolean {
+    return this.currentUid === user.uid || user.role === Role.ADMIN;
+  }
+
+  impersonateTooltip(user: User): string {
+    if (this.currentUid === user.uid) {
+      return "you cannot impersonate yourself";
+    }
+    if (user.role === Role.ADMIN) {
+      return "you cannot impersonate another admin";
+    }
+    return "log in as this user";
+  }
+
   clickToViewFeedbacks(uid: number): void {
     this.modalService.create({
       nzContent: FeedbackComponent,

--- a/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.html
+++ b/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.html
@@ -30,6 +30,12 @@
 <nz-dropdown-menu #menu="nzDropdownMenu">
   <ul nz-menu>
     <li
+      *ngIf="isImpersonating"
+      (click)="onClickStopImpersonating()"
+      nz-menu-item>
+      Stop impersonating
+    </li>
+    <li
       (click)="onClickLogout()"
       nz-menu-item>
       Sign Out

--- a/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-icon/user-icon.component.ts
@@ -27,6 +27,7 @@ import { UserAvatarComponent } from "../user-avatar/user-avatar.component";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzDropdownDirective, NzDropdownMenuComponent } from "ng-zorro-antd/dropdown";
 import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
+import { NgIf } from "@angular/common";
 
 /**
  * UserIconComponent is used to control user system on the top right corner
@@ -45,16 +46,19 @@ import { NzMenuDirective, NzMenuItemComponent } from "ng-zorro-antd/menu";
     NzDropdownMenuComponent,
     NzMenuDirective,
     NzMenuItemComponent,
+    NgIf,
   ],
 })
 export class UserIconComponent {
   public user: User | undefined;
+  public isImpersonating: boolean;
 
   constructor(
     private userService: UserService,
     private router: Router
   ) {
     this.user = this.userService.getCurrentUser();
+    this.isImpersonating = this.userService.isImpersonating();
   }
 
   /**
@@ -64,5 +68,15 @@ export class UserIconComponent {
     this.userService.logout();
     document.cookie = "flarum_remember=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
     this.router.navigate([ABOUT]);
+  }
+
+  /**
+   * Restores the admin session that was stashed when impersonation started, then
+   * does a full reload back to the admin user dashboard.
+   */
+  public onClickStopImpersonating(): void {
+    this.userService.stopImpersonation().subscribe({
+      complete: () => (window.location.href = "/dashboard/admin/user"),
+    });
   }
 }

--- a/frontend/src/app/dashboard/service/admin/user/admin-user.service.ts
+++ b/frontend/src/app/dashboard/service/admin/user/admin-user.service.ts
@@ -37,6 +37,7 @@ export const USER_ACCESS_WORKFLOWS = `${USER_BASE_URL}/access_workflows`;
 export const USER_ACCESS_FILES = `${USER_BASE_URL}/access_files`;
 export const USER_QUOTA_SIZE = `${USER_BASE_URL}/user_quota_size`;
 export const USER_DELETE_EXECUTION_COLLECTION = `${USER_BASE_URL}/deleteCollection`;
+export const USER_IMPERSONATE_URL = `${USER_BASE_URL}/impersonate`;
 
 @Injectable({
   providedIn: "root",
@@ -93,5 +94,14 @@ export class AdminUserService {
 
   public deleteExecutionCollection(eid: number): Observable<void> {
     return this.http.delete<void>(`${USER_DELETE_EXECUTION_COLLECTION}/${eid.toString()}`);
+  }
+
+  /**
+   * Requests a JWT that lets the current admin log in as (impersonate) the given user.
+   * The backend endpoint is guarded by @RolesAllowed("ADMIN").
+   * @param uid the uid of the user to impersonate
+   */
+  public impersonateUser(uid: number): Observable<Readonly<{ accessToken: string }>> {
+    return this.http.post<Readonly<{ accessToken: string }>>(`${USER_IMPERSONATE_URL}/${uid.toString()}`, {});
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?
- Add an admin-only `POST /admin/user/impersonate/{uid}` endpoint on `AdminUserResource` that mints a JWT for the target user via the same `jwtToken(jwtClaims(user, ...))` path as login; returns 404 for a missing user and 400 for an INACTIVE user.
- Block admin-to-admin impersonation: the endpoint returns 403 when the target has the ADMIN role, and the "Login As" button is disabled for admin rows in the UI.
- Add a per-row "Login As" button in the admin user table (`/dashboard/admin/user`) that swaps the admin's token for the target user's token, stashing the admin's own token under a separate localStorage key.
- Add a "Stop impersonating" item in the account menu that restores the stashed admin session.
### Any related issues, documentation, discussions?
Closes: #6060
### How was this PR tested?
- Backend: run `sbt "project WorkflowExecutionService" "testOnly org.apache.texera.web.resource.AdminUserResourceSpec"`, expect 4 passing tests (issued token claims match the target user, 404 for a missing uid, 400 for an INACTIVE user, 403 for an ADMIN target).
- Frontend: run `npx ng test --watch=false --include=src/app/common/service/user/user.service.spec.ts` from `frontend/`, expect the impersonation specs to pass (start stashes the admin token and swaps in the target token, stop restores it, isImpersonating reflects state).
- Manual: as an admin, open `/dashboard/admin/user`, click the Login As button on a REGULAR-user row, confirm the dashboard reloads as that user, then choose "Stop impersonating" from the account menu and confirm the admin session returns.
- Manual (admin guard): confirm the Login As button is disabled on admin rows, and that `POST /admin/user/impersonate/{uid}` returns 403 for an ADMIN target while a REGULAR target returns 200.
<img width="567" height="295" alt="Screenshot from 2026-07-02 10-13-17" src="https://github.com/user-attachments/assets/c6afbe59-9f09-4209-b2e3-afc441938697" />
<img width="1839" height="969" alt="Screenshot from 2026-07-02 10-13-55" src="https://github.com/user-attachments/assets/46ec65e6-fc8a-4732-b9f8-84fc1896c483" />

### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF
