### PR TITLE
docs: add notebook-migration-service to AGENTS.md Architecture Map

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ engine, an Angular UI, and the agent service. JVM modules wired in
 | Area | Path | Detail |
 | --- | --- | --- |
 | Workflow execution engine (Amber) | `amber/` | [amber/README.md](amber/README.md) |
-| Backend services | `config-service/`, `access-control-service/`, `file-service/`, `computing-unit-managing-service/`, `workflow-compiling-service/` | `build.sbt` |
+| Backend services | `config-service/`, `access-control-service/`, `file-service/`, `computing-unit-managing-service/`, `workflow-compiling-service/`, `notebook-migration-service/` | `build.sbt` |
 | Shared Scala libs | `common/` (`auth`, `config`, `dao`, `workflow-core`, `workflow-operator`, `pybuilder`) | `build.sbt` |
 | Frontend (Angular) | `frontend/` | [frontend/README.md](frontend/README.md) |
 | Agent service (Bun/TS, LLM agents) | `agent-service/` | `agent-service/package.json` |


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds `notebook-migration-service/` to the Backend services row of the Architecture Map in `AGENTS.md`. The module is wired in `build.sbt` but was missing from the map. This was originally part of #6113 and dropped there so the `release/v1.2` backport applies cleanly (the service does not exist on that branch); this PR targets `main` only and should not be backported.

### Any related issues, documentation, discussions?

Closes #6117. Follow-up to #6113.

### How was this PR tested?

Docs-only change. Verified `notebook-migration-service` is wired in `build.sbt`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)