### PR TITLE
chore(deps): Upgrade to Pekko 1.6.0

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -445,17 +445,17 @@ Scala/Java jars:
   - org.apache.parquet.parquet-format-structures-1.13.1.jar
   - org.apache.parquet.parquet-hadoop-1.13.1.jar
   - org.apache.parquet.parquet-jackson-1.13.1.jar
-  - org.apache.pekko.pekko-actor_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-cluster-metrics_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-cluster-tools_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-cluster_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-coordination_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-persistence_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-pki_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-protobuf-v3_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-remote_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-slf4j_2.13-1.2.1.jar
-  - org.apache.pekko.pekko-stream_2.13-1.2.1.jar
+  - org.apache.pekko.pekko-actor_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-cluster-metrics_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-cluster-tools_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-cluster_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-coordination_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-persistence_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-pki_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-protobuf-v3_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-remote_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-slf4j_2.13-1.6.0.jar
+  - org.apache.pekko.pekko-stream_2.13-1.6.0.jar
   - org.apache.yetus.audience-annotations-0.13.0.jar
   - org.apache.zookeeper.zookeeper-3.5.6.jar
   - org.apache.zookeeper.zookeeper-jute-3.5.6.jar

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -88,7 +88,7 @@ PB.generate / excludeFilter := "scalapb.proto"
 
 /////////////////////////////////////////////////////////////////////////////
 // Pekko related
-val pekkoVersion = "1.2.1"
+val pekkoVersion = "1.6.0"
 val pekkoDependencies = Seq(
   "org.apache.pekko" %% "pekko-actor" % pekkoVersion,
   "org.apache.pekko" %% "pekko-remote" % pekkoVersion,


### PR DESCRIPTION
### What changes were proposed in this PR?

Bump Apache Pekko from 1.2.1 to 1.6.0: `pekkoVersion` in `amber/build.sbt`, plus the 11 corresponding `org.apache.pekko.*` jar entries in `amber/LICENSE-binary-java`.

Pekko is amber's actor runtime (actor, remote, cluster, persistence, stream, …); all modules move together on the shared version. The jump spans the 1.3.x → 1.6.0 maintenance lines — bug-fix and performance releases that stay binary compatible within the 1.x series ([1.6.x release notes](https://pekko.apache.org/docs/pekko/current/release-notes/releases-1.6.html)). No other bundled jars change (transitive dependencies are unaffected), so the LICENSE-binary diff is limited to the Pekko version strings.

### Any related issues, documentation, discussions?

Pekko release notes: [1.6.x](https://pekko.apache.org/docs/pekko/current/release-notes/releases-1.6.html) (see the linked notes for 1.3.x–1.5.x covered by this jump).

### How was this PR tested?

Existing test cases via the label-gated `engine` CI stack (amber unit tests + amber-integration on Linux/macOS); dependency bump only, no code change. The binary licensing check verifies the bundled jars against `amber/LICENSE-binary-java`.

### Was this PR authored or co-authored using generative AI tooling?

The dependency bump was authored by @pjfanning (no AI declaration). This PR description was written with generative AI tooling: Generated-by: Claude Code (Claude Fable 5).