### PR TITLE
docs: fix stale repo, branch, and architecture references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ engine, an Angular UI, and the agent service. JVM modules wired in
 | Area | Path | Detail |
 | --- | --- | --- |
 | Workflow execution engine (Amber) | `amber/` | [amber/README.md](amber/README.md) |
-| Backend services | `config-service/`, `access-control-service/`, `file-service/`, `computing-unit-managing-service/`, `workflow-compiling-service/` | `build.sbt` |
+| Backend services | `config-service/`, `access-control-service/`, `file-service/`, `computing-unit-managing-service/`, `workflow-compiling-service/`, `notebook-migration-service/` | `build.sbt` |
 | Shared Scala libs | `common/` (`auth`, `config`, `dao`, `workflow-core`, `workflow-operator`, `pybuilder`) | `build.sbt` |
 | Frontend (Angular) | `frontend/` | [frontend/README.md](frontend/README.md) |
 | Agent service (Bun/TS, LLM agents) | `agent-service/` | `agent-service/package.json` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ engine, an Angular UI, and the agent service. JVM modules wired in
 | Area | Path | Detail |
 | --- | --- | --- |
 | Workflow execution engine (Amber) | `amber/` | [amber/README.md](amber/README.md) |
-| Backend services | `config-service/`, `access-control-service/`, `file-service/`, `computing-unit-managing-service/`, `workflow-compiling-service/`, `notebook-migration-service/` | `build.sbt` |
+| Backend services | `config-service/`, `access-control-service/`, `file-service/`, `computing-unit-managing-service/`, `workflow-compiling-service/` | `build.sbt` |
 | Shared Scala libs | `common/` (`auth`, `config`, `dao`, `workflow-core`, `workflow-operator`, `pybuilder`) | `build.sbt` |
 | Frontend (Angular) | `frontend/` | [frontend/README.md](frontend/README.md) |
 | Agent service (Bun/TS, LLM agents) | `agent-service/` | `agent-service/package.json` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thank you for your interest in contributing to Texera! Please follow the steps b
 ## 🛠 Contribution Steps
 
 ### 1. Fork the Repo
-- Fork the [Texera repository](https://github.com/Texera/texera) to your own GitHub account.
+- Fork the [Texera repository](https://github.com/apache/texera) to your own GitHub account.
 
 ### 2. Find an Existing Issue or Open an Issue
 - Find an existing issue that you want to work on, or create one issue for new proposal/bug description.
@@ -29,7 +29,7 @@ Thank you for your interest in contributing to Texera! Please follow the steps b
   
 #### PR Title and Commit Messages
 - We require all PR titles and commit messages to follow the [Conventional Commits spec](https://www.conventionalcommits.org/en/v1.0.0/).
-- All PR titles will be used as the **squashed commit message** when merged into the `master` branch.
+- All PR titles will be used as the **squashed commit message** when merged into the `main` branch.
 - Example PR titles:
   - `feat: add a new join operator`
   - `fix(ui): prevent racing of requests`
@@ -67,7 +67,7 @@ Do not include any of the following in your PR:
 * For the amber engine's tests, the working directory should be `amber`
 * For the other services' tests, the working directory should be the root directory
 #### Testing the frontend 
-Before merging your code to the master branch, you need to pass the existing unit tests first.
+Before merging your code to the main branch, you need to pass the existing unit tests first.
 1. Open a command line. Navigate to the `frontend` directory.
 2. Start the test:
 ```
@@ -85,7 +85,7 @@ yarn format:fix
 - [ ] Ask a Texera Committer (by commenting on the PR) to triage your PR, i.e., request a reviewer, and assign the PR to you.
 - [ ] Add appropriate labels such as `fix`, `enhancement`, `docs`, etc.
 - [ ] If the change should also land in a release branch, add the matching `release/<branch>` label (e.g. `release/v1.1.0-incubating`); the change will be backported to that branch automatically.
-- [ ] Ensure that all CI checks pass (see [GitHub Actions](https://github.com/Texera/texera/actions)).
+- [ ] Ensure that all CI checks pass (see [GitHub Actions](https://github.com/apache/texera/actions)).
 - [ ] Fully test your changes locally.
 
 > ℹ️ If your PR is not ready for review, please mark it as a draft. You can change it to “Ready for review” when it is complete.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ Texera supports the following resource types:
 
 - **Datasets**: Input data imported or uploaded for workflow processing
 - **Workflows**: Data analytics pipelines defined by users
-- **Computing Units**: Execution environments for running workflows (e.g., Kubernates PODs)
+- **Computing Units**: Execution environments for running workflows (e.g., Kubernetes pods)
 - **Results**: Output from workflow executions, including but not limited to data, logs, metrics, and visualizations
 
 ### Resource Ownership and Access Control

--- a/docs/contribution-guidelines/_index.md
+++ b/docs/contribution-guidelines/_index.md
@@ -31,7 +31,7 @@ Texera welcomes contributions from everyone — whether you’re fixing a small 
 ## 🛠 How to Contribute Code
 
 ### 1. Fork the Repository
-Fork the [Texera repository](https://github.com/Texera/texera) on GitHub and clone it locally.
+Fork the [Texera repository](https://github.com/apache/texera) on GitHub and clone it locally.
 
 ### 2. Find or Open an Issue
 - Pick an existing issue or create a new one describing your proposal or bug.
@@ -110,7 +110,7 @@ Write `.spec.ts` tests for new functionality to ensure future safety.
 ## 🔍 Pull Request Review Process
 1. Request a committer to review your PR.
 2. Add labels (e.g., `fix`, `enhancement`, `docs`).
-3. Wait for CI to pass ([GitHub Actions](https://github.com/Texera/texera/actions)).
+3. Wait for CI to pass ([GitHub Actions](https://github.com/apache/texera/actions)).
 4. Mark your PR as **draft** if it’s not ready.
 5. Once approved, a committer will merge your PR.
 
@@ -135,7 +135,7 @@ To automate this in IntelliJ:
 ## ✍️ Contributing to Documentation
 
 Texera uses [Hugo](https://gohugo.io/) and the [Docsy](https://github.com/google/docsy) theme to build its website.  
-All documentation is stored in the [Texera GitHub repository](https://github.com/Texera/texera).
+All documentation is stored in the [Texera GitHub repository](https://github.com/apache/texera).
 
 ### Quick Steps
 1. Click **Edit this page** at the top of any doc page to edit directly on GitHub.
@@ -153,7 +153,7 @@ Visit `http://localhost:1313` to view the site as you edit.
 ---
 
 ## 📚 Resources
-- [Texera GitHub Repository](https://github.com/Texera/texera)
+- [Texera GitHub Repository](https://github.com/apache/texera)
 - [Conventional Commits Spec](https://www.conventionalcommits.org/en/v1.0.0/)
 - [Hugo Documentation](https://gohugo.io/documentation/)
 - [Docsy Guide](https://www.docsy.dev/docs/)

--- a/docs/contribution-guidelines/guide-for-developers.md
+++ b/docs/contribution-guidelines/guide-for-developers.md
@@ -80,7 +80,7 @@ ng version
 
 In the terminal, clone the Texera repo:
 ```console
-git clone git@github.com:Texera/texera.git
+git clone git@github.com:apache/texera.git
 ```
 
 Do the following changes to the configuration files:

--- a/docs/examples/_index.md
+++ b/docs/examples/_index.md
@@ -41,7 +41,7 @@ To try these examples on your local Texera instance:
 
 1. Launch Texera following the [Getting Started](/docs/getting-started/) guide.
 2. Open the **Workflow Editor** in your browser at `http://localhost:4200`.
-3. Import an example workflow file (`.json`) from the [Texera Example Repository](https://github.com/Texera/texera/tree/master/examples).
+3. Import an example workflow file (`.json`) into the editor.
 4. Run the workflow to see Texera’s operators and data visualizations in action.
 
 ---
@@ -49,7 +49,7 @@ To try these examples on your local Texera instance:
 ## 🧠 Want to Contribute an Example?
 
 If you’ve built your own workflow and want to share it:
-- Fork the [Texera repository](https://github.com/Texera/texera).
+- Fork the [Texera repository](https://github.com/apache/texera).
 - Add your workflow under `examples/` with a short README.
 - Submit a pull request following our [Contribution Guidelines](/docs/contribution-guidelines/).
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Cleans up leftovers from before the ASF migration, plus two small adjacent doc fixes:

- `github.com/Texera/texera` → `github.com/apache/texera` in `CONTRIBUTING.md` (fork + Actions links), `docs/contribution-guidelines/_index.md`, `docs/examples/_index.md`, and the clone URL in `guide-for-developers.md`.
- `CONTRIBUTING.md`: PRs are squash-merged into `main`, not `master` (two mentions).
- `docs/examples/_index.md`: dropped the dead link to an `examples/` directory that has never existed in this repo.
- `SECURITY.md`: "Kubernates PODs" → "Kubernetes pods".

### Any related issues, documentation, discussions?

Closes #6107

### How was this PR tested?

Docs-only change. Verified `main` is the default branch and `apache/texera` the canonical repo (`git remote -v`, `.github/workflows/required-checks.yml`), and that `grep -rn "github.com/Texera/texera"` finds no remaining hits outside files handled by #6111.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)