### PR TITLE
test(workflow-operator): fill uncovered branches in source/scan and projection descriptors

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/ProjectionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/ProjectionOpDescSpec.scala
@@ -20,7 +20,13 @@
 package org.apache.texera.amber.operator.projection
 
 import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
-import org.apache.texera.amber.core.workflow.PortIdentity
+import org.apache.texera.amber.core.workflow.{
+  HashPartition,
+  PortIdentity,
+  RangePartition,
+  SinglePartition,
+  UnknownPartition
+}
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
@@ -108,6 +114,26 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
 
+  }
+
+  it should "preserve a HashPartition when its attributes are non-empty" in {
+    val out = projectionOpDesc.derivePartition()(List(HashPartition(List("field1"))))
+    assert(out == HashPartition(List("field1")))
+  }
+
+  it should "downgrade an empty HashPartition to UnknownPartition" in {
+    val out = projectionOpDesc.derivePartition()(List(HashPartition(List.empty)))
+    assert(out == UnknownPartition())
+  }
+
+  it should "preserve a RangePartition when its attributes are non-empty" in {
+    val out = projectionOpDesc.derivePartition()(List(RangePartition(List("field2"), 0L, 100L)))
+    assert(out == RangePartition(List("field2"), 0L, 100L))
+  }
+
+  it should "pass through partitions that are neither hash nor range" in {
+    val out = projectionOpDesc.derivePartition()(List(SinglePartition()))
+    assert(out == SinglePartition())
   }
 
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/ProjectionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/ProjectionOpDescSpec.scala
@@ -131,6 +131,13 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(out == RangePartition(List("field2"), 0L, 100L))
   }
 
+  it should "downgrade an empty RangePartition to UnknownPartition" in {
+    // RangePartition's companion apply already rewrites empty attributes to UnknownPartition,
+    // so an empty range never reaches the range arm; either way the result is UnknownPartition.
+    val out = projectionOpDesc.derivePartition()(List(RangePartition(List.empty, 0L, 100L)))
+    assert(out == UnknownPartition())
+  }
+
   it should "pass through partitions that are neither hash nor range" in {
     val out = projectionOpDesc.derivePartition()(List(SinglePartition()))
     assert(out == SinglePartition())

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanOpDescSpec.scala
@@ -26,6 +26,8 @@ import org.apache.texera.amber.core.tuple.{
   SchemaEnforceable,
   Tuple
 }
+import org.apache.texera.amber.core.executor.OpExecWithClassName
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.operator.TestOperators
 import org.apache.texera.amber.operator.source.scan.{FileAttributeType, FileDecodingMethod}
 import org.apache.texera.amber.util.JSONUtils.objectMapper
@@ -95,5 +97,25 @@ class FileScanOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
 
     assert(processedTuple.getField[String]("filename") == inputFilePath)
     fileScanOpExec.close()
+  }
+
+  "FileScanOpDesc.getPhysicalOp" should
+    "wire the FileScanOpExec class with one input port and one output port" in {
+    val physical = fileScanOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, payload) =>
+        assert(className == "org.apache.texera.amber.operator.source.scan.file.FileScanOpExec")
+        assert(payload.nonEmpty)
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    assert(physical.inputPorts.size == 1)
+    assert(physical.outputPorts.size == 1)
+  }
+
+  it should "propagate sourceSchema to its single output port" in {
+    val physical = fileScanOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
+    val outPortId = fileScanOpDesc.operatorInfo.outputPorts.head.id
+    val out = physical.propagateSchema.func(Map.empty)
+    assert(out(outPortId) == fileScanOpDesc.sourceSchema())
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanOpDescSpec.scala
@@ -104,7 +104,7 @@ class FileScanOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     val physical = fileScanOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
     physical.opExecInitInfo match {
       case OpExecWithClassName(className, payload) =>
-        assert(className == "org.apache.texera.amber.operator.source.scan.file.FileScanOpExec")
+        assert(className == classOf[FileScanOpExec].getName)
         assert(payload.nonEmpty)
       case other => fail(s"expected OpExecWithClassName, got $other")
     }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanSourceOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanSourceOpDescSpec.scala
@@ -194,9 +194,7 @@ class FileScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       fileScanSourceOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
     physical.opExecInitInfo match {
       case OpExecWithClassName(className, descString) =>
-        assert(
-          className == "org.apache.texera.amber.operator.source.scan.file.FileScanSourceOpExec"
-        )
+        assert(className == classOf[FileScanSourceOpExec].getName)
         assert(descString.nonEmpty)
       case other => fail(s"expected OpExecWithClassName, got $other")
     }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanSourceOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/file/FileScanSourceOpDescSpec.scala
@@ -19,8 +19,11 @@
 
 package org.apache.texera.amber.operator.source.scan.file
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.storage.FileResolver
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema, SchemaEnforceable, Tuple}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.operator.TestOperators
 import org.apache.texera.amber.operator.source.scan.{FileAttributeType, FileDecodingMethod}
 import org.apache.texera.amber.util.JSONUtils.objectMapper
@@ -183,6 +186,41 @@ class FileScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(processedTuple.next().getField("line").equals("line5"))
     assertThrows[java.util.NoSuchElementException](processedTuple.next().getField("line"))
     FileScanSourceOpExec.close()
+  }
+
+  "FileScanSourceOpDesc.getPhysicalOp" should
+    "wire the FileScanSourceOpExec class as a source op and propagate its schema" in {
+    val physical =
+      fileScanSourceOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, descString) =>
+        assert(
+          className == "org.apache.texera.amber.operator.source.scan.file.FileScanSourceOpExec"
+        )
+        assert(descString.nonEmpty)
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    assert(physical.inputPorts.isEmpty)
+    val outPortId = fileScanSourceOpDesc.operatorInfo.outputPorts.head.id
+    assert(physical.outputPorts.keySet == Set(outPortId))
+    val propagated = physical.propagateSchema.func(Map.empty)
+    assert(propagated(outPortId) == fileScanSourceOpDesc.sourceSchema())
+  }
+
+  "FileScanSourceOpDesc.sourceSchema" should
+    "prepend a filename column when outputFileName is enabled" in {
+    // outputFileName is a val; round-trip through JSON (which carries the operatorType
+    // discriminator) with the flag flipped on, since it can't be set on an instance.
+    val node =
+      objectMapper
+        .readTree(objectMapper.writeValueAsString(fileScanSourceOpDesc))
+        .asInstanceOf[ObjectNode]
+    node.put("outputFileName", true)
+    val withFlag = objectMapper.treeToValue(node, classOf[FileScanSourceOpDesc])
+    val schema: Schema = withFlag.sourceSchema()
+    assert(schema.getAttributes.length == 2)
+    assert(schema.getAttribute("filename").getType == AttributeType.STRING)
+    assert(schema.getAttribute("line").getType == AttributeType.STRING)
   }
 
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/text/TextInputSourceOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/text/TextInputSourceOpDescSpec.scala
@@ -189,9 +189,7 @@ class TextInputSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       textInputSourceOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
     physical.opExecInitInfo match {
       case OpExecWithClassName(className, _) =>
-        assert(
-          className == "org.apache.texera.amber.operator.source.scan.text.TextInputSourceOpExec"
-        )
+        assert(className == classOf[TextInputSourceOpExec].getName)
       case other => fail(s"expected OpExecWithClassName, got $other")
     }
     assert(physical.inputPorts.isEmpty)

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/text/TextInputSourceOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/source/scan/text/TextInputSourceOpDescSpec.scala
@@ -19,7 +19,9 @@
 
 package org.apache.texera.amber.operator.source.scan.text
 
+import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema, SchemaEnforceable, Tuple}
+import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.operator.TestOperators
 import org.apache.texera.amber.operator.source.scan.FileAttributeType
 import org.apache.texera.amber.util.JSONUtils.objectMapper
@@ -179,5 +181,30 @@ class TextInputSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
   def readFileIntoString(filePath: String): String = {
     val path: Path = Paths.get(filePath)
     new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+  }
+
+  "TextInputSourceOpDesc.getPhysicalOp" should
+    "wire the TextInputSourceOpExec class as a source op with one output port" in {
+    val physical =
+      textInputSourceOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
+    physical.opExecInitInfo match {
+      case OpExecWithClassName(className, _) =>
+        assert(
+          className == "org.apache.texera.amber.operator.source.scan.text.TextInputSourceOpExec"
+        )
+      case other => fail(s"expected OpExecWithClassName, got $other")
+    }
+    assert(physical.inputPorts.isEmpty)
+    assert(physical.outputPorts.size == 1)
+  }
+
+  it should "propagate sourceSchema to its single output port" in {
+    textInputSourceOpDesc.attributeType = FileAttributeType.STRING
+    val physical =
+      textInputSourceOpDesc.getPhysicalOp(WorkflowIdentity(1L), ExecutionIdentity(1L))
+    val outPortId = textInputSourceOpDesc.operatorInfo.outputPorts.head.id
+    val out = physical.propagateSchema.func(Map.empty)
+    assert(out.keySet == Set(outPortId))
+    assert(out(outPortId) == textInputSourceOpDesc.sourceSchema())
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Fill uncovered branches in four source/scan and projection descriptors, selected from the Codecov report. No production-code changes — extends the existing specs.

| File | Codecov before | Missed branches now covered |
| --- | --- | --- |
| `ProjectionOpDesc.scala` | 69% | `derivePartition` — the hash (kept/empty→unknown), range, and pass-through arms |
| `TextInputSourceOpDesc.scala` | 47% | `getPhysicalOp` wiring (exec class, ports) + schema propagation |
| `FileScanSourceOpDesc.scala` | 37% | `getPhysicalOp` wiring + propagation, and the `outputFileName` filename-column branch of `sourceSchema` |
| `FileScanOpDesc.scala` | 58% | `getPhysicalOp` wiring (input/output ports) + schema propagation |

All targets exercise pure in-memory descriptor logic (`getPhysicalOp`/`derivePartition`/`sourceSchema`); the existing specs only drove the executors or `sourceSchema` defaults.

### Any related issues, documentation, discussions?

Follow-up to the review feedback on #6043: prioritize tests that fill uncovered code paths.

### How was this PR tested?

- `sbt "WorkflowOperator/testOnly *ProjectionOpDescSpec *TextInputSourceOpDescSpec *FileScanSourceOpDescSpec *FileScanOpDescSpec"` — 37 tests, all green
- `sbt "WorkflowOperator/Test/scalafmtCheck"` and `sbt "WorkflowOperator/scalafixAll --check"` — clean

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
