### PR TITLE
fix(deps, v1.2): replace EOL log4j 1.2 with log4j 2.26.1 bridges

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -368,7 +368,6 @@ Scala/Java jars:
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
   - joda-time.joda-time-2.11.0.jar
-  - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.7.jar
   - net.minidev.json-smart-2.4.7.jar
   - org.agrona.agrona-1.22.0.jar
@@ -430,6 +429,9 @@ Scala/Java jars:
   - org.apache.kerby.kerby-util-1.0.1.jar
   - org.apache.kerby.kerby-xdr-1.0.1.jar
   - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.logging.log4j.log4j-1.2-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-to-slf4j-2.26.1.jar
   - org.apache.lucene.lucene-analyzers-common-8.11.4.jar
   - org.apache.lucene.lucene-core-8.11.4.jar
   - org.apache.lucene.lucene-memory-8.7.0.jar

--- a/amber/NOTICE-binary
+++ b/amber/NOTICE-binary
@@ -512,16 +512,6 @@ which can be obtained from
   https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.0.3-20170922.tar.gz
 
 --------------------------------------------------------------------------------
-ch.qos.reload4j.reload4j
---------------------------------------------------------------------------------
-
-Apache log4j
-Copyright 2007 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.lucene
 --------------------------------------------------------------------------------
 
@@ -907,6 +897,16 @@ org.apache.kerby.kerb-util
 
 Kerby-kerb Util
 Copyright 2014-2017 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+ch.qos.reload4j.reload4j
+--------------------------------------------------------------------------------
+
+Apache log4j
+Copyright 2007 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1305,6 +1305,17 @@ org.apache.httpcomponents.client5.httpclient5
 
 Apache HttpClient
 Copyright 1999-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-api
+--------------------------------------------------------------------------------
+
+Apache Log4j API
+Copyright 1999-2026 The Apache Software Foundation
+
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1765,6 +1776,17 @@ Unless required by applicable law or agreed to in writing, software distributed 
 is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 or implied. See the License for the specific language governing permissions and limitations under
 the License.
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-to-slf4j
+--------------------------------------------------------------------------------
+
+Log4j API to SLF4J Adapter
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-server
@@ -2252,6 +2274,17 @@ another country, of encryption software. BEFORE using any encryption software,
 please check the country's laws, regulations and policies concerning the import,
 possession, or use, and re-export of encryption software, to see if this is
 permitted.
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-1.2-api
+--------------------------------------------------------------------------------
+
+Apache Log4j 1.x Compatibility API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-common

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,12 @@ lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOpera
 
 val jacksonVersion = "2.18.8"
 
+// Hadoop/ZooKeeper (declared in common/workflow-core and amber) pull in the
+// EOL log4j 1.2.17, which has open CVEs and no fixed 1.x release. Keep it out
+// of every module; the log4j 2.x bridges declared in common/workflow-core
+// keep the org.apache.log4j API available at runtime.
+ThisBuild / excludeDependencies += ExclusionRule("log4j", "log4j")
+
 lazy val DAO = (project in file("common/dao")).settings(asfLicensingSettings)
 lazy val Config = (project in file("common/config")).settings(asfLicensingSettings)
 lazy val Auth = (project in file("common/auth"))

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -153,6 +153,7 @@ val excludeJsp = ExclusionRule(organization = "javax.servlet.jsp")
 val excludeXmlBind = ExclusionRule(organization = "javax.xml.bind")
 val excludeJackson = ExclusionRule(organization = "com.fasterxml.jackson.core")
 val excludeJacksonModule = ExclusionRule(organization = "com.fasterxml.jackson.module")
+val log4jVersion = "2.26.1"
 
 libraryDependencies ++= Seq(
   "org.apache.iceberg" % "iceberg-api" % "1.7.1",
@@ -192,6 +193,12 @@ libraryDependencies ++= Seq(
     excludeJackson,
     excludeJacksonModule
   ),
+  // log4j:log4j is excluded build-wide (root build.sbt) because 1.x is EOL
+  // with open CVEs. These log4j 2.x bridges keep hadoop/zookeeper's
+  // org.apache.log4j calls working by routing them through the log4j 2 API
+  // into slf4j (and on to logback).
+  "org.apache.logging.log4j" % "log4j-1.2-api" % log4jVersion,
+  "org.apache.logging.log4j" % "log4j-to-slf4j" % log4jVersion,
   "org.postgresql" % "postgresql" % "42.7.10"
 )
 

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -376,7 +376,6 @@ Scala/Java jars:
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
-  - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.2.jar
   - net.minidev.json-smart-2.4.2.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
@@ -435,6 +434,9 @@ Scala/Java jars:
   - org.apache.kerby.kerby-util-1.0.1.jar
   - org.apache.kerby.kerby-xdr-1.0.1.jar
   - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.logging.log4j.log4j-1.2-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-to-slf4j-2.26.1.jar
   - org.apache.orc.orc-core-1.9.4-nohive.jar
   - org.apache.orc.orc-shims-1.9.4.jar
   - org.apache.parquet.parquet-avro-1.13.1.jar
@@ -546,7 +548,7 @@ Scala/Java jars:
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jul-to-slf4j-2.0.12.jar
-  - org.slf4j.slf4j-api-2.0.16.jar
+  - org.slf4j.slf4j-api-2.0.17.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the BSD 3-Clause License

--- a/computing-unit-managing-service/NOTICE-binary
+++ b/computing-unit-managing-service/NOTICE-binary
@@ -788,16 +788,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-log4j.log4j
---------------------------------------------------------------------------------
-
-Apache log4j
-Copyright 2007 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 commons-codec.commons-codec
 --------------------------------------------------------------------------------
 
@@ -1476,6 +1466,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-api
+--------------------------------------------------------------------------------
+
+Apache Log4j API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.kerby.kerb-crypto
 --------------------------------------------------------------------------------
 
@@ -1799,6 +1800,17 @@ org.apache.httpcomponents.core5.httpcore5-h2
 
 Apache HttpComponents Core HTTP/2
 Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-to-slf4j
+--------------------------------------------------------------------------------
+
+Log4j API to SLF4J Adapter
+Copyright 1999-2026 The Apache Software Foundation
+
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2403,6 +2415,17 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-1.2-api
+--------------------------------------------------------------------------------
+
+Apache Log4j 1.x Compatibility API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-common

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -340,7 +340,6 @@ Scala/Java jars:
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
-  - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.2.jar
   - net.minidev.json-smart-2.4.2.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
@@ -398,6 +397,9 @@ Scala/Java jars:
   - org.apache.kerby.kerby-util-1.0.1.jar
   - org.apache.kerby.kerby-xdr-1.0.1.jar
   - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.logging.log4j.log4j-1.2-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-to-slf4j-2.26.1.jar
   - org.apache.orc.orc-core-1.9.4-nohive.jar
   - org.apache.orc.orc-shims-1.9.4.jar
   - org.apache.parquet.parquet-avro-1.13.1.jar
@@ -507,7 +509,7 @@ Scala/Java jars:
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jul-to-slf4j-2.0.12.jar
-  - org.slf4j.slf4j-api-2.0.16.jar
+  - org.slf4j.slf4j-api-2.0.17.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the BSD 3-Clause License

--- a/file-service/NOTICE-binary
+++ b/file-service/NOTICE-binary
@@ -788,16 +788,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-log4j.log4j
---------------------------------------------------------------------------------
-
-Apache log4j
-Copyright 2007 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 commons-codec.commons-codec
 --------------------------------------------------------------------------------
 
@@ -1476,6 +1466,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-api
+--------------------------------------------------------------------------------
+
+Apache Log4j API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.kerby.kerb-crypto
 --------------------------------------------------------------------------------
 
@@ -1789,6 +1790,17 @@ org.apache.httpcomponents.core5.httpcore5-h2
 
 Apache HttpComponents Core HTTP/2
 Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-to-slf4j
+--------------------------------------------------------------------------------
+
+Log4j API to SLF4J Adapter
+Copyright 1999-2026 The Apache Software Foundation
+
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2389,6 +2401,17 @@ another country, of encryption software. BEFORE using any encryption software,
 please check the country's laws, regulations and policies concerning the import,
 possession, or use, and re-export of encryption software, to see if this is
 permitted.
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-1.2-api
+--------------------------------------------------------------------------------
+
+Apache Log4j 1.x Compatibility API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-common

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -342,7 +342,6 @@ Scala/Java jars:
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
-  - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.2.jar
   - net.minidev.json-smart-2.4.2.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
@@ -403,6 +402,9 @@ Scala/Java jars:
   - org.apache.kerby.kerby-util-1.0.1.jar
   - org.apache.kerby.kerby-xdr-1.0.1.jar
   - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.logging.log4j.log4j-1.2-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-api-2.26.1.jar
+  - org.apache.logging.log4j.log4j-to-slf4j-2.26.1.jar
   - org.apache.lucene.lucene-analyzers-common-8.11.4.jar
   - org.apache.lucene.lucene-core-8.11.4.jar
   - org.apache.lucene.lucene-memory-8.7.0.jar
@@ -518,7 +520,7 @@ Scala/Java jars:
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jul-to-slf4j-2.0.12.jar
-  - org.slf4j.slf4j-api-2.0.16.jar
+  - org.slf4j.slf4j-api-2.0.17.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the BSD 3-Clause License

--- a/workflow-compiling-service/NOTICE-binary
+++ b/workflow-compiling-service/NOTICE-binary
@@ -1226,16 +1226,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-log4j.log4j
---------------------------------------------------------------------------------
-
-Apache log4j
-Copyright 2007 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 commons-codec.commons-codec
 --------------------------------------------------------------------------------
 
@@ -1904,6 +1894,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-api
+--------------------------------------------------------------------------------
+
+Apache Log4j API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.kerby.kerb-crypto
 --------------------------------------------------------------------------------
 
@@ -2217,6 +2218,17 @@ org.apache.httpcomponents.core5.httpcore5-h2
 
 Apache HttpComponents Core HTTP/2
 Copyright 2005-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-to-slf4j
+--------------------------------------------------------------------------------
+
+Log4j API to SLF4J Adapter
+Copyright 1999-2026 The Apache Software Foundation
+
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2837,6 +2849,17 @@ another country, of encryption software. BEFORE using any encryption software,
 please check the country's laws, regulations and policies concerning the import,
 possession, or use, and re-export of encryption software, to see if this is
 permitted.
+
+--------------------------------------------------------------------------------
+org.apache.logging.log4j.log4j-1.2-api
+--------------------------------------------------------------------------------
+
+Apache Log4j 1.x Compatibility API
+Copyright 1999-2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-common


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6199 to `release/v1.2` (the automated backport hit a `build.sbt` context conflict, so this is a manual port of the same change):

- exclude `log4j:log4j` 1.2.17 build-wide (`ThisBuild / excludeDependencies`, root `build.sbt`) — it arrives transitively via Hadoop/ZooKeeper and log4j 1.x is EOL with open CVEs;
- add the `log4j-1.2-api` / `log4j-to-slf4j` 2.26.1 bridges in `common/workflow-core`, keeping the `org.apache.log4j` API routed through the log4j 2 API into slf4j/logback;
- update `LICENSE-binary` and regenerate `NOTICE-binary` for the four dists that bundled log4j 1.2.17 (amber, computing-unit-managing-service, file-service, workflow-compiling-service). `log4j-to-slf4j` bumps `slf4j-api` 2.0.16 → 2.0.17 in the three platform services (amber stays pinned at 1.7.26).

### Any related issues, documentation, discussions?

Backport of #6199. Resolves the six open `log4j:log4j` Dependabot alerts for the v1.2 line: CVE-2019-17571, CVE-2022-23307, CVE-2022-23305 (critical); CVE-2023-26464, CVE-2022-23302, CVE-2021-4104 (high).

### How was this PR tested?

Dependency-only change; existing CI compile/test stacks cover it. Verified locally on this branch:

- built the four dists and confirmed `log4j-1.2.17.jar` is gone and only the three 2.26.1 jars remain;
- `./bin/licensing/check_binary_deps.py --ignore-transitive-version jar --license-binary <svc>/LICENSE-binary <dist>/lib` passes for all four dists;
- `NOTICE-binary` files regenerated with `./bin/licensing/generate_notice_binary.py` from the rebuilt dists.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)