### PR TITLE
fix(deps): exclude pjfanning jersey-json from hadoop to unbreak service startup

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -678,9 +678,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
   - javax.websocket.javax.websocket-api-1.0.jar
   - javax.websocket.javax.websocket-client-api-1.0.jar
   - javax.xml.bind.jaxb-api-2.3.0.jar

--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -160,11 +160,14 @@ val luceneDependencies = Seq(
 // Hadoop related
 val hadoopVersion = "3.4.3"
 val excludeHadoopJersey = ExclusionRule(organization = "com.sun.jersey")
+// Hadoop 3.3.2+ ships jersey-json via the com.github.pjfanning fork; its Jersey 1.x
+// providers break Jersey 2 auto-discovery at startup, so exclude it as well.
+val excludeHadoopJerseyJsonFork = ExclusionRule(organization = "com.github.pjfanning", name = "jersey-json")
 val excludeHadoopSlf4j = ExclusionRule(organization = "org.slf4j")
 val excludeHadoopJetty = ExclusionRule(organization = "org.eclipse.jetty")
 val excludeHadoopJsp = ExclusionRule(organization = "javax.servlet.jsp")
 val hadoopDependencies = Seq(
-  "org.apache.hadoop" % "hadoop-common" % hadoopVersion excludeAll(excludeHadoopJersey, excludeHadoopSlf4j, excludeHadoopJsp, excludeHadoopJetty)
+  "org.apache.hadoop" % "hadoop-common" % hadoopVersion excludeAll(excludeHadoopJersey, excludeHadoopJerseyJsonFork, excludeHadoopSlf4j, excludeHadoopJsp, excludeHadoopJetty)
 )
 
 /////////////////////////////////////////////////////////////////////////////

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -157,6 +157,9 @@ dependencyOverrides ++= Seq(
 // Iceberg-related Dependencies
 /////////////////////////////////////////////////////////////////////////////
 val excludeJersey = ExclusionRule(organization = "com.sun.jersey")
+// Hadoop 3.3.2+ ships jersey-json via the com.github.pjfanning fork; its Jersey 1.x
+// providers break Jersey 2 auto-discovery at startup, so exclude it as well.
+val excludeJerseyJsonFork = ExclusionRule(organization = "com.github.pjfanning", name = "jersey-json")
 val excludeGlassfishJersey = ExclusionRule(organization = "org.glassfish.jersey")
 val excludeSlf4j = ExclusionRule(organization = "org.slf4j")
 val excludeJetty = ExclusionRule(organization = "org.eclipse.jetty")
@@ -189,6 +192,7 @@ libraryDependencies ++= Seq(
     excludeXmlBind,
     excludeGlassfishJersey,
     excludeJersey,
+    excludeJerseyJsonFork,
     excludeSlf4j,
     excludeJetty,
     excludeJsp,
@@ -201,6 +205,7 @@ libraryDependencies ++= Seq(
     excludeXmlBind,
     excludeGlassfishJersey,
     excludeJersey,
+    excludeJerseyJsonFork,
     excludeSlf4j,
     excludeJetty,
     excludeJsp,

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -618,9 +618,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -581,9 +581,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -592,9 +592,7 @@ CDDL 1.1
 ~~~~~~~~
 
 Scala/Java jars:
-  - com.github.pjfanning.jersey-json-1.22.0.jar
   - com.sun.jersey.contribs.jersey-guice-1.19.4.jar
-  - com.sun.xml.bind.jaxb-impl-2.2.3-1.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the Eclipse Distribution License, Version 1.0


### PR DESCRIPTION
### What changes were proposed in this PR?

After #6201 upgraded Hadoop to 3.4.3, `texera-web` crashes on boot with
`NoClassDefFoundError: com/sun/jersey/core/provider/jaxb/AbstractRootElementProvider`.

Hadoop 3.4 ships Jersey 1's JSON module via the fork
`com.github.pjfanning:jersey-json` instead of `com.sun.jersey:jersey-json`, so the
existing `ExclusionRule(organization = "com.sun.jersey")` rules no longer catch it and
the jar lands on the runtime classpath. Its `META-INF/services/javax.ws.rs.ext.MessageBodyReader|Writer`
entries register Jersey 1.x providers (e.g. `JSONRootElementProvider`) whose superclasses
live in jersey-core 1.x — which *is* excluded — so Dropwizard's Jersey 2 `ServiceFinder`
dies loading them during startup.

This PR:
- adds an exclusion for `com.github.pjfanning:jersey-json` to the `hadoop-common`
  (and `hadoop-mapreduce-client-core`) dependencies in `common/workflow-core/build.sbt`
  and `amber/build.sbt`. The module only serves hadoop's own web endpoints; the
  Iceberg `HadoopCatalog`/`HadoopFileIO` and `HDFSRecordStorage` code paths don't use it.
- removes the two jars that consequently leave the dists —
  `com.github.pjfanning.jersey-json-1.22.0.jar` and its transitive
  `com.sun.xml.bind.jaxb-impl-2.2.3-1.jar` — from the `LICENSE-binary`(-java) manifests
  of the four affected services (amber, file-service, workflow-compiling-service,
  computing-unit-managing-service). `jettison` stays: hadoop-common declares it directly.

### Any related issues, documentation, discussions?

Fixes #6204. Regression introduced by #6201.

### How was this PR tested?

- Rebuilt all four affected dists (`sbt <svc>/dist`) and verified via `unzip -l` that
  `jersey-json` and `jaxb-impl` are no longer bundled in any of them (before the fix,
  all four bundled both).
- `./bin/licensing/check_binary_deps.py --ignore-transitive-version jar --license-binary ...`
  (the CI PR-mode check) passes for all four services against the freshly built dists.
- `./bin/licensing/generate_notice_binary.py` regenerated all four `NOTICE-binary` files
  from the same dists: no drift (the removed jars carry no NOTICE entries).
- Brought the stack up from this branch with `bin/local-dev.sh`: `file-service` and
  `workflow-compiling-service` — Dropwizard services that previously bundled the jar via
  workflow-core and exhibit the same startup path — start cleanly (Jetty up, graceful
  shutdown on `down`). On unmodified `main`, `texera-web` reproducibly crashes with the
  `NoClassDefFoundError` above; with the jar excluded there is nothing left on the
  classpath for `ServiceFinder` to trip over.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)