### PR TITLE
test(common): cover auth header fields and visualization descriptors

### DIFF
--- a/common/auth/src/test/scala/org/apache/texera/auth/util/HeaderFieldSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/util/HeaderFieldSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.auth.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class HeaderFieldSpec extends AnyFlatSpec with Matchers {
+
+  "HeaderField" should "expose the expected HTTP header names" in {
+    HeaderField.UserComputingUnitAccess shouldBe "x-user-computing-unit-access"
+    HeaderField.UserId shouldBe "x-user-id"
+    HeaderField.UserName shouldBe "x-user-name"
+    HeaderField.UserEmail shouldBe "x-user-email"
+  }
+
+  it should "use a distinct name for each field" in {
+    Set(
+      HeaderField.UserComputingUnitAccess,
+      HeaderField.UserId,
+      HeaderField.UserName,
+      HeaderField.UserEmail
+    ).size shouldBe 4
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDescSpec.scala
@@ -86,8 +86,11 @@ class DumbbellPlotOpDescSpec extends AnyFlatSpec with Matchers {
     dot2.dotValue = "q2"
     d.dots = java.util.Arrays.asList(dot1, dot2)
     val withDots = d.addPlotlyDots().plain
-    withDots should include("dotColumnNames = [")
-    withDots should not include "dotColumnNames = []"
+    // both configured dots must be emitted: the rendered list has two comma-separated
+    // (base64-encoded) entries, e.g. dotColumnNames = [<enc-q1>,<enc-q2>]
+    val dotsLine = withDots.linesIterator.find(_.contains("dotColumnNames = [")).getOrElse("")
+    dotsLine should not include "dotColumnNames = []"
+    dotsLine.split(",") should have length 2
 
     (new DumbbellPlotOpDesc).addPlotlyDots().plain should include("dotColumnNames = []")
   }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDescSpec.scala
@@ -67,6 +67,31 @@ class DumbbellPlotOpDescSpec extends AnyFlatSpec with Matchers {
     code should include("go.Scatter(")
   }
 
+  "DumbbellPlotOpDesc.createPlotlyDumbbellLineFigure" should
+    "select the showlegend flag from showLegends" in {
+    val on = new DumbbellPlotOpDesc
+    on.showLegends = true
+    on.createPlotlyDumbbellLineFigure().plain should include("showlegend=True")
+
+    val off = new DumbbellPlotOpDesc // showLegends defaults to false
+    off.createPlotlyDumbbellLineFigure().plain should include("showlegend=False")
+  }
+
+  "DumbbellPlotOpDesc.addPlotlyDots" should
+    "list the configured dot columns and default to an empty list" in {
+    val d = new DumbbellPlotOpDesc
+    val dot1 = new DumbbellDotConfig
+    dot1.dotValue = "q1"
+    val dot2 = new DumbbellDotConfig
+    dot2.dotValue = "q2"
+    d.dots = java.util.Arrays.asList(dot1, dot2)
+    val withDots = d.addPlotlyDots().plain
+    withDots should include("dotColumnNames = [")
+    withDots should not include "dotColumnNames = []"
+
+    (new DumbbellPlotOpDesc).addPlotlyDots().plain should include("dotColumnNames = []")
+  }
+
   "DumbbellPlotOpDesc" should "round-trip its column fields through the polymorphic base" in {
     val d = new DumbbellPlotOpDesc
     d.categoryColumnName = "entity"

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDescSpec.scala
@@ -19,7 +19,7 @@
 
 package org.apache.texera.amber.operator.visualization.filledAreaPlot
 
-import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.operator.LogicalOp
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
@@ -109,12 +109,10 @@ class FilledAreaPlotOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matc
   }
 
   "FilledAreaPlotOpDesc.getOutputSchemas" should
-    "return a single html-content STRING column" in {
-    val out = opDesc.getOutputSchemas(Map.empty)
-    out should have size 1
-    val schema = out.values.head
-    schema.getAttributeNames should contain("html-content")
-    schema.getAttribute("html-content").getType shouldBe AttributeType.STRING
+    "return exactly one html-content STRING column" in {
+    opDesc.getOutputSchemas(Map.empty) shouldBe Map(
+      opDesc.operatorInfo.outputPorts.head.id -> Schema().add("html-content", AttributeType.STRING)
+    )
   }
 
   "FilledAreaPlotOpDesc.createPlotlyFigure" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDescSpec.scala
@@ -19,6 +19,9 @@
 
 package org.apache.texera.amber.operator.visualization.filledAreaPlot
 
+import org.apache.texera.amber.core.tuple.AttributeType
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -103,5 +106,49 @@ class FilledAreaPlotOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matc
     plain should include("area_x")
     plain should include("area_y")
     plain should include("px.area")
+  }
+
+  "FilledAreaPlotOpDesc.getOutputSchemas" should
+    "return a single html-content STRING column" in {
+    val out = opDesc.getOutputSchemas(Map.empty)
+    out should have size 1
+    val schema = out.values.head
+    schema.getAttributeNames should contain("html-content")
+    schema.getAttribute("html-content").getType shouldBe AttributeType.STRING
+  }
+
+  "FilledAreaPlotOpDesc.createPlotlyFigure" should
+    "emit the optional plotly args when color, facet, line group, and pattern are set" in {
+    opDesc.x = "area_x"
+    opDesc.y = "area_y"
+    opDesc.color = "c"
+    opDesc.facetColumn = true
+    opDesc.lineGroup = "grp"
+    opDesc.pattern = "p"
+    val plain = opDesc.createPlotlyFigure().plain
+    plain should include("px.area")
+    plain should include("color=")
+    plain should include("facet_col=")
+    plain should include("line_group=")
+    plain should include("pattern_shape=")
+  }
+
+  "FilledAreaPlotOpDesc" should "round-trip its config fields through the polymorphic base" in {
+    opDesc.x = "area_x"
+    opDesc.y = "area_y"
+    opDesc.lineGroup = "grp"
+    opDesc.color = "c"
+    opDesc.facetColumn = true
+    opDesc.pattern = "p"
+    val restored =
+      objectMapper.readValue(objectMapper.writeValueAsString(opDesc), classOf[LogicalOp])
+    restored shouldBe a[FilledAreaPlotOpDesc]
+    val fp = restored.asInstanceOf[FilledAreaPlotOpDesc]
+    fp.x shouldBe "area_x"
+    fp.y shouldBe "area_y"
+    fp.lineGroup shouldBe "grp"
+    fp.color shouldBe "c"
+    fp.facetColumn shouldBe true
+    fp.pattern shouldBe "p"
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds unit-test coverage for uncovered lines Codecov reports across `common/auth` and `common/workflow-operator`:

- **`HeaderFieldSpec`** (new, `common/auth`) — pins the four HTTP header-name constants and their distinctness.
- **`FilledAreaPlotOpDescSpec`** (extended) — adds the `getOutputSchemas` single `html-content` STRING column assertion, the `facet_col=` branch when `facetColumn` is enabled with a line group, and a Jackson JSON round-trip through the polymorphic base.
- **`DumbbellPlotOpDescSpec`** (extended) — adds the `showlegend` flag branch driven by `showLegends` and the `addPlotlyDots` configured-vs-empty dot-column branch.

No production code is changed; this is test-only.

### Any related issues, documentation, discussions?

Coverage gaps identified from the Codecov report for `apache/texera`.

### How was this PR tested?

New/extended ScalaTest specs, run locally:

```
sbt "Auth/testOnly *HeaderFieldSpec" \
    "WorkflowOperator/testOnly *FilledAreaPlotOpDescSpec *DumbbellPlotOpDescSpec"
```

All pass. `scalafmt` and `scalafixAll --check` are clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
