### PR TITLE
chore(frontend): remove unused analyze script and webpack-bundle-analyzer

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,7 +25,6 @@ yarn install
 | Format (Prettier + ESLint --fix)                      | `yarn format:fix`                    |
 | Format check (CI shape)                               | `yarn format:ci`                     |
 | Lint only                                             | `yarn lint`                          |
-| Bundle analyzer                                       | `yarn analyze`                       |
 
 Run `ng help` for the full Angular CLI surface.
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "start": "concurrently --kill-others \"npx y-websocket\" \"ng serve\"",
     "build": "node build-version.js && node --max-old-space-size=8192 ./node_modules/@angular/cli/bin/ng build --configuration=production --progress=false --source-map=false",
     "build:ci": "node build-version.js && node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js build --configuration=production --progress=false --source-map=false",
-    "analyze": "ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/stats.json",
     "test": "ng test --watch=false",
     "test:ci": "node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test --watch=false --progress=false --coverage --coverage-reporters=lcovonly",
     "prettier:fix": "prettier --write ./src",
@@ -132,8 +131,7 @@
     "sass": "1.71.1",
     "ts-proto": "2.2.0",
     "typescript": "5.9.3",
-    "vitest": "4.1.9",
-    "webpack-bundle-analyzer": "4.5.0"
+    "vitest": "4.1.9"
   },
   "browserslist": [
     "defaults",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5139,7 +5139,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@polka/url@npm:^1.0.0-next.20, @polka/url@npm:^1.0.0-next.24":
+"@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
   checksum: 10c0/0d58e081844095cb029d3c19a659bfefd09d5d51a2f791bc61eba7ea826f13d6ee204a8a448c2f5a855c17df07b37517373ff916dd05801063c0568ae9937684
@@ -7180,21 +7180,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-walk@npm:^8.0.0, acorn-walk@npm:^8.1.1":
+"acorn-walk@npm:^8.1.1":
   version: 8.3.5
   resolution: "acorn-walk@npm:8.3.5"
   dependencies:
     acorn: "npm:^8.11.0"
   checksum: 10c0/e31bf5b5423ed1349437029d66d708b9fbd1b77a644b031501e2c753b028d13b56348210ed901d5b1d0d86eb3381c0a0fc0d0998511a9d546d1194936266a332
-  languageName: node
-  linkType: hard
-
-"acorn@npm:^8.0.4":
-  version: 8.17.0
-  resolution: "acorn@npm:8.17.0"
-  bin:
-    acorn: bin/acorn
-  checksum: 10c0/5dcefea5f8f023b6cc24cbe71fb5a8112b601d36c4fa07d14e4e6ffc2ee47383332c46b36c766d9437725aa6660156eae50efa0c838719823b50d7c327c4ed42
   languageName: node
   linkType: hard
 
@@ -8437,13 +8428,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "commander@npm:7.2.0"
-  checksum: 10c0/8d690ff13b0356df7e0ebbe6c59b4712f754f4b724d4f473d3cc5b3fdcf978e3a5dc3078717858a2ceb50b0f84d0660a7f22a96cdc50fb877d0c9bb31593d23a
-  languageName: node
-  linkType: hard
-
 "common-path-prefix@npm:^3.0.0":
   version: 3.0.0
   resolution: "common-path-prefix@npm:3.0.0"
@@ -9342,13 +9326,6 @@ __metadata:
   dependencies:
     readable-stream: "npm:^2.0.2"
   checksum: 10c0/0765a4cc6fe6d9615d43cc6dbccff6f8412811d89a6f6aa44828ca9422a0a469625ce023bf81cee68f52930dbedf9c5716056ff264ac886612702d134b5e39b4
-  languageName: node
-  linkType: hard
-
-"duplexer@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "duplexer@npm:0.1.2"
-  checksum: 10c0/c57bcd4bdf7e623abab2df43a7b5b23d18152154529d166c1e0da6bee341d84c432d157d7e97b32fecb1bf3a8b8857dd85ed81a915789f550637ed25b8e64fc2
   languageName: node
   linkType: hard
 
@@ -10826,7 +10803,6 @@ __metadata:
     typescript: "npm:5.9.3"
     uuid: "npm:14.0.0"
     vitest: "npm:4.1.9"
-    webpack-bundle-analyzer: "npm:4.5.0"
     y-monaco: "npm:0.1.5"
     y-protocols: "npm:1.0.5"
     y-quill: "npm:0.1.5"
@@ -10836,15 +10812,6 @@ __metadata:
     zone.js: "npm:0.15.1"
   languageName: unknown
   linkType: soft
-
-"gzip-size@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "gzip-size@npm:6.0.0"
-  dependencies:
-    duplexer: "npm:^0.1.2"
-  checksum: 10c0/4ccb924626c82125897a997d1c84f2377846a6ef57fbee38f7c0e6b41387fba4d00422274440747b58008b5d60114bac2349c2908e9aba55188345281af40a3f
-  languageName: node
-  linkType: hard
 
 "handle-thing@npm:^2.0.0":
   version: 2.0.1
@@ -12492,7 +12459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.21":
   version: 4.18.1
   resolution: "lodash@npm:4.18.1"
   checksum: 10c0/757228fc68805c59789e82185135cf85f05d0b2d3d54631d680ca79ec21944ec8314d4533639a14b8bcfbd97a517e78960933041a5af17ecb693ec6eecb99a27
@@ -13090,13 +13057,6 @@ __metadata:
   version: 2.0.1
   resolution: "mrmime@npm:2.0.1"
   checksum: 10c0/af05afd95af202fdd620422f976ad67dc18e6ee29beb03dd1ce950ea6ef664de378e44197246df4c7cdd73d47f2e7143a6e26e473084b9e4aa2095c0ad1e1761
-  languageName: node
-  linkType: hard
-
-"mrmime@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "mrmime@npm:1.0.1"
-  checksum: 10c0/ab071441da76fd23b3b0d1823d77aacf8679d379a4a94cacd83e487d3d906763b277f3203a594c613602e31ab5209c26a8119b0477c4541ef8555b293a9db6d3
   languageName: node
   linkType: hard
 
@@ -13813,7 +13773,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"opener@npm:^1.5.1, opener@npm:^1.5.2":
+"opener@npm:^1.5.1":
   version: 1.5.2
   resolution: "opener@npm:1.5.2"
   bin:
@@ -16303,17 +16263,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sirv@npm:^1.0.7":
-  version: 1.0.19
-  resolution: "sirv@npm:1.0.19"
-  dependencies:
-    "@polka/url": "npm:^1.0.0-next.20"
-    mrmime: "npm:^1.0.0"
-    totalist: "npm:^1.0.0"
-  checksum: 10c0/393cc0471e82d3e754a8c1b2b348a86249db1f686aeb11c17e4217326a8b1a96029d9f1b58362ebb3e511b7b98c47cd43c4305dde98322bb1259d07dec2d4908
-  languageName: node
-  linkType: hard
-
 "sirv@npm:^3.0.2":
   version: 3.0.2
   resolution: "sirv@npm:3.0.2"
@@ -16962,13 +16911,6 @@ __metadata:
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
-  languageName: node
-  linkType: hard
-
-"totalist@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "totalist@npm:1.1.0"
-  checksum: 10c0/2adbd4501c8290c2a96617a83dc67dfdd02bcbd360032017e27ccf27bbb09649bbe8dad1c45d97be6874281178aca5b3f62ed059d1eeda77c479cfb8eb3a9266
   languageName: node
   linkType: hard
 
@@ -17811,25 +17753,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:4.5.0":
-  version: 4.5.0
-  resolution: "webpack-bundle-analyzer@npm:4.5.0"
-  dependencies:
-    acorn: "npm:^8.0.4"
-    acorn-walk: "npm:^8.0.0"
-    chalk: "npm:^4.1.0"
-    commander: "npm:^7.2.0"
-    gzip-size: "npm:^6.0.0"
-    lodash: "npm:^4.17.20"
-    opener: "npm:^1.5.2"
-    sirv: "npm:^1.0.7"
-    ws: "npm:^7.3.1"
-  bin:
-    webpack-bundle-analyzer: lib/bin/analyzer.js
-  checksum: 10c0/5130be9fa58645e412e9824f98bd961afe540b9918951ddc87b688f3e176f4a101fcb16a304c74f0d1ddd9f2528ec2fa44bcfcea3fe07635fa9af0e3104644aa
-  languageName: node
-  linkType: hard
-
 "webpack-dev-middleware@npm:7.4.5, webpack-dev-middleware@npm:^7.4.2":
   version: 7.4.5
   resolution: "webpack-dev-middleware@npm:7.4.5"
@@ -18159,21 +18082,6 @@ __metadata:
   dependencies:
     async-limiter: "npm:~1.0.0"
   checksum: 10c0/5c2b9474164f9cb68c7776a1d10b0461c186f3a69bffb1028fca33eba5ab7206a09173fb0b311d6c5a81c8cf148406f8deb0b7d899542ab8ca67407d99717dad
-  languageName: node
-  linkType: hard
-
-"ws@npm:^7.3.1":
-  version: 7.5.11
-  resolution: "ws@npm:7.5.11"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/7972670b676fb1ccba73b0899ca3c2e04e8c2075629c2614cced7f556536f96a672bbf4619fc5a06c8b8720bb839a47ca88c69c95dc14c9c61a99fbecba1c866
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove the developer-only `analyze` npm script and its `webpack-bundle-analyzer` devDependency from the frontend.

| File | Change |
| --- | --- |
| `frontend/package.json` | Drop the `"analyze"` script and the `"webpack-bundle-analyzer": "4.5.0"` devDependency |
| `frontend/yarn.lock` | Regenerated — removes `webpack-bundle-analyzer` and its **exclusive** transitive deps (`commander`, `duplexer`, `gzip-size`, `mrmime`, `sirv`, `totalist`, `ws@^7.3.1`). Deps shared with other packages (`acorn`, `lodash`, `opener`, `@polka/url`, `acorn-walk`) stay — only their merged version-descriptors are trimmed |
| `frontend/README.md` | Drop the now-stale `Bundle analyzer → yarn analyze` row from the "Common commands" table |

The `analyze` script — `ng build --configuration=production --stats-json && webpack-bundle-analyzer dist/stats.json` — is a manual, on-demand bundle-inspection helper. It is not invoked by any build, CI, container, or test path, and `webpack-bundle-analyzer` is not imported programmatically anywhere in the repo, so both the script and its devDependency are safe to drop.

### Any related issues, documentation, discussions?

Closes #6161.

Split out of #4997 per review feedback in https://github.com/apache/texera/pull/4997#discussion_r3524565737, where this removal was flagged as unrelated to the monaco-languageclient v10 upgrade. That PR restores the script; this PR removes it independently so the change is reviewed on its own.

### How was this PR tested?

- **Lockfile consistency:** regenerated `frontend/yarn.lock` with `yarn install --mode=update-lockfile` (Yarn 4.14.1). A second pass produced no further changes, so CI's `yarn install --immutable` stays green.
- **Scope check:** confirmed the `yarn.lock` diff is limited to the `webpack-bundle-analyzer` subtree — shared transitive deps remain; only merged version-descriptors were trimmed (e.g. `acorn`'s `^8.0.4` spec dropped, the rest kept).
- **No dangling references:** whole-repo grep for `webpack-bundle-analyzer` / `BundleAnalyzerPlugin` (no source imports), no custom webpack config under `frontend/`, and no hits in `.github/workflows/**`, Dockerfiles, shell scripts, `nx.json`, `angular.json`, or any `LICENSE-binary` (dev-only tool, so no license-manifest entry to sync).
- `frontend/package.json` re-validated as parseable JSON after the edit.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
