### PR TITLE
test(workflow-operator): cover OperatorMetadataGenerator unregistered-class error

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/OperatorMetadataGeneratorSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/OperatorMetadataGeneratorSpec.scala
@@ -27,8 +27,8 @@ class OperatorMetadataGeneratorSpec extends AnyFlatSpec with Matchers {
 
   "OperatorMetadataGenerator.generateOperatorMetadata" should
     "throw a RuntimeException for a class that is not a registered operator type" in {
-    // the abstract base LogicalOp is not a concrete @JsonTypeName subtype, so it is
-    // never collected into operatorTypeMap
+    // the abstract base LogicalOp is not one of the concrete subtypes registered via the
+    // @JsonSubTypes list on LogicalOp, so it is never collected into operatorTypeMap
     OperatorMetadataGenerator.operatorTypeMap.contains(classOf[LogicalOp]) shouldBe false
 
     val ex = intercept[RuntimeException] {

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/OperatorMetadataGeneratorSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/metadata/OperatorMetadataGeneratorSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.metadata
+
+import org.apache.texera.amber.operator.LogicalOp
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class OperatorMetadataGeneratorSpec extends AnyFlatSpec with Matchers {
+
+  "OperatorMetadataGenerator.generateOperatorMetadata" should
+    "throw a RuntimeException for a class that is not a registered operator type" in {
+    // the abstract base LogicalOp is not a concrete @JsonTypeName subtype, so it is
+    // never collected into operatorTypeMap
+    OperatorMetadataGenerator.operatorTypeMap.contains(classOf[LogicalOp]) shouldBe false
+
+    val ex = intercept[RuntimeException] {
+      OperatorMetadataGenerator.generateOperatorMetadata(classOf[LogicalOp])
+    }
+    ex.getMessage should include(classOf[LogicalOp].toString)
+    ex.getMessage should include("is not registered")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds a unit test for `OperatorMetadataGenerator` covering its previously-untested error branch: `generateOperatorMetadata` throws a `RuntimeException` when passed a class that is not registered in `operatorTypeMap` (the existing metadata specs only exercise the happy path). The test uses the abstract `LogicalOp` base — which is not a registered concrete `@JsonTypeName` subtype — so the throw fires before any instantiation, needing no DB/actor.

No production code is changed; this is test-only.

### Any related issues, documentation, discussions?

Coverage gaps identified from the Codecov report for `apache/texera`.

### How was this PR tested?

New ScalaTest spec, run locally:

```
sbt "WorkflowOperator/testOnly *OperatorMetadataGeneratorSpec"
```

Passes. `scalafmt` and `scalafixAll --check` are clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
