### PR TITLE
fix(deps, v1.2): upgrade Apache Hadoop to 3.4.3 to resolve hadoop-common CVEs

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -671,9 +671,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
   - javax.websocket.javax.websocket-api-1.0.jar
   - javax.websocket.javax.websocket-client-api-1.0.jar
   - javax.xml.bind.jaxb-api-2.3.0.jar

--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -220,7 +220,7 @@ Dependencies under the Apache License, Version 2.0
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - ch.qos.reload4j.reload4j-1.2.18.3.jar
+  - ch.qos.reload4j.reload4j-1.2.22.jar
   - com.fasterxml.classmate-1.3.1.jar
   - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
   - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
@@ -230,22 +230,21 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.11.4.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-joda-2.9.10.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.16.0.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
   - com.fasterxml.jackson.module.jackson-module-afterburner-2.9.10.jar
-  - com.fasterxml.jackson.module.jackson-module-jaxb-annotations-2.10.5.jar
+  - com.fasterxml.jackson.module.jackson-module-jaxb-annotations-2.12.7.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.9.10.jar
   - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
-  - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
+  - com.fasterxml.woodstox.woodstox-core-5.4.0.jar
   - com.flipkart.zjsonpatch.zjsonpatch-0.4.13.jar
   - com.github.ben-manes.caffeine.caffeine-2.9.3.jar
   - com.github.dirkraft.dropwizard.dropwizard-file-assets-0.0.2.jar
   - com.github.nscala-time.nscala-time_2.13-2.32.0.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar
   - com.github.sisyphsu.retree-1.0.4.jar
-  - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.github.toastshaman.dropwizard-auth-jwt-1.1.2-0.jar
   - com.github.tototoshi.scala-csv_2.13-1.3.10.jar
   - com.google.android.annotations-4.1.1.4.jar
@@ -261,20 +260,19 @@ Scala/Java jars:
   - com.google.http-client.google-http-client-1.42.3.jar
   - com.google.http-client.google-http-client-apache-v2-1.42.3.jar
   - com.google.http-client.google-http-client-gson-1.42.3.jar
-  - com.google.inject.extensions.guice-servlet-4.0.jar
-  - com.google.inject.guice-4.0.jar
+  - com.google.inject.extensions.guice-servlet-4.2.3.jar
+  - com.google.inject.guice-4.2.3.jar
   - com.google.j2objc.j2objc-annotations-2.8.jar
   - com.google.oauth-client.google-oauth-client-1.34.1.jar
   - com.google.oauth-client.google-oauth-client-java6-1.34.1.jar
   - com.google.oauth-client.google-oauth-client-jetty-1.34.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.hierynomus.asn-one-0.6.0.jar
-  - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
+  - com.nimbusds.nimbus-jose-jwt-10.4.jar
   - com.papertrail.profiler-1.0.2.jar
   - com.softwaremill.common.tagging_2.13-2.3.5.jar
   - com.softwaremill.macwire.proxy_2.13-2.6.7.jar
   - com.softwaremill.macwire.util_2.13-2.6.7.jar
-  - com.squareup.okhttp.okhttp-2.7.5.jar
   - com.squareup.okhttp3.logging-interceptor-4.12.0.jar
   - com.squareup.okhttp3.okhttp-4.12.0.jar
   - com.squareup.okio.okio-3.6.0.jar
@@ -292,13 +290,11 @@ Scala/Java jars:
   - com.typesafe.ssl-config-core_2.13-0.6.1.jar
   - com.univocity.univocity-parsers-2.9.1.jar
   - com.zaxxer.HikariCP-5.1.0.jar
-  - commons-beanutils.commons-beanutils-1.9.4.jar
-  - commons-cli.commons-cli-1.2.jar
+  - commons-cli.commons-cli-1.9.0.jar
   - commons-codec.commons-codec-1.17.1.jar
-  - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
-  - commons-logging.commons-logging-1.2.jar
-  - commons-net.commons-net-3.6.jar
+  - commons-logging.commons-logging-1.3.0.jar
+  - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
   - io.airlift.aircompressor-0.27.jar
@@ -341,7 +337,6 @@ Scala/Java jars:
   - io.gsonfire.gson-fire-1.8.5.jar
   - io.kamon.sigar-loader-1.6.6-rev002.jar
   - io.lakefs.sdk-1.51.0.jar
-  - io.netty.netty-3.10.6.Final.jar
   - io.netty.netty-buffer-4.1.96.Final.jar
   - io.netty.netty-codec-4.1.96.Final.jar
   - io.netty.netty-codec-http-4.1.96.Final.jar
@@ -359,6 +354,8 @@ Scala/Java jars:
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
   - io.netty.netty-tcnative-classes-2.0.61.Final.jar
   - io.netty.netty-transport-4.1.96.Final.jar
+  - io.netty.netty-transport-classes-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-epoll-4.1.127.Final.jar
   - io.netty.netty-transport-native-unix-common-4.1.96.Final.jar
   - io.opencensus.opencensus-api-0.31.1.jar
   - io.opencensus.opencensus-contrib-http-util-0.31.1.jar
@@ -368,9 +365,6 @@ Scala/Java jars:
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
   - joda-time.joda-time-2.11.0.jar
-  - log4j.log4j-1.2.17.jar
-  - net.minidev.accessors-smart-2.4.7.jar
-  - net.minidev.json-smart-2.4.7.jar
   - org.agrona.agrona-1.22.0.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
   - org.apache.arrow.arrow-memory-core-15.0.2.jar
@@ -379,27 +373,27 @@ Scala/Java jars:
   - org.apache.arrow.flight-core-15.0.2.jar
   - org.apache.arrow.flight-grpc-15.0.2.jar
   - org.apache.avro.avro-1.12.0.jar
-  - org.apache.commons.commons-collections4-4.2.jar
+  - org.apache.commons.commons-collections4-4.4.jar
   - org.apache.commons.commons-compress-1.27.1.jar
-  - org.apache.commons.commons-configuration2-2.1.1.jar
+  - org.apache.commons.commons-configuration2-2.10.1.jar
   - org.apache.commons.commons-jcs3-core-3.2.jar
-  - org.apache.commons.commons-lang3-3.16.0.jar
-  - org.apache.commons.commons-math3-3.1.1.jar
-  - org.apache.commons.commons-text-1.4.jar
+  - org.apache.commons.commons-lang3-3.18.0.jar
+  - org.apache.commons.commons-math3-3.6.1.jar
+  - org.apache.commons.commons-text-1.14.0.jar
   - org.apache.commons.commons-vfs2-2.9.0.jar
-  - org.apache.curator.curator-client-4.2.0.jar
-  - org.apache.curator.curator-framework-4.2.0.jar
-  - org.apache.curator.curator-recipes-4.2.0.jar
-  - org.apache.hadoop.hadoop-annotations-3.3.3.jar
-  - org.apache.hadoop.hadoop-auth-3.3.3.jar
-  - org.apache.hadoop.hadoop-common-3.3.3.jar
-  - org.apache.hadoop.hadoop-hdfs-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-mapreduce-client-core-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-api-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-common-3.3.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.1.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_7-1.1.1.jar
+  - org.apache.curator.curator-client-5.2.0.jar
+  - org.apache.curator.curator-framework-5.2.0.jar
+  - org.apache.curator.curator-recipes-5.2.0.jar
+  - org.apache.hadoop.hadoop-annotations-3.4.3.jar
+  - org.apache.hadoop.hadoop-auth-3.4.3.jar
+  - org.apache.hadoop.hadoop-common-3.4.3.jar
+  - org.apache.hadoop.hadoop-hdfs-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-mapreduce-client-core-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-api-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
   - org.apache.httpcomponents.client5.httpclient5-5.4.jar
   - org.apache.httpcomponents.core5.httpcore5-5.3.jar
   - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
@@ -415,21 +409,13 @@ Scala/Java jars:
   - org.apache.iceberg.iceberg-core-1.7.1.jar
   - org.apache.iceberg.iceberg-data-1.7.1.jar
   - org.apache.iceberg.iceberg-parquet-1.7.1.jar
-  - org.apache.kerby.kerb-admin-1.0.1.jar
-  - org.apache.kerby.kerb-client-1.0.1.jar
-  - org.apache.kerby.kerb-common-1.0.1.jar
-  - org.apache.kerby.kerb-core-1.0.1.jar
-  - org.apache.kerby.kerb-crypto-1.0.1.jar
-  - org.apache.kerby.kerb-identity-1.0.1.jar
-  - org.apache.kerby.kerb-server-1.0.1.jar
-  - org.apache.kerby.kerb-simplekdc-1.0.1.jar
-  - org.apache.kerby.kerb-util-1.0.1.jar
-  - org.apache.kerby.kerby-asn1-1.0.1.jar
-  - org.apache.kerby.kerby-config-1.0.1.jar
-  - org.apache.kerby.kerby-pkix-1.0.1.jar
-  - org.apache.kerby.kerby-util-1.0.1.jar
-  - org.apache.kerby.kerby-xdr-1.0.1.jar
-  - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.kerby.kerb-core-2.0.3.jar
+  - org.apache.kerby.kerb-crypto-2.0.3.jar
+  - org.apache.kerby.kerb-util-2.0.3.jar
+  - org.apache.kerby.kerby-asn1-2.0.3.jar
+  - org.apache.kerby.kerby-config-2.0.3.jar
+  - org.apache.kerby.kerby-pkix-2.0.3.jar
+  - org.apache.kerby.kerby-util-2.0.3.jar
   - org.apache.lucene.lucene-analyzers-common-8.11.4.jar
   - org.apache.lucene.lucene-core-8.11.4.jar
   - org.apache.lucene.lucene-memory-8.7.0.jar
@@ -457,29 +443,30 @@ Scala/Java jars:
   - org.apache.pekko.pekko-slf4j_2.13-1.2.1.jar
   - org.apache.pekko.pekko-stream_2.13-1.2.1.jar
   - org.apache.yetus.audience-annotations-0.13.0.jar
-  - org.apache.zookeeper.zookeeper-3.5.6.jar
-  - org.apache.zookeeper.zookeeper-jute-3.5.6.jar
+  - org.apache.zookeeper.zookeeper-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
+  - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-annotations-9.4.18.v20190429.jar
-  - org.eclipse.jetty.jetty-client-9.4.40.v20210413.jar
+  - org.eclipse.jetty.jetty-client-9.4.57.v20241219.jar
   - org.eclipse.jetty.jetty-continuation-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-http-9.4.20.v20190813.jar
-  - org.eclipse.jetty.jetty-io-9.4.40.v20210413.jar
+  - org.eclipse.jetty.jetty-io-9.4.57.v20241219.jar
   - org.eclipse.jetty.jetty-jndi-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-plus-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-security-9.4.20.v20190813.jar
   - org.eclipse.jetty.jetty-server-9.4.20.v20190813.jar
   - org.eclipse.jetty.jetty-servlet-9.4.20.v20190813.jar
   - org.eclipse.jetty.jetty-servlets-9.4.18.v20190429.jar
-  - org.eclipse.jetty.jetty-util-9.4.40.v20210413.jar
+  - org.eclipse.jetty.jetty-util-9.4.57.v20241219.jar
   - org.eclipse.jetty.jetty-webapp-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-xml-9.4.18.v20190429.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.3.jar
   - org.eclipse.jetty.websocket.javax-websocket-client-impl-9.4.18.v20190429.jar
   - org.eclipse.jetty.websocket.javax-websocket-server-impl-9.4.18.v20190429.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.40.v20210413.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
   - org.eclipse.jetty.websocket.websocket-server-9.4.18.v20190429.jar
   - org.eclipse.jetty.websocket.websocket-servlet-9.4.18.v20190429.jar
   - org.ehcache.sizeof-0.4.3.jar
@@ -512,7 +499,7 @@ Scala/Java jars:
   - org.typelevel.cats-effect-std_2.13-3.6.3.jar
   - org.typelevel.cats-effect_2.13-3.6.3.jar
   - org.typelevel.cats-mtl_2.13-1.3.1.jar
-  - org.xerial.snappy.snappy-java-1.1.8.3.jar
+  - org.xerial.snappy.snappy-java-1.1.10.4.jar
   - org.yaml.snakeyaml-1.23.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -573,6 +560,7 @@ Scala/Java jars:
   - com.liveperson.dropwizard-websockets-1.3.14.jar
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.8.1.jar
+  - org.bouncycastle.bcprov-jdk18on-1.82.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
   - org.projectlombok.lombok-1.18.24.jar
@@ -600,7 +588,7 @@ Scala/Java jars:
   - com.thoughtworks.paranamer.paranamer-2.8.jar
   - org.fusesource.leveldbjni.leveldbjni-all-1.8.jar
   - org.jline.jline-3.9.0.jar
-  - org.ow2.asm.asm-9.1.jar
+  - org.ow2.asm.asm-7.0.jar
   - org.ow2.asm.asm-analysis-7.0.jar
   - org.ow2.asm.asm-commons-7.0.jar
   - org.ow2.asm.asm-tree-7.0.jar
@@ -614,7 +602,7 @@ Dependencies under the BSD 2-Clause License
 Scala/Java jars:
   - com.github.luben.zstd-jni-1.5.0-1.jar
   - com.github.marianobarrios.lbmq-0.6.0.jar
-  - dnsjava.dnsjava-2.1.7.jar
+  - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar
 
@@ -683,7 +671,9 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.sun.jersey.contribs.jersey-guice-1.19.jar
+  - com.github.pjfanning.jersey-json-1.22.0.jar
+  - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
+  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
   - javax.websocket.javax.websocket-api-1.0.jar
   - javax.websocket.javax.websocket-client-api-1.0.jar
   - javax.xml.bind.jaxb-api-2.3.0.jar

--- a/amber/NOTICE-binary
+++ b/amber/NOTICE-binary
@@ -512,16 +512,6 @@ which can be obtained from
   https://bitbucket.org/eunjeon/mecab-ko-dic/downloads/mecab-ko-dic-2.0.3-20170922.tar.gz
 
 --------------------------------------------------------------------------------
-ch.qos.reload4j.reload4j
---------------------------------------------------------------------------------
-
-Apache log4j
-Copyright 2007 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.lucene
 --------------------------------------------------------------------------------
 
@@ -862,31 +852,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-framework
+org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
-Curator Framework
-Copyright 2011-2019 The Apache Software Foundation
+Kerby-kerb core
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-beanutils.commons-beanutils
+org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
-Apache Commons BeanUtils
-Copyright 2000-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper
---------------------------------------------------------------------------------
-
-Apache ZooKeeper - Server
-Copyright 2008-2019 The Apache Software Foundation
+Curator Recipes
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -902,14 +882,34 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-util
+org.apache.kerby.kerby-asn1
 --------------------------------------------------------------------------------
 
-Kerby-kerb Util
-Copyright 2014-2017 The Apache Software Foundation
+Kerby ASN1 Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+ch.qos.reload4j.reload4j
+--------------------------------------------------------------------------------
+
+Apache log4j
+Copyright 2007 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-lang3
+--------------------------------------------------------------------------------
+
+Apache Commons Lang
+Copyright 2001-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.jasypt.jasypt
@@ -1099,102 +1099,14 @@ Other developers who have contributed code are:
   quality
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-admin
+commons-cli.commons-cli
 --------------------------------------------------------------------------------
 
-Kerby-kerb Admin
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons CLI
+Copyright 2002-2024 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-math3
---------------------------------------------------------------------------------
-
-Apache Commons Math
-Copyright 2001-2012 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-===============================================================================
-
-The BracketFinder (package org.apache.commons.math3.optimization.univariate)
-and PowellOptimizer (package org.apache.commons.math3.optimization.general)
-classes are based on the Python code in module "optimize.py" (version 0.5)
-developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
-Copyright © 2003-2009 SciPy Developers.
-===============================================================================
-
-The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
-RelationShip, SimplexSolver and SimplexTableau classes in package
-org.apache.commons.math3.optimization.linear include software developed by
-Benjamin McCann (http://www.benmccann.com) and distributed with
-the following copyright: Copyright 2009 Google Inc.
-===============================================================================
-
-This product includes software developed by the
-University of Chicago, as Operator of Argonne National
-Laboratory.
-The LevenbergMarquardtOptimizer class in package
-org.apache.commons.math3.optimization.general includes software
-translated from the lmder, lmpar and qrsolv Fortran routines
-from the Minpack package
-Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
-===============================================================================
-
-The GraggBulirschStoerIntegrator class in package
-org.apache.commons.math3.ode.nonstiff includes software translated
-from the odex Fortran routine developed by E. Hairer and G. Wanner.
-Original source copyright:
-Copyright (c) 2004, Ernst Hairer
-===============================================================================
-
-The EigenDecompositionImpl class in package
-org.apache.commons.math3.linear includes software translated
-from some LAPACK Fortran routines.  Original source copyright:
-Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
-===============================================================================
-
-The MersenneTwister class in package org.apache.commons.math3.random
-includes software translated from the 2002-01-26 version of
-the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
-Nishimura. Original source copyright:
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-All rights reserved
-===============================================================================
-
-The LocalizedFormatsTest class in the unit tests is an adapted version of
-the OrekitMessagesTest class from the orekit library distributed under the
-terms of the Apache 2 licence. Original source copyright:
-Copyright 2010 CS Systèmes d'Information
-===============================================================================
-
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
-
-The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
-by an original code donated by Sébastien Brisard.
-===============================================================================
-
-
-The complete text of licenses and disclaimers associated with the the original
-sources enumerated above at the time of code translation are in the LICENSE.txt
-file.
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-config
---------------------------------------------------------------------------------
-
-Kerby Config
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.yetus.audience-annotations
@@ -1205,6 +1117,16 @@ Copyright 2015-2020 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+commons-logging.commons-logging
+--------------------------------------------------------------------------------
+
+Apache Commons Logging
+Copyright 2001-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.datatype.jackson-datatype-jsr310
@@ -1227,6 +1149,16 @@ as per accompanying LICENSE file.
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-configuration2
+--------------------------------------------------------------------------------
+
+Apache Commons Configuration
+Copyright 2001-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.parquet.parquet-avro
@@ -1280,21 +1212,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.arrow-vector
+org.apache.kerby.kerb-crypto
 --------------------------------------------------------------------------------
 
-Arrow Vectors
-Copyright 2024 The Apache Software Foundation
+Kerby-kerb Crypto
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.commons.commons-collections4
+org.apache.arrow.arrow-vector
 --------------------------------------------------------------------------------
 
-Apache Commons Collections
-Copyright 2001-2018 The Apache Software Foundation
+Arrow Vectors
+Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1310,31 +1242,45 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-crypto
+org.apache.commons.commons-math3
 --------------------------------------------------------------------------------
 
-Kerby-kerb Crypto
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Math
+Copyright 2001-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software developed for Orekit by
+CS Systèmes d'Information (http://www.c-s.fr/)
+Copyright 2010-2012 CS Systèmes d'Information
+
+--------------------------------------------------------------------------------
+org.apache.curator.curator-client
+--------------------------------------------------------------------------------
+
+Curator Client
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.commons.commons-text
+commons-net.commons-net
 --------------------------------------------------------------------------------
 
-Apache Commons Text
-Copyright 2014-2018 The Apache Software Foundation
+Apache Commons Net
+Copyright 2001-2022 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-core
+org.apache.kerby.kerby-pkix
 --------------------------------------------------------------------------------
 
-Kerby-kerb core
-Copyright 2014-2017 The Apache Software Foundation
+Kerby PKIX Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1350,11 +1296,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.token-provider
+org.apache.commons.commons-collections4
 --------------------------------------------------------------------------------
 
-Token provider
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Collections
+Copyright 2001-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1442,11 +1388,11 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-simplekdc
+org.apache.kerby.kerby-config
 --------------------------------------------------------------------------------
 
-Kerb Simple Kdc
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Config
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1457,6 +1403,16 @@ org.apache.httpcomponents.httpcore
 
 Apache HttpCore
 Copyright 2005-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+com.google.inject.extensions.guice-servlet
+--------------------------------------------------------------------------------
+
+Google Guice - Extensions - Servlet
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1500,16 +1456,6 @@ JUnit (4.12)
 * License: Eclipse Public License
 
 --------------------------------------------------------------------------------
-commons-logging.commons-logging
---------------------------------------------------------------------------------
-
-Apache Commons Logging
-Copyright 2003-2014 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.pekko.pekko-protobuf-v3_2.13
 --------------------------------------------------------------------------------
 
@@ -1536,16 +1482,6 @@ Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
 
 Apache Pekko is derived from Akka 2.6.x, the last version that was distributed under the
 Apache License, Version 2.0 License.
-
---------------------------------------------------------------------------------
-org.apache.curator.curator-recipes
---------------------------------------------------------------------------------
-
-Curator Recipes
-Copyright 2011-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-pool.commons-pool
@@ -1644,26 +1580,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-client
---------------------------------------------------------------------------------
-
-Curator Client
-Copyright 2011-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-collections.commons-collections
---------------------------------------------------------------------------------
-
-Apache Commons Collections
-Copyright 2001-2015 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 io.r2dbc.r2dbc-spi
 --------------------------------------------------------------------------------
 
@@ -1722,16 +1638,6 @@ JUnit (4.12)
 * License: Eclipse Public License
 
 --------------------------------------------------------------------------------
-commons-cli.commons-cli
---------------------------------------------------------------------------------
-
-Apache Commons CLI
-Copyright 2001-2009 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5-h2
 --------------------------------------------------------------------------------
 
@@ -1767,11 +1673,21 @@ or implied. See the License for the specific language governing permissions and 
 the License.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-server
+org.apache.curator.curator-framework
 --------------------------------------------------------------------------------
 
-Kerby-kerb Server
-Copyright 2014-2017 The Apache Software Foundation
+Curator Framework
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+cglib.cglib
+--------------------------------------------------------------------------------
+
+Google Guice - Core Library
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1785,6 +1701,16 @@ Copyright 2002-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-text
+--------------------------------------------------------------------------------
+
+Apache Commons Text
+Copyright 2014-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.httpcomponents.httpclient
@@ -1805,16 +1731,6 @@ joda-time.joda-time
 =============================================================================
 This product includes software developed by
 Joda.org (https://www.joda.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.extensions.guice-servlet
---------------------------------------------------------------------------------
-
-Google Guice - Extensions - Servlet
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5
@@ -1894,6 +1810,16 @@ in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
+org.apache.kerby.kerby-util
+--------------------------------------------------------------------------------
+
+Kerby Util
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 com.fasterxml.classmate
 --------------------------------------------------------------------------------
 
@@ -1902,36 +1828,6 @@ Java ClassMate library was originally written by Tatu Saloranta (tatu.saloranta@
 Other developers who have contributed code are:
 
 * Brian Langel
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerb-client
---------------------------------------------------------------------------------
-
-Kerby-kerb Client
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-xdr
---------------------------------------------------------------------------------
-
-Kerby XDR Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-asn1
---------------------------------------------------------------------------------
-
-Kerby ASN1 Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.core.jackson-core
@@ -1991,26 +1887,6 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerby-pkix
---------------------------------------------------------------------------------
-
-Kerby PKIX Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerb-identity
---------------------------------------------------------------------------------
-
-Kerby-kerb Identity
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-afterburner
 --------------------------------------------------------------------------------
 
@@ -2037,31 +1913,11 @@ in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper-jute
---------------------------------------------------------------------------------
-
-Apache ZooKeeper - Jute
-Copyright 2008-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.httpcomponents.httpcore-nio
 --------------------------------------------------------------------------------
 
 Apache HttpCore NIO
 Copyright 2005-2020 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-util
---------------------------------------------------------------------------------
-
-Kerby Util
-Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2077,39 +1933,6 @@ com.esotericsoftware.kryo5
 
 Objenesis
 Copyright 2006-2022 Joe Walnes, Henri Tremblay, Leonardo Mesquita
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-lang3
---------------------------------------------------------------------------------
-
-Apache Commons Lang
-Copyright 2001-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-configuration2
---------------------------------------------------------------------------------
-
-Apache Commons Configuration
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.guice
---------------------------------------------------------------------------------
-
-Google Guice - Core Library
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 software.amazon.awssdk.third-party-jackson-core
@@ -2211,6 +2034,16 @@ https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16
 - as is required by that license.)
 
 --------------------------------------------------------------------------------
+org.apache.kerby.kerb-util
+--------------------------------------------------------------------------------
+
+Kerby-kerb Util
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 jakarta.annotation.jakarta.annotation-api
 --------------------------------------------------------------------------------
 
@@ -2254,16 +2087,6 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-common
---------------------------------------------------------------------------------
-
-Kerby-kerb Common
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
@@ -2282,136 +2105,6 @@ Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-net.commons-net
---------------------------------------------------------------------------------
-
-Apache Commons Net
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-io.netty.netty
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2011 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
-Also, please refer to each LICENSE.<component>.txt file, which is located in
-the 'license' directory of the distribution file, for the license terms of the
-components that this product depends on.
-
--------------------------------------------------------------------------------
-This product contains the extensions to Java Collections Framework which has
-been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
-
-  * LICENSE:
-    * license/LICENSE.jsr166y.txt (Public Domain)
-  * HOMEPAGE:
-    * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
-    * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
-
-This product contains a modified version of Robert Harder's Public Domain
-Base64 Encoder and Decoder, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.base64.txt (Public Domain)
-  * HOMEPAGE:
-    * http://iharder.sourceforge.net/current/java/base64/
-
-This product contains a modified version of 'JZlib', a re-implementation of
-zlib in pure Java, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jzlib.txt (BSD Style License)
-  * HOMEPAGE:
-    * http://www.jcraft.com/jzlib/
-
-This product contains a modified version of 'Webbit', a Java event based
-WebSocket and HTTP server:
-
-  * LICENSE:
-    * license/LICENSE.webbit.txt (BSD License)
-  * HOMEPAGE:
-    * https://github.com/joewalnes/webbit
-
-This product optionally depends on 'Protocol Buffers', Google's data
-interchange format, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
-  * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
-
-This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
-a temporary self-signed X.509 certificate when the JVM does not provide the
-equivalent functionality.  It can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.bouncycastle.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.bouncycastle.org/
-
-This product optionally depends on 'SLF4J', a simple logging facade for Java,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.slf4j.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.slf4j.org/
-
-This product optionally depends on 'Apache Commons Logging', a logging
-framework, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.commons-logging.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://commons.apache.org/logging/
-
-This product optionally depends on 'Apache Log4J', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.log4j.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://logging.apache.org/log4j/
-
-This product optionally depends on 'JBoss Logging', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jboss-logging.txt (GNU LGPL 2.1)
-  * HOMEPAGE:
-    * http://anonsvn.jboss.org/repos/common/common-logging-spi/
-
-This product optionally depends on 'Apache Felix', an open source OSGi
-framework implementation, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.felix.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://felix.apache.org/
 
 --------------------------------------------------------------------------------
 org.apache.httpcomponents.httpmime

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -153,11 +153,14 @@ val luceneDependencies = Seq(
 // Hadoop related
 val hadoopVersion = "3.4.3"
 val excludeHadoopJersey = ExclusionRule(organization = "com.sun.jersey")
+// Hadoop 3.3.2+ ships jersey-json via the com.github.pjfanning fork; its Jersey 1.x
+// providers break Jersey 2 auto-discovery at startup, so exclude it as well.
+val excludeHadoopJerseyJsonFork = ExclusionRule(organization = "com.github.pjfanning", name = "jersey-json")
 val excludeHadoopSlf4j = ExclusionRule(organization = "org.slf4j")
 val excludeHadoopJetty = ExclusionRule(organization = "org.eclipse.jetty")
 val excludeHadoopJsp = ExclusionRule(organization = "javax.servlet.jsp")
 val hadoopDependencies = Seq(
-  "org.apache.hadoop" % "hadoop-common" % hadoopVersion excludeAll(excludeHadoopJersey, excludeHadoopSlf4j, excludeHadoopJsp, excludeHadoopJetty)
+  "org.apache.hadoop" % "hadoop-common" % hadoopVersion excludeAll(excludeHadoopJersey, excludeHadoopJerseyJsonFork, excludeHadoopSlf4j, excludeHadoopJsp, excludeHadoopJetty)
 )
 
 /////////////////////////////////////////////////////////////////////////////

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -151,7 +151,7 @@ val luceneDependencies = Seq(
 
 /////////////////////////////////////////////////////////////////////////////
 // Hadoop related
-val hadoopVersion = "3.3.3"
+val hadoopVersion = "3.4.3"
 val excludeHadoopJersey = ExclusionRule(organization = "com.sun.jersey")
 val excludeHadoopSlf4j = ExclusionRule(organization = "org.slf4j")
 val excludeHadoopJetty = ExclusionRule(organization = "org.eclipse.jetty")

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -146,6 +146,9 @@ dependencyOverrides ++= Seq(
 // Iceberg-related Dependencies
 /////////////////////////////////////////////////////////////////////////////
 val excludeJersey = ExclusionRule(organization = "com.sun.jersey")
+// Hadoop 3.3.2+ ships jersey-json via the com.github.pjfanning fork; its Jersey 1.x
+// providers break Jersey 2 auto-discovery at startup, so exclude it as well.
+val excludeJerseyJsonFork = ExclusionRule(organization = "com.github.pjfanning", name = "jersey-json")
 val excludeGlassfishJersey = ExclusionRule(organization = "org.glassfish.jersey")
 val excludeSlf4j = ExclusionRule(organization = "org.slf4j")
 val excludeJetty = ExclusionRule(organization = "org.eclipse.jetty")
@@ -177,6 +180,7 @@ libraryDependencies ++= Seq(
     excludeXmlBind,
     excludeGlassfishJersey,
     excludeJersey,
+    excludeJerseyJsonFork,
     excludeSlf4j,
     excludeJetty,
     excludeJsp,
@@ -189,6 +193,7 @@ libraryDependencies ++= Seq(
     excludeXmlBind,
     excludeGlassfishJersey,
     excludeJersey,
+    excludeJerseyJsonFork,
     excludeSlf4j,
     excludeJetty,
     excludeJsp,

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -153,6 +153,7 @@ val excludeJsp = ExclusionRule(organization = "javax.servlet.jsp")
 val excludeXmlBind = ExclusionRule(organization = "javax.xml.bind")
 val excludeJackson = ExclusionRule(organization = "com.fasterxml.jackson.core")
 val excludeJacksonModule = ExclusionRule(organization = "com.fasterxml.jackson.module")
+val excludeNetty = ExclusionRule(organization = "io.netty")
 
 libraryDependencies ++= Seq(
   "org.apache.iceberg" % "iceberg-api" % "1.7.1",
@@ -172,7 +173,7 @@ libraryDependencies ++= Seq(
     excludeJackson,
     excludeJacksonModule
   ),
-  "org.apache.hadoop" % "hadoop-common" % "3.3.1" excludeAll(
+  "org.apache.hadoop" % "hadoop-common" % "3.4.3" excludeAll(
     excludeXmlBind,
     excludeGlassfishJersey,
     excludeJersey,
@@ -182,7 +183,9 @@ libraryDependencies ++= Seq(
     excludeJackson,
     excludeJacksonModule
   ),
-  "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "3.3.1" excludeAll(
+  // hadoop 3.4 adds a direct netty-all dependency; exclude it — the netty
+  // artifacts this module needs are declared explicitly above.
+  "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "3.4.3" excludeAll(
     excludeXmlBind,
     excludeGlassfishJersey,
     excludeJersey,
@@ -190,7 +193,8 @@ libraryDependencies ++= Seq(
     excludeJetty,
     excludeJsp,
     excludeJackson,
-    excludeJacksonModule
+    excludeJacksonModule,
+    excludeNetty
   ),
   "org.postgresql" % "postgresql" % "42.7.10"
 )

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -612,9 +612,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -220,6 +220,7 @@ Dependencies under the Apache License, Version 2.0
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
+  - ch.qos.reload4j.reload4j-1.2.22.jar
   - com.fasterxml.classmate-1.7.0.jar
   - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
   - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
@@ -230,19 +231,18 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.17.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
-  - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
+  - com.fasterxml.woodstox.woodstox-core-5.4.0.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar
   - com.github.sisyphsu.retree-1.0.4.jar
-  - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.google.android.annotations-4.1.1.4.jar
   - com.google.api.grpc.proto-google-common-protos-2.22.0.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
@@ -252,17 +252,16 @@ Scala/Java jars:
   - com.google.guava.failureaccess-1.0.2.jar
   - com.google.guava.guava-33.0.0-jre.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  - com.google.inject.extensions.guice-servlet-4.0.jar
-  - com.google.inject.guice-4.0.jar
+  - com.google.inject.extensions.guice-servlet-4.2.3.jar
+  - com.google.inject.guice-4.2.3.jar
   - com.google.j2objc.j2objc-annotations-2.8.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
-  - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
+  - com.nimbusds.nimbus-jose-jwt-10.4.jar
   - com.softwaremill.sttp.client4.core_2.13-4.0.0-M6.jar
   - com.softwaremill.sttp.model.core_2.13-1.7.2.jar
   - com.softwaremill.sttp.shared.core_2.13-1.3.16.jar
   - com.softwaremill.sttp.shared.ws_2.13-1.3.16.jar
-  - com.squareup.okhttp.okhttp-2.7.5.jar
   - com.squareup.okhttp3.logging-interceptor-4.12.0.jar
   - com.squareup.okhttp3.okhttp-4.12.0.jar
   - com.squareup.okio.okio-3.6.0.jar
@@ -275,13 +274,11 @@ Scala/Java jars:
   - com.typesafe.play.play-json_2.13-2.10.6.jar
   - com.typesafe.scala-logging.scala-logging_2.13-3.9.5.jar
   - com.zaxxer.HikariCP-5.1.0.jar
-  - commons-beanutils.commons-beanutils-1.9.4.jar
-  - commons-cli.commons-cli-1.2.jar
+  - commons-cli.commons-cli-1.9.0.jar
   - commons-codec.commons-codec-1.17.1.jar
-  - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
-  - commons-logging.commons-logging-1.2.jar
-  - commons-net.commons-net-3.6.jar
+  - commons-logging.commons-logging-1.3.0.jar
+  - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
   - io.airlift.aircompressor-0.27.jar
@@ -350,16 +347,15 @@ Scala/Java jars:
   - io.kubernetes.client-java-api-21.0.0.jar
   - io.kubernetes.client-java-proto-21.0.0.jar
   - io.lakefs.sdk-1.51.0.jar
-  - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.104.Final.jar
-  - io.netty.netty-codec-4.1.104.Final.jar
+  - io.netty.netty-buffer-4.1.127.Final.jar
+  - io.netty.netty-codec-4.1.127.Final.jar
   - io.netty.netty-codec-http-4.1.100.Final.jar
   - io.netty.netty-codec-http2-4.1.100.Final.jar
   - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.104.Final.jar
-  - io.netty.netty-handler-4.1.104.Final.jar
+  - io.netty.netty-common-4.1.127.Final.jar
+  - io.netty.netty-handler-4.1.127.Final.jar
   - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.104.Final.jar
+  - io.netty.netty-resolver-4.1.127.Final.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
@@ -367,8 +363,10 @@ Scala/Java jars:
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
   - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.104.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.104.Final.jar
+  - io.netty.netty-transport-4.1.127.Final.jar
+  - io.netty.netty-transport-classes-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.1.127.Final.jar
   - io.perfmark.perfmark-api-0.26.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - io.swagger.swagger-annotations-1.6.14.jar
@@ -376,9 +374,6 @@ Scala/Java jars:
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
-  - log4j.log4j-1.2.17.jar
-  - net.minidev.accessors-smart-2.4.2.jar
-  - net.minidev.json-smart-2.4.2.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
   - org.apache.arrow.arrow-memory-core-15.0.2.jar
   - org.apache.arrow.arrow-memory-netty-15.0.2.jar
@@ -388,26 +383,25 @@ Scala/Java jars:
   - org.apache.avro.avro-1.12.0.jar
   - org.apache.commons.commons-collections4-4.4.jar
   - org.apache.commons.commons-compress-1.26.2.jar
-  - org.apache.commons.commons-configuration2-2.1.1.jar
+  - org.apache.commons.commons-configuration2-2.10.1.jar
   - org.apache.commons.commons-jcs3-core-3.2.jar
-  - org.apache.commons.commons-lang3-3.14.0.jar
-  - org.apache.commons.commons-math3-3.1.1.jar
-  - org.apache.commons.commons-text-1.11.0.jar
+  - org.apache.commons.commons-lang3-3.18.0.jar
+  - org.apache.commons.commons-math3-3.6.1.jar
+  - org.apache.commons.commons-text-1.14.0.jar
   - org.apache.commons.commons-vfs2-2.9.0.jar
-  - org.apache.curator.curator-client-4.2.0.jar
-  - org.apache.curator.curator-framework-4.2.0.jar
-  - org.apache.curator.curator-recipes-4.2.0.jar
-  - org.apache.hadoop.hadoop-annotations-3.3.1.jar
-  - org.apache.hadoop.hadoop-auth-3.3.1.jar
-  - org.apache.hadoop.hadoop-common-3.3.1.jar
-  - org.apache.hadoop.hadoop-hdfs-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-mapreduce-client-core-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-api-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-common-3.3.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.1.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_7-1.1.1.jar
-  - org.apache.htrace.htrace-core4-4.1.0-incubating.jar
+  - org.apache.curator.curator-client-5.2.0.jar
+  - org.apache.curator.curator-framework-5.2.0.jar
+  - org.apache.curator.curator-recipes-5.2.0.jar
+  - org.apache.hadoop.hadoop-annotations-3.4.3.jar
+  - org.apache.hadoop.hadoop-auth-3.4.3.jar
+  - org.apache.hadoop.hadoop-common-3.4.3.jar
+  - org.apache.hadoop.hadoop-hdfs-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-mapreduce-client-core-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-api-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
   - org.apache.httpcomponents.client5.httpclient5-5.4.jar
   - org.apache.httpcomponents.core5.httpcore5-5.3.jar
   - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
@@ -420,21 +414,13 @@ Scala/Java jars:
   - org.apache.iceberg.iceberg-core-1.7.1.jar
   - org.apache.iceberg.iceberg-data-1.7.1.jar
   - org.apache.iceberg.iceberg-parquet-1.7.1.jar
-  - org.apache.kerby.kerb-admin-1.0.1.jar
-  - org.apache.kerby.kerb-client-1.0.1.jar
-  - org.apache.kerby.kerb-common-1.0.1.jar
-  - org.apache.kerby.kerb-core-1.0.1.jar
-  - org.apache.kerby.kerb-crypto-1.0.1.jar
-  - org.apache.kerby.kerb-identity-1.0.1.jar
-  - org.apache.kerby.kerb-server-1.0.1.jar
-  - org.apache.kerby.kerb-simplekdc-1.0.1.jar
-  - org.apache.kerby.kerb-util-1.0.1.jar
-  - org.apache.kerby.kerby-asn1-1.0.1.jar
-  - org.apache.kerby.kerby-config-1.0.1.jar
-  - org.apache.kerby.kerby-pkix-1.0.1.jar
-  - org.apache.kerby.kerby-util-1.0.1.jar
-  - org.apache.kerby.kerby-xdr-1.0.1.jar
-  - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.kerby.kerb-core-2.0.3.jar
+  - org.apache.kerby.kerb-crypto-2.0.3.jar
+  - org.apache.kerby.kerb-util-2.0.3.jar
+  - org.apache.kerby.kerby-asn1-2.0.3.jar
+  - org.apache.kerby.kerby-config-2.0.3.jar
+  - org.apache.kerby.kerby-pkix-2.0.3.jar
+  - org.apache.kerby.kerby-util-2.0.3.jar
   - org.apache.orc.orc-core-1.9.4-nohive.jar
   - org.apache.orc.orc-shims-1.9.4.jar
   - org.apache.parquet.parquet-avro-1.13.1.jar
@@ -445,9 +431,10 @@ Scala/Java jars:
   - org.apache.parquet.parquet-hadoop-1.13.1.jar
   - org.apache.parquet.parquet-jackson-1.13.1.jar
   - org.apache.yetus.audience-annotations-0.13.0.jar
-  - org.apache.zookeeper.zookeeper-3.5.6.jar
-  - org.apache.zookeeper.zookeeper-jute-3.5.6.jar
+  - org.apache.zookeeper.zookeeper-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
+  - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-http-11.0.20.jar
   - org.eclipse.jetty.jetty-io-11.0.20.jar
   - org.eclipse.jetty.jetty-security-11.0.20.jar
@@ -457,9 +444,9 @@ Scala/Java jars:
   - org.eclipse.jetty.jetty-util-11.0.20.jar
   - org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api-5.0.2.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.4.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.40.v20210413.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
   - org.ehcache.sizeof-0.4.3.jar
   - org.hibernate.validator.hibernate-validator-7.0.5.Final.jar
   - org.javassist.javassist-3.30.2-GA.jar
@@ -481,7 +468,7 @@ Scala/Java jars:
   - org.slf4j.jcl-over-slf4j-2.0.12.jar
   - org.slf4j.log4j-over-slf4j-2.0.12.jar
   - org.snakeyaml.snakeyaml-engine-2.7.jar
-  - org.xerial.snappy.snappy-java-1.1.8.3.jar
+  - org.xerial.snappy.snappy-java-1.1.10.4.jar
   - org.yaml.snakeyaml-2.2.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -539,7 +526,7 @@ Source files derived from third-party MIT-licensed projects:
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
   - org.bouncycastle.bcpkix-jdk18on-1.78.1.jar
-  - org.bouncycastle.bcprov-jdk18on-1.78.1.jar
+  - org.bouncycastle.bcprov-jdk18on-1.82.jar
   - org.bouncycastle.bcutil-jdk18on-1.78.1.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
@@ -558,7 +545,6 @@ Scala/Java jars:
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
   - org.jline.jline-3.9.0.jar
-  - org.ow2.asm.asm-8.0.1.jar
   - org.threeten.threeten-extra-1.7.1.jar
 
 --------------------------------------------------------------------------------
@@ -567,7 +553,7 @@ Dependencies under the BSD 2-Clause License
 
 Scala/Java jars:
   - com.github.luben.zstd-jni-1.5.0-1.jar
-  - dnsjava.dnsjava-2.1.7.jar
+  - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar
 
@@ -626,7 +612,9 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.sun.jersey.contribs.jersey-guice-1.19.jar
+  - com.github.pjfanning.jersey-json-1.22.0.jar
+  - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
+  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0
@@ -646,6 +634,7 @@ Dependencies in the Public Domain (CC0)
 
 Scala/Java jars:
   - aopalliance.aopalliance-1.0.jar
+
 
 Individual jars may contain their own META-INF/LICENSE and META-INF/NOTICE
 files that apply to their specific contents; those files continue to govern

--- a/computing-unit-managing-service/NOTICE-binary
+++ b/computing-unit-managing-service/NOTICE-binary
@@ -748,47 +748,37 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-framework
+org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
-Curator Framework
-Copyright 2011-2019 The Apache Software Foundation
+Kerby-kerb core
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-beanutils.commons-beanutils
+org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
-Apache Commons BeanUtils
-Copyright 2000-2019 The Apache Software Foundation
+Curator Recipes
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper
+org.apache.kerby.kerby-asn1
 --------------------------------------------------------------------------------
 
-Apache ZooKeeper - Server
-Copyright 2008-2019 The Apache Software Foundation
+Kerby ASN1 Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-util
---------------------------------------------------------------------------------
-
-Kerby-kerb Util
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-log4j.log4j
+ch.qos.reload4j.reload4j
 --------------------------------------------------------------------------------
 
 Apache log4j
@@ -796,6 +786,16 @@ Copyright 2007 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-lang3
+--------------------------------------------------------------------------------
+
+Apache Commons Lang
+Copyright 2001-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-codec.commons-codec
@@ -808,102 +808,14 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-admin
+commons-cli.commons-cli
 --------------------------------------------------------------------------------
 
-Kerby-kerb Admin
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-lang3
---------------------------------------------------------------------------------
-
-Apache Commons Lang
-Copyright 2001-2023 The Apache Software Foundation
+Apache Commons CLI
+Copyright 2002-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-math3
---------------------------------------------------------------------------------
-
-Apache Commons Math
-Copyright 2001-2012 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-===============================================================================
-
-The BracketFinder (package org.apache.commons.math3.optimization.univariate)
-and PowellOptimizer (package org.apache.commons.math3.optimization.general)
-classes are based on the Python code in module "optimize.py" (version 0.5)
-developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
-Copyright © 2003-2009 SciPy Developers.
-===============================================================================
-
-The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
-RelationShip, SimplexSolver and SimplexTableau classes in package
-org.apache.commons.math3.optimization.linear include software developed by
-Benjamin McCann (http://www.benmccann.com) and distributed with
-the following copyright: Copyright 2009 Google Inc.
-===============================================================================
-
-This product includes software developed by the
-University of Chicago, as Operator of Argonne National
-Laboratory.
-The LevenbergMarquardtOptimizer class in package
-org.apache.commons.math3.optimization.general includes software
-translated from the lmder, lmpar and qrsolv Fortran routines
-from the Minpack package
-Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
-===============================================================================
-
-The GraggBulirschStoerIntegrator class in package
-org.apache.commons.math3.ode.nonstiff includes software translated
-from the odex Fortran routine developed by E. Hairer and G. Wanner.
-Original source copyright:
-Copyright (c) 2004, Ernst Hairer
-===============================================================================
-
-The EigenDecompositionImpl class in package
-org.apache.commons.math3.linear includes software translated
-from some LAPACK Fortran routines.  Original source copyright:
-Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
-===============================================================================
-
-The MersenneTwister class in package org.apache.commons.math3.random
-includes software translated from the 2002-01-26 version of
-the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
-Nishimura. Original source copyright:
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-All rights reserved
-===============================================================================
-
-The LocalizedFormatsTest class in the unit tests is an adapted version of
-the OrekitMessagesTest class from the orekit library distributed under the
-terms of the Apache 2 licence. Original source copyright:
-Copyright 2010 CS Systèmes d'Information
-===============================================================================
-
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
-
-The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
-by an original code donated by Sébastien Brisard.
-===============================================================================
-
-
-The complete text of licenses and disclaimers associated with the the original
-sources enumerated above at the time of code translation are in the LICENSE.txt
-file.
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-no-ctor-deser
@@ -929,16 +841,6 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-config
---------------------------------------------------------------------------------
-
-Kerby Config
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api
@@ -1175,6 +1077,26 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
+
+--------------------------------------------------------------------------------
+commons-logging.commons-logging
+--------------------------------------------------------------------------------
+
+Apache Commons Logging
+Copyright 2001-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-configuration2
+--------------------------------------------------------------------------------
+
+Apache Commons Configuration
+Copyright 2001-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.parquet.parquet-avro
@@ -1456,6 +1378,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.kerby.kerb-crypto
+--------------------------------------------------------------------------------
+
+Kerby-kerb Crypto
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.arrow.arrow-vector
 --------------------------------------------------------------------------------
 
@@ -1476,21 +1408,45 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-crypto
+org.apache.commons.commons-math3
 --------------------------------------------------------------------------------
 
-Kerby-kerb Crypto
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Math
+Copyright 2001-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software developed for Orekit by
+CS Systèmes d'Information (http://www.c-s.fr/)
+Copyright 2010-2012 CS Systèmes d'Information
+
+--------------------------------------------------------------------------------
+org.apache.curator.curator-client
+--------------------------------------------------------------------------------
+
+Curator Client
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-core
+commons-net.commons-net
 --------------------------------------------------------------------------------
 
-Kerby-kerb core
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Net
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.kerby.kerby-pkix
+--------------------------------------------------------------------------------
+
+Kerby PKIX Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1511,16 +1467,6 @@ org.apache.commons.commons-collections4
 
 Apache Commons Collections
 Copyright 2001-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.token-provider
---------------------------------------------------------------------------------
-
-Token provider
-Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1608,11 +1554,11 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-simplekdc
+org.apache.kerby.kerby-config
 --------------------------------------------------------------------------------
 
-Kerb Simple Kdc
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Config
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1628,21 +1574,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-logging.commons-logging
+com.google.inject.extensions.guice-servlet
 --------------------------------------------------------------------------------
 
-Apache Commons Logging
-Copyright 2003-2014 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.curator.curator-recipes
---------------------------------------------------------------------------------
-
-Curator Recipes
-Copyright 2011-2019 The Apache Software Foundation
+Google Guice - Extensions - Servlet
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1744,26 +1680,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-client
---------------------------------------------------------------------------------
-
-Curator Client
-Copyright 2011-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-collections.commons-collections
---------------------------------------------------------------------------------
-
-Apache Commons Collections
-Copyright 2001-2015 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 io.r2dbc.r2dbc-spi
 --------------------------------------------------------------------------------
 
@@ -1784,16 +1700,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------------------
-commons-cli.commons-cli
---------------------------------------------------------------------------------
-
-Apache Commons CLI
-Copyright 2001-2009 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5-h2
 --------------------------------------------------------------------------------
 
@@ -1804,11 +1710,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-server
+org.apache.curator.curator-framework
 --------------------------------------------------------------------------------
 
-Kerby-kerb Server
-Copyright 2014-2017 The Apache Software Foundation
+Curator Framework
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+cglib.cglib
+--------------------------------------------------------------------------------
+
+Google Guice - Core Library
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1824,24 +1740,14 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.htrace.htrace-core4
+org.apache.commons.commons-text
 --------------------------------------------------------------------------------
 
-htrace-core4
-Copyright 2016 The Apache Software Foundation
+Apache Commons Text
+Copyright 2014-2025 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.extensions.guice-servlet
---------------------------------------------------------------------------------
-
-Google Guice - Extensions - Servlet
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 jakarta.annotation.jakarta.annotation-api
@@ -1953,31 +1859,11 @@ in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-client
+org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
-Kerby-kerb Client
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-xdr
---------------------------------------------------------------------------------
-
-Kerby XDR Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-asn1
---------------------------------------------------------------------------------
-
-Kerby ASN1 Project
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Util
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2040,26 +1926,6 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerby-pkix
---------------------------------------------------------------------------------
-
-Kerby PKIX Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerb-identity
---------------------------------------------------------------------------------
-
-Kerby-kerb Identity
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-blackbird
 --------------------------------------------------------------------------------
 
@@ -2084,49 +1950,6 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper-jute
---------------------------------------------------------------------------------
-
-Apache ZooKeeper - Jute
-Copyright 2008-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-util
---------------------------------------------------------------------------------
-
-Kerby Util
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-configuration2
---------------------------------------------------------------------------------
-
-Apache Commons Configuration
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.guice
---------------------------------------------------------------------------------
-
-Google Guice - Core Library
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 software.amazon.awssdk.third-party-jackson-core
@@ -2240,6 +2063,16 @@ Other developers who have contributed code are:
 ## Copyright
 
 Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+--------------------------------------------------------------------------------
+org.apache.kerby.kerb-util
+--------------------------------------------------------------------------------
+
+Kerby-kerb Util
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.glassfish.jersey.core.jersey-common
@@ -2405,16 +2238,6 @@ W3.org documents
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-common
---------------------------------------------------------------------------------
-
-Kerby-kerb Common
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
@@ -2433,143 +2256,3 @@ Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-text
---------------------------------------------------------------------------------
-
-Apache Commons Text
-Copyright 2014-2023 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-net.commons-net
---------------------------------------------------------------------------------
-
-Apache Commons Net
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-io.netty.netty
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2011 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
-Also, please refer to each LICENSE.<component>.txt file, which is located in
-the 'license' directory of the distribution file, for the license terms of the
-components that this product depends on.
-
--------------------------------------------------------------------------------
-This product contains the extensions to Java Collections Framework which has
-been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
-
-  * LICENSE:
-    * license/LICENSE.jsr166y.txt (Public Domain)
-  * HOMEPAGE:
-    * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
-    * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
-
-This product contains a modified version of Robert Harder's Public Domain
-Base64 Encoder and Decoder, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.base64.txt (Public Domain)
-  * HOMEPAGE:
-    * http://iharder.sourceforge.net/current/java/base64/
-
-This product contains a modified version of 'JZlib', a re-implementation of
-zlib in pure Java, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jzlib.txt (BSD Style License)
-  * HOMEPAGE:
-    * http://www.jcraft.com/jzlib/
-
-This product contains a modified version of 'Webbit', a Java event based
-WebSocket and HTTP server:
-
-  * LICENSE:
-    * license/LICENSE.webbit.txt (BSD License)
-  * HOMEPAGE:
-    * https://github.com/joewalnes/webbit
-
-This product optionally depends on 'Protocol Buffers', Google's data
-interchange format, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
-  * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
-
-This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
-a temporary self-signed X.509 certificate when the JVM does not provide the
-equivalent functionality.  It can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.bouncycastle.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.bouncycastle.org/
-
-This product optionally depends on 'SLF4J', a simple logging facade for Java,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.slf4j.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.slf4j.org/
-
-This product optionally depends on 'Apache Commons Logging', a logging
-framework, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.commons-logging.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://commons.apache.org/logging/
-
-This product optionally depends on 'Apache Log4J', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.log4j.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://logging.apache.org/log4j/
-
-This product optionally depends on 'JBoss Logging', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jboss-logging.txt (GNU LGPL 2.1)
-  * HOMEPAGE:
-    * http://anonsvn.jboss.org/repos/common/common-logging-spi/
-
-This product optionally depends on 'Apache Felix', an open source OSGi
-framework implementation, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.felix.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://felix.apache.org/

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -220,6 +220,7 @@ Dependencies under the Apache License, Version 2.0
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
+  - ch.qos.reload4j.reload4j-1.2.22.jar
   - com.fasterxml.classmate-1.7.0.jar
   - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
   - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
@@ -230,19 +231,18 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
-  - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
+  - com.fasterxml.woodstox.woodstox-core-5.4.0.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar
   - com.github.sisyphsu.retree-1.0.4.jar
-  - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.google.android.annotations-4.1.1.4.jar
   - com.google.api.grpc.proto-google-common-protos-2.22.0.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
@@ -252,13 +252,12 @@ Scala/Java jars:
   - com.google.guava.failureaccess-1.0.2.jar
   - com.google.guava.guava-33.0.0-jre.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  - com.google.inject.extensions.guice-servlet-4.0.jar
-  - com.google.inject.guice-4.0.jar
+  - com.google.inject.extensions.guice-servlet-4.2.3.jar
+  - com.google.inject.guice-4.2.3.jar
   - com.google.j2objc.j2objc-annotations-2.8.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
-  - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
-  - com.squareup.okhttp.okhttp-2.7.5.jar
+  - com.nimbusds.nimbus-jose-jwt-10.4.jar
   - com.squareup.okhttp3.logging-interceptor-4.12.0.jar
   - com.squareup.okhttp3.okhttp-4.12.0.jar
   - com.squareup.okio.okio-3.6.0.jar
@@ -269,13 +268,11 @@ Scala/Java jars:
   - com.typesafe.config-1.4.6.jar
   - com.typesafe.scala-logging.scala-logging_2.13-3.9.5.jar
   - com.zaxxer.HikariCP-5.1.0.jar
-  - commons-beanutils.commons-beanutils-1.9.4.jar
-  - commons-cli.commons-cli-1.2.jar
+  - commons-cli.commons-cli-1.9.0.jar
   - commons-codec.commons-codec-1.17.1.jar
-  - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
-  - commons-logging.commons-logging-1.2.jar
-  - commons-net.commons-net-3.6.jar
+  - commons-logging.commons-logging-1.3.0.jar
+  - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
   - io.airlift.aircompressor-0.27.jar
@@ -315,16 +312,15 @@ Scala/Java jars:
   - io.grpc.grpc-util-1.60.0.jar
   - io.gsonfire.gson-fire-1.8.5.jar
   - io.lakefs.sdk-1.51.0.jar
-  - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.104.Final.jar
-  - io.netty.netty-codec-4.1.104.Final.jar
+  - io.netty.netty-buffer-4.1.127.Final.jar
+  - io.netty.netty-codec-4.1.127.Final.jar
   - io.netty.netty-codec-http-4.1.100.Final.jar
   - io.netty.netty-codec-http2-4.1.100.Final.jar
   - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.104.Final.jar
-  - io.netty.netty-handler-4.1.104.Final.jar
+  - io.netty.netty-common-4.1.127.Final.jar
+  - io.netty.netty-handler-4.1.127.Final.jar
   - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.104.Final.jar
+  - io.netty.netty-resolver-4.1.127.Final.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
@@ -332,17 +328,16 @@ Scala/Java jars:
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
   - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.104.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.104.Final.jar
+  - io.netty.netty-transport-4.1.127.Final.jar
+  - io.netty.netty-transport-classes-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.1.127.Final.jar
   - io.perfmark.perfmark-api-0.26.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
-  - log4j.log4j-1.2.17.jar
-  - net.minidev.accessors-smart-2.4.2.jar
-  - net.minidev.json-smart-2.4.2.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
   - org.apache.arrow.arrow-memory-core-15.0.2.jar
   - org.apache.arrow.arrow-memory-netty-15.0.2.jar
@@ -350,27 +345,27 @@ Scala/Java jars:
   - org.apache.arrow.flight-core-15.0.2.jar
   - org.apache.arrow.flight-grpc-15.0.2.jar
   - org.apache.avro.avro-1.12.0.jar
+  - org.apache.commons.commons-collections4-4.4.jar
   - org.apache.commons.commons-compress-1.26.2.jar
-  - org.apache.commons.commons-configuration2-2.1.1.jar
+  - org.apache.commons.commons-configuration2-2.10.1.jar
   - org.apache.commons.commons-jcs3-core-3.2.jar
-  - org.apache.commons.commons-lang3-3.14.0.jar
-  - org.apache.commons.commons-math3-3.1.1.jar
-  - org.apache.commons.commons-text-1.11.0.jar
+  - org.apache.commons.commons-lang3-3.18.0.jar
+  - org.apache.commons.commons-math3-3.6.1.jar
+  - org.apache.commons.commons-text-1.14.0.jar
   - org.apache.commons.commons-vfs2-2.9.0.jar
-  - org.apache.curator.curator-client-4.2.0.jar
-  - org.apache.curator.curator-framework-4.2.0.jar
-  - org.apache.curator.curator-recipes-4.2.0.jar
-  - org.apache.hadoop.hadoop-annotations-3.3.1.jar
-  - org.apache.hadoop.hadoop-auth-3.3.1.jar
-  - org.apache.hadoop.hadoop-common-3.3.1.jar
-  - org.apache.hadoop.hadoop-hdfs-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-mapreduce-client-core-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-api-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-common-3.3.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.1.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_7-1.1.1.jar
-  - org.apache.htrace.htrace-core4-4.1.0-incubating.jar
+  - org.apache.curator.curator-client-5.2.0.jar
+  - org.apache.curator.curator-framework-5.2.0.jar
+  - org.apache.curator.curator-recipes-5.2.0.jar
+  - org.apache.hadoop.hadoop-annotations-3.4.3.jar
+  - org.apache.hadoop.hadoop-auth-3.4.3.jar
+  - org.apache.hadoop.hadoop-common-3.4.3.jar
+  - org.apache.hadoop.hadoop-hdfs-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-mapreduce-client-core-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-api-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
   - org.apache.httpcomponents.client5.httpclient5-5.4.jar
   - org.apache.httpcomponents.core5.httpcore5-5.3.jar
   - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
@@ -383,21 +378,13 @@ Scala/Java jars:
   - org.apache.iceberg.iceberg-core-1.7.1.jar
   - org.apache.iceberg.iceberg-data-1.7.1.jar
   - org.apache.iceberg.iceberg-parquet-1.7.1.jar
-  - org.apache.kerby.kerb-admin-1.0.1.jar
-  - org.apache.kerby.kerb-client-1.0.1.jar
-  - org.apache.kerby.kerb-common-1.0.1.jar
-  - org.apache.kerby.kerb-core-1.0.1.jar
-  - org.apache.kerby.kerb-crypto-1.0.1.jar
-  - org.apache.kerby.kerb-identity-1.0.1.jar
-  - org.apache.kerby.kerb-server-1.0.1.jar
-  - org.apache.kerby.kerb-simplekdc-1.0.1.jar
-  - org.apache.kerby.kerb-util-1.0.1.jar
-  - org.apache.kerby.kerby-asn1-1.0.1.jar
-  - org.apache.kerby.kerby-config-1.0.1.jar
-  - org.apache.kerby.kerby-pkix-1.0.1.jar
-  - org.apache.kerby.kerby-util-1.0.1.jar
-  - org.apache.kerby.kerby-xdr-1.0.1.jar
-  - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.kerby.kerb-core-2.0.3.jar
+  - org.apache.kerby.kerb-crypto-2.0.3.jar
+  - org.apache.kerby.kerb-util-2.0.3.jar
+  - org.apache.kerby.kerby-asn1-2.0.3.jar
+  - org.apache.kerby.kerby-config-2.0.3.jar
+  - org.apache.kerby.kerby-pkix-2.0.3.jar
+  - org.apache.kerby.kerby-util-2.0.3.jar
   - org.apache.orc.orc-core-1.9.4-nohive.jar
   - org.apache.orc.orc-shims-1.9.4.jar
   - org.apache.parquet.parquet-avro-1.13.1.jar
@@ -408,9 +395,10 @@ Scala/Java jars:
   - org.apache.parquet.parquet-hadoop-1.13.1.jar
   - org.apache.parquet.parquet-jackson-1.13.1.jar
   - org.apache.yetus.audience-annotations-0.13.0.jar
-  - org.apache.zookeeper.zookeeper-3.5.6.jar
-  - org.apache.zookeeper.zookeeper-jute-3.5.6.jar
+  - org.apache.zookeeper.zookeeper-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
+  - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-http-11.0.20.jar
   - org.eclipse.jetty.jetty-io-11.0.20.jar
   - org.eclipse.jetty.jetty-security-11.0.20.jar
@@ -420,9 +408,9 @@ Scala/Java jars:
   - org.eclipse.jetty.jetty-util-11.0.20.jar
   - org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api-5.0.2.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.4.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.40.v20210413.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
   - org.ehcache.sizeof-0.4.3.jar
   - org.hibernate.validator.hibernate-validator-7.0.5.Final.jar
   - org.javassist.javassist-3.30.2-GA.jar
@@ -445,7 +433,7 @@ Scala/Java jars:
   - org.scala-lang.scala-reflect-2.13.18.jar
   - org.slf4j.jcl-over-slf4j-2.0.12.jar
   - org.slf4j.log4j-over-slf4j-2.0.12.jar
-  - org.xerial.snappy.snappy-java-1.1.8.3.jar
+  - org.xerial.snappy.snappy-java-1.1.10.4.jar
   - org.yaml.snakeyaml-2.2.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -502,6 +490,7 @@ Source files derived from third-party MIT-licensed projects:
 
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
+  - org.bouncycastle.bcprov-jdk18on-1.82.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
   - org.projectlombok.lombok-1.18.24.jar
@@ -519,7 +508,6 @@ Scala/Java jars:
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
   - org.jline.jline-3.9.0.jar
-  - org.ow2.asm.asm-8.0.1.jar
   - org.threeten.threeten-extra-1.7.1.jar
 
 --------------------------------------------------------------------------------
@@ -528,7 +516,7 @@ Dependencies under the BSD 2-Clause License
 
 Scala/Java jars:
   - com.github.luben.zstd-jni-1.5.0-1.jar
-  - dnsjava.dnsjava-2.1.7.jar
+  - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar
 
@@ -587,7 +575,9 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.sun.jersey.contribs.jersey-guice-1.19.jar
+  - com.github.pjfanning.jersey-json-1.22.0.jar
+  - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
+  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0
@@ -607,6 +597,7 @@ Dependencies in the Public Domain (CC0)
 
 Scala/Java jars:
   - aopalliance.aopalliance-1.0.jar
+
 
 Individual jars may contain their own META-INF/LICENSE and META-INF/NOTICE
 files that apply to their specific contents; those files continue to govern

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -575,9 +575,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0

--- a/file-service/NOTICE-binary
+++ b/file-service/NOTICE-binary
@@ -748,47 +748,37 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-framework
+org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
-Curator Framework
-Copyright 2011-2019 The Apache Software Foundation
+Kerby-kerb core
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-beanutils.commons-beanutils
+org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
-Apache Commons BeanUtils
-Copyright 2000-2019 The Apache Software Foundation
+Curator Recipes
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper
+org.apache.kerby.kerby-asn1
 --------------------------------------------------------------------------------
 
-Apache ZooKeeper - Server
-Copyright 2008-2019 The Apache Software Foundation
+Kerby ASN1 Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-util
---------------------------------------------------------------------------------
-
-Kerby-kerb Util
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-log4j.log4j
+ch.qos.reload4j.reload4j
 --------------------------------------------------------------------------------
 
 Apache log4j
@@ -796,6 +786,16 @@ Copyright 2007 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-lang3
+--------------------------------------------------------------------------------
+
+Apache Commons Lang
+Copyright 2001-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-codec.commons-codec
@@ -808,102 +808,14 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-admin
+commons-cli.commons-cli
 --------------------------------------------------------------------------------
 
-Kerby-kerb Admin
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-lang3
---------------------------------------------------------------------------------
-
-Apache Commons Lang
-Copyright 2001-2023 The Apache Software Foundation
+Apache Commons CLI
+Copyright 2002-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-math3
---------------------------------------------------------------------------------
-
-Apache Commons Math
-Copyright 2001-2012 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-===============================================================================
-
-The BracketFinder (package org.apache.commons.math3.optimization.univariate)
-and PowellOptimizer (package org.apache.commons.math3.optimization.general)
-classes are based on the Python code in module "optimize.py" (version 0.5)
-developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
-Copyright © 2003-2009 SciPy Developers.
-===============================================================================
-
-The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
-RelationShip, SimplexSolver and SimplexTableau classes in package
-org.apache.commons.math3.optimization.linear include software developed by
-Benjamin McCann (http://www.benmccann.com) and distributed with
-the following copyright: Copyright 2009 Google Inc.
-===============================================================================
-
-This product includes software developed by the
-University of Chicago, as Operator of Argonne National
-Laboratory.
-The LevenbergMarquardtOptimizer class in package
-org.apache.commons.math3.optimization.general includes software
-translated from the lmder, lmpar and qrsolv Fortran routines
-from the Minpack package
-Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
-===============================================================================
-
-The GraggBulirschStoerIntegrator class in package
-org.apache.commons.math3.ode.nonstiff includes software translated
-from the odex Fortran routine developed by E. Hairer and G. Wanner.
-Original source copyright:
-Copyright (c) 2004, Ernst Hairer
-===============================================================================
-
-The EigenDecompositionImpl class in package
-org.apache.commons.math3.linear includes software translated
-from some LAPACK Fortran routines.  Original source copyright:
-Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
-===============================================================================
-
-The MersenneTwister class in package org.apache.commons.math3.random
-includes software translated from the 2002-01-26 version of
-the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
-Nishimura. Original source copyright:
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-All rights reserved
-===============================================================================
-
-The LocalizedFormatsTest class in the unit tests is an adapted version of
-the OrekitMessagesTest class from the orekit library distributed under the
-terms of the Apache 2 licence. Original source copyright:
-Copyright 2010 CS Systèmes d'Information
-===============================================================================
-
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
-
-The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
-by an original code donated by Sébastien Brisard.
-===============================================================================
-
-
-The complete text of licenses and disclaimers associated with the the original
-sources enumerated above at the time of code translation are in the LICENSE.txt
-file.
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-no-ctor-deser
@@ -929,16 +841,6 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-config
---------------------------------------------------------------------------------
-
-Kerby Config
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api
@@ -1175,6 +1077,26 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
+
+--------------------------------------------------------------------------------
+commons-logging.commons-logging
+--------------------------------------------------------------------------------
+
+Apache Commons Logging
+Copyright 2001-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-configuration2
+--------------------------------------------------------------------------------
+
+Apache Commons Configuration
+Copyright 2001-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.parquet.parquet-avro
@@ -1456,6 +1378,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.kerby.kerb-crypto
+--------------------------------------------------------------------------------
+
+Kerby-kerb Crypto
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.arrow.arrow-vector
 --------------------------------------------------------------------------------
 
@@ -1476,21 +1408,45 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-crypto
+org.apache.commons.commons-math3
 --------------------------------------------------------------------------------
 
-Kerby-kerb Crypto
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Math
+Copyright 2001-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software developed for Orekit by
+CS Systèmes d'Information (http://www.c-s.fr/)
+Copyright 2010-2012 CS Systèmes d'Information
+
+--------------------------------------------------------------------------------
+org.apache.curator.curator-client
+--------------------------------------------------------------------------------
+
+Curator Client
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-core
+commons-net.commons-net
 --------------------------------------------------------------------------------
 
-Kerby-kerb core
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Net
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.kerby.kerby-pkix
+--------------------------------------------------------------------------------
+
+Kerby PKIX Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1506,11 +1462,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.token-provider
+org.apache.commons.commons-collections4
 --------------------------------------------------------------------------------
 
-Token provider
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Collections
+Copyright 2001-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1598,11 +1554,11 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-simplekdc
+org.apache.kerby.kerby-config
 --------------------------------------------------------------------------------
 
-Kerb Simple Kdc
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Config
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1618,21 +1574,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-logging.commons-logging
+com.google.inject.extensions.guice-servlet
 --------------------------------------------------------------------------------
 
-Apache Commons Logging
-Copyright 2003-2014 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.curator.curator-recipes
---------------------------------------------------------------------------------
-
-Curator Recipes
-Copyright 2011-2019 The Apache Software Foundation
+Google Guice - Extensions - Servlet
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1734,26 +1680,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-client
---------------------------------------------------------------------------------
-
-Curator Client
-Copyright 2011-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-collections.commons-collections
---------------------------------------------------------------------------------
-
-Apache Commons Collections
-Copyright 2001-2015 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 io.r2dbc.r2dbc-spi
 --------------------------------------------------------------------------------
 
@@ -1774,16 +1700,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------------------
-commons-cli.commons-cli
---------------------------------------------------------------------------------
-
-Apache Commons CLI
-Copyright 2001-2009 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5-h2
 --------------------------------------------------------------------------------
 
@@ -1794,11 +1710,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-server
+org.apache.curator.curator-framework
 --------------------------------------------------------------------------------
 
-Kerby-kerb Server
-Copyright 2014-2017 The Apache Software Foundation
+Curator Framework
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+cglib.cglib
+--------------------------------------------------------------------------------
+
+Google Guice - Core Library
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1814,24 +1740,14 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.htrace.htrace-core4
+org.apache.commons.commons-text
 --------------------------------------------------------------------------------
 
-htrace-core4
-Copyright 2016 The Apache Software Foundation
+Apache Commons Text
+Copyright 2014-2025 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.extensions.guice-servlet
---------------------------------------------------------------------------------
-
-Google Guice - Extensions - Servlet
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5
@@ -1896,31 +1812,11 @@ in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-client
+org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
-Kerby-kerb Client
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-xdr
---------------------------------------------------------------------------------
-
-Kerby XDR Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-asn1
---------------------------------------------------------------------------------
-
-Kerby ASN1 Project
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Util
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1983,26 +1879,6 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerby-pkix
---------------------------------------------------------------------------------
-
-Kerby PKIX Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerb-identity
---------------------------------------------------------------------------------
-
-Kerby-kerb Identity
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-blackbird
 --------------------------------------------------------------------------------
 
@@ -2027,49 +1903,6 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper-jute
---------------------------------------------------------------------------------
-
-Apache ZooKeeper - Jute
-Copyright 2008-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-util
---------------------------------------------------------------------------------
-
-Kerby Util
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-configuration2
---------------------------------------------------------------------------------
-
-Apache Commons Configuration
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.guice
---------------------------------------------------------------------------------
-
-Google Guice - Core Library
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 software.amazon.awssdk.third-party-jackson-core
@@ -2183,6 +2016,16 @@ Other developers who have contributed code are:
 ## Copyright
 
 Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+--------------------------------------------------------------------------------
+org.apache.kerby.kerb-util
+--------------------------------------------------------------------------------
+
+Kerby-kerb Util
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.glassfish.jersey.core.jersey-common
@@ -2391,16 +2234,6 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-common
---------------------------------------------------------------------------------
-
-Kerby-kerb Common
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
@@ -2419,143 +2252,3 @@ Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-text
---------------------------------------------------------------------------------
-
-Apache Commons Text
-Copyright 2014-2023 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-net.commons-net
---------------------------------------------------------------------------------
-
-Apache Commons Net
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-io.netty.netty
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2011 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
-Also, please refer to each LICENSE.<component>.txt file, which is located in
-the 'license' directory of the distribution file, for the license terms of the
-components that this product depends on.
-
--------------------------------------------------------------------------------
-This product contains the extensions to Java Collections Framework which has
-been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
-
-  * LICENSE:
-    * license/LICENSE.jsr166y.txt (Public Domain)
-  * HOMEPAGE:
-    * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
-    * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
-
-This product contains a modified version of Robert Harder's Public Domain
-Base64 Encoder and Decoder, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.base64.txt (Public Domain)
-  * HOMEPAGE:
-    * http://iharder.sourceforge.net/current/java/base64/
-
-This product contains a modified version of 'JZlib', a re-implementation of
-zlib in pure Java, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jzlib.txt (BSD Style License)
-  * HOMEPAGE:
-    * http://www.jcraft.com/jzlib/
-
-This product contains a modified version of 'Webbit', a Java event based
-WebSocket and HTTP server:
-
-  * LICENSE:
-    * license/LICENSE.webbit.txt (BSD License)
-  * HOMEPAGE:
-    * https://github.com/joewalnes/webbit
-
-This product optionally depends on 'Protocol Buffers', Google's data
-interchange format, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
-  * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
-
-This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
-a temporary self-signed X.509 certificate when the JVM does not provide the
-equivalent functionality.  It can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.bouncycastle.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.bouncycastle.org/
-
-This product optionally depends on 'SLF4J', a simple logging facade for Java,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.slf4j.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.slf4j.org/
-
-This product optionally depends on 'Apache Commons Logging', a logging
-framework, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.commons-logging.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://commons.apache.org/logging/
-
-This product optionally depends on 'Apache Log4J', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.log4j.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://logging.apache.org/log4j/
-
-This product optionally depends on 'JBoss Logging', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jboss-logging.txt (GNU LGPL 2.1)
-  * HOMEPAGE:
-    * http://anonsvn.jboss.org/repos/common/common-logging-spi/
-
-This product optionally depends on 'Apache Felix', an open source OSGi
-framework implementation, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.felix.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://felix.apache.org/

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -586,9 +586,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -220,6 +220,7 @@ Dependencies under the Apache License, Version 2.0
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
+  - ch.qos.reload4j.reload4j-1.2.22.jar
   - com.fasterxml.classmate-1.7.0.jar
   - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
   - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
@@ -230,19 +231,18 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-scala_2.13-2.18.8.jar
-  - com.fasterxml.woodstox.woodstox-core-5.3.0.jar
+  - com.fasterxml.woodstox.woodstox-core-5.4.0.jar
   - com.github.ben-manes.caffeine.caffeine-3.1.8.jar
   - com.github.sisyphsu.dateparser-1.0.11.jar
   - com.github.sisyphsu.retree-1.0.4.jar
-  - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.github.tototoshi.scala-csv_2.13-1.3.10.jar
   - com.google.android.annotations-4.1.1.4.jar
   - com.google.api.grpc.proto-google-common-protos-2.22.0.jar
@@ -253,13 +253,12 @@ Scala/Java jars:
   - com.google.guava.failureaccess-1.0.2.jar
   - com.google.guava.guava-33.0.0-jre.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  - com.google.inject.extensions.guice-servlet-4.0.jar
-  - com.google.inject.guice-4.0.jar
+  - com.google.inject.extensions.guice-servlet-4.2.3.jar
+  - com.google.inject.guice-4.2.3.jar
   - com.google.j2objc.j2objc-annotations-2.8.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
-  - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
-  - com.squareup.okhttp.okhttp-2.7.5.jar
+  - com.nimbusds.nimbus-jose-jwt-10.4.jar
   - com.squareup.okhttp3.logging-interceptor-4.12.0.jar
   - com.squareup.okhttp3.okhttp-4.12.0.jar
   - com.squareup.okio.okio-3.6.0.jar
@@ -269,15 +268,13 @@ Scala/Java jars:
   - com.thesamet.scalapb.scalapb-runtime_2.13-0.11.20.jar
   - com.typesafe.config-1.4.6.jar
   - com.typesafe.scala-logging.scala-logging_2.13-3.9.5.jar
-  - com.zaxxer.HikariCP-5.1.0.jar
   - com.univocity.univocity-parsers-2.9.1.jar
-  - commons-beanutils.commons-beanutils-1.9.4.jar
-  - commons-cli.commons-cli-1.2.jar
+  - com.zaxxer.HikariCP-5.1.0.jar
+  - commons-cli.commons-cli-1.9.0.jar
   - commons-codec.commons-codec-1.17.1.jar
-  - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
-  - commons-logging.commons-logging-1.2.jar
-  - commons-net.commons-net-3.6.jar
+  - commons-logging.commons-logging-1.3.0.jar
+  - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
   - io.airlift.aircompressor-0.27.jar
@@ -317,16 +314,15 @@ Scala/Java jars:
   - io.grpc.grpc-util-1.60.0.jar
   - io.gsonfire.gson-fire-1.8.5.jar
   - io.lakefs.sdk-1.51.0.jar
-  - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.104.Final.jar
-  - io.netty.netty-codec-4.1.104.Final.jar
+  - io.netty.netty-buffer-4.1.127.Final.jar
+  - io.netty.netty-codec-4.1.127.Final.jar
   - io.netty.netty-codec-http-4.1.100.Final.jar
   - io.netty.netty-codec-http2-4.1.100.Final.jar
   - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.104.Final.jar
-  - io.netty.netty-handler-4.1.104.Final.jar
+  - io.netty.netty-common-4.1.127.Final.jar
+  - io.netty.netty-handler-4.1.127.Final.jar
   - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.104.Final.jar
+  - io.netty.netty-resolver-4.1.127.Final.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
@@ -334,17 +330,16 @@ Scala/Java jars:
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
   - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
   - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.104.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.104.Final.jar
+  - io.netty.netty-transport-4.1.127.Final.jar
+  - io.netty.netty-transport-classes-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-epoll-4.1.127.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.1.127.Final.jar
   - io.perfmark.perfmark-api-0.26.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
-  - log4j.log4j-1.2.17.jar
-  - net.minidev.accessors-smart-2.4.2.jar
-  - net.minidev.json-smart-2.4.2.jar
   - org.apache.arrow.arrow-format-15.0.2.jar
   - org.apache.arrow.arrow-memory-core-15.0.2.jar
   - org.apache.arrow.arrow-memory-netty-15.0.2.jar
@@ -352,27 +347,27 @@ Scala/Java jars:
   - org.apache.arrow.flight-core-15.0.2.jar
   - org.apache.arrow.flight-grpc-15.0.2.jar
   - org.apache.avro.avro-1.12.0.jar
+  - org.apache.commons.commons-collections4-4.4.jar
   - org.apache.commons.commons-compress-1.27.1.jar
-  - org.apache.commons.commons-configuration2-2.1.1.jar
+  - org.apache.commons.commons-configuration2-2.10.1.jar
   - org.apache.commons.commons-jcs3-core-3.2.jar
-  - org.apache.commons.commons-lang3-3.16.0.jar
-  - org.apache.commons.commons-math3-3.1.1.jar
-  - org.apache.commons.commons-text-1.11.0.jar
+  - org.apache.commons.commons-lang3-3.18.0.jar
+  - org.apache.commons.commons-math3-3.6.1.jar
+  - org.apache.commons.commons-text-1.14.0.jar
   - org.apache.commons.commons-vfs2-2.9.0.jar
-  - org.apache.curator.curator-client-4.2.0.jar
-  - org.apache.curator.curator-framework-4.2.0.jar
-  - org.apache.curator.curator-recipes-4.2.0.jar
-  - org.apache.hadoop.hadoop-annotations-3.3.1.jar
-  - org.apache.hadoop.hadoop-auth-3.3.1.jar
-  - org.apache.hadoop.hadoop-common-3.3.1.jar
-  - org.apache.hadoop.hadoop-hdfs-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-mapreduce-client-core-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-api-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-client-3.3.1.jar
-  - org.apache.hadoop.hadoop-yarn-common-3.3.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.1.1.jar
-  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_7-1.1.1.jar
-  - org.apache.htrace.htrace-core4-4.1.0-incubating.jar
+  - org.apache.curator.curator-client-5.2.0.jar
+  - org.apache.curator.curator-framework-5.2.0.jar
+  - org.apache.curator.curator-recipes-5.2.0.jar
+  - org.apache.hadoop.hadoop-annotations-3.4.3.jar
+  - org.apache.hadoop.hadoop-auth-3.4.3.jar
+  - org.apache.hadoop.hadoop-common-3.4.3.jar
+  - org.apache.hadoop.hadoop-hdfs-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-mapreduce-client-core-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-api-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-client-3.4.3.jar
+  - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
+  - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
   - org.apache.httpcomponents.client5.httpclient5-5.4.jar
   - org.apache.httpcomponents.core5.httpcore5-5.3.jar
   - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
@@ -388,21 +383,13 @@ Scala/Java jars:
   - org.apache.iceberg.iceberg-core-1.7.1.jar
   - org.apache.iceberg.iceberg-data-1.7.1.jar
   - org.apache.iceberg.iceberg-parquet-1.7.1.jar
-  - org.apache.kerby.kerb-admin-1.0.1.jar
-  - org.apache.kerby.kerb-client-1.0.1.jar
-  - org.apache.kerby.kerb-common-1.0.1.jar
-  - org.apache.kerby.kerb-core-1.0.1.jar
-  - org.apache.kerby.kerb-crypto-1.0.1.jar
-  - org.apache.kerby.kerb-identity-1.0.1.jar
-  - org.apache.kerby.kerb-server-1.0.1.jar
-  - org.apache.kerby.kerb-simplekdc-1.0.1.jar
-  - org.apache.kerby.kerb-util-1.0.1.jar
-  - org.apache.kerby.kerby-asn1-1.0.1.jar
-  - org.apache.kerby.kerby-config-1.0.1.jar
-  - org.apache.kerby.kerby-pkix-1.0.1.jar
-  - org.apache.kerby.kerby-util-1.0.1.jar
-  - org.apache.kerby.kerby-xdr-1.0.1.jar
-  - org.apache.kerby.token-provider-1.0.1.jar
+  - org.apache.kerby.kerb-core-2.0.3.jar
+  - org.apache.kerby.kerb-crypto-2.0.3.jar
+  - org.apache.kerby.kerb-util-2.0.3.jar
+  - org.apache.kerby.kerby-asn1-2.0.3.jar
+  - org.apache.kerby.kerby-config-2.0.3.jar
+  - org.apache.kerby.kerby-pkix-2.0.3.jar
+  - org.apache.kerby.kerby-util-2.0.3.jar
   - org.apache.lucene.lucene-analyzers-common-8.11.4.jar
   - org.apache.lucene.lucene-core-8.11.4.jar
   - org.apache.lucene.lucene-memory-8.7.0.jar
@@ -419,9 +406,10 @@ Scala/Java jars:
   - org.apache.parquet.parquet-hadoop-1.13.1.jar
   - org.apache.parquet.parquet-jackson-1.13.1.jar
   - org.apache.yetus.audience-annotations-0.13.0.jar
-  - org.apache.zookeeper.zookeeper-3.5.6.jar
-  - org.apache.zookeeper.zookeeper-jute-3.5.6.jar
+  - org.apache.zookeeper.zookeeper-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
+  - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-http-11.0.20.jar
   - org.eclipse.jetty.jetty-io-11.0.20.jar
   - org.eclipse.jetty.jetty-security-11.0.20.jar
@@ -431,9 +419,9 @@ Scala/Java jars:
   - org.eclipse.jetty.jetty-util-11.0.20.jar
   - org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api-5.0.2.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.4.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.40.v20210413.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.40.v20210413.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
   - org.ehcache.sizeof-0.4.3.jar
   - org.hibernate.validator.hibernate-validator-7.0.5.Final.jar
   - org.javassist.javassist-3.30.2-GA.jar
@@ -454,7 +442,7 @@ Scala/Java jars:
   - org.scala-lang.scala-reflect-2.13.18.jar
   - org.slf4j.jcl-over-slf4j-2.0.12.jar
   - org.slf4j.log4j-over-slf4j-2.0.12.jar
-  - org.xerial.snappy.snappy-java-1.1.8.3.jar
+  - org.xerial.snappy.snappy-java-1.1.10.4.jar
   - org.yaml.snakeyaml-2.2.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -513,6 +501,7 @@ Scala/Java jars:
   - com.konghq.unirest-java-3.14.2.jar
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
+  - org.bouncycastle.bcprov-jdk18on-1.82.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
   - org.projectlombok.lombok-1.18.24.jar
@@ -530,7 +519,6 @@ Scala/Java jars:
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
   - org.jline.jline-3.9.0.jar
-  - org.ow2.asm.asm-8.0.1.jar
   - org.threeten.threeten-extra-1.7.1.jar
 
 --------------------------------------------------------------------------------
@@ -539,7 +527,7 @@ Dependencies under the BSD 2-Clause License
 
 Scala/Java jars:
   - com.github.luben.zstd-jni-1.5.0-1.jar
-  - dnsjava.dnsjava-2.1.7.jar
+  - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar
 
@@ -598,7 +586,9 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.sun.jersey.contribs.jersey-guice-1.19.jar
+  - com.github.pjfanning.jersey-json-1.22.0.jar
+  - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
+  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0

--- a/workflow-compiling-service/NOTICE-binary
+++ b/workflow-compiling-service/NOTICE-binary
@@ -1176,31 +1176,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-framework
+org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
-Curator Framework
-Copyright 2011-2019 The Apache Software Foundation
+Kerby-kerb core
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-beanutils.commons-beanutils
+org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
-Apache Commons BeanUtils
-Copyright 2000-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper
---------------------------------------------------------------------------------
-
-Apache ZooKeeper - Server
-Copyright 2008-2019 The Apache Software Foundation
+Curator Recipes
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1216,17 +1206,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-util
+org.apache.kerby.kerby-asn1
 --------------------------------------------------------------------------------
 
-Kerby-kerb Util
-Copyright 2014-2017 The Apache Software Foundation
+Kerby ASN1 Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-log4j.log4j
+ch.qos.reload4j.reload4j
 --------------------------------------------------------------------------------
 
 Apache log4j
@@ -1234,6 +1224,16 @@ Copyright 2007 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-lang3
+--------------------------------------------------------------------------------
+
+Apache Commons Lang
+Copyright 2001-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-codec.commons-codec
@@ -1246,92 +1246,14 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-admin
+commons-cli.commons-cli
 --------------------------------------------------------------------------------
 
-Kerby-kerb Admin
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons CLI
+Copyright 2002-2024 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-math3
---------------------------------------------------------------------------------
-
-Apache Commons Math
-Copyright 2001-2012 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
-===============================================================================
-
-The BracketFinder (package org.apache.commons.math3.optimization.univariate)
-and PowellOptimizer (package org.apache.commons.math3.optimization.general)
-classes are based on the Python code in module "optimize.py" (version 0.5)
-developed by Travis E. Oliphant for the SciPy library (http://www.scipy.org/)
-Copyright © 2003-2009 SciPy Developers.
-===============================================================================
-
-The LinearConstraint, LinearObjectiveFunction, LinearOptimizer,
-RelationShip, SimplexSolver and SimplexTableau classes in package
-org.apache.commons.math3.optimization.linear include software developed by
-Benjamin McCann (http://www.benmccann.com) and distributed with
-the following copyright: Copyright 2009 Google Inc.
-===============================================================================
-
-This product includes software developed by the
-University of Chicago, as Operator of Argonne National
-Laboratory.
-The LevenbergMarquardtOptimizer class in package
-org.apache.commons.math3.optimization.general includes software
-translated from the lmder, lmpar and qrsolv Fortran routines
-from the Minpack package
-Minpack Copyright Notice (1999) University of Chicago.  All rights reserved
-===============================================================================
-
-The GraggBulirschStoerIntegrator class in package
-org.apache.commons.math3.ode.nonstiff includes software translated
-from the odex Fortran routine developed by E. Hairer and G. Wanner.
-Original source copyright:
-Copyright (c) 2004, Ernst Hairer
-===============================================================================
-
-The EigenDecompositionImpl class in package
-org.apache.commons.math3.linear includes software translated
-from some LAPACK Fortran routines.  Original source copyright:
-Copyright (c) 1992-2008 The University of Tennessee.  All rights reserved.
-===============================================================================
-
-The MersenneTwister class in package org.apache.commons.math3.random
-includes software translated from the 2002-01-26 version of
-the Mersenne-Twister generator written in C by Makoto Matsumoto and Takuji
-Nishimura. Original source copyright:
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-All rights reserved
-===============================================================================
-
-The LocalizedFormatsTest class in the unit tests is an adapted version of
-the OrekitMessagesTest class from the orekit library distributed under the
-terms of the Apache 2 licence. Original source copyright:
-Copyright 2010 CS Systèmes d'Information
-===============================================================================
-
-The HermiteInterpolator class and its corresponding test have been imported from
-the orekit library distributed under the terms of the Apache 2 licence. Original
-source copyright:
-Copyright 2010-2012 CS Systèmes d'Information
-===============================================================================
-
-The creation of the package "o.a.c.m.analysis.integration.gauss" was inspired
-by an original code donated by Sébastien Brisard.
-===============================================================================
-
-
-The complete text of licenses and disclaimers associated with the the original
-sources enumerated above at the time of code translation are in the LICENSE.txt
-file.
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-no-ctor-deser
@@ -1357,16 +1279,6 @@ FasterXML.com (http://fasterxml.com).
 A list of contributors may be found from CREDITS file, which is included
 in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-config
---------------------------------------------------------------------------------
-
-Kerby Config
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api
@@ -1603,6 +1515,26 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
+
+--------------------------------------------------------------------------------
+commons-logging.commons-logging
+--------------------------------------------------------------------------------
+
+Apache Commons Logging
+Copyright 2001-2023 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.commons.commons-configuration2
+--------------------------------------------------------------------------------
+
+Apache Commons Configuration
+Copyright 2001-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.parquet.parquet-avro
@@ -1884,6 +1816,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.kerby.kerb-crypto
+--------------------------------------------------------------------------------
+
+Kerby-kerb Crypto
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.arrow.arrow-vector
 --------------------------------------------------------------------------------
 
@@ -1904,21 +1846,45 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-crypto
+org.apache.commons.commons-math3
 --------------------------------------------------------------------------------
 
-Kerby-kerb Crypto
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Math
+Copyright 2001-2016 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This product includes software developed for Orekit by
+CS Systèmes d'Information (http://www.c-s.fr/)
+Copyright 2010-2012 CS Systèmes d'Information
+
+--------------------------------------------------------------------------------
+org.apache.curator.curator-client
+--------------------------------------------------------------------------------
+
+Curator Client
+Copyright 2011-2021 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-core
+commons-net.commons-net
 --------------------------------------------------------------------------------
 
-Kerby-kerb core
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Net
+Copyright 2001-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.kerby.kerby-pkix
+--------------------------------------------------------------------------------
+
+Kerby PKIX Project
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1934,11 +1900,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.token-provider
+org.apache.commons.commons-collections4
 --------------------------------------------------------------------------------
 
-Token provider
-Copyright 2014-2017 The Apache Software Foundation
+Apache Commons Collections
+Copyright 2001-2019 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2026,11 +1992,11 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-simplekdc
+org.apache.kerby.kerby-config
 --------------------------------------------------------------------------------
 
-Kerb Simple Kdc
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Config
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2046,21 +2012,11 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-logging.commons-logging
+com.google.inject.extensions.guice-servlet
 --------------------------------------------------------------------------------
 
-Apache Commons Logging
-Copyright 2003-2014 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.curator.curator-recipes
---------------------------------------------------------------------------------
-
-Curator Recipes
-Copyright 2011-2019 The Apache Software Foundation
+Google Guice - Extensions - Servlet
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2162,26 +2118,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.curator.curator-client
---------------------------------------------------------------------------------
-
-Curator Client
-Copyright 2011-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-collections.commons-collections
---------------------------------------------------------------------------------
-
-Apache Commons Collections
-Copyright 2001-2015 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 io.r2dbc.r2dbc-spi
 --------------------------------------------------------------------------------
 
@@ -2202,16 +2138,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 --------------------------------------------------------------------------------
-commons-cli.commons-cli
---------------------------------------------------------------------------------
-
-Apache Commons CLI
-Copyright 2001-2009 The Apache Software Foundation
-
-This product includes software developed by
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5-h2
 --------------------------------------------------------------------------------
 
@@ -2222,11 +2148,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-server
+org.apache.curator.curator-framework
 --------------------------------------------------------------------------------
 
-Kerby-kerb Server
-Copyright 2014-2017 The Apache Software Foundation
+Curator Framework
+Copyright 2011-2021 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+cglib.cglib
+--------------------------------------------------------------------------------
+
+Google Guice - Core Library
+Copyright 2006-2020 Google, Inc.
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2242,24 +2178,14 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.htrace.htrace-core4
+org.apache.commons.commons-text
 --------------------------------------------------------------------------------
 
-htrace-core4
-Copyright 2016 The Apache Software Foundation
+Apache Commons Text
+Copyright 2014-2025 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.extensions.guice-servlet
---------------------------------------------------------------------------------
-
-Google Guice - Extensions - Servlet
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
+The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.httpcomponents.core5.httpcore5
@@ -2324,31 +2250,11 @@ in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-client
+org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
-Kerby-kerb Client
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-xdr
---------------------------------------------------------------------------------
-
-Kerby XDR Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-asn1
---------------------------------------------------------------------------------
-
-Kerby ASN1 Project
-Copyright 2014-2017 The Apache Software Foundation
+Kerby Util
+Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2411,26 +2317,6 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerby-pkix
---------------------------------------------------------------------------------
-
-Kerby PKIX Project
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerb-identity
---------------------------------------------------------------------------------
-
-Kerby-kerb Identity
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.fasterxml.jackson.module.jackson-module-blackbird
 --------------------------------------------------------------------------------
 
@@ -2457,16 +2343,6 @@ in some artifacts (usually source distributions); but is always available
 from the source code management (SCM) system project uses.
 
 --------------------------------------------------------------------------------
-org.apache.zookeeper.zookeeper-jute
---------------------------------------------------------------------------------
-
-Apache ZooKeeper - Jute
-Copyright 2008-2019 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.httpcomponents.httpcore-nio
 --------------------------------------------------------------------------------
 
@@ -2474,49 +2350,6 @@ Apache HttpCore NIO
 Copyright 2005-2020 The Apache Software Foundation
 
 This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.kerby.kerby-util
---------------------------------------------------------------------------------
-
-Kerby Util
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-lang3
---------------------------------------------------------------------------------
-
-Apache Commons Lang
-Copyright 2001-2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-configuration2
---------------------------------------------------------------------------------
-
-Apache Commons Configuration
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.inject.guice
---------------------------------------------------------------------------------
-
-Google Guice - Core Library
-Copyright 2006-2015 Google, Inc.
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-This product includes software developed by
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
@@ -2631,6 +2464,16 @@ Other developers who have contributed code are:
 ## Copyright
 
 Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+--------------------------------------------------------------------------------
+org.apache.kerby.kerb-util
+--------------------------------------------------------------------------------
+
+Kerby-kerb Util
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.glassfish.jersey.core.jersey-common
@@ -2839,16 +2682,6 @@ possession, or use, and re-export of encryption software, to see if this is
 permitted.
 
 --------------------------------------------------------------------------------
-org.apache.kerby.kerb-common
---------------------------------------------------------------------------------
-
-Kerby-kerb Common
-Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
@@ -2867,146 +2700,6 @@ Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.commons.commons-text
---------------------------------------------------------------------------------
-
-Apache Commons Text
-Copyright 2014-2023 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-commons-net.commons-net
---------------------------------------------------------------------------------
-
-Apache Commons Net
-Copyright 2001-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-io.netty.netty
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2011 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
-Also, please refer to each LICENSE.<component>.txt file, which is located in
-the 'license' directory of the distribution file, for the license terms of the
-components that this product depends on.
-
--------------------------------------------------------------------------------
-This product contains the extensions to Java Collections Framework which has
-been derived from the works by JSR-166 EG, Doug Lea, and Jason T. Greene:
-
-  * LICENSE:
-    * license/LICENSE.jsr166y.txt (Public Domain)
-  * HOMEPAGE:
-    * http://gee.cs.oswego.edu/cgi-bin/viewcvs.cgi/jsr166/
-    * http://viewvc.jboss.org/cgi-bin/viewvc.cgi/jbosscache/experimental/jsr166/
-
-This product contains a modified version of Robert Harder's Public Domain
-Base64 Encoder and Decoder, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.base64.txt (Public Domain)
-  * HOMEPAGE:
-    * http://iharder.sourceforge.net/current/java/base64/
-
-This product contains a modified version of 'JZlib', a re-implementation of
-zlib in pure Java, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jzlib.txt (BSD Style License)
-  * HOMEPAGE:
-    * http://www.jcraft.com/jzlib/
-
-This product contains a modified version of 'Webbit', a Java event based
-WebSocket and HTTP server:
-
-  * LICENSE:
-    * license/LICENSE.webbit.txt (BSD License)
-  * HOMEPAGE:
-    * https://github.com/joewalnes/webbit
-
-This product optionally depends on 'Protocol Buffers', Google's data
-interchange format, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.protobuf.txt (New BSD License)
-  * HOMEPAGE:
-    * http://code.google.com/p/protobuf/
-
-This product optionally depends on 'Bouncy Castle Crypto APIs' to generate
-a temporary self-signed X.509 certificate when the JVM does not provide the
-equivalent functionality.  It can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.bouncycastle.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.bouncycastle.org/
-
-This product optionally depends on 'SLF4J', a simple logging facade for Java,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.slf4j.txt (MIT License)
-  * HOMEPAGE:
-    * http://www.slf4j.org/
-
-This product optionally depends on 'Apache Commons Logging', a logging
-framework, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.commons-logging.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://commons.apache.org/logging/
-
-This product optionally depends on 'Apache Log4J', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.log4j.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://logging.apache.org/log4j/
-
-This product optionally depends on 'JBoss Logging', a logging framework,
-which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.jboss-logging.txt (GNU LGPL 2.1)
-  * HOMEPAGE:
-    * http://anonsvn.jboss.org/repos/common/common-logging-spi/
-
-This product optionally depends on 'Apache Felix', an open source OSGi
-framework implementation, which can be obtained at:
-
-  * LICENSE:
-    * license/LICENSE.felix.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://felix.apache.org/
 
 --------------------------------------------------------------------------------
 org.apache.httpcomponents.httpmime


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#6201 to `release/v1.2`: upgrade `org.apache.hadoop:hadoop-common` to 3.4.3 in both places it is pinned (`common/workflow-core/build.sbt` was at 3.3.1, `amber/build.sbt` at 3.3.3), and upgrade `hadoop-mapreduce-client-core` to 3.4.3 alongside it with hadoop 3.4's new direct `netty-all` dependency excluded.

This resolves the same 4 Dependabot alerts on `hadoop-common` for the release line:
- [#656](https://github.com/apache/texera/security/dependabot/656) CVE-2022-25168 (critical, argument injection in `FileUtil.unTar`, fixed in 3.3.3)
- [#732](https://github.com/apache/texera/security/dependabot/732) CVE-2022-26612 (critical, fixed in 3.3.3)
- [#654](https://github.com/apache/texera/security/dependabot/654) CVE-2021-37404 (critical, heap overflow in libhdfs, fixed in 3.3.2)
- [#700](https://github.com/apache/texera/security/dependabot/700) CVE-2024-23454 (low, fixed in 3.4.0)

Cherry-pick of 1094a6569 with conflicts resolved:
- `common/workflow-core/build.sbt`: took only this PR's `excludeNetty` addition; the adjacent `log4jVersion` line in the conflict hunk belongs to #6199, which is not on `release/v1.2` (its backport #6202 is separate and still open).
- The 8 `LICENSE-binary`(-java) / `NOTICE-binary` manifests were **regenerated from freshly built `release/v1.2` dists** rather than taken from `main`, because `main`'s manifests reflect deps this branch does not have: the log4j 2.26.1 bridge entries (from #6199) are removed, and pekko stays 1.2.1 (main: 1.6.0), ssl-config-core 0.6.1 (main: 0.7.1), slf4j-api 2.0.16 (main: 2.0.17). `NOTICE-binary` files were regenerated with `generate_notice_binary.py` (amber with `--extras amber/NOTICE-binary-python`).

**Update:** this PR also folds in the startup-regression fix from apache/texera#6205 (issue #6204), so the hadoop upgrade lands on `release/v1.2` without ever breaking service startup. Hadoop 3.4 ships Jersey 1's JSON module via the fork `com.github.pjfanning:jersey-json`, which the existing `com.sun.jersey` exclusion rules do not catch; its `META-INF/services` entries register Jersey 1.x providers whose superclasses live in the (excluded) jersey-core 1.x, so Dropwizard's Jersey 2 `ServiceFinder` dies with `NoClassDefFoundError: com/sun/jersey/core/provider/jaxb/AbstractRootElementProvider` on boot. The fix excludes `com.github.pjfanning:jersey-json` from the hadoop dependencies in `common/workflow-core/build.sbt` and `amber/build.sbt`, and removes the two jars that consequently leave the dists (`jersey-json-1.22.0`, its transitive `jaxb-impl-2.2.3-1`) from the four `LICENSE-binary`(-java) manifests, regenerated against dists rebuilt on this branch.

### Any related issues, documentation, discussions?

Backports apache/texera#6201 (merged to `main`), which resolves #6200. Also includes the fix from apache/texera#6205 for #6204 (startup regression introduced by #6201). No `release/*` label is added — this PR *is* the backport.

### How was this PR tested?

Binary licensing manifests were verified the same way CI checks them: built the four affected dists on this branch (`sbt WorkflowExecutionService/dist FileService/dist ComputingUnitManagingService/dist WorkflowCompilingService/dist`), then ran `check_binary_deps.py` in strict (nightly) mode against each unzipped dist — all four pass (`OK: 395/300/337/312 JVM jars match LICENSE-binary`).

For the folded-in #6205 fix: rebuilt all four dists on this branch after adding the exclusion and verified via `unzip -l` that `jersey-json` and `jaxb-impl` are no longer bundled in any of them; `check_binary_deps.py` re-run against the fresh dists passes for all four services (`OK: 393/298/310/335 JVM jars match LICENSE-binary`), and `generate_notice_binary.py` reports no `NOTICE-binary` drift (the removed jars carry no NOTICE entries). On `main` the same exclusion was verified end to end: `texera-web` reproducibly crashes on boot without it and starts cleanly with it (Jetty up on :8080).

Tested with existing test cases:
- `sbt WorkflowCore/test`: 294 tests passed, 0 failed. (4 suites — `S3StorageClientSpec` and the `LargeBinary*` specs — abort because they need an external MinIO service; verified they abort identically on unmodified `release/v1.2`, unrelated to this change.)
- `sbt WorkflowExecutionService/Test/compile` passes (95 test sources; `SequentialRecordStorageSpec`, run on `main` for the `HDFSRecordStorage` path, does not exist on `release/v1.2` — `HDFSRecordStorage` itself compiles against hadoop 3.4.3).
- `sbt "WorkflowCore/testOnly *IcebergUtilSpec"` (Iceberg + hadoop `Configuration` usage): 14 tests passed. (`DocumentFactorySpec` from the original PR's test list also does not exist on `release/v1.2`.)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)

