### PR TITLE
chore: pin y-websocket node image, drop stale toolchain fields

### DIFF
--- a/agent-service/package.json
+++ b/agent-service/package.json
@@ -32,6 +32,5 @@
     "prettier": "3.8.4",
     "tsx": "4.21.0",
     "typescript": "6.0.3"
-  },
-  "packageManager": "yarn@4.5.1+sha512.341db9396b6e289fecc30cd7ab3af65060e05ebff4b3b47547b278b9e67b08f485ecd8c79006b405446262142c7a38154445ef7f17c1d5d1de7d90bf9ce7054d"
+  }
 }

--- a/bin/y-websocket-server/Dockerfile
+++ b/bin/y-websocket-server/Dockerfile
@@ -25,7 +25,7 @@
 # has yet to be fully endorsed by the ASF.
 
 # Use an official Node runtime as a parent image
-FROM node:latest
+FROM node:24-slim
 
 # Set the working directory in the container
 WORKDIR /usr/src/app

--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,3 +1,1 @@
-lts/*
-engine-strict=true
-save-exact=true
+24


### PR DESCRIPTION
### What changes were proposed in this PR?

Three toolchain declarations had drifted from what the project actually targets:

| File | Before | After |
| --- | --- | --- |
| `bin/y-websocket-server/Dockerfile` | `FROM node:latest` (floating; image referenced by `bin/k8s`) | `FROM node:24-slim`, matching the project's Node 24 |
| `frontend/.nvmrc` | `lts/*` plus stray `engine-strict=true` / `save-exact=true` lines (`.npmrc` keys that nvm cannot parse and yarn 4 ignores) | `24`, matching `engines.node >=24` and CI's Node 24 |
| `agent-service/package.json` | `"packageManager": "yarn@4.5.1"` | removed — the service is Bun-managed (`bun.lock`; CI runs `bun install` / `bun test`) |

Intentionally left alone: `bin/pylsp/Dockerfile` stays on `python:3.10-slim` (its pinned `python-lsp-server==1.5.0` / `pylint==2.15.10` predate Python 3.12), and agent-service's own `0.1.0` version.

### Any related issues, documentation, discussions?

Closes #6109

### How was this PR tested?

- `docker build` of `bin/y-websocket-server` succeeds on `node:24-slim`; a smoke-run container (`docker run -p 12345:1234`) answered HTTP 200 and logged the expected `running at '0.0.0.0' on port 1234`.
- `cd agent-service && bun install --frozen-lockfile && bun test` — 115 pass, 0 fail.
- `python3 -c "import json; json.load(open('agent-service/package.json'))"` confirms the JSON stays valid.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)