### PR TITLE
refactor(build): separate common module settings from asfLicensingSettings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ ThisBuild / Test / testOptions += Tests.Argument(TestFrameworks.ScalaTest, "-u",
 // sbt-jacoco emits only HTML by default; add XML so Codecov can consume
 // per-module jacoco.xml at target/scala-2.13/jacoco/report/jacoco.xml.
 // JacocoPlugin defines a project-scoped default that overrides ThisBuild,
-// so this Seq is bundled into asfLicensingSettings (applied to every module).
+// so this Seq is folded into commonModuleSettings (applied to every module).
 import com.github.sbt.jacoco.report.{JacocoReportFormats, JacocoReportSettings}
 lazy val coverageReportSettings = Seq(
   jacocoReportSettings := JacocoReportSettings()
@@ -57,22 +57,28 @@ lazy val universalJvmFlagsSettings = Seq(
 // See project/AddMetaInfLicenseFiles.scala.
 // Dist-producing modules additionally override Universal / mappings in their own
 // build.sbt (not here) — see AddMetaInfLicenseFiles.distMappings.
-lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
-lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
+lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings
+lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings
+
+// Aggregate of the settings every module shares. These are independent
+// concerns — ASF licensing, jacoco XML coverage, and universal JVM flags —
+// grouped only so each module can apply them with a single .settings(...) call.
+lazy val commonModuleSettings = asfLicensingSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
+lazy val commonModuleSettingsWithVendored = asfLicensingSettingsWithVendored ++ coverageReportSettings ++ universalJvmFlagsSettings
 
 val jacksonVersion = "2.18.6"
 
-lazy val DAO = (project in file("common/dao")).settings(asfLicensingSettings)
-lazy val Config = (project in file("common/config")).settings(asfLicensingSettings)
-lazy val Resource = (project in file("common/resource")).settings(asfLicensingSettings)
+lazy val DAO = (project in file("common/dao")).settings(commonModuleSettings)
+lazy val Config = (project in file("common/config")).settings(commonModuleSettings)
+lazy val Resource = (project in file("common/resource")).settings(commonModuleSettings)
 lazy val Auth = (project in file("common/auth"))
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .configs(Test)
   .dependsOn(DAO, Config)
   .dependsOn(DAO % "test->test") // reuse MockTexeraDB embedded Postgres in tests
 lazy val ConfigService = (project in file("config-service"))
   .dependsOn(Auth, Config, Resource)
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher
@@ -81,7 +87,7 @@ lazy val ConfigService = (project in file("config-service"))
   )
 lazy val AccessControlService = (project in file("access-control-service"))
   .dependsOn(Auth, Config, DAO, Resource)
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher
@@ -94,18 +100,18 @@ lazy val AccessControlService = (project in file("access-control-service"))
 //This Scala module defines a pyb"..." macro-based DSL for composing Python code templates as an immutable PythonTemplateBuilder.
 //Used mainly for Python Native Operators
 lazy val PyBuilder = (project in file("common/pybuilder"))
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .configs(Test)
   .dependsOn(DAO % "test->test") // test scope dependency
 
 lazy val WorkflowCore = (project in file("common/workflow-core"))
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .dependsOn(DAO, Config, PyBuilder)
   .configs(Test)
   .dependsOn(DAO % "test->test") // test scope dependency
 lazy val ComputingUnitManagingService = (project in file("computing-unit-managing-service"))
   .dependsOn(WorkflowCore, Auth, Config, Resource)
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher
@@ -113,7 +119,7 @@ lazy val ComputingUnitManagingService = (project in file("computing-unit-managin
     )
   )
 lazy val FileService = (project in file("file-service"))
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .dependsOn(WorkflowCore, Auth, Config, Resource)
   .configs(Test)
   .dependsOn(DAO % "test->test") // test scope dependency
@@ -136,10 +142,10 @@ lazy val FileService = (project in file("file-service"))
     }
   )
 
-lazy val WorkflowOperator = (project in file("common/workflow-operator")).settings(asfLicensingSettingsWithVendored).dependsOn(WorkflowCore)
+lazy val WorkflowOperator = (project in file("common/workflow-operator")).settings(commonModuleSettingsWithVendored).dependsOn(WorkflowCore)
 lazy val WorkflowCompilingService = (project in file("workflow-compiling-service"))
   .dependsOn(WorkflowOperator, Auth, Config, Resource)
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher
@@ -151,7 +157,7 @@ lazy val WorkflowCompilingService = (project in file("workflow-compiling-service
 
 lazy val WorkflowExecutionService = (project in file("amber"))
   .dependsOn(WorkflowOperator, Auth, Config)
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .settings(
     dependencyOverrides ++= Seq(
       "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
@@ -182,7 +188,7 @@ lazy val WorkflowExecutionService = (project in file("amber"))
   .dependsOn(DAO % "test->test", Auth % "test->test") // test scope dependency
 lazy val NotebookMigrationService = (project in file("notebook-migration-service"))
   .dependsOn(Auth, Config, DAO, Resource)
-  .settings(asfLicensingSettings)
+  .settings(commonModuleSettings)
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher


### PR DESCRIPTION
### What changes were proposed in this PR?

Refactor of `build.sbt` only — no behavior change.

`asfLicensingSettings` bundled three unrelated concerns: ASF licensing (`AddMetaInfLicenseFiles.*`), the jacoco coverage-report format, and the universal JVM flags. Its licensing-centric name and the adjacent `coverageReportSettings` comment implied coverage was a licensing concern, which is misleading.

This PR:
- Narrows `asfLicensingSettings` and `asfLicensingSettingsWithVendored` to hold **only** the licensing settings, so the name is accurate.
- Introduces `commonModuleSettings` / `commonModuleSettingsWithVendored` as the per-module bundle (licensing + coverage + JVM flags) that each module applies via `.settings(...)`.
- Updates the 15 module call sites and rewrites the misleading comment to state the three concerns are independent, grouped only for reuse.

### Any related issues, documentation, discussions?

Closes #6089

### How was this PR tested?

No new tests — this is a behavior-preserving build refactor. Verified locally with JDK 17:
- `sbt projects` loads the build cleanly; all 15 projects resolve with no errors.
- `sbt "show NotebookMigrationService/jacocoReportSettings"` still reports `ScalaHTML + XML` formats, confirming coverage settings continue to reach every module through the new `commonModuleSettings` path.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)