### PR TITLE
fix(deps): pin jackson-databind to 2.18.8 in computing-unit-managing-service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,7 +150,13 @@ lazy val ComputingUnitManagingService = (project in file("computing-unit-managin
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+      // Arrow 19 (via WorkflowCore) evicts jackson-databind up to 2.21.0, past
+      // the 2.18 range jackson-module-scala allows; pin it back to jacksonVersion
+      // so the Scala module can initialize (else the service aborts at startup
+      // with "Scala module 2.18.8 requires Jackson Databind version >= 2.18.0
+      // and < 2.19.0 - Found jackson-databind version 2.21.0").
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
     ) ++ nettyDependencyOverrides
   )
 lazy val FileService = (project in file("file-service"))

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -224,7 +224,7 @@ Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
   - com.fasterxml.jackson.core.jackson-annotations-2.21.jar
   - com.fasterxml.jackson.core.jackson-core-2.21.0.jar
-  - com.fasterxml.jackson.core.jackson-databind-2.21.0.jar
+  - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.17.0.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar


### PR DESCRIPTION
### What changes were proposed in this PR?

`computing-unit-managing-service` crashes at startup on `main` (since #6185, the Arrow 19 upgrade) with:

```
Exception in thread "main" com.fasterxml.jackson.databind.JsonMappingException:
  Scala module 2.18.8 requires Jackson Databind version >= 2.18.0 and < 2.19.0
  - Found jackson-databind version 2.21.0
    at com.fasterxml.jackson.module.scala.JacksonModule.setupModule
    at org.apache.texera.service.ComputingUnitManagingService.initialize
```

**Root cause.** #6185 counters Arrow 19 evicting `jackson-databind` up to `2.21.0` (past the range `jackson-module-scala` allows) by pinning the Jackson core family — in `workflow-core`/`workflow-operator`, and by pinning `jackson-databind` directly in `file-service` and `workflow-compiling-service`. `ComputingUnitManagingService` was the one Arrow-bundling service left overriding **only** `jackson-module-scala`, so nothing held `jackson-databind` down. Its dist bundled `jackson-databind-2.21.0.jar` next to `jackson-module-scala_2.13-2.18.8.jar` and aborted at init.

**Before → after** (resolved `Runtime/managedClasspath` of `ComputingUnitManagingService`):

| artifact | before | after |
| --- | --- | --- |
| jackson-annotations | 2.21 | 2.21 |
| jackson-core | 2.21.0 | 2.21.0 |
| **jackson-databind** | **2.21.0** ❌ | **2.18.8** ✅ |

The fix mirrors `file-service` / `workflow-compiling-service` exactly: add `"com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion` to the module's `dependencyOverrides`, and re-sync the one drifted line in `computing-unit-managing-service/LICENSE-binary` (`2.21.0` → `2.18.8`). `NOTICE-binary` is version-less by design (the generator strips versions so routine bumps don't churn it) and the jar *set* is unchanged, so it needs no edit.

### Any related issues, documentation, discussions?

Fixes #6206. Follow-up to #6185.

### How was this PR tested?

Reproduced the CI binary-license check locally against the module's resolved runtime classpath (per the repo's `check_binary_deps.py` recipe):

- `sbt "print ComputingUnitManagingService/Runtime/managedClasspath"` now resolves `jackson-databind-2.18.8.jar` (was `2.21.0`) — the only delta; no other dep drifted.
- `check_binary_deps.py jar <staged-lib> --license-binary computing-unit-managing-service/LICENSE-binary` → `OK: 339 JVM jars match LICENSE-binary.`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])