### PR TITLE
fix(pve, v1.2): repair Python virtual environment in single-node deployment

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveManager.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveManager.scala
@@ -94,11 +94,15 @@ object PveManager {
     }
   }
 
+  // The lock file is copied to /tmp/system-requirements-lock.txt inside every
+  // deployed image (see bin/computing-unit-master.dockerfile), so single-node
+  // Docker and Kubernetes both find it there. Only a source-tree dev run reads
+  // the repo-relative amber/ copy. `isLocal` alone can't distinguish a
+  // containerized single-node run (also non-k8s) from a dev run, so probe.
   private def getSystemPath(isLocal: Boolean): Path = {
-    Paths.get(
-      if (isLocal) "amber/system-requirements-lock.txt"
-      else "/tmp/system-requirements-lock.txt"
-    )
+    val deployPath = Paths.get("/tmp/system-requirements-lock.txt")
+    if (Files.exists(deployPath)) deployPath
+    else Paths.get("amber/system-requirements-lock.txt")
   }
 
   def getSystemPackages(isLocal: Boolean): Seq[String] = {

--- a/bin/k8s/templates/gateway-routes.yaml
+++ b/bin/k8s/templates/gateway-routes.yaml
@@ -124,20 +124,9 @@ spec:
         - path:
             type: PathPrefix
             value: /api/executions/result/export
-      backendRefs:
-        - group: gateway.envoyproxy.io
-          kind: Backend
-          name: texera-dynamic-backend
-    - matches:
         - path:
             type: PathPrefix
-            value: /pve
-      filters:
-        - type: URLRewrite
-          urlRewrite:
-            path:
-              type: ReplacePrefixMatch
-              replacePrefixMatch: /api/pve
+            value: /api/pve
       backendRefs:
         - group: gateway.envoyproxy.io
           kind: Backend

--- a/bin/single-node/nginx.conf
+++ b/bin/single-node/nginx.conf
@@ -95,8 +95,8 @@ http {
             proxy_set_header Host $host;
         }
 
-        location /pve/ {
-            proxy_pass http://workflow-runtime-coordinator-service:8085/api/pve/;
+        location /api/pve/ {
+            proxy_pass http://workflow-runtime-coordinator-service:8085;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }

--- a/bin/single-node/nginx.conf
+++ b/bin/single-node/nginx.conf
@@ -95,12 +95,8 @@ http {
             proxy_set_header Host $host;
         }
 
-        # Python Virtual Environment (PVE) REST endpoints are served by the
-        # amber webserver under /api/pve. Mirror the dev proxy and k8s gateway
-        # by rewriting /pve -> /api/pve before proxying.
         location /pve/ {
-            rewrite ^/pve/(.*)$ /api/pve/$1 break;
-            proxy_pass http://workflow-runtime-coordinator-service:8085;
+            proxy_pass http://workflow-runtime-coordinator-service:8085/api/pve/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }

--- a/bin/single-node/nginx.conf
+++ b/bin/single-node/nginx.conf
@@ -95,6 +95,16 @@ http {
             proxy_set_header Host $host;
         }
 
+        # Python Virtual Environment (PVE) REST endpoints are served by the
+        # amber webserver under /api/pve. Mirror the dev proxy and k8s gateway
+        # by rewriting /pve -> /api/pve before proxying.
+        location /pve/ {
+            rewrite ^/pve/(.*)$ /api/pve/$1 break;
+            proxy_pass http://workflow-runtime-coordinator-service:8085;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
         # Fallback for all other routes
         location / {
             proxy_pass http://dashboard-service:8080;

--- a/bin/single-node/nginx.conf
+++ b/bin/single-node/nginx.conf
@@ -81,6 +81,13 @@ http {
             proxy_send_timeout 1d;
         }
 
+        location /api/pve/ {
+            proxy_pass http://workflow-runtime-coordinator-service:8085;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        # nginx prefix locations match by longest prefix
         location /api/ {
             proxy_pass http://dashboard-service:8080;
             proxy_set_header Host $host;
@@ -93,12 +100,6 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
             proxy_set_header Host $host;
-        }
-
-        location /api/pve/ {
-            proxy_pass http://workflow-runtime-coordinator-service:8085;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
         }
 
         # Fallback for all other routes

--- a/frontend/proxy.config.json
+++ b/frontend/proxy.config.json
@@ -50,18 +50,15 @@
     "secure": false,
     "changeOrigin": true
   },
+  "/api/pve": {
+    "target": "http://localhost:8085",
+    "secure": false,
+    "changeOrigin": false
+  },
   "/api": {
     "target": "http://localhost:8080",
     "secure": false,
     "changeOrigin": false
-  },
-  "/pve": {
-    "target": "http://localhost:8085",
-    "secure": false,
-    "changeOrigin": false,
-    "pathRewrite": {
-      "^/pve": "/api/pve"
-    }
   },
   "/wsapi": {
     "target": "http://localhost:8085",

--- a/frontend/src/app/workspace/service/virtual-environment/virtual-environment.service.ts
+++ b/frontend/src/app/workspace/service/virtual-environment/virtual-environment.service.ts
@@ -21,6 +21,7 @@ import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { HttpClient, HttpParams } from "@angular/common/http";
 import { AuthService } from "../../../common/service/user/auth.service";
+import { AppSettings } from "../../../common/app-setting";
 
 export interface PackageResponse {
   system: string[];
@@ -51,12 +52,12 @@ export class WorkflowPveService {
 
   getSystemPackages(cuid: number): Observable<PackageResponse> {
     const params = this.buildBaseParams().set("cuid", cuid.toString());
-    return this.http.get<PackageResponse>("/pve/system", { params });
+    return this.http.get<PackageResponse>(`${AppSettings.getApiEndpoint()}/pve/system`, { params });
   }
 
   fetchPVEs(cuid: number): Observable<PvePackageResponse[]> {
     const params = this.buildBaseParams().set("cuid", cuid.toString());
-    return this.http.get<PvePackageResponse[]>("/pve/pves", { params });
+    return this.http.get<PvePackageResponse[]>(`${AppSettings.getApiEndpoint()}/pve/pves`, { params });
   }
 
   getUserPackages(cuid: number, pveName: string): Observable<string[]> {
@@ -64,14 +65,14 @@ export class WorkflowPveService {
   }
 
   deleteEnvironments(cuid: number) {
-    return this.http.delete(`/pve/pves/${cuid}`);
+    return this.http.delete(`${AppSettings.getApiEndpoint()}/pve/pves/${cuid}`);
   }
 
   deletePackage(cuid: number, pveName: string, packageName: string) {
     const params = this.buildBaseParams();
 
     return this.http.delete<string[]>(
-      `/pve/${cuid}/${encodeURIComponent(pveName)}/packages/${encodeURIComponent(packageName)}`,
+      `${AppSettings.getApiEndpoint()}/pve/${cuid}/${encodeURIComponent(pveName)}/packages/${encodeURIComponent(packageName)}`,
       { params }
     );
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Python Virtual Environments (PVE) are broken in the single-node deployment on `release/v1.2` for two independent reasons, fixed together here:

**1. PVE REST calls returned 404 through single-node NGINX.** The frontend requested `/pve/...` while the backend (`PveResource`, `@Path("/pve")`, Jersey mounted under `/api/*` on the coordinator) serves `/api/pve/...`, so every gateway had to carry its own `/pve` to `/api/pve` rewrite rule, and the single-node config was missing one. In the UI this surfaces as a *"Could not load Python virtual environments"* popup on every Python UDF operator selection.

Mirroring apache/texera#6130 on `main`, this removes the mismatch at the source instead of adding a third rewrite rule: the frontend now builds PVE URLs with `AppSettings.getApiEndpoint()` and requests `/api/pve/...` directly, and every routing layer becomes a plain routing entry with no path rewriting:

- `bin/single-node/nginx.conf`: `location /api/pve/` passes through to the coordinator
- `frontend/proxy.config.json`: `/api/pve` entry (ordered before `/api`), `pathRewrite` removed
- `bin/k8s/templates/gateway-routes.yaml`: `/api/pve` joins the existing dynamic-backend match list, the `URLRewrite` filter is removed

This is an adapted port rather than a cherry-pick of the `main` commit: this branch predates the StoredPve db endpoints (`/pve/db`) and the gateway chart reorganization, so the same change lands in fewer files.

**2. The system-package list was empty even with routing fixed.** The system-requirements lock file is copied to `/tmp/system-requirements-lock.txt` in every deployed image (`bin/computing-unit-master.dockerfile`), but `PveManager.getSystemPath` chose its path from the `isLocal` flag (`isLocal → amber/…`, else `/tmp/…`). A containerized single-node run is also non-k8s, so `isLocal` is `true` and it looked for the repo-relative `amber/system-requirements-lock.txt`, which does not exist in the container → empty system-package set. The flag cannot distinguish a source-tree dev run from a containerized single-node run, so this probes for `/tmp/system-requirements-lock.txt` first and falls back to the repo-relative copy for dev runs.

**Note:** part 2 is `release/v1.2`-specific: `main` has a significantly refactored `PveManager` that does not use the lock file.

### Any related issues, documentation, discussions?

Closes #5963. Ports apache/texera#6130 (the `/api/pve` routing cleanup on `main`) to `release/v1.2`.

### How was this PR tested?

On the single-node Docker stack (rc2 images + dashboard/coordinator rebuilt from this branch):

- `GET /api/pve/pves?cuid=1` returns 200 JSON from the coordinator; the old `/pve` path 404s to the dashboard catch-all as expected.
- `getSystemPath` before/after: the unmodified rc2 coordinator returns `{"system":[]}`, this branch's coordinator returns the full system-package list.
- The k8s route was applied to a minikube cluster: HTTPRoute `Accepted`, envoy routes `/api/pve` to the dynamic backend with no rewrite.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8, Claude Fable 5)
