### PR TITLE
test(amber): cover DataProcessor state-frame and executor-exception paths

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -23,8 +23,9 @@ import org.apache.texera.amber.core.executor.OperatorExecutor
 import org.apache.texera.amber.core.state.State
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema, Tuple, TupleLike}
 import org.apache.texera.amber.core.virtualidentity._
-import org.apache.texera.amber.core.workflow.PortIdentity
+import org.apache.texera.amber.core.workflow.{PhysicalLink, PortIdentity}
 import org.apache.texera.amber.core.workflow.WorkflowContext.DEFAULT_WORKFLOW_ID
+import org.apache.texera.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
 import org.apache.texera.amber.engine.architecture.logreplay.{ReplayLogManager, ReplayLogRecord}
 import org.apache.texera.amber.engine.architecture.messaginglayer.WorkerTimerService
 import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
@@ -251,7 +252,13 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with 
     val dp = mkDataProcessor
     dp.executor = executor
     dp.stateManager.transitTo(READY)
-    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    val emitted = scala.collection.mutable.ArrayBuffer[WorkflowFIFOMessage]()
+    (outputHandler.apply _)
+      .expects(*)
+      .onCall { (m: Either[MainThreadDelegateMessage, WorkflowFIFOMessage]) =>
+        m.foreach(emitted += _); ()
+      }
+      .anyNumberOfTimes()
     val inputState = State(Map("field1" -> 1))
     (
         (
@@ -266,19 +273,30 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with 
       .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
       .setPortId(inputPortId)
     dp.outputManager.addPort(outputPortId, schema, None)
-    noException should be thrownBy {
-      dp.processDataPayload(
-        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
-        StateFrame(inputState)
-      )
-    }
+    // A downstream partitioner makes emitState observable: the produced state is sent
+    // downstream as a StateFrame, captured via the output handler.
+    dp.outputManager.addPartitionerWithPartitioning(
+      PhysicalLink(testOpId, outputPortId, upstreamOpId, inputPortId),
+      OneToOnePartitioning(1, Seq(ChannelIdentity(testWorkerId, senderWorkerId, isControl = false)))
+    )
+    dp.processDataPayload(
+      ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+      StateFrame(inputState)
+    )
+    assert(emitted.exists(_.payload.isInstanceOf[StateFrame]))
   }
 
   "data processor" should "not emit when processState yields None" in {
     val dp = mkDataProcessor
     dp.executor = executor
     dp.stateManager.transitTo(READY)
-    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    val emitted = scala.collection.mutable.ArrayBuffer[WorkflowFIFOMessage]()
+    (outputHandler.apply _)
+      .expects(*)
+      .onCall { (m: Either[MainThreadDelegateMessage, WorkflowFIFOMessage]) =>
+        m.foreach(emitted += _); ()
+      }
+      .anyNumberOfTimes()
     val inputState = State(Map("field1" -> 2))
     (
         (
@@ -293,12 +311,17 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with 
       .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
       .setPortId(inputPortId)
     dp.outputManager.addPort(outputPortId, schema, None)
-    noException should be thrownBy {
-      dp.processDataPayload(
-        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
-        StateFrame(inputState)
-      )
-    }
+    // Same downstream partitioner as the emit test; because processState returns None,
+    // no StateFrame must be emitted.
+    dp.outputManager.addPartitionerWithPartitioning(
+      PhysicalLink(testOpId, outputPortId, upstreamOpId, inputPortId),
+      OneToOnePartitioning(1, Seq(ChannelIdentity(testWorkerId, senderWorkerId, isControl = false)))
+    )
+    dp.processDataPayload(
+      ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+      StateFrame(inputState)
+    )
+    assert(!emitted.exists(_.payload.isInstanceOf[StateFrame]))
   }
 
   "data processor" should "handle an exception thrown while processing a state frame" in {
@@ -326,6 +349,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with 
         StateFrame(inputState)
       )
     }
+    // handleExecutorException must engage an operator-logic pause.
+    dp.pauseManager.isPaused shouldBe true
   }
 
   "data processor" should "handle an exception thrown while processing an input tuple" in {
@@ -353,6 +378,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with 
         DataFrame(Array(tuples.head))
       )
     }
+    // handleExecutorException must engage an operator-logic pause.
+    dp.pauseManager.isPaused shouldBe true
   }
 
   "data processor" should "handle an exception thrown while advancing the output iterator" in {
@@ -379,6 +406,9 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with 
     noException should be thrownBy {
       dp.continueDataProcessing()
     }
+    // handleExecutorException must pause the operator and reset the output iterator to empty.
+    dp.pauseManager.isPaused shouldBe true
+    dp.outputManager.hasUnfinishedOutput shouldBe false
   }
 
 }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -20,6 +20,7 @@
 package org.apache.texera.amber.engine.architecture.worker
 
 import org.apache.texera.amber.core.executor.OperatorExecutor
+import org.apache.texera.amber.core.state.State
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema, Tuple, TupleLike}
 import org.apache.texera.amber.core.virtualidentity._
 import org.apache.texera.amber.core.workflow.PortIdentity
@@ -42,7 +43,11 @@ import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.{
   MainThreadDelegateMessage
 }
 import org.apache.texera.amber.engine.architecture.worker.statistics.WorkerState.READY
-import org.apache.texera.amber.engine.common.ambermessage.{DataFrame, WorkflowFIFOMessage}
+import org.apache.texera.amber.engine.common.ambermessage.{
+  DataFrame,
+  StateFrame,
+  WorkflowFIFOMessage
+}
 import org.apache.texera.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import org.apache.texera.amber.engine.common.storage.SequentialRecordStorage
 import org.apache.texera.amber.engine.common.virtualidentity.util.COORDINATOR
@@ -50,10 +55,11 @@ import org.apache.texera.amber.util.VirtualIdentityUtils
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.util.concurrent.LinkedBlockingQueue
 
-class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfterEach {
+class DataProcessorSpec extends AnyFlatSpec with MockFactory with Matchers with BeforeAndAfterEach {
   private val testOpId = PhysicalOpIdentity(OperatorIdentity("testop"), "main")
   private val upstreamOpId = PhysicalOpIdentity(OperatorIdentity("sender"), "main")
   private val testWorkerId: ActorVirtualIdentity = VirtualIdentityUtils.createWorkerIdentity(
@@ -237,6 +243,140 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       logManager
     )
     while (dp.inputManager.hasUnfinishedInput || dp.outputManager.hasUnfinishedOutput) {
+      dp.continueDataProcessing()
+    }
+  }
+
+  "data processor" should "process a state frame and emit the produced state" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    val inputState = State(Map("field1" -> 1))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .returning(Some(inputState))
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    noException should be thrownBy {
+      dp.processDataPayload(
+        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+        StateFrame(inputState)
+      )
+    }
+  }
+
+  "data processor" should "not emit when processState yields None" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    val inputState = State(Map("field1" -> 2))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .returning(None)
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    noException should be thrownBy {
+      dp.processDataPayload(
+        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+        StateFrame(inputState)
+      )
+    }
+  }
+
+  "data processor" should "handle an exception thrown while processing a state frame" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    val inputState = State(Map("field1" -> 3))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .throwing(new RuntimeException("boom on state"))
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    noException should be thrownBy {
+      dp.processDataPayload(
+        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+        StateFrame(inputState)
+      )
+    }
+  }
+
+  "data processor" should "handle an exception thrown while processing an input tuple" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    (
+        (
+            tuple: Tuple,
+            input: Int
+        ) => executor.processTupleMultiPort(tuple, input)
+    )
+      .expects(tuples.head, 0)
+      .throwing(new RuntimeException("boom on tuple"))
+    (adaptiveBatchingMonitor.startAdaptiveBatching _).expects().anyNumberOfTimes()
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    noException should be thrownBy {
+      dp.processDataPayload(
+        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+        DataFrame(Array(tuples.head))
+      )
+    }
+  }
+
+  "data processor" should "handle an exception thrown while advancing the output iterator" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    (adaptiveBatchingMonitor.startAdaptiveBatching _).expects().anyNumberOfTimes()
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    // Poison the output iterator: hasNext is true so continueDataProcessing routes
+    // into outputOneTuple, but next() throws to exercise the catch branch.
+    dp.outputManager.outputIterator.setTupleOutput(
+      new Iterator[(TupleLike, Option[PortIdentity])] {
+        override def hasNext: Boolean = true
+        override def next(): (TupleLike, Option[PortIdentity]) =
+          throw new RuntimeException("boom on next")
+      }
+    )
+    assert(dp.outputManager.hasUnfinishedOutput)
+    noException should be thrownBy {
       dp.continueDataProcessing()
     }
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends `DataProcessorSpec` to cover previously-untested state and error paths of `DataProcessor` (amber worker), reusing the spec's existing in-JVM harness (real `DataProcessor` with a ScalaMock `OperatorExecutor` and mocked output handler / timer service) — no actor system or external service:

- `processDataPayload(StateFrame)` → `processInputState` → `emitState` when `processState` returns `Some`, and the no-emit path when it returns `None`;
- executor exceptions on `processState`, `processTupleMultiPort`, and while advancing the output iterator — each routed through `handleExecutorException` without propagating.

No production code changed.

### Any related issues, documentation, discussions?

Coverage gaps identified from the Codecov report for `apache/texera` (amber module coverage push toward 80%).

### How was this PR tested?

```
sbt "WorkflowExecutionService/testOnly *DataProcessorSpec"
```

All pass. `scalafmt` and `scalafixAll --check` are clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
