### PR TITLE
test(pybuilder): cover PythonLexerUtils triple-quote escape and toggle branches

### DIFF
--- a/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/PythonLexerUtilsSpec.scala
+++ b/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/PythonLexerUtilsSpec.scala
@@ -131,6 +131,25 @@ class PythonLexerUtilsSpec extends AnyFunSuite {
     assert(state.isEmpty)
   }
 
+  test(
+    "updateTripleQuotedStringState: an escaped quote inside an ordinary string is not a boundary"
+  ) {
+    // Python:  x = "a\"b"  — the escaped " must not close the double-quoted string
+    assert(PythonLexerUtils.updateTripleQuotedStringState("x = \"a\\\"b\"", None).isEmpty)
+    // Python:  y = 'a\'b'  — same for a single-quoted string
+    assert(PythonLexerUtils.updateTripleQuotedStringState("y = 'a\\'b'", None).isEmpty)
+  }
+
+  test("updateTripleQuotedStringState: a lone single-quoted string toggles single-quote mode") {
+    // Python:  name = 'abc'  — opens then closes single-quote mode, leaving no active delimiter
+    assert(PythonLexerUtils.updateTripleQuotedStringState("name = 'abc'", None).isEmpty)
+  }
+
+  test("updateTripleQuotedStringState: a hash inside a double-quoted string is not a comment") {
+    // Python:  s = "a # b" + c  — the # is inside the string, so scanning must not early-return
+    assert(PythonLexerUtils.updateTripleQuotedStringState("s = \"a # b\" + c", None).isEmpty)
+  }
+
   // -------- hasUnclosedQuote --------
 
   test("hasUnclosedQuote: empty string has no unclosed quote") {

--- a/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/PythonLexerUtilsSpec.scala
+++ b/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/PythonLexerUtilsSpec.scala
@@ -134,20 +134,36 @@ class PythonLexerUtilsSpec extends AnyFunSuite {
   test(
     "updateTripleQuotedStringState: an escaped quote inside an ordinary string is not a boundary"
   ) {
-    // Python:  x = "a\"b"  — the escaped " must not close the double-quoted string
-    assert(PythonLexerUtils.updateTripleQuotedStringState("x = \"a\\\"b\"", None).isEmpty)
-    // Python:  y = 'a\'b'  — same for a single-quoted string
-    assert(PythonLexerUtils.updateTripleQuotedStringState("y = 'a\\'b'", None).isEmpty)
+    // Python:  x = "a\"b" '''  — the escaped " must not close the double-quoted string, so it ends
+    // before the trailing ''', which opens a triple. If the escape were mishandled the string would
+    // stay open and the ''' would be treated as content, yielding None instead of Some("'''").
+    assert(
+      PythonLexerUtils.updateTripleQuotedStringState("x = \"a\\\"b\" '''", None).contains("'''")
+    )
+    // Python:  y = 'a\'b' """  — same for a single-quoted string, then a triple-double opens.
+    assert(
+      PythonLexerUtils.updateTripleQuotedStringState("y = 'a\\'b' \"\"\"", None).contains("\"\"\"")
+    )
   }
 
-  test("updateTripleQuotedStringState: a lone single-quoted string toggles single-quote mode") {
-    // Python:  name = 'abc'  — opens then closes single-quote mode, leaving no active delimiter
-    assert(PythonLexerUtils.updateTripleQuotedStringState("name = 'abc'", None).isEmpty)
+  test(
+    "updateTripleQuotedStringState: single-quote mode suppresses a later comment and delimiter"
+  ) {
+    // Python:  a = '#' '''  — the # sits inside the single-quoted string (not a comment); the string
+    // closes and ''' opens a triple. If single-quote mode failed to toggle on, the # would
+    // early-return as a comment and the result would be None instead of Some("'''").
+    assert(PythonLexerUtils.updateTripleQuotedStringState("a = '#' '''", None).contains("'''"))
   }
 
   test("updateTripleQuotedStringState: a hash inside a double-quoted string is not a comment") {
-    // Python:  s = "a # b" + c  — the # is inside the string, so scanning must not early-return
-    assert(PythonLexerUtils.updateTripleQuotedStringState("s = \"a # b\" + c", None).isEmpty)
+    // Python:  s = "a # b" """  — the # is inside the double-quoted string, which closes before the
+    // trailing triple-double. If the # were wrongly treated as a comment the scan would early-return
+    // None instead of Some("\"\"\"").
+    assert(
+      PythonLexerUtils
+        .updateTripleQuotedStringState("s = \"a # b\" \"\"\"", None)
+        .contains("\"\"\"")
+    )
   }
 
   // -------- hasUnclosedQuote --------


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends `PythonLexerUtilsSpec` in `common/pybuilder` to cover the remaining uncovered branches of `PythonLexerUtils.updateTripleQuotedStringState`, which Codecov flags as missed/partial:

- an escaped quote inside an ordinary single- or double-quoted string is not treated as a string boundary (the backslash-sets-escaped and escaped-consumes-next branches);
- a lone single-quoted string toggles single-quote mode on and off;
- a `#` inside a double-quoted string is not treated as a comment (the comment guard is skipped while inside a string).

No production code is changed; this is test-only.

### Any related issues, documentation, discussions?

Coverage gaps identified from the Codecov report for `apache/texera`.

### How was this PR tested?

Extended ScalaTest spec, run locally:

```
sbt "PyBuilder/testOnly *PythonLexerUtilsSpec"
```

All 37 pass. `scalafmt` and `scalafixAll --check` are clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
