### PR TITLE
test(config): add unit test coverage for KubernetesConfig, UserSystemConfig, and AuthConfig

### DIFF
--- a/common/config/src/test/scala/org/apache/texera/common/config/AuthConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/AuthConfigSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.common.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Spec for [[AuthConfig]]. Reading each value forces resolution from auth.conf, so a renamed or
+  * mistyped key surfaces here as a ConfigException. Exact-value assertions are guarded on the env
+  * override being unset; the random-secret path is exercised directly via getRandomHexString.
+  */
+class AuthConfigSpec extends AnyFlatSpec with Matchers {
+
+  "AuthConfig.jwtExpirationMinutes" should "resolve from auth.conf" in {
+    if (sys.env.get("AUTH_JWT_EXPIRATION_IN_MINUTES").isEmpty) {
+      AuthConfig.jwtExpirationMinutes shouldBe 10080
+    } else {
+      AuthConfig.jwtExpirationMinutes should be > 0
+    }
+  }
+
+  "AuthConfig.jwtSecretKey" should "return the configured secret (lowercased) and memoize it" in {
+    val first = AuthConfig.jwtSecretKey
+    if (sys.env.get("AUTH_JWT_SECRET").isEmpty) {
+      first shouldBe "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
+    } else {
+      first should not be empty
+    }
+    first shouldBe first.toLowerCase
+    AuthConfig.jwtSecretKey shouldBe first // second call hits the memoized path
+  }
+
+  "AuthConfig.getRandomHexString" should "generate a fresh 32-char lowercase-hex string" in {
+    val method = AuthConfig.getClass.getDeclaredMethod("getRandomHexString")
+    method.setAccessible(true)
+    val hex1 = method.invoke(AuthConfig).asInstanceOf[String]
+    hex1 should have length 32
+    hex1 should fullyMatch regex "[0-9a-f]{32}"
+    val hex2 = method.invoke(AuthConfig).asInstanceOf[String]
+    hex2 should not be hex1
+  }
+}

--- a/common/config/src/test/scala/org/apache/texera/common/config/AuthConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/AuthConfigSpec.scala
@@ -29,8 +29,12 @@ import org.scalatest.matchers.should.Matchers
   */
 class AuthConfigSpec extends AnyFlatSpec with Matchers {
 
+  // `${?VAR}` in HOCON can be satisfied by an OS env var or a JVM system property.
+  private def isOverridden(name: String): Boolean =
+    sys.env.contains(name) || sys.props.contains(name)
+
   "AuthConfig.jwtExpirationMinutes" should "resolve from auth.conf" in {
-    if (sys.env.get("AUTH_JWT_EXPIRATION_IN_MINUTES").isEmpty) {
+    if (!isOverridden("AUTH_JWT_EXPIRATION_IN_MINUTES")) {
       AuthConfig.jwtExpirationMinutes shouldBe 10080
     } else {
       AuthConfig.jwtExpirationMinutes should be > 0
@@ -39,7 +43,7 @@ class AuthConfigSpec extends AnyFlatSpec with Matchers {
 
   "AuthConfig.jwtSecretKey" should "return the configured secret (lowercased) and memoize it" in {
     val first = AuthConfig.jwtSecretKey
-    if (sys.env.get("AUTH_JWT_SECRET").isEmpty) {
+    if (!isOverridden("AUTH_JWT_SECRET")) {
       first shouldBe "8a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d"
     } else {
       first should not be empty

--- a/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
@@ -29,8 +29,10 @@ import org.scalatest.matchers.should.Matchers
   */
 class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
 
-  private def ifUnset(env: String)(assertion: => Any): Unit =
-    if (sys.env.get(env).isEmpty) assertion
+  // `${?VAR}` in HOCON can be satisfied by an OS env var or a JVM system property,
+  // so treat either as an override.
+  private def ifUnset(name: String)(assertion: => Any): Unit =
+    if (!sys.env.contains(name) && !sys.props.contains(name)) assertion
 
   "KubernetesConfig.computeUnitPortNumber" should "load the fixed port (no env override)" in {
     KubernetesConfig.computeUnitPortNumber shouldBe 8085
@@ -64,7 +66,8 @@ class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
     ifUnset("MAX_NUM_OF_RUNNING_COMPUTING_UNITS_PER_USER")(
       KubernetesConfig.maxNumOfRunningComputingUnitsPerUser shouldBe 10
     )
-    KubernetesConfig.maxNumOfRunningComputingUnitsPerUser should be > 0
+    // an override may legitimately set 0 (to disable), so only require non-negative
+    KubernetesConfig.maxNumOfRunningComputingUnitsPerUser should be >= 0
   }
 
   "KubernetesConfig limit options" should "parse into trimmed, non-empty lists" in {
@@ -77,6 +80,9 @@ class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
     ifUnset("KUBERNETES_COMPUTING_UNIT_GPU_LIMIT_OPTIONS")(
       KubernetesConfig.gpuLimitOptions shouldBe List("0", "1", "2")
     )
+    // the parser trims and drops blanks; assert that invariant without requiring a
+    // non-empty result, since a blank/whitespace override would legitimately parse to
+    // an empty list.
     for (
       options <- Seq(
         KubernetesConfig.cpuLimitOptions,
@@ -84,7 +90,6 @@ class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
         KubernetesConfig.gpuLimitOptions
       )
     ) {
-      options should not be empty
       options.forall(s => s == s.trim && s.nonEmpty) shouldBe true
     }
   }

--- a/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.common.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Spec for [[KubernetesConfig]]. Reading each value forces resolution from kubernetes.conf, so a
+  * renamed or mistyped key surfaces here as a ConfigException. Every value except the port number
+  * carries a `${?ENV}` override, so exact-value assertions are guarded on the env var being unset.
+  */
+class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
+
+  private def ifUnset(env: String)(assertion: => Any): Unit =
+    if (sys.env.get(env).isEmpty) assertion
+
+  "KubernetesConfig.computeUnitPortNumber" should "load the fixed port (no env override)" in {
+    KubernetesConfig.computeUnitPortNumber shouldBe 8085
+  }
+
+  "KubernetesConfig string settings" should "resolve to their kubernetes.conf defaults" in {
+    ifUnset("KUBERNETES_COMPUTE_UNIT_SERVICE_NAME")(
+      KubernetesConfig.computeUnitServiceName shouldBe "workflow-computing-unit-svc"
+    )
+    ifUnset("KUBERNETES_COMPUTE_UNIT_POOL_NAME")(
+      KubernetesConfig.computeUnitPoolName shouldBe "texera-workflow-computing-unit"
+    )
+    ifUnset("KUBERNETES_COMPUTE_UNIT_POOL_NAMESPACE")(
+      KubernetesConfig.computeUnitPoolNamespace shouldBe "texera-workflow-computing-unit-pool"
+    )
+    ifUnset("KUBERNETES_IMAGE_NAME")(
+      KubernetesConfig.computeUnitImageName shouldBe "bobbai/texera-workflow-computing-unit:dev"
+    )
+    ifUnset("KUBERNETES_IMAGE_PULL_POLICY")(
+      KubernetesConfig.computingUnitImagePullPolicy shouldBe "Always"
+    )
+    ifUnset("KUBERNETES_COMPUTING_UNIT_GPU_RESOURCE_KEY")(
+      KubernetesConfig.gpuResourceKey shouldBe "nvidia.com/gpu"
+    )
+  }
+
+  "KubernetesConfig numeric and boolean settings" should "resolve to their kubernetes.conf defaults" in {
+    ifUnset("KUBERNETES_COMPUTING_UNIT_ENABLED")(
+      KubernetesConfig.kubernetesComputingUnitEnabled shouldBe false
+    )
+    ifUnset("MAX_NUM_OF_RUNNING_COMPUTING_UNITS_PER_USER")(
+      KubernetesConfig.maxNumOfRunningComputingUnitsPerUser shouldBe 10
+    )
+    KubernetesConfig.maxNumOfRunningComputingUnitsPerUser should be > 0
+  }
+
+  "KubernetesConfig limit options" should "parse into trimmed, non-empty lists" in {
+    ifUnset("KUBERNETES_COMPUTING_UNIT_CPU_LIMIT_OPTIONS")(
+      KubernetesConfig.cpuLimitOptions shouldBe List("1", "2", "4")
+    )
+    ifUnset("KUBERNETES_COMPUTING_UNIT_MEMORY_LIMIT_OPTIONS")(
+      KubernetesConfig.memoryLimitOptions shouldBe List("1Gi", "2Gi", "4Gi")
+    )
+    ifUnset("KUBERNETES_COMPUTING_UNIT_GPU_LIMIT_OPTIONS")(
+      KubernetesConfig.gpuLimitOptions shouldBe List("0", "1", "2")
+    )
+    for (
+      options <- Seq(
+        KubernetesConfig.cpuLimitOptions,
+        KubernetesConfig.memoryLimitOptions,
+        KubernetesConfig.gpuLimitOptions
+      )
+    ) {
+      options should not be empty
+      options.forall(s => s == s.trim && s.nonEmpty) shouldBe true
+    }
+  }
+}

--- a/common/config/src/test/scala/org/apache/texera/common/config/UserSystemConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/UserSystemConfigSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.common.config
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/**
+  * Spec for [[UserSystemConfig]]. Reading each value forces resolution from user-system.conf, so a
+  * renamed or mistyped key surfaces here as a ConfigException. Every value carries a `${?ENV}`
+  * override, so exact-value assertions are guarded on the env var being unset.
+  */
+class UserSystemConfigSpec extends AnyFlatSpec with Matchers {
+
+  private def ifUnset(env: String)(assertion: => Any): Unit =
+    if (sys.env.get(env).isEmpty) assertion
+
+  "UserSystemConfig" should "resolve every value from user-system.conf" in {
+    // reference each val to force resolution regardless of environment
+    UserSystemConfig.adminUsername should not be null
+    UserSystemConfig.adminPassword should not be null
+    UserSystemConfig.googleClientId should not be null
+    UserSystemConfig.gmail should not be null
+    UserSystemConfig.smtpPassword should not be null
+    UserSystemConfig.projectName should not be null
+    UserSystemConfig.workflowVersionCollapseIntervalInMinutes should be >= 0
+  }
+
+  it should "match the user-system.conf defaults when no env override is set" in {
+    ifUnset("USER_SYS_ADMIN_USERNAME")(UserSystemConfig.adminUsername shouldBe "texera")
+    ifUnset("USER_SYS_ADMIN_PASSWORD")(UserSystemConfig.adminPassword shouldBe "texera")
+    ifUnset("USER_SYS_GOOGLE_CLIENT_ID")(UserSystemConfig.googleClientId shouldBe "")
+    ifUnset("USER_SYS_GOOGLE_SMTP_GMAIL")(UserSystemConfig.gmail shouldBe "")
+    ifUnset("USER_SYS_GOOGLE_SMTP_PASSWORD")(UserSystemConfig.smtpPassword shouldBe "")
+    ifUnset("USER_SYS_PROJECT_NAME")(UserSystemConfig.projectName shouldBe "Texera")
+    ifUnset("USER_SYS_INVITE_ONLY")(UserSystemConfig.inviteOnly shouldBe false)
+    ifUnset("USER_SYS_VERSION_TIME_LIMIT_IN_MINUTES")(
+      UserSystemConfig.workflowVersionCollapseIntervalInMinutes shouldBe 60
+    )
+  }
+
+  it should "return None for appDomain when the domain is blank/unset" in {
+    if (sys.env.get("USER_SYS_DOMAIN").forall(_.trim.isEmpty)) {
+      UserSystemConfig.appDomain shouldBe None
+    } else {
+      UserSystemConfig.appDomain shouldBe defined
+    }
+  }
+}

--- a/common/config/src/test/scala/org/apache/texera/common/config/UserSystemConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/UserSystemConfigSpec.scala
@@ -29,8 +29,12 @@ import org.scalatest.matchers.should.Matchers
   */
 class UserSystemConfigSpec extends AnyFlatSpec with Matchers {
 
-  private def ifUnset(env: String)(assertion: => Any): Unit =
-    if (sys.env.get(env).isEmpty) assertion
+  // `${?VAR}` in HOCON can be satisfied by an OS env var or a JVM system property,
+  // so treat either as an override.
+  private def isOverridden(name: String): Boolean =
+    sys.env.contains(name) || sys.props.contains(name)
+  private def ifUnset(name: String)(assertion: => Any): Unit =
+    if (!isOverridden(name)) assertion
 
   "UserSystemConfig" should "resolve every value from user-system.conf" in {
     // reference each val to force resolution regardless of environment
@@ -57,7 +61,8 @@ class UserSystemConfigSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "return None for appDomain when the domain is blank/unset" in {
-    if (sys.env.get("USER_SYS_DOMAIN").forall(_.trim.isEmpty)) {
+    val overrideValue = sys.env.get("USER_SYS_DOMAIN").orElse(sys.props.get("USER_SYS_DOMAIN"))
+    if (overrideValue.forall(_.trim.isEmpty)) {
       UserSystemConfig.appDomain shouldBe None
     } else {
       UserSystemConfig.appDomain shouldBe defined


### PR DESCRIPTION
### What changes were proposed in this PR?

Add unit test coverage for three more `common/config` objects, selected from the Codecov report (all 0%). No production-code changes.

| File | Codecov before | What the tests pin |
| --- | --- | --- |
| `KubernetesConfig.scala` | 0% | the fixed port, string/numeric/boolean settings, and comma-separated CPU/memory/GPU limit-option parsing (trimmed, non-empty) |
| `UserSystemConfig.scala` | 0% | admin/google/smtp/project defaults, the version-collapse interval (name≠key), and the `appDomain` `None` path for a blank domain |
| `AuthConfig.scala` | 0% | `jwtExpirationMinutes`, the configured lowercased secret + memoization, and `getRandomHexString` (32-char lowercase hex, fresh per call) via reflection |

Reading each value forces resolution from the backing `.conf`; env-overridable values are guarded on the env var being unset (mirroring `StorageConfigSpec`). The random-secret branch is exercised directly rather than through the env-dependent `"random"` path.

### Any related issues, documentation, discussions?

Follow-up to the review feedback on #6043: prioritize tests that fill uncovered code paths.

### How was this PR tested?

- `sbt "Config/testOnly *KubernetesConfigSpec *UserSystemConfigSpec *AuthConfigSpec"` — 10 tests, all green
- `sbt "Config/Test/scalafmtCheck"` and `sbt "Config/scalafixAll --check"` — clean

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
