### PR TITLE
chore(ci): disable Codecov carryforward for a one-time flag rebaseline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,11 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Codecov configuration for apache/texera. The repo uploads four flags
-# (frontend, scala, pyamber, agent-service); without an explicit config,
-# defaults bite us in three places that this file fixes:
-#   1. Single-stack PRs leave non-uploaded flags as `?` in the comment
-#      and drop them from the rollup. Carry forward instead.
+# Codecov configuration for apache/texera. CI uploads 11 flags: frontend,
+# amber, amber-integration, pyamber, agent-service, and the six platform
+# services (config-service, access-control-service, file-service,
+# computing-unit-managing-service, workflow-compiling-service,
+# notebook-migration-service). Without an explicit config, defaults bite us
+# in three places that this file fixes:
+#   1. Single-stack PRs leave non-uploaded flags as `?` in the comment and
+#      drop them from the rollup; carrying forward the base-branch report
+#      backfills them.
+#      TEMPORARILY DISABLED for one main rebaseline (see #6079): older flag
+#      names (`python` -> `pyamber`, `scala` -> `amber`) linger in the
+#      carryforward chain and keep reappearing in every PR comment. Turning
+#      carryforward off for one full main build flushes the stale names;
+#      the follow-up PR restores it.
 #   2. Coverage of generated code (protobuf), build output, and the
 #      tests themselves dilutes the "real" coverage figure. Ignore
 #      those paths.
@@ -27,11 +36,9 @@
 #      even when behavior is preserved. Allow 1% slack on project and
 #      require 60% patch coverage.
 
-flag_management:
-  default_rules:
-    # If the current PR didn't run the job for a given flag, inherit
-    # the latest report on the base branch instead of showing `?`.
-    carryforward: true
+# flag_management.default_rules.carryforward is intentionally omitted here
+# for the one-time rebaseline described above (#6079). It is restored in the
+# follow-up PR once main has a full build under the current flag set.
 
 ignore:
   # Generated protobuf — line counts swamp real code.
@@ -78,10 +85,10 @@ coverage:
         threshold: 10%
 
 comment:
-  # `flag_management.default_rules.carryforward: true` above already
-  # backfills missing flags from main, but Codecov's default still
-  # hides those rows from the PR comment. Show them so a frontend-only
-  # or pyamber-only PR's table lists every flag — fresh-data rows track
-  # the patch and carryforward'd rows render with `<ø>` to make their
-  # unchanged status obvious.
+  # Once carryforward is restored (see #6079), it backfills missing flags
+  # from main, but Codecov's default still hides those rows from the PR
+  # comment. Show them so a frontend-only or pyamber-only PR's table lists
+  # every flag — fresh-data rows track the patch and carryforward'd rows
+  # render with `<ø>` to make their unchanged status obvious. (A harmless
+  # no-op while carryforward is temporarily off for the rebaseline.)
   show_carryforward_flags: true


### PR DESCRIPTION
### What changes were proposed in this PR?
Step 1 of the Codecov carryforward reset (see the linked issue). Codecov has drifted from `codecov.yml`:

- Renamed flags (`python` → `pyamber`, `scala` → `amber`) still live in Codecov's carryforward chain, so the stale `python` flag is carried forward from a pre-rename commit and shows up in **every** PR comment (e.g. apache/texera#6048).
- The `codecov.yml` header comment claimed the repo uploads four flags (`frontend`, `scala`, `pyamber`, `agent-service`); CI actually uploads **11**: `frontend`, `amber`, `amber-integration`, `pyamber`, `agent-service`, and the six platform services.

This PR removes `flag_management.default_rules.carryforward` so the next full `main` build rebaselines Codecov against the current flag set, flushing the stale names out of the chain. It also rewrites the drifted header comment to list the real flag inventory.

**This is intentionally temporary.** A follow-up PR restores `carryforward: true` once `main` has a clean full-build baseline. During the window, single-stack PRs may show non-run flags as `?` — expected, and the reason carryforward exists.

Ordered operational steps (per Codecov's [reset guidance](https://community.codecov.com/t/remove-old-carryforward-flag/3428)):
1. Merge this PR.
2. Let a full build run on `main` (all 11 flags upload; no `python`).
3. Merge the follow-up PR re-enabling carryforward.
4. Rebase open PRs onto the new `main`.

### Any related issues, documentation, discussions?
Closes #6079

### How was this PR tested?
Config-only change. Validated `codecov.yml` parses as valid YAML (`yaml.safe_load`) and that the top-level keys are now `ignore`, `coverage`, `comment` (the `flag_management` block is removed as intended). No behavior to unit-test; effect is verifiable on `main` post-merge by confirming the `python` flag no longer appears in subsequent PR comments.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.8 (1M context)
