### PR TITLE
ci: enable weekly Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Weekly Dependabot version updates. Minor/patch bumps are grouped into
+# one PR per ecosystem to limit CI and review load; major bumps come as
+# individual PRs. Security alerts are fed separately: npm/pip manifests
+# are parsed natively, sbt via .github/workflows/dependency-graph.yml.
+version: 2
+updates:
+  # Scala backend (root sbt build, all modules). Dependabot sbt support
+  # is in beta (2026-05); it cannot follow every build.sbt pattern yet,
+  # so treat missed updates as expected rather than misconfiguration.
+  - package-ecosystem: "sbt"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      sbt-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      frontend-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Angular majors need a guided `ng update` migration, and the
+      # framework/CLI lines must move together (see #6155).
+      - dependency-name: "@angular*/*"
+        update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "npm"
+    directory: "/pyright-language-service"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      pyright-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "pip"
+    directory: "/amber"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      python-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Weekly Dependabot version updates. Minor/patch bumps are grouped into
-# one PR per ecosystem to limit CI and review load; major bumps come as
-# individual PRs. Security alerts are fed separately: npm/pip manifests
+# Weekly Dependabot version updates. Patch bumps are grouped into one
+# PR per ecosystem (bug-fix only, low risk); minor and major bumps come
+# as individual PRs so each one passes or fails CI on its own. Security alerts are fed separately: npm/pip manifests
 # are parsed natively, sbt via .github/workflows/dependency-graph.yml.
 version: 2
 updates:
@@ -32,9 +32,8 @@ updates:
     commit-message:
       prefix: "fix(deps)"
     groups:
-      sbt-minor-and-patch:
+      sbt-patch:
         update-types:
-          - "minor"
           - "patch"
 
   - package-ecosystem: "npm"
@@ -46,9 +45,8 @@ updates:
       prefix: "fix(deps)"
       prefix-development: "chore(deps)"
     groups:
-      frontend-minor-and-patch:
+      frontend-patch:
         update-types:
-          - "minor"
           - "patch"
     ignore:
       # Angular majors need a guided `ng update` migration, and the
@@ -65,9 +63,8 @@ updates:
       prefix: "fix(deps)"
       prefix-development: "chore(deps)"
     groups:
-      pyright-minor-and-patch:
+      pyright-patch:
         update-types:
-          - "minor"
           - "patch"
 
   - package-ecosystem: "bun"
@@ -79,9 +76,8 @@ updates:
       prefix: "fix(deps)"
       prefix-development: "chore(deps)"
     groups:
-      agent-service-minor-and-patch:
+      agent-service-patch:
         update-types:
-          - "minor"
           - "patch"
 
   - package-ecosystem: "npm"
@@ -102,9 +98,8 @@ updates:
       prefix: "fix(deps)"
       prefix-development: "chore(deps)"
     groups:
-      python-minor-and-patch:
+      python-patch:
         update-types:
-          - "minor"
           - "patch"
 
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,6 +68,27 @@ updates:
           - "minor"
           - "patch"
 
+  - package-ecosystem: "bun"
+    directory: "/agent-service"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      agent-service-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/bin/y-websocket-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+
   - package-ecosystem: "pip"
     directory: "/amber"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,8 +42,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps)"
+      prefix: "fix(deps, frontend)"
+      prefix-development: "chore(deps, frontend)"
     groups:
       frontend-patch:
         update-types:
@@ -60,8 +60,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps)"
+      prefix: "fix(deps, pyright-language-service)"
+      prefix-development: "chore(deps, pyright-language-service)"
     groups:
       pyright-patch:
         update-types:
@@ -73,8 +73,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps)"
+      prefix: "fix(deps, agent-service)"
+      prefix-development: "chore(deps, agent-service)"
     groups:
       agent-service-patch:
         update-types:
@@ -86,8 +86,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps)"
+      prefix: "fix(deps, y-websocket-server)"
+      prefix-development: "chore(deps, y-websocket-server)"
 
   - package-ecosystem: "pip"
     directory: "/amber"
@@ -95,8 +95,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "fix(deps)"
-      prefix-development: "chore(deps)"
+      prefix: "fix(deps, pyamber)"
+      prefix-development: "chore(deps, pyamber)"
     groups:
       python-patch:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,7 +30,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
     groups:
       sbt-minor-and-patch:
         update-types:
@@ -43,7 +43,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
     groups:
       frontend-minor-and-patch:
         update-types:
@@ -61,7 +62,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
     groups:
       pyright-minor-and-patch:
         update-types:
@@ -74,7 +76,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
     groups:
       agent-service-minor-and-patch:
         update-types:
@@ -87,7 +90,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
 
   - package-ecosystem: "pip"
     directory: "/amber"
@@ -95,7 +99,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
+      prefix-development: "chore(deps)"
     groups:
       python-minor-and-patch:
         update-types:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,8 +124,10 @@ Short, **Conventional Commits**, same shape for branch and commit subject.
 
 Both ≤ ~60 chars. For code changes, if you use a scope, use the module name
 (`amber`, `pyamber`, `frontend`, `agent-service`, `file-service`, …) — not
-`amber-python`. Use `chore(deps): ...` for dependency-only updates, and
-`ci: ...` for CI-only changes. No `Co-authored-by:` trailer for the repo
+`amber-python`. Dependency-only updates split by semantics: `fix(deps): ...` for
+runtime/production dependency bumps (they ship to users),
+`chore(deps): ...` for dev/toolchain-only bumps, and `ci: ...` for
+CI-only changes (including GitHub Actions bumps). No `Co-authored-by:` trailer for the repo
 owner.
 
 ### Issues and PRs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,9 @@ Both ≤ ~60 chars. For code changes, if you use a scope, use the module name
 `amber-python`. Dependency-only updates split by semantics: `fix(deps): ...` for
 runtime/production dependency bumps (they ship to users),
 `chore(deps): ...` for dev/toolchain-only bumps, and `ci: ...` for
-CI-only changes (including GitHub Actions bumps). No `Co-authored-by:` trailer for the repo
+CI-only changes (including GitHub Actions bumps). Append the module
+as a second scope when the bump is module-specific, e.g.
+`fix(deps, pyamber): ...`; omit it for cross-module bumps (sbt). No `Co-authored-by:` trailer for the repo
 owner.
 
 ### Issues and PRs


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `.github/dependabot.yml` to enable weekly Dependabot **version updates** — the complementary half of #6163 (which feeds security *alerts*): alerts flag vulnerable dependencies, version updates keep dependencies current so alerts rarely fire.

| Ecosystem | Directory | Notes |
| --- | --- | --- |
| `sbt` | `/` (root build, all modules) | New Dependabot ecosystem (beta, 2026-05); first use in the ASF org |
| `npm` | `/frontend`, `/pyright-language-service` | Angular majors ignored — they need a guided `ng update` migration with framework/CLI lines moving together (see #6155) |
| `bun` | `/agent-service` | agent-service is a Bun project (`bun.lock`) |
| `npm` | `/bin/y-websocket-server` | Single-dependency utility, no lockfile |
| `pip` | `/amber` | Covers `pyproject.toml` and all `*requirements*.txt` in the directory (`requirements`, `operator-requirements`, `dev-requirements`) — same detection the dependency graph already uses for alerts |
| `github-actions` | `/` | Commit prefix `ci` per repo convention |

Noise control: **weekly** schedule, **patch bumps grouped into a single PR per ecosystem** (bug-fix only, low risk); **minor and major bumps come as individual PRs** — a failed group PR cannot be bisected by the bot, so anything that can carry behavior changes passes or fails CI on its own. ≤5 open PRs per ecosystem bounds the volume. (github-actions stays fully grouped: SHA/tag bumps, ci-only blast radius.)

Commit/PR-title prefixes are split by dependency semantics (and AGENTS.md is updated to record the convention): runtime/production bumps get `fix(deps, <module>)` — they ship to users — while dev/toolchain bumps get `chore(deps, <module>)` via `prefix-development` (npm devDependencies, pip `dev-requirements.txt`, bun devDependencies), with the module as second scope per the repo convention (`pyamber`, `frontend`, `agent-service`, …; the cross-module sbt entry stays plain `fix(deps)`); GitHub Actions bumps use `ci`. All types pass the PR title check. 267 ASF repos already use `dependabot.yml`.

Notes for review:

- Local schema validation passes except the `sbt` enum value — schemastore still lags the 2026-05 beta; GitHub's changelog ([Dependabot version updates now support the sbt ecosystem](https://github.blog/changelog/2026-05-26-dependabot-version-updates-now-support-the-sbt-ecosystem/)) is authoritative for the key. After merge, any config error would surface under Insights → Dependency graph → Dependabot.
- The sbt ecosystem is beta: it may not follow every `build.sbt` pattern (e.g. version `val`s), so missed sbt updates are expected at first, not misconfiguration.
- `.asf.yaml`'s `dependabot_updates` (automatic security-*fix* PRs) is deliberately left `false` to avoid a burst of bot PRs for the existing alert backlog while #6152/#6155 are in flight; it can be flipped separately later.

### Any related issues, documentation, discussions?

Closes #6164. Related: #6162 / #6163 (sbt dependency graph for alerts).

### How was this PR tested?

Config-only change; Dependabot runs server-side after merge, so it cannot be exercised by PR CI. Validated locally:

- `yaml.safe_load` parses the file.
- `check-jsonschema --builtin-schema vendor.dependabot` passes for all entries except the not-yet-in-schema `sbt` ecosystem value (see note above).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)



