### PR TITLE
fix(local-dev): drop sbt build knobs that ship an unrunnable dist

### DIFF
--- a/bin/local-dev/main.sh
+++ b/bin/local-dev/main.sh
@@ -1916,15 +1916,28 @@ build_all() {
     fi
 
     # CLI-only build knobs applied to the local-dev entrypoint (build.sbt
-    # untouched): skip scaladoc (biggest single win on dist), pipeline
-    # signature-then-body compile across projects, raise heap + G1GC.
+    # untouched): raise heap + G1GC. Nothing here may alter what the dist
+    # actually ships.
+    #
+    # The removed knobs each produced a dist that packaged and reported success
+    # but could not run:
+    #   * -Dsbt.pipelining=true — inter-project deps are consumed as
+    #     early-output signature jars and the dist drops the real dependency
+    #     jars (dao/auth/config/resource) from lib/, so every service dies at
+    #     startup with NoClassDefFoundError on a sibling-module class.
+    #   * set every (Compile / doc / sources) := Seq.empty — `set every`
+    #     ignores the written scope and zeroes the shared `sources` key in
+    #     EVERY scope (incl. Compile / sources): nothing compiles, no main
+    #     class is discovered, and no bin/<service> launcher is generated.
+    #   * set every (Compile / packageDoc / publishArtifact) := false — same
+    #     `set every` trap: it turns off `publishArtifact` for the main jar
+    #     artifacts too, so inter-project dependency jars drop out of the dist.
+    # Skipping scaladoc has to be done per-project in build.sbt, not with a
+    # global `set every`, so it is left out here until done safely.
     local -a sbt_opts=(
         -no-colors
         -J-Xmx4g
         -J-XX:+UseG1GC
-        -Dsbt.pipelining=true
-        'set every (Compile / doc / sources) := Seq.empty'
-        'set every (Compile / packageDoc / publishArtifact) := false'
     )
 
     if [[ "${FRESH:-false}" == "true" ]]; then

--- a/bin/local-dev/tests/test_local_dev_sh.sh
+++ b/bin/local-dev/tests/test_local_dev_sh.sh
@@ -413,20 +413,29 @@ for fn in cmd_up cmd_auto; do
     fi
 done
 
-# 24) build_all applies CLI-only sbt speedups: skip scaladoc + enable
-#     pipelining. Keeping the knobs here (not in build.sbt) means CI and
-#     standalone sbt invocations are unaffected.
+# 24) build_all's CLI-only sbt knobs must never alter what the dist ships.
+#     Three knobs are banned because each produced a dist that packaged fine
+#     but could not run: `-Dsbt.pipelining=true` and the two `set every`
+#     settings all drop inter-project dependency jars or the bin/<service>
+#     launcher from the dist. Match against code only (comments name the
+#     banned knobs to explain them).
 build_body=$(awk '/^build_all\(\)/{f=1} f{print} f&&/^}/{exit}' \
     "$REPO_ROOT/bin/local-dev/main.sh")
-if [[ "$build_body" == *"-Dsbt.pipelining=true"* ]]; then
-    _pass "build_all: sbt invocation enables -Dsbt.pipelining=true"
+build_code=$(printf '%s\n' "$build_body" | grep -vE '^[[:space:]]*#')
+if [[ "$build_code" == *"-Dsbt.pipelining=true"* ]]; then
+    _fail "build_all: '-Dsbt.pipelining=true' drops inter-project dependency jars from the dist"
 else
-    _fail "build_all: -Dsbt.pipelining=true flag missing"
+    _pass "build_all: does not enable sbt pipelining"
 fi
-if [[ "$build_body" == *"Compile / doc / sources) := Seq.empty"* ]]; then
-    _pass "build_all: scaladoc sources emptied via 'set every'"
+if [[ "$build_code" == *"doc / sources) := Seq.empty"* ]]; then
+    _fail "build_all: 'set every (Compile / doc / sources) := Seq.empty' empties Compile/sources → no launcher"
 else
-    _fail "build_all: doc-skip 'set every' setting missing"
+    _pass "build_all: does not clobber Compile/sources via 'set every ... doc / sources'"
+fi
+if [[ "$build_code" == *"packageDoc / publishArtifact) := false"* ]]; then
+    _fail "build_all: 'set every (Compile / packageDoc / publishArtifact) := false' drops dependency jars from the dist"
+else
+    _pass "build_all: does not disable publishArtifact via 'set every ... packageDoc'"
 fi
 
 # 25) --skip=<svc> flows into the sbt build: skipped JVM services drop out


### PR DESCRIPTION
### What changes were proposed in this PR?

`build_all` in `bin/local-dev/main.sh` passed three CLI-only sbt knobs that each made `sbt <svc>/dist` produce a dist that packaged and reported success but could not run. This PR removes all three and keeps only the heap/GC flags.

- `-Dsbt.pipelining=true`: inter-project dependencies are consumed as early-output signature jars, so the dist drops the real `dao`/`auth`/`config`/`resource` jars from `lib/` and every service dies at startup with `NoClassDefFoundError` on a sibling-module class (e.g. `org/apache/texera/dao/SqlServer$`).
- `set every (Compile / doc / sources) := Seq.empty`: `set every` ignores the written scope and zeroes the shared `sources` key in every scope, including `Compile / sources`, so nothing compiles, no main class is discovered, and no `bin/<service>` launcher is generated.
- `set every (Compile / packageDoc / publishArtifact) := false`: the same `set every` trap turns off `publishArtifact` for the main jar artifacts too, so the inter-project dependency jars drop out of the dist.

The regression tests in `test_local_dev_sh.sh` are flipped to guards that fail if any of these knobs is reintroduced. Skipping scaladoc has to be done per-project in `build.sbt`, not with a global `set every`, so it is left out until it can be done safely.

### Any related issues, documentation, discussions?

Closes #6096

### How was this PR tested?

Verified a clean multi-project dist bundles the `dao`/`auth`/`config`/`resource` jars and a working `bin/<service>` launcher, and that `bin/local-dev/tests/test_local_dev_sh.sh` passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
