### PR TITLE
chore(deps, 1.2): upgrade to jackson 2.18.8 

### DIFF
--- a/access-control-service/LICENSE-binary
+++ b/access-control-service/LICENSE-binary
@@ -221,9 +221,9 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.18.6.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
@@ -233,7 +233,7 @@ Scala/Java jars:
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
   - com.google.errorprone.error_prone_annotations-2.25.0.jar

--- a/access-control-service/NOTICE-binary
+++ b/access-control-service/NOTICE-binary
@@ -430,83 +430,6 @@ limitations under the License.
 This software includes projects with other licenses -- see `doc/LICENSE.md`.
 
 --------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
-# FastDoubleParser
-
-This is a Java port of Daniel Lemire's fast_float project.
-This project provides parsers for double, float, BigDecimal and BigInteger values.
-
-## Copyright
-
-Copyright © 2024 Werner Randelshofer, Switzerland.
-
-## Licensing
-
-This code is licensed under MIT License.
-https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
-(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-Some portions of the code have been derived from other projects.
-All these projects require that we include a copyright notice, and some require that we also include some text of their
-license file.
-
-fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
-https://github.com/lemire/fast_double_parser
-https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
-https://github.com/fastfloat/fast_float
-https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
-https://github.com/tbuktu/bigint/tree/floatfft
-https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
-https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
-(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
---------------------------------------------------------------------------------
 org.apache.commons.commons-lang3
 --------------------------------------------------------------------------------
 
@@ -1161,6 +1084,53 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+## Schubfach
+
+jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+under the following copyright.
+
+Copyright 2018-2020 Raffaello Giulietti
+
+See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-blackbird

--- a/access-control-service/build.sbt
+++ b/access-control-service/build.sbt
@@ -83,5 +83,5 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "io.dropwizard" % "dropwizard-core" % dropwizardVersion,
   "io.dropwizard" % "dropwizard-auth" % dropwizardVersion, // Dropwizard Authentication module
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.6"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.8"
 )

--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -222,9 +222,9 @@ Dependencies under the Apache License, Version 2.0
 Scala/Java jars:
   - ch.qos.reload4j.reload4j-1.2.18.3.jar
   - com.fasterxml.classmate-1.3.1.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.18.6.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.9.10.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.9.10.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.11.4.jar
@@ -234,10 +234,10 @@ Scala/Java jars:
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
   - com.fasterxml.jackson.module.jackson-module-afterburner-2.9.10.jar
   - com.fasterxml.jackson.module.jackson-module-jaxb-annotations-2.10.5.jar
-  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.6.jar
-  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
+  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.9.10.jar
-  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
   - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
   - com.flipkart.zjsonpatch.zjsonpatch-0.4.13.jar
   - com.github.ben-manes.caffeine.caffeine-2.9.3.jar

--- a/amber/NOTICE-binary
+++ b/amber/NOTICE-binary
@@ -882,83 +882,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
-# FastDoubleParser
-
-This is a Java port of Daniel Lemire's fast_float project.
-This project provides parsers for double, float, BigDecimal and BigInteger values.
-
-## Copyright
-
-Copyright © 2024 Werner Randelshofer, Switzerland.
-
-## Licensing
-
-This code is licensed under MIT License.
-https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
-(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-Some portions of the code have been derived from other projects.
-All these projects require that we include a copyright notice, and some require that we also include some text of their
-license file.
-
-fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
-https://github.com/lemire/fast_double_parser
-https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
-https://github.com/fastfloat/fast_float
-https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
-https://github.com/tbuktu/bigint/tree/floatfft
-https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
-https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
-(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
---------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -2009,6 +1932,53 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+## Schubfach
+
+jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+under the following copyright.
+
+Copyright 2018-2020 Raffaello Giulietti
+
+See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -120,7 +120,7 @@ val dropwizardDependencies = Seq(
 )
 
 
-val jacksonVersion = "2.18.6"
+val jacksonVersion = "2.18.8"
 val mbknorJacksonJsonSchemaDependencies = Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "javax.validation" % "validation-api" % "2.0.1.Final",

--- a/build.sbt
+++ b/build.sbt
@@ -60,7 +60,7 @@ lazy val universalJvmFlagsSettings = Seq(
 lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
 lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
 
-val jacksonVersion = "2.18.6"
+val jacksonVersion = "2.18.8"
 
 lazy val DAO = (project in file("common/dao")).settings(asfLicensingSettings)
 lazy val Config = (project in file("common/config")).settings(asfLicensingSettings)

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -96,7 +96,7 @@ libraryDependencies ++= Seq(
 // Jackson-related Dependencies
 /////////////////////////////////////////////////////////////////////////////
 
-val jacksonVersion = "2.18.6"
+val jacksonVersion = "2.18.8"
 libraryDependencies ++= Seq(
   "javax.validation" % "validation-api" % "2.0.1.Final",
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,        // Jackson Databind

--- a/common/workflow-operator/build.sbt
+++ b/common/workflow-operator/build.sbt
@@ -64,7 +64,7 @@ libraryDependencies ++= Seq(
 // Jackson-related Dependencies
 /////////////////////////////////////////////////////////////////////////////
 
-val jacksonVersion = "2.18.6"
+val jacksonVersion = "2.18.8"
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,                  // Jackson Databind
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,               // Jackson Annotation

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -221,9 +221,9 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.18.6.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.17.0.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
@@ -234,10 +234,10 @@ Scala/Java jars:
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.6.jar
-  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
+  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
   - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar

--- a/computing-unit-managing-service/NOTICE-binary
+++ b/computing-unit-managing-service/NOTICE-binary
@@ -768,83 +768,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
-# FastDoubleParser
-
-This is a Java port of Daniel Lemire's fast_float project.
-This project provides parsers for double, float, BigDecimal and BigInteger values.
-
-## Copyright
-
-Copyright © 2024 Werner Randelshofer, Switzerland.
-
-## Licensing
-
-This code is licensed under MIT License.
-https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
-(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-Some portions of the code have been derived from other projects.
-All these projects require that we include a copyright notice, and some require that we also include some text of their
-license file.
-
-fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
-https://github.com/lemire/fast_double_parser
-https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
-https://github.com/fastfloat/fast_float
-https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
-https://github.com/tbuktu/bigint/tree/floatfft
-https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
-https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
-(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
---------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -2058,6 +1981,53 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+## Schubfach
+
+jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+under the following copyright.
+
+Copyright 2018-2020 Raffaello Giulietti
+
+See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io

--- a/config-service/LICENSE-binary
+++ b/config-service/LICENSE-binary
@@ -221,9 +221,9 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.18.6.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
@@ -233,7 +233,7 @@ Scala/Java jars:
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
   - com.google.errorprone.error_prone_annotations-2.25.0.jar

--- a/config-service/NOTICE-binary
+++ b/config-service/NOTICE-binary
@@ -430,83 +430,6 @@ limitations under the License.
 This software includes projects with other licenses -- see `doc/LICENSE.md`.
 
 --------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
-# FastDoubleParser
-
-This is a Java port of Daniel Lemire's fast_float project.
-This project provides parsers for double, float, BigDecimal and BigInteger values.
-
-## Copyright
-
-Copyright © 2024 Werner Randelshofer, Switzerland.
-
-## Licensing
-
-This code is licensed under MIT License.
-https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
-(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-Some portions of the code have been derived from other projects.
-All these projects require that we include a copyright notice, and some require that we also include some text of their
-license file.
-
-fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
-https://github.com/lemire/fast_double_parser
-https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
-https://github.com/fastfloat/fast_float
-https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
-https://github.com/tbuktu/bigint/tree/floatfft
-https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
-https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
-(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
---------------------------------------------------------------------------------
 org.apache.commons.commons-lang3
 --------------------------------------------------------------------------------
 
@@ -1161,6 +1084,53 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+## Schubfach
+
+jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+under the following copyright.
+
+Copyright 2018-2020 Raffaello Giulietti
+
+See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-blackbird

--- a/config-service/build.sbt
+++ b/config-service/build.sbt
@@ -83,7 +83,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "io.dropwizard" % "dropwizard-core" % dropwizardVersion,
   "io.dropwizard" % "dropwizard-auth" % dropwizardVersion, // Dropwizard Authentication module
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.6",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.8",
   "jakarta.ws.rs" % "jakarta.ws.rs-api" % "3.1.0", // Ensure Jakarta JAX-RS API is available
   "org.bitbucket.b_c" % "jose4j" % "0.9.6",
   "org.playframework" %% "play-json" % "3.1.0-M1",

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -221,9 +221,9 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.18.6.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
@@ -234,10 +234,10 @@ Scala/Java jars:
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.6.jar
-  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
+  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
   - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar

--- a/file-service/NOTICE-binary
+++ b/file-service/NOTICE-binary
@@ -768,83 +768,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
-# FastDoubleParser
-
-This is a Java port of Daniel Lemire's fast_float project.
-This project provides parsers for double, float, BigDecimal and BigInteger values.
-
-## Copyright
-
-Copyright © 2024 Werner Randelshofer, Switzerland.
-
-## Licensing
-
-This code is licensed under MIT License.
-https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
-(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-Some portions of the code have been derived from other projects.
-All these projects require that we include a copyright notice, and some require that we also include some text of their
-license file.
-
-fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
-https://github.com/lemire/fast_double_parser
-https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
-https://github.com/fastfloat/fast_float
-https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
-https://github.com/tbuktu/bigint/tree/floatfft
-https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
-https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
-(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
---------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -2001,6 +1924,53 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+## Schubfach
+
+jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+under the following copyright.
+
+Copyright 2018-2020 Raffaello Giulietti
+
+See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io

--- a/file-service/build.sbt
+++ b/file-service/build.sbt
@@ -87,7 +87,7 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "io.dropwizard" % "dropwizard-core" % dropwizardVersion,
   "io.dropwizard" % "dropwizard-auth" % dropwizardVersion, // Dropwizard Authentication module
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.6",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.8",
   "jakarta.ws.rs" % "jakarta.ws.rs-api" % "3.1.0", // Ensure Jakarta JAX-RS API is available
   "org.bitbucket.b_c" % "jose4j" % "0.9.6",
   "org.playframework" %% "play-json" % "3.1.0-M1",

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -221,9 +221,9 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.6.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.18.6.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
@@ -234,10 +234,10 @@ Scala/Java jars:
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.6.jar
-  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
+  - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
-  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.6.jar
+  - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
   - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar

--- a/workflow-compiling-service/NOTICE-binary
+++ b/workflow-compiling-service/NOTICE-binary
@@ -1196,83 +1196,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
-and the licenses and copyrights that apply to that code.
-
-# FastDoubleParser
-
-This is a Java port of Daniel Lemire's fast_float project.
-This project provides parsers for double, float, BigDecimal and BigInteger values.
-
-## Copyright
-
-Copyright © 2024 Werner Randelshofer, Switzerland.
-
-## Licensing
-
-This code is licensed under MIT License.
-https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
-(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-Some portions of the code have been derived from other projects.
-All these projects require that we include a copyright notice, and some require that we also include some text of their
-license file.
-
-fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
-https://github.com/lemire/fast_double_parser
-https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
-https://github.com/fastfloat/fast_float
-https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
-bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
-https://github.com/tbuktu/bigint/tree/floatfft
-https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
-https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
-(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
-(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
-- as is required by that license.)
-
---------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -2429,6 +2352,53 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
+included in FastDoubleParser and the licenses and copyrights that apply to that code.
+
+## Schubfach
+
+jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
+That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
+under the following copyright.
+
+Copyright 2018-2020 Raffaello Giulietti
+
+See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io

--- a/workflow-compiling-service/build.sbt
+++ b/workflow-compiling-service/build.sbt
@@ -85,5 +85,5 @@ libraryDependencies ++= Seq(
 libraryDependencies ++= Seq(
   "io.dropwizard" % "dropwizard-core" % dropwizardVersion,
   "io.dropwizard" % "dropwizard-auth" % dropwizardVersion, // Dropwizard Authentication module
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.6"
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.18.8"
 )


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6152 to `release/v1.2`: bump Jackson 2.18.6 → 2.18.8 (`jacksonVersion` in the root `build.sbt`), update the jar entries in each service's `LICENSE-binary`, and regenerate the `NOTICE-binary` files for the updated `META-INF` NOTICE content shipped in the 2.18.8 jars.

Motivation is security: seven jackson-databind CVEs disclosed on 2026-06-22 (CVE-2026-54512 … 54518) are all fixed in 2.18.8, including two PolymorphicTypeValidator allowlist bypasses that allow arbitrary class instantiation when polymorphic deserialization is enabled ([CVE-2026-54512](https://github.com/advisories/GHSA-j3rv-43j4-c7qm), [CVE-2026-54513](https://nvd.nist.gov/vuln/detail/CVE-2026-54513)). See #6152 for details.

Differences from the mainline PR: the `notebook-migration-service/` changes are dropped — that module does not exist on `release/v1.2` (this is why the label-driven backport check on #6152 could not pass).

### Any related issues, documentation, discussions?

Backport of #6152.

### How was this PR tested?

Existing test cases via the label-gated CI stacks; dependency bump only, no code change. The binary licensing check verifies LICENSE-binary/NOTICE-binary against the built distributables.

### Was this PR authored or co-authored using generative AI tooling?

The original dependency bump was authored by @pjfanning (no AI declaration). The cherry-pick, NOTICE-binary regeneration, and this description were prepared with generative AI tooling: Generated-by: Claude Code (Claude Fable 5).