### PR TITLE
ci: submit sbt dependency graph for Dependabot alerts

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Submits the resolved sbt dependency graph (all modules, transitive
+# dependencies included) to GitHub via the Dependency Submission API so
+# that Dependabot alerts cover Scala dependencies, which GitHub cannot
+# parse from build.sbt on its own.
+name: Update Dependency Graph
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    if: github.repository == 'apache/texera'
+    permissions:
+      # The Dependency Submission API requires write permission
+      # on the repository
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: Setup sbt launcher
+        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+
+      - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
+
+      - name: Submit sbt dependency graph
+        uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.1.1
+        with:
+          configs-ignore: provided optional test compile-internal runtime-internal scala-tool scala-doc-tool


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `.github/workflows/dependency-graph.yml`: on every push to `main`, resolve the sbt build and submit the full dependency graph (all modules, transitive dependencies included) to GitHub via the Dependency Submission API, using [scalacenter/sbt-dependency-submission](https://github.com/scalacenter/sbt-dependency-submission).

GitHub cannot parse `build.sbt`, so today Dependabot alerts cover only the npm/pip manifests and Scala dependencies are invisible — the jackson-databind CVE batch fixed in #6152 never appeared in the security tab and was caught by hand. With the graph submitted, Scala dependencies (Jackson, Pekko, …) get Dependabot alerts like npm/pip. Alerts only — no automatic PRs (Dependabot security updates do not support sbt).

Notes for review:

- The third-party actions are pinned to full commit SHAs per the [ASF GitHub Actions policy](https://infra.apache.org/github-actions-policy.html); `sbt/setup-sbt` and `coursier/cache-action` reuse the exact pins already used elsewhere in this repo. The same submission action (same SHA) is used by apache/pekko and 7 other ASF repos.
- `configs-ignore` drops test/provided/optional/tooling scopes so alerts reflect what ships.
- The job is guarded with `if: github.repository == 'apache/texera'` and only triggers on push to `main`, so it never runs on forks or PRs.

### Any related issues, documentation, discussions?

Closes #6162

### How was this PR tested?

The workflow itself only runs post-merge on `apache/texera` `main` (see guard above), so it cannot be exercised by PR CI. Verified locally by running the underlying sbt plugin against this build:

```
sbt --addPluginSbtFile=<plugin.sbt> \
  'githubGenerateSnapshot {"ignoredConfigs":["provided","optional","test","compile-internal","runtime-internal","scala-tool","scala-doc-tool"]}'
```

completes with `[success]` and writes a snapshot containing 577 resolved packages across all modules, including `com.fasterxml.jackson.core:jackson-databind:2.18.8` and `org.apache.pekko:pekko-actor_2.13:1.6.0`. (It also surfaces a stale transitive `jackson-databind:2.12.3` in the tree — exactly the kind of finding this graph will make visible as an alert.)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)