### PR TITLE
chore(ci): restore Codecov carryforward after flag rebaseline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -82,10 +82,8 @@ coverage:
         threshold: 10%
 
 comment:
-  # `flag_management.default_rules.carryforward: true` above already
-  # backfills missing flags from main, but Codecov's default still
-  # hides those rows from the PR comment. Show them so a frontend-only
-  # or pyamber-only PR's table lists every flag — fresh-data rows track
-  # the patch and carryforward'd rows render with `<ø>` to make their
-  # unchanged status obvious.
+  # CI is label-gated: a single-stack PR (e.g. a frontend-only change)
+  # uploads only its own flag. carryforward backfills the rest from main;
+  # this surfaces those carried rows (rendered `<ø>`) instead of hiding
+  # them, so every PR's table lists all flags.
   show_carryforward_flags: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,11 +23,6 @@
 #   1. Single-stack PRs leave non-uploaded flags as `?` in the comment and
 #      drop them from the rollup; carrying forward the base-branch report
 #      backfills them.
-#      TEMPORARILY DISABLED for one main rebaseline (see #6079): older flag
-#      names (`python` -> `pyamber`, `scala` -> `amber`) linger in the
-#      carryforward chain and keep reappearing in every PR comment. Turning
-#      carryforward off for one full main build flushes the stale names;
-#      the follow-up PR restores it.
 #   2. Coverage of generated code (protobuf), build output, and the
 #      tests themselves dilutes the "real" coverage figure. Ignore
 #      those paths.
@@ -36,9 +31,11 @@
 #      even when behavior is preserved. Allow 1% slack on project and
 #      require 60% patch coverage.
 
-# flag_management.default_rules.carryforward is intentionally omitted here
-# for the one-time rebaseline described above (#6079). It is restored in the
-# follow-up PR once main has a full build under the current flag set.
+flag_management:
+  default_rules:
+    # If the current PR didn't run the job for a given flag, inherit
+    # the latest report on the base branch instead of showing `?`.
+    carryforward: true
 
 ignore:
   # Generated protobuf — line counts swamp real code.
@@ -85,10 +82,10 @@ coverage:
         threshold: 10%
 
 comment:
-  # Once carryforward is restored (see #6079), it backfills missing flags
-  # from main, but Codecov's default still hides those rows from the PR
-  # comment. Show them so a frontend-only or pyamber-only PR's table lists
-  # every flag — fresh-data rows track the patch and carryforward'd rows
-  # render with `<ø>` to make their unchanged status obvious. (A harmless
-  # no-op while carryforward is temporarily off for the rebaseline.)
+  # `flag_management.default_rules.carryforward: true` above already
+  # backfills missing flags from main, but Codecov's default still
+  # hides those rows from the PR comment. Show them so a frontend-only
+  # or pyamber-only PR's table lists every flag — fresh-data rows track
+  # the patch and carryforward'd rows render with `<ø>` to make their
+  # unchanged status obvious.
   show_carryforward_flags: true


### PR DESCRIPTION
### What changes were proposed in this PR?
Step 2 (final) of the Codecov carryforward reset started in #6080.

#6080 removed `flag_management.default_rules.carryforward` and let `main` rebuild once under the current flag set, flushing the stale renamed flags (`python`, `scala`, and the newly-surfaced `python-rest`, `amber-rest`) out of the carryforward chain. This PR re-enables carryforward so single-stack PRs keep backfilling non-run flags from the base report, and drops the temporary `#6079` markers.

Net effect versus pre-#6080: **identical functional config** — the only lasting change from the whole exercise is the header comment, now corrected to the real 11-flag inventory (was falsely claiming four: `frontend`, `scala`, `pyamber`, `agent-service`).

**⚠️ Draft / verification gate.** This PR's own Codecov comment is the A/B test for the reset:
- #6080 (carryforward **off**) rendered `python` as `?` and omitted `scala` / `python-rest` / `amber-rest`.
- This PR (carryforward **on**) must NOT resurrect any of those as a `0.00%` carried-forward row.

Do not merge until the Codecov comment here is confirmed clean. If a stale flag reappears, it means `main`'s report still retains a `0.0` entry for it (the flags API currently shows `python`/`scala`/`python-rest`/`amber-rest` at `0.0`), and it must be deleted from the Codecov Flags page (admin) before this merges.

### Any related issues, documentation, discussions?
Follows #6080. Closes #6079.

### How was this PR tested?
Config-only change. Validated `codecov.yml` parses as valid YAML and that the functional blocks (`flag_management`, `coverage`, `comment`) match the pre-#6080 configuration byte-for-byte, leaving only the corrected header comment. Behavioral verification is the Codecov comment on this PR (see the verification gate above).

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Opus 4.8 (1M context)
