### PR TITLE
docs: update outdated environment requirements in dev guide

### DIFF
--- a/docs/contribution-guidelines/guide-for-developers.md
+++ b/docs/contribution-guidelines/guide-for-developers.md
@@ -5,16 +5,16 @@ weight: 20
 
 ## 0. Requirements
 
-#### **Java 11 JDK**
+#### **Java 17 JDK**
 
-Install `Java JDK 11 (Java Development Kit)` (recommend: `[adoptopenjdk](https://adoptium.net/installation/)`). To verify the installation, run:
+Install `Java JDK 17 (Java Development Kit)` (recommend: `[adoptopenjdk](https://adoptium.net/installation/)`). To verify the installation, run:
 ```console
 java -version
 ```
 
 Next, set `JAVA_HOME`. On macOS you can run:
 ```
-export JAVA_HOME=$(/usr/libexec/java_home -v 11)
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
 ```
 On Windows, add a system environment variable called `JAVA_HOME` that points to the JDK directory.
 
@@ -44,9 +44,9 @@ sbt --version
 
 If the above command fails on Windows after installation, it is recommended to restart your computer.
 
-#### **node LTS Version > 18.x**
+#### **node LTS Version >= 24**
 
-Install an LTS version (not the latest) of `node`. Currently, we require LTS version > 18.x. 
+Install an LTS version of `node`. Currently, we require version 24 or newer (see `engines` in `frontend/package.json`).
 
 On Windows, install from [https://nodejs.org/en/](https://nodejs.org/en/).
 
@@ -57,11 +57,11 @@ Verify the installation by:
 node -v
 ```
 
-#### **Angular 16 Cli**
+#### **Angular 21 Cli**
 
-Install the angular 16 cli globally:
+Install the angular 21 cli globally:
 ```console
-npm install -g @angular/cli@16
+npm install -g @angular/cli@21
 ```
 
 Verify the installation by:
@@ -280,7 +280,7 @@ This command will optimize the frontend code to make it run faster. This step wi
 This part is optional; you only need to do this if you are working on a specific task.
 
 ### To create a new database table and write queries using Java through Jooq
-1. Create the needed new table in MySQL and update `sql/texera_ddl.sql` to include the new table.
+1. Create the needed new table in PostgreSQL and update `sql/texera_ddl.sql` to include the new table.
 2. Run `sbt DAO/jooqGenerate` to generate the classes for the new table.
 
 Note: Jooq creates DAO for simple operations if the requested SQL query is complex, then the developer can use the generated Table classes to implement the operation

--- a/docs/contribution-guidelines/guide-to-frontend-development.md
+++ b/docs/contribution-guidelines/guide-to-frontend-development.md
@@ -6,7 +6,7 @@ weight: 30
 **Author: Yinan Zhou**
 
 # Introduction:
-  If you are new to Texera frontend development team or have little frontend experience using angular framework (version 6), this read intends to provide you with a simple guide of how to get started.
+  If you are new to Texera frontend development team or have little frontend experience using the angular framework, this read intends to provide you with a simple guide of how to get started.
 
 # Preparation phase:
   In a nutshell, angular provides modularity, scalability, and robustness to traditional frontend code design. It separates a website into different individual components that can each perform a certain level of independent tasks. It then connects different components with services so they can work collaboratively. It also provides unit testing at the component level as well as application level. 


### PR DESCRIPTION
### What changes were proposed in this PR?

`guide-for-developers.md` told new developers to install a toolchain the repo no longer builds with. Updated to match the actual requirements:

| Before | After | Source of truth |
| --- | --- | --- |
| Java JDK 11 (incl. `java_home -v 11`) | JDK 17 | `build.sbt`, `.jvmopts` |
| node "LTS > 18.x" | Node 24 or newer | `frontend/package.json` `engines` |
| `npm install -g @angular/cli@16` | `@angular/cli@21` | `@angular/core` 21.2.x |
| create new tables "in MySQL" | PostgreSQL | Texera runs on Postgres |

`guide-to-frontend-development.md` no longer introduces the frontend as "angular framework (version 6)".

### Any related issues, documentation, discussions?

Closes #6106

### How was this PR tested?

Docs-only change. Each stated version was cross-checked against the repo: `build.sbt` / `.jvmopts` (JDK 17), `frontend/package.json` (`"node": ">=24.0.0"`, Angular 21.2.x), and the Postgres-based setup instructions earlier in the same guide.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)