### PR TITLE
refactor: Refactor MockTexeraDB into a JVM singleton

### DIFF
--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -27,7 +27,13 @@ import java.nio.file.Paths
 import java.sql.{Connection, DriverManager}
 import scala.io.Source
 
-trait MockTexeraDB {
+/**
+  * Provides a JVM-singleton EmbeddedPostgres for tests. Multiple specs that mix
+  * in this trait share one Postgres instance for the lifetime of the JVM, which
+  * avoids the OverlappingFileLockException that occurs when each spec tries to
+  * extract the embedded Postgres binaries into the same directory in parallel.
+  */
+object MockTexeraDB {
 
   private var dbInstance: Option[EmbeddedPostgres] = None
   private var dslContext: Option[DSLContext] = None
@@ -35,130 +41,129 @@ trait MockTexeraDB {
   private val username: String = "postgres"
   private val password: String = ""
 
+  private var dbInstance: Option[EmbeddedPostgres] = None
+  private var dslContext: Option[DSLContext] = None
+
+  def ensureInitialized(): Unit =
+    synchronized {
+      if (dbInstance.isDefined) return
+
+      val driver = new org.postgresql.Driver()
+      DriverManager.registerDriver(driver)
+
+      val embedded = EmbeddedPostgres.builder().start()
+      dbInstance = Some(embedded)
+
+      val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
+      val source = Source.fromFile(ddlPath.toString)
+      val content =
+        try source.mkString
+        finally source.close()
+      val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
+      def removeCCommands(sql: String): String =
+        sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
+      val createDBStatement =
+        """DROP DATABASE IF EXISTS texera_db;
+          |CREATE DATABASE texera_db;""".stripMargin
+      executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
+      val texeraDB = embedded.getDatabase(username, database)
+      var tablesAndIndexCreation = removeCCommands(parts(1))
+
+      // remove indexes creation for pgroonga because we cannot install the plugin
+      val blockPattern =
+        """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
+      val replacementText =
+        """CREATE INDEX idx_workflow_name_description_content
+          |    ON workflow
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '') || ' ' ||
+          |    COALESCE(content, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_user_name
+          |    ON "user"
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_user_project_name_description
+          |    ON project
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_dataset_name_description
+          |    ON dataset
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_dataset_version_name
+          |    ON dataset_version
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '')
+          |    )
+          |    );""".stripMargin
+
+      tablesAndIndexCreation =
+        blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
+      executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
+      SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
+      val sqlServerInstance = SqlServer.getInstance()
+      val ctx = DSL.using(texeraDB, SQLDialect.POSTGRES)
+      dslContext = Some(ctx)
+      sqlServerInstance.replaceDSLContext(ctx)
+    }
+
+  def getDSLContext: DSLContext =
+    dslContext.getOrElse(
+      throw new RuntimeException(
+        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
+      )
+    )
+
+  def getDBInstance: EmbeddedPostgres =
+    dbInstance.getOrElse(
+      throw new RuntimeException(
+        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
+      )
+    )
+
+  private def executeScriptInJDBC(conn: Connection, script: String): Unit = {
+    conn.prepareStatement(script).execute()
+    conn.close()
+  }
+}
+
+trait MockTexeraDB {
+
   def executeScriptInJDBC(conn: Connection, script: String): Unit = {
-    assert(dbInstance.nonEmpty)
     conn.prepareStatement(script).execute()
     conn.close()
   }
 
-  def getDSLContext: DSLContext = {
-    dslContext match {
-      case Some(value) => value
-      case None =>
-        throw new RuntimeException(
-          "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-        )
-    }
-  }
+  def getDSLContext: DSLContext = MockTexeraDB.getDSLContext
 
-  def getDBInstance: EmbeddedPostgres = {
-    dbInstance match {
-      case Some(value) => value
-      case None =>
-        throw new RuntimeException(
-          "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-        )
-    }
-  }
+  def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def shutdownDB(): Unit = {
-    dbInstance match {
-      case Some(value) =>
-        value.close()
-        dbInstance = None
-        dslContext = None
-      case None =>
-      // do nothing
-    }
-  }
+  def initializeDBAndReplaceDSLContext(): Unit = MockTexeraDB.ensureInitialized()
 
-  def initializeDBAndReplaceDSLContext(): Unit = {
-    assert(dbInstance.isEmpty && dslContext.isEmpty)
-
-    val driver = new org.postgresql.Driver()
-    DriverManager.registerDriver(driver)
-
-    val embedded = EmbeddedPostgres.builder().start()
-
-    dbInstance = Some(embedded)
-
-    val ddlPath = {
-      Paths.get("sql/texera_ddl.sql").toRealPath()
-    }
-    val source = Source.fromFile(ddlPath.toString)
-    val content =
-      try {
-        source.mkString
-      } finally {
-        source.close()
-      }
-    val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
-    def removeCCommands(sql: String): String =
-      sql.linesIterator
-        .filterNot(_.trim.startsWith("\\c"))
-        .mkString("\n")
-    val createDBStatement =
-      """DROP DATABASE IF EXISTS texera_db;
-        |CREATE DATABASE texera_db;""".stripMargin
-    executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
-    val texeraDB = embedded.getDatabase(username, database)
-    var tablesAndIndexCreation = removeCCommands(parts(1))
-
-    // remove indexes creation for pgroonga because we cannot install the plugin
-    val blockPattern =
-      """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
-    // replace with native fulltext indexes
-    val replacementText =
-      """CREATE INDEX idx_workflow_name_description_content
-        |    ON workflow
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '') || ' ' ||
-        |    COALESCE(content, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_user_name
-        |    ON "user"
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_user_project_name_description
-        |    ON project
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_dataset_name_description
-        |    ON dataset
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_dataset_version_name
-        |    ON dataset_version
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '')
-        |    )
-        |    );""".stripMargin
-
-    tablesAndIndexCreation = blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
-    executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
-    SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
-    val sqlServerInstance = SqlServer.getInstance()
-    dslContext = Some(DSL.using(texeraDB, SQLDialect.POSTGRES))
-
-    sqlServerInstance.replaceDSLContext(dslContext.get)
-  }
+  /**
+    * No-op. The singleton EmbeddedPostgres lives for the lifetime of the JVM,
+    * so individual specs should not shut it down. Kept for API compatibility
+    * with existing afterAll hooks.
+    */
+  def shutdownDB(): Unit = ()
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -34,9 +34,6 @@ import scala.io.Source
   * extract the embedded Postgres binaries into the same directory in parallel.
   */
 object MockTexeraDB {
-
-  private var dbInstance: Option[EmbeddedPostgres] = None
-  private var dslContext: Option[DSLContext] = None
   private val database: String = "texera_db"
   private val username: String = "postgres"
   private val password: String = ""


### PR DESCRIPTION
### What changes were proposed in this PR?
Closes #6063, by refactoring the trait `MockTexeraDB` to be a API wrapper for a single shared `EmbeddedPostgres` instead of having each MockTexeraDB creating its own `EmbeddedPostgres` which would result in a `OverlappingFileLockException` from two connections fighting over a shared resource.

### Any related issues, documentation, discussions?
Follow up on #4525 where a refactor of `MockTexeraDB` was needed to allow for future concurrent execution of test suites. Code was cherry picked from #4527, specifically commit `bd93161` written by @Yicong-Huang 

### How was this PR tested?
Verified by compiling the backend test suites locally on JDK 17 to ensure that the structural split between the companion `object MockTexeraDB` and the `trait MockTexeraDB` interface preserves complete API backward compatibility. All specs compile and initialize cleanly without breaking any existing test lifecycle setups.

Run configuration command used to validate the project modules:
```bash
sbt test:compile
```

### Was this PR authored or co-authored using generative AI tooling?
No