### PR TITLE
fix(local-dev): rebuild when unpacked dist dirs are missing even if stamps are clean

### DIFF
--- a/bin/local-dev/main.sh
+++ b/bin/local-dev/main.sh
@@ -1731,6 +1731,25 @@ any_jvm_src_changed() {
     return 1
 }
 
+# True iff every non-skipped JVM service's launcher exists on disk. Guards
+# the auto short-circuit in build_all so an externally cleaned target/
+# (e.g. someone ran `sbt clean dist` directly, produced zips but never
+# unzipped) can't leave `up` doing nothing while services fail to launch.
+# SVC_LAUNCHER embeds ${TEXERA_VERSION}, so this doubles as a version check
+# — a bumped version's launcher path won't match the old one on disk.
+all_launchers_present() {
+    local svc="" cwd="" launcher=""
+    for svc in "${SERVICES[@]}"; do
+        [[ "$(amap_get SVC_TYPE "$svc")" == "jvm" ]] || continue
+        is_skipped "$svc" && continue
+        launcher=$(amap_get SVC_LAUNCHER "$svc")
+        [[ -n "$launcher" ]] || continue
+        cwd=$(amap_get SVC_CWD "$svc")
+        [[ -x "$cwd/$launcher" ]] || return 1
+    done
+    return 0
+}
+
 needs_yarn_install() {
     [[ ! -f frontend/node_modules/.yarn-state.yml ]] && return 0
     [[ frontend/yarn.lock -nt frontend/node_modules/.yarn-state.yml ]] && return 0
@@ -1917,7 +1936,7 @@ build_all() {
             tui_err "sbt: clean dist FAILED  ${DIM}(tail -f $log)${RESET}"
             return 1
         fi
-    elif [[ "${BUILD:-auto}" == "auto" ]] && ! any_jvm_src_changed; then
+    elif [[ "${BUILD:-auto}" == "auto" ]] && ! any_jvm_src_changed && all_launchers_present; then
         tui_skip "sbt dist: skipped (no source changes since last build)"
         return 0
     else

--- a/bin/local-dev/tests/test_local_dev_sh.sh
+++ b/bin/local-dev/tests/test_local_dev_sh.sh
@@ -448,5 +448,21 @@ else
     _fail "build_all: unzip loop touches --skip'd services"
 fi
 
+# 26) build_all's auto short-circuit also checks that every unpacked
+#     launcher is on disk, not just that source hashes match the last
+#     build. Without this, an externally cleaned target/ leaves stamps
+#     valid while target/<svc>-<version>/ is gone, so `up` skips build
+#     + unzip and each JVM fails with "launcher missing".
+if grep -qE '^all_launchers_present\(\) \{' "$REPO_ROOT/bin/local-dev/main.sh"; then
+    _pass "all_launchers_present helper is defined"
+else
+    _fail "all_launchers_present helper missing"
+fi
+if [[ "$build_body" == *"all_launchers_present"* ]]; then
+    _pass "build_all: auto short-circuit gated on all_launchers_present"
+else
+    _fail "build_all: auto short-circuit ignores missing launchers"
+fi
+
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
 (( FAIL == 0 ))


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `all_launchers_present` in `bin/local-dev/main.sh`: a helper that returns 0 iff every non-skipped JVM service's `SVC_LAUNCHER` file exists on disk. Gate `build_all()`'s auto short-circuit on this predicate — instead of `! any_jvm_src_changed`, it's now `! any_jvm_src_changed && all_launchers_present`. When any expected launcher is missing, the short-circuit is bypassed so the normal build + unzip pipeline runs and restores the unpacked dist dirs. `SVC_LAUNCHER` already embeds `${TEXERA_VERSION}` (`target/<svc>-${TEXERA_VERSION}/bin/<svc>`), so the presence check also catches version bumps — an old launcher path won't satisfy the new one.

### Any related issues, documentation, discussions?

Closes #6091.

### How was this PR tested?

Added a static regression test in `bin/local-dev/tests/test_local_dev_sh.sh` covering the helper's definition and the short-circuit's use of it (35/35 pass), and reproduced the pre-fix failure locally by `sbt clean dist`-then-`up` — before this change `up` reported `sbt dist: skipped (no source changes since last build)` followed by `launcher missing`, after this change it re-runs the build + unzip and every JVM launches.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 4.7 (1M context)