### PR TITLE
feat(agent-service): add workflow revert & redo for AI agent turns

### DIFF
--- a/agent-service/src/agent/texera-agent.spec.ts
+++ b/agent-service/src/agent/texera-agent.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Exercises revert/redo over REAL sendMessage() turns (driven by a mock model),
+// so the step-tree, HEAD movement, per-step workflow snapshots, and redo-stack
+// lifecycle are covered end to end rather than via hand-built internal state.
+
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { MockLanguageModelV3 } from "ai/test";
+import { TexeraAgent } from "./texera-agent";
+import { INITIAL_STEP_ID } from "../types/agent";
+
+// Controllable backend doubles for the persistence/serialization tests below.
+// Defaults are benign no-ops so the mock is invisible to every other test
+// (none of which set a delegate config, so the real module is never needed).
+let persistImpl: (...args: any[]) => Promise<void> = async () => {};
+let retrieveImpl: () => Promise<any> = async () => ({ content: emptyContent() });
+
+mock.module("../api/workflow-api", () => ({
+  persistWorkflow: (...args: any[]) => persistImpl(...args),
+  retrieveWorkflow: () => retrieveImpl(),
+}));
+
+function emptyContent(): any {
+  return { operators: [], operatorPositions: {}, links: [], commentBoxes: [], settings: {} };
+}
+
+function contentWith(...operatorIds: string[]): any {
+  return { ...emptyContent(), operators: operatorIds.map(operatorID => ({ operatorID })) };
+}
+
+function textModel(text: string): any {
+  return new MockLanguageModelV3({
+    doGenerate: async () =>
+      ({
+        content: [{ type: "text", text }],
+        finishReason: "stop",
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        warnings: [],
+      }) as any,
+  });
+}
+
+function throwingModel(message: string): any {
+  return new MockLanguageModelV3({
+    doGenerate: async () => {
+      throw new Error(message);
+    },
+  });
+}
+
+function makeAgent(model: any): TexeraAgent {
+  return new TexeraAgent({ model, modelType: "mock", agentId: "test-agent" });
+}
+
+describe("TexeraAgent revert/redo over real turns", () => {
+  test("a completed turn records a workflow snapshot on every step", async () => {
+    const agent = makeAgent(textModel("done"));
+    await agent.sendMessage("hello");
+
+    const steps = agent.getAllSteps();
+    expect(steps.length).toBeGreaterThan(0);
+    for (const s of steps) {
+      expect(s.afterWorkflowContent).toBeDefined();
+    }
+    // HEAD is the turn's last step and is on the visible path.
+    expect(agent.getVisibleReActSteps().at(-1)?.id).toBe(agent.getHead());
+  });
+
+  test("a new prompt clears the redo stack (a branch invalidates redo)", async () => {
+    const agent = makeAgent(textModel("done"));
+    await agent.sendMessage("first");
+
+    const userStep = agent.getAllSteps().find(s => s.role === "user");
+    expect(userStep).toBeDefined();
+    await agent.revertToTurnStart(userStep!.messageId);
+    expect(agent.canRedo()).toBe(true);
+
+    await agent.sendMessage("second"); // branch from the reverted HEAD
+    expect(agent.canRedo()).toBe(false);
+  });
+
+  test("revert then redo round-trips HEAD across a real turn", async () => {
+    const agent = makeAgent(textModel("done"));
+    await agent.sendMessage("only turn");
+    const leaf = agent.getHead();
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+
+    const reverted = await agent.revertToTurnStart(userStep.messageId);
+    expect(agent.getHead()).toBe(reverted.headId);
+    expect(agent.getHead()).not.toBe(leaf);
+
+    const redone = await agent.redo();
+    expect(redone.headId).toBe(leaf);
+    expect(agent.getHead()).toBe(leaf);
+    expect(agent.canRedo()).toBe(false);
+  });
+
+  test("a turn that errors still snapshots its final step (so it can be reverted/redone)", async () => {
+    const agent = makeAgent(throwingModel("boom"));
+    const result = await agent.sendMessage("hello");
+    expect(result.error).toBeDefined();
+
+    const headStep = agent.getStepsById().get(agent.getHead());
+    expect(headStep?.afterWorkflowContent).toBeDefined();
+
+    // The errored turn is still revertable + redoable.
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+    await agent.revertToTurnStart(userStep.messageId);
+    const redone = await agent.redo();
+    expect(redone.workflowContent).toBeDefined();
+  });
+
+  test("reverting a turn that is no longer on the HEAD path is rejected", async () => {
+    const agent = makeAgent(textModel("done"));
+    await agent.sendMessage("only turn");
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+
+    await agent.revertToTurnStart(userStep.messageId);
+    // A second revert of the same turn (e.g. a stale client) must not push a
+    // bogus redo entry or move HEAD again.
+    await expect(agent.revertToTurnStart(userStep.messageId)).rejects.toThrow(
+      "Turn is not on the current conversation path"
+    );
+    expect(agent.getHead()).toBe(userStep.parentId!);
+    expect((agent as any).redoStack).toHaveLength(1);
+  });
+
+  test("revert restores the pre-turn workflow through a real turn's snapshots", async () => {
+    const agent = makeAgent(textModel("done"));
+    agent.getWorkflowState().setWorkflowContent(contentWith("opA"));
+    await agent.sendMessage("turn 1"); // snapshots capture the opA workflow
+    // The workflow drifts after the turn; revert must restore the snapshot,
+    // not just move HEAD.
+    agent.getWorkflowState().setWorkflowContent(contentWith("opA", "opB"));
+
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+    const reverted = await agent.revertToTurnStart(userStep.messageId);
+
+    expect(reverted.workflowContent.operators.map((o: any) => o.operatorID)).toEqual(["opA"]);
+    expect(
+      agent
+        .getWorkflowState()
+        .getWorkflowContent()
+        .operators.map((o: any) => o.operatorID)
+    ).toEqual(["opA"]);
+  });
+});
+
+describe("TexeraAgent revert/redo persistence & serialization", () => {
+  const delegate = { userToken: "tok", workflowId: 42 };
+
+  // NOTE: with a delegate config the run loop also calls the
+  // workflow-compiling service; whether that fetch is refused (CI) or
+  // rejected by a live service, compile-api returns null and the agent
+  // proceeds without schemas, so it needs no mocking here.
+
+  afterEach(() => {
+    persistImpl = async () => {};
+    retrieveImpl = async () => ({ content: emptyContent() });
+  });
+
+  test("a revert whose persistence fails is rolled back and surfaces an error", async () => {
+    const agent = makeAgent(textModel("done"));
+    agent.setDelegateConfig(delegate);
+    await agent.sendMessage("turn 1");
+    const leaf = agent.getHead();
+    const leafContent = agent.getWorkflowState().getWorkflowContent();
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+
+    persistImpl = async () => {
+      throw new Error("backend down");
+    };
+    await expect(agent.revertToTurnStart(userStep.messageId)).rejects.toThrow("Failed to save the restored workflow");
+
+    // Nothing moved: a "reverted" reply with the backend still on the old
+    // workflow would let the next prompt's refresh silently undo the revert.
+    expect(agent.getHead()).toBe(leaf);
+    expect(agent.canRedo()).toBe(false);
+    expect(agent.getWorkflowState().getWorkflowContent()).toEqual(leafContent);
+  });
+
+  test("overlapping revert and redo run serialized, never concurrently", async () => {
+    const agent = makeAgent(textModel("done"));
+    agent.setDelegateConfig(delegate);
+    await agent.sendMessage("turn 1");
+    const leaf = agent.getHead();
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+
+    const events: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    let gated = true;
+    persistImpl = async () => {
+      events.push(`persist-start@${agent.getHead()}`);
+      if (gated) {
+        gated = false;
+        await gate; // hold the revert's persistence open
+      }
+      events.push("persist-end");
+    };
+
+    const revertP = agent.revertToTurnStart(userStep.messageId);
+    const redoP = agent.redo(); // must queue behind the in-flight revert
+    await new Promise(resolve => setTimeout(resolve, 10));
+    // The redo has not touched anything while the revert persistence is open.
+    expect(events).toEqual([`persist-start@${INITIAL_STEP_ID}`]);
+
+    release();
+    await revertP;
+    await redoP;
+
+    expect(events).toEqual([`persist-start@${INITIAL_STEP_ID}`, "persist-end", `persist-start@${leaf}`, "persist-end"]);
+    expect(agent.getHead()).toBe(leaf);
+    expect(agent.canRedo()).toBe(false);
+  });
+
+  test("a redo arriving during prompt startup is rejected instead of interleaving", async () => {
+    const agent = makeAgent(textModel("done"));
+    agent.setDelegateConfig(delegate);
+    await agent.sendMessage("turn 1");
+    const userStep = agent.getAllSteps().find(s => s.role === "user")!;
+    await agent.revertToTurnStart(userStep.messageId); // HEAD -> initial, redo available
+
+    // Gate the second prompt's backend refresh so its startup holds the lock
+    // with the agent still reporting AVAILABLE — the original race window.
+    let releaseRetrieve!: () => void;
+    const retrieveGate = new Promise<void>(resolve => (releaseRetrieve = resolve));
+    retrieveImpl = async () => {
+      await retrieveGate;
+      return { content: emptyContent() };
+    };
+
+    const promptP = agent.sendMessage("turn 2");
+    const redoP = agent.redo(); // queued behind the prompt startup
+    redoP.catch(() => {}); // it can only settle after the gate opens below
+    await new Promise(resolve => setTimeout(resolve, 10));
+    releaseRetrieve();
+
+    // NOTE: bun's expect(promise).rejects spin-waits synchronously for the
+    // promise to settle, so it must not be created while settlement still
+    // depends on test code that runs later (the gate release above).
+    await expect(redoP).rejects.toThrow("Cannot redo while the agent is busy");
+    const result = await promptP;
+    expect(result.error).toBeUndefined();
+    // The prompt invalidated redo; the late redo neither restored the
+    // abandoned branch nor left a stale redo entry behind.
+    expect(agent.canRedo()).toBe(false);
+  });
+});

--- a/agent-service/src/agent/texera-agent.ts
+++ b/agent-service/src/agent/texera-agent.ts
@@ -91,6 +91,8 @@ export class TexeraAgent {
   private workflowState: WorkflowState;
   private metadataStore: WorkflowSystemMetadata;
   private head: string = INITIAL_STEP_ID;
+  // Pre-revert HEADs, pushed on revert and cleared on a new prompt.
+  private redoStack: string[] = [];
   private stepsById: Map<string, ReActStep> = new Map();
   private stepCounter = 0;
   private workflowResultState: WorkflowResultState;
@@ -122,6 +124,12 @@ export class TexeraAgent {
   private abortController: AbortController | null = null;
 
   private workflowChangeSubscription: Subscription | null = null;
+
+  // Serializes history mutations (revert/redo, prompt startup) together with
+  // their backend persistence. Without it, a second WS frame arriving while a
+  // revert awaits persistence would pass the server's busy-guard and interleave
+  // HEAD moves, redo-stack edits, and backend writes out of order.
+  private historyOp: Promise<void> = Promise.resolve();
 
   private log: Logger;
 
@@ -449,20 +457,9 @@ export class TexeraAgent {
 
     if (this.delegateConfig?.workflowId && this.delegateConfig.userToken) {
       const persistSubscription = workflowChanged$.pipe(debounceTime(PERSIST_DEBOUNCE_MS)).subscribe(async () => {
-        if (!this.delegateConfig?.workflowId || !this.delegateConfig.userToken) {
-          return;
-        }
-
         try {
-          const { persistWorkflow } = await import("../api/workflow-api");
-          const workflowContent = this.workflowState.getWorkflowContent();
-          await persistWorkflow(
-            this.delegateConfig.userToken,
-            this.delegateConfig.workflowId,
-            this.delegateConfig.workflowName || "Agent Workflow",
-            workflowContent
-          );
-          this.log.debug({ workflowId: this.delegateConfig.workflowId }, "auto-persisted workflow");
+          await this.persistWorkflowToBackend();
+          this.log.debug({ workflowId: this.delegateConfig?.workflowId }, "auto-persisted workflow");
         } catch (error) {
           this.log.error({ err: error }, "failed to auto-persist workflow");
         }
@@ -475,15 +472,43 @@ export class TexeraAgent {
     this.workflowState.addSubscription(subscription);
   }
 
+  /** Run fn after all queued history operations; queue everything behind it. */
+  private runExclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const run = this.historyOp.then(fn);
+    this.historyOp = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  private async persistWorkflowToBackend(): Promise<void> {
+    if (!this.delegateConfig?.workflowId || !this.delegateConfig.userToken) {
+      return;
+    }
+    const { persistWorkflow } = await import("../api/workflow-api");
+    await persistWorkflow(
+      this.delegateConfig.userToken,
+      this.delegateConfig.workflowId,
+      this.delegateConfig.workflowName || "Agent Workflow",
+      this.workflowState.getWorkflowContent()
+    );
+  }
+
   async sendMessage(userMessage: string, messageSource?: "chat" | "feedback"): Promise<AgentMessageResult> {
     const messageId = `msg-${this.agentId}-${++this.messageCounter}-${Date.now()}`;
     let stepIndex = 0;
 
-    await this.refreshWorkflowFromBackend();
-
-    this.abortController = new AbortController();
-
-    this.state = AgentStateEnum.GENERATING;
+    // The startup section runs under the history lock: it clears the redo
+    // stack and awaits a backend fetch before the busy state is visible, so an
+    // unserialized revert/redo could interleave into that window. Once the
+    // state is GENERATING the lock is released and revert/redo reject on it.
+    await this.runExclusive(async () => {
+      this.redoStack = []; // a new prompt invalidates redo
+      await this.refreshWorkflowFromBackend();
+      this.abortController = new AbortController();
+      this.state = AgentStateEnum.GENERATING;
+    });
 
     this.currentMessageId = messageId;
 
@@ -662,6 +687,8 @@ export class TexeraAgent {
       if (isAborted) {
         stepIndex++;
         const stoppedStepId = this.generateStepId();
+        // Snapshot so revert/redo work when a turn ends on this step.
+        const stoppedContent = this.workflowState.getWorkflowContent();
         const stoppedStep: ReActStep = {
           id: stoppedStepId,
           parentId: this.head,
@@ -672,6 +699,8 @@ export class TexeraAgent {
           content: "Generation stopped by user.",
           isBegin: false,
           isEnd: true,
+          beforeWorkflowContent: stoppedContent,
+          afterWorkflowContent: stoppedContent,
         };
         this.addStep(stoppedStep);
         this.head = stoppedStepId;
@@ -686,6 +715,8 @@ export class TexeraAgent {
 
       stepIndex++;
       const errorStepId = this.generateStepId();
+      // Snapshot so revert/redo work when a turn ends on an error step.
+      const errorContent = this.workflowState.getWorkflowContent();
       const errorStep: ReActStep = {
         id: errorStepId,
         parentId: this.head,
@@ -696,6 +727,8 @@ export class TexeraAgent {
         content: `Error: ${error.message || String(error)}`,
         isBegin: false,
         isEnd: true,
+        beforeWorkflowContent: errorContent,
+        afterWorkflowContent: errorContent,
       };
       this.addStep(errorStep);
       this.head = errorStepId;
@@ -730,10 +763,146 @@ export class TexeraAgent {
     }
   }
 
+  /**
+   * Revert the conversation to the state immediately BEFORE the given turn.
+   * Moves HEAD to that turn's parent step and restores the workflow to the
+   * turn's pre-edit snapshot. The reverted turn (and any later turns on this
+   * branch) drop out of the visible path but remain in the tree, so a later
+   * prompt simply branches from the new HEAD.
+   *
+   * @returns the new HEAD id and the restored workflow content
+   * @throws if the messageId is not a known turn, or the turn is not on the
+   *   path from root to the current HEAD (already reverted, or left on an
+   *   abandoned branch by a stale client)
+   */
+  revertToTurnStart(messageId: string): Promise<{ headId: string; workflowContent: any }> {
+    return this.runExclusive(async () => {
+      // Re-checked under the lock: the server's busy-guard ran when the frame
+      // arrived, but a prompt queued ahead of us may have started since.
+      this.assertNotBusy("revert");
+      const steps = this.reActStepsByMessageId.get(messageId);
+      if (!steps || steps.length === 0) {
+        throw new Error(`Unknown turn: ${messageId}`);
+      }
+      // steps[0] is the user step: its parentId is the prior HEAD.
+      const userStep = steps[0];
+      if (!this.isOnHeadPath(userStep.id)) {
+        throw new Error("Turn is not on the current conversation path");
+      }
+      const newHead = userStep.parentId ?? INITIAL_STEP_ID;
+      const workflowContent = userStep.beforeWorkflowContent;
+
+      const priorHead = this.head;
+      const priorMessageId = this.currentMessageId;
+      this.redoStack.push(this.head);
+      this.head = newHead;
+      this.currentMessageId = undefined;
+      if (workflowContent !== undefined) {
+        const priorWorkflowContent = this.workflowState.getWorkflowContent();
+        this.workflowState.setWorkflowContent(workflowContent);
+        try {
+          await this.persistRestoredWorkflow();
+        } catch (error) {
+          // Roll back rather than report success: with the backend still on the
+          // pre-revert workflow, the next prompt's backend refresh would
+          // silently undo the revert.
+          this.redoStack.pop();
+          this.head = priorHead;
+          this.currentMessageId = priorMessageId;
+          this.workflowState.setWorkflowContent(priorWorkflowContent);
+          throw error;
+        }
+      }
+      this.log.info({ messageId, newHead }, "reverted to turn start");
+      return { headId: newHead, workflowContent };
+    });
+  }
+
+  /** @throws when a run is in flight — history must not move under it. */
+  private assertNotBusy(action: string): void {
+    if (this.state === AgentStateEnum.GENERATING || this.state === AgentStateEnum.STOPPING) {
+      throw new Error(`Cannot ${action} while the agent is busy`);
+    }
+  }
+
+  /** Whether the given step id lies on the path from root to the current HEAD. */
+  private isOnHeadPath(stepId: string): boolean {
+    for (let cursor: string | undefined = this.head; cursor !== undefined;) {
+      if (cursor === stepId) {
+        return true;
+      }
+      cursor = this.stepsById.get(cursor)?.parentId;
+    }
+    return false;
+  }
+
+  /**
+   * setWorkflowContent emits no workflow-changed events, so the auto-persist
+   * subscription never fires for a revert/redo restore. Persist directly —
+   * otherwise the next refreshWorkflowFromBackend (HEAD back at the initial
+   * sentinel) would re-fetch the pre-revert content and silently undo the
+   * revert. Failures propagate so the caller can roll back the history move.
+   */
+  private async persistRestoredWorkflow(): Promise<void> {
+    try {
+      await this.persistWorkflowToBackend();
+    } catch (error) {
+      this.log.warn({ err: error }, "failed to persist restored workflow");
+      throw new Error("Failed to save the restored workflow; the operation was rolled back");
+    }
+  }
+
+  /** Whether a previously reverted turn can be redone. */
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /**
+   * Redo the most recent revert: move HEAD forward to the step it pointed at
+   * before that revert, restoring that step's resulting workflow.
+   *
+   * @returns the new HEAD id and the restored workflow content
+   * @throws if there is nothing to redo
+   */
+  redo(): Promise<{ headId: string; workflowContent: any }> {
+    return this.runExclusive(async () => {
+      this.assertNotBusy("redo");
+      const target = this.redoStack.pop();
+      if (target === undefined) {
+        throw new Error("Nothing to redo");
+      }
+      const priorHead = this.head;
+      this.head = target;
+      // Fall back to the nearest ancestor snapshot if this step has none.
+      let workflowContent: any;
+      let cursor: string | undefined = target;
+      while (workflowContent === undefined && cursor) {
+        const step = this.stepsById.get(cursor);
+        workflowContent = step?.afterWorkflowContent;
+        cursor = step?.parentId;
+      }
+      if (workflowContent !== undefined) {
+        const priorWorkflowContent = this.workflowState.getWorkflowContent();
+        this.workflowState.setWorkflowContent(workflowContent);
+        try {
+          await this.persistRestoredWorkflow();
+        } catch (error) {
+          this.head = priorHead;
+          this.redoStack.push(target);
+          this.workflowState.setWorkflowContent(priorWorkflowContent);
+          throw error;
+        }
+      }
+      this.log.info({ target }, "redid revert");
+      return { headId: target, workflowContent };
+    });
+  }
+
   clearHistory(): void {
     this.reActStepsByMessageId.clear();
     this.stepsById.clear();
     this.currentMessageId = undefined;
+    this.redoStack = [];
     this.head = INITIAL_STEP_ID;
     const initialStep: ReActStep = {
       id: INITIAL_STEP_ID,

--- a/agent-service/src/server.ts
+++ b/agent-service/src/server.ts
@@ -41,7 +41,13 @@ import type {
 } from "./types/agent";
 import { AgentState, OperatorResultSerializationMode } from "./types/agent";
 import type { WsClientCommand, WsServerEvent } from "./types/ws";
-import { WsServerSnapshotEvent, WsServerStepEvent, WsServerStatusEvent, WsServerErrorEvent } from "./types/ws";
+import {
+  WsServerSnapshotEvent,
+  WsServerStepEvent,
+  WsServerStatusEvent,
+  WsServerErrorEvent,
+  WsServerHeadChangeEvent,
+} from "./types/ws";
 import type { OperatorResultSummary } from "./types/execution";
 
 const agentStore = new Map<string, TexeraAgent>();
@@ -458,7 +464,10 @@ export function buildApp() {
 
         agent.addClient(ws);
 
-        sendEventToClient(ws, new WsServerSnapshotEvent(agent.getState(), agent.getAllSteps(), agent.getHead()));
+        sendEventToClient(
+          ws,
+          new WsServerSnapshotEvent(agent.getState(), agent.getAllSteps(), agent.getHead(), agent.canRedo())
+        );
       },
 
       async message(ws, messageData) {
@@ -519,6 +528,42 @@ export function buildApp() {
               // This status frame is the run-end signal (it also unsticks the client
               // from GENERATING after errors).
               broadcastToAgentClients(agentId, new WsServerStatusEvent(agent.getState()));
+            }
+            return;
+          }
+
+          case "WsClientRevertCommand": {
+            if (!msg.messageId || typeof msg.messageId !== "string") {
+              sendEventToClient(ws, new WsServerErrorEvent("messageId is required to revert"));
+              return;
+            }
+            // Don't rewind while a run is in flight or unwinding — it would race
+            // the loop's own HEAD/workflow mutations (incl. the aborted stopped step).
+            if (agent.getState() === AgentState.GENERATING || agent.getState() === AgentState.STOPPING) {
+              sendEventToClient(ws, new WsServerErrorEvent("Cannot revert while the agent is busy"));
+              return;
+            }
+            try {
+              const { headId, workflowContent } = await agent.revertToTurnStart(msg.messageId);
+              broadcastToAgentClients(agentId, new WsServerHeadChangeEvent(headId, workflowContent, agent.canRedo()));
+              wsLog.info({ agentId, messageId: msg.messageId, headId }, "reverted turn");
+            } catch (error: any) {
+              sendEventToClient(ws, new WsServerErrorEvent(error.message));
+            }
+            return;
+          }
+
+          case "WsClientRedoCommand": {
+            if (agent.getState() === AgentState.GENERATING || agent.getState() === AgentState.STOPPING) {
+              sendEventToClient(ws, new WsServerErrorEvent("Cannot redo while the agent is busy"));
+              return;
+            }
+            try {
+              const { headId, workflowContent } = await agent.redo();
+              broadcastToAgentClients(agentId, new WsServerHeadChangeEvent(headId, workflowContent, agent.canRedo()));
+              wsLog.info({ agentId, headId }, "redid revert");
+            } catch (error: any) {
+              sendEventToClient(ws, new WsServerErrorEvent(error.message));
             }
             return;
           }
@@ -588,8 +633,10 @@ function printStartupMessage(app: ReturnType<typeof buildApp>) {
     }
     console.log("         Send: { type: 'WsClientPromptCommand', content: '...' }");
     console.log("         Send: { type: 'WsClientStopCommand' }");
+    console.log("         Send: { type: 'WsClientRevertCommand', messageId: '...' }");
+    console.log("         Send: { type: 'WsClientRedoCommand' }");
     console.log(
-      "         Recv: { type: 'WsServerSnapshotEvent' | 'WsServerStepEvent' | 'WsServerStatusEvent' | 'WsServerErrorEvent', ... }"
+      "         Recv: { type: 'WsServerSnapshotEvent' | 'WsServerStepEvent' | 'WsServerStatusEvent' | 'WsServerErrorEvent' | 'WsServerHeadChangeEvent', ... }"
     );
   }
 

--- a/agent-service/src/server.ws.spec.ts
+++ b/agent-service/src/server.ws.spec.ts
@@ -159,8 +159,26 @@ describe(`WS ${API}/agents/:id/react`, () => {
     expect(snapshot.state).toBe("AVAILABLE");
     expect(Array.isArray(snapshot.steps)).toBe(true);
     expect(typeof snapshot.headId).toBe("string");
+    // The snapshot must NOT carry the agent's workflow copy: it can lag the
+    // backend (manual canvas edits never reach it), so pushing it on connect
+    // would overwrite the user's canvas. Backend polling owns canvas sync.
+    expect("workflowContent" in snapshot).toBe(false);
     // Results are pulled on demand, never pushed on the snapshot.
     expect("operatorResults" in snapshot).toBe(false);
+  });
+
+  test("a client connecting after a revert gets the moved HEAD + canRedo in its snapshot", async () => {
+    const id = await createAgent();
+    const { agent } = seedRevertableTurn(id);
+    await agent.revertToTurnStart("turn-1"); // HEAD -> initial, redo available
+
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    const snapshot = await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    expect(snapshot.headId).toBe("step-initial");
+    expect(snapshot.canRedo).toBe(true);
+    expect("workflowContent" in snapshot).toBe(false);
   });
 
   test("errors and closes when connecting to an unknown agent", async () => {
@@ -326,5 +344,232 @@ describe(`WS ${API}/agents/:id/react`, () => {
     await new Promise(resolve => setTimeout(resolve, 50));
 
     expect(ws.readyState).toBe(WebSocket.CLOSED);
+  });
+
+  // --- Revert (WsClientRevertCommand) ---------------------------------------
+
+  const EMPTY_CONTENT = { operators: [], operatorPositions: {}, links: [], commentBoxes: [], settings: {} };
+  const ONE_OP_CONTENT = {
+    operators: [{ operatorID: "op1" }],
+    operatorPositions: {},
+    links: [],
+    commentBoxes: [],
+    settings: {},
+  };
+
+  // Seed a single completed turn ("turn-1") whose pre-edit workflow was empty and
+  // whose post-edit workflow has one operator; leave HEAD at the turn's last step.
+  function seedRevertableTurn(id: string) {
+    const agent = _getAgentForTests(id)! as any;
+    const priorHead = agent.getHead(); // INITIAL_STEP_ID on a fresh agent
+    const userStep = {
+      id: "u1",
+      parentId: priorHead,
+      messageId: "turn-1",
+      stepId: 0,
+      timestamp: Date.now(),
+      role: "user",
+      content: "add an operator",
+      isBegin: true,
+      isEnd: true,
+      beforeWorkflowContent: EMPTY_CONTENT,
+      afterWorkflowContent: EMPTY_CONTENT,
+    };
+    const agentStep = {
+      id: "a1",
+      parentId: "u1",
+      messageId: "turn-1",
+      stepId: 1,
+      timestamp: Date.now(),
+      role: "agent",
+      content: "done",
+      isBegin: true,
+      isEnd: true,
+      afterWorkflowContent: ONE_OP_CONTENT,
+    };
+    agent.reActStepsByMessageId.set("turn-1", [userStep, agentStep]);
+    agent.stepsById.set("u1", userStep);
+    agent.stepsById.set("a1", agentStep);
+    agent.head = "a1";
+    agent.getWorkflowState().setWorkflowContent(ONE_OP_CONTENT);
+    return { agent, priorHead };
+  }
+
+  test("a revert command rewinds HEAD and broadcasts a head-change frame", async () => {
+    const id = await createAgent();
+    const { agent, priorHead } = seedRevertableTurn(id);
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "turn-1" }));
+
+    const head = await messages.waitFor(m => m.type === "WsServerHeadChangeEvent");
+    expect(head.headId).toBe(priorHead);
+    expect(head.workflowContent.operators).toHaveLength(0);
+    // The agent truly rewound: HEAD moved and its working workflow is the pre-turn state.
+    expect(agent.getHead()).toBe(priorHead);
+    expect(agent.getWorkflowState().getWorkflowContent().operators).toHaveLength(0);
+  });
+
+  test("a revert command without a messageId yields an error frame", async () => {
+    const id = await createAgent();
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand" }));
+
+    const err = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(err.error).toBe("messageId is required to revert");
+  });
+
+  test("a revert command for an unknown turn yields an error frame", async () => {
+    const id = await createAgent();
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "no-such-turn" }));
+
+    const err = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(err.error).toBe("Unknown turn: no-such-turn");
+  });
+
+  test("a revert command while generating is rejected", async () => {
+    const id = await createAgent();
+    seedRevertableTurn(id);
+    const agent = _getAgentForTests(id)! as any;
+    agent.state = "GENERATING";
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "turn-1" }));
+
+    const err = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(err.error).toBe("Cannot revert while the agent is busy");
+    // HEAD must not have moved.
+    expect(agent.getHead()).toBe("a1");
+  });
+
+  test("a revert command for a turn no longer on the HEAD path yields an error frame", async () => {
+    const id = await createAgent();
+    const { agent } = seedRevertableTurn(id);
+    await agent.revertToTurnStart("turn-1"); // turn-1 drops off the visible path
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    // A duplicate/stale revert (e.g. from a second client) must not execute.
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "turn-1" }));
+
+    const err = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(err.error).toBe("Turn is not on the current conversation path");
+    expect(agent.getHead()).toBe("step-initial");
+  });
+
+  test("revert and redo are rejected while STOPPING (aborted run still unwinding)", async () => {
+    const id = await createAgent();
+    const { agent } = seedRevertableTurn(id);
+    await agent.revertToTurnStart("turn-1"); // make redo available
+    (agent as any).state = "STOPPING";
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "turn-1" }));
+    const rerr = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(rerr.error).toBe("Cannot revert while the agent is busy");
+
+    ws.send(JSON.stringify({ type: "WsClientRedoCommand" }));
+    const derr = await messages.waitFor(m => m.type === "WsServerErrorEvent" && m.error.includes("redo"));
+    expect(derr.error).toBe("Cannot redo while the agent is busy");
+  });
+
+  // --- Redo (WsClientRedoCommand) -------------------------------------------
+
+  test("revert then redo returns HEAD and workflow to the post-turn state", async () => {
+    const id = await createAgent();
+    const { agent } = seedRevertableTurn(id);
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    // Revert: HEAD -> parent, canRedo becomes true.
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "turn-1" }));
+    const reverted = await messages.waitFor(m => m.type === "WsServerHeadChangeEvent" && m.headId === "step-initial");
+    expect(reverted.canRedo).toBe(true);
+
+    // Redo: HEAD -> back to the turn's leaf, workflow restored.
+    ws.send(JSON.stringify({ type: "WsClientRedoCommand" }));
+    const redone = await messages.waitFor(m => m.type === "WsServerHeadChangeEvent" && m.headId === "a1");
+    expect(redone.workflowContent.operators).toHaveLength(1);
+    expect(redone.canRedo).toBe(false);
+    expect(agent.getHead()).toBe("a1");
+    expect(agent.getWorkflowState().getWorkflowContent().operators).toHaveLength(1);
+  });
+
+  test("redo restores the canvas even when the leaf step has no snapshot (error/stopped turn)", async () => {
+    const id = await createAgent();
+    const { agent } = seedRevertableTurn(id);
+    // Simulate a turn that ended on an error/stopped step: a leaf with no
+    // afterWorkflowContent, whose parent (a1) holds the real snapshot.
+    const errorLeaf = {
+      id: "err1",
+      parentId: "a1",
+      messageId: "turn-1",
+      stepId: 2,
+      timestamp: Date.now(),
+      role: "agent",
+      content: "Error: rate limit",
+      isBegin: false,
+      isEnd: true,
+    };
+    (agent as any).reActStepsByMessageId.get("turn-1").push(errorLeaf);
+    (agent as any).stepsById.set("err1", errorLeaf);
+    (agent as any).head = "err1";
+
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRevertCommand", messageId: "turn-1" }));
+    await messages.waitFor(m => m.type === "WsServerHeadChangeEvent" && m.headId === "step-initial");
+
+    ws.send(JSON.stringify({ type: "WsClientRedoCommand" }));
+    const redone = await messages.waitFor(m => m.type === "WsServerHeadChangeEvent" && m.headId === "err1");
+    // The leaf carries no snapshot, but redo walks up to a1's snapshot.
+    expect(redone.workflowContent?.operators).toHaveLength(1);
+    expect(agent.getWorkflowState().getWorkflowContent().operators).toHaveLength(1);
+  });
+
+  test("a redo with nothing to redo yields an error frame", async () => {
+    const id = await createAgent();
+    seedRevertableTurn(id);
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRedoCommand" }));
+
+    const err = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(err.error).toBe("Nothing to redo");
+  });
+
+  test("a redo while generating is rejected", async () => {
+    const id = await createAgent();
+    const { agent } = seedRevertableTurn(id);
+    // Make redo available, then flip to GENERATING.
+    await agent.revertToTurnStart("turn-1");
+    agent.state = "GENERATING";
+    const { ws, messages } = connect(id);
+    await waitOpen(ws);
+    await messages.waitFor(m => m.type === "WsServerSnapshotEvent");
+
+    ws.send(JSON.stringify({ type: "WsClientRedoCommand" }));
+
+    const err = await messages.waitFor(m => m.type === "WsServerErrorEvent");
+    expect(err.error).toBe("Cannot redo while the agent is busy");
   });
 });

--- a/agent-service/src/types/ws/client.ts
+++ b/agent-service/src/types/ws/client.ts
@@ -36,5 +36,23 @@ export class WsClientStopCommand {
   readonly type = "WsClientStopCommand";
 }
 
+/**
+ * Revert the workflow to the state BEFORE the given turn and rewind the agent's
+ * HEAD to that turn's parent step, so a subsequent prompt continues from the
+ * reverted state. `messageId` identifies the turn (the user-message group).
+ */
+export class WsClientRevertCommand {
+  readonly type = "WsClientRevertCommand";
+  constructor(readonly messageId: string) {}
+}
+
+/**
+ * Redo the most recent revert: move HEAD forward to the step it pointed at before
+ * that revert. Repeatable while the redo stack has entries. Carries no payload.
+ */
+export class WsClientRedoCommand {
+  readonly type = "WsClientRedoCommand";
+}
+
 /** Discriminated union of every client -> server frame. */
-export type WsClientCommand = WsClientPromptCommand | WsClientStopCommand;
+export type WsClientCommand = WsClientPromptCommand | WsClientStopCommand | WsClientRevertCommand | WsClientRedoCommand;

--- a/agent-service/src/types/ws/server.ts
+++ b/agent-service/src/types/ws/server.ts
@@ -34,7 +34,12 @@ export class WsServerSnapshotEvent {
   constructor(
     readonly state: AgentState,
     readonly steps: ReActStep[],
-    readonly headId: string
+    readonly headId: string,
+    // Deliberately no workflowContent: the agent's in-memory copy can lag the
+    // backend (it never sees manual canvas edits), so pushing it on connect
+    // would overwrite the user's canvas with stale state. Canvas sync stays
+    // owned by backend polling; only live revert/redo events carry content.
+    readonly canRedo: boolean = false
   ) {}
 }
 
@@ -59,5 +64,20 @@ export class WsServerErrorEvent {
   constructor(readonly error: string) {}
 }
 
+/**
+ * HEAD moved without a new step being produced — emitted after a revert. Carries
+ * the new HEAD id and the workflow content at that point, so clients can recompute
+ * the visible step path and reload the canvas.
+ */
+export class WsServerHeadChangeEvent {
+  readonly type = "WsServerHeadChangeEvent";
+  constructor(
+    readonly headId: string,
+    readonly workflowContent: any,
+    readonly canRedo: boolean = false
+  ) {}
+}
+
 /** Discriminated union of every server -> client frame. */
-export type WsServerEvent = WsServerSnapshotEvent | WsServerStepEvent | WsServerStatusEvent | WsServerErrorEvent;
+export type WsServerEvent =
+  WsServerSnapshotEvent | WsServerStepEvent | WsServerStatusEvent | WsServerErrorEvent | WsServerHeadChangeEvent;

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.html
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.html
@@ -48,6 +48,24 @@
         </button>
       </div>
 
+      <!-- Redo the last revert -->
+      <div
+        class="toolbar-item"
+        *ngIf="canRedo()">
+        <button
+          nz-button
+          nzType="text"
+          nzSize="small"
+          (click)="redo()"
+          nz-tooltip
+          nzTooltipTitle="Redo the last revert">
+          <i
+            nz-icon
+            nzType="redo"
+            nzTheme="outline"></i>
+        </button>
+      </div>
+
       <!-- Export ReAct steps button -->
       <div class="toolbar-item">
         <button
@@ -105,6 +123,24 @@
               [nzType]="response.role === 'user' ? 'user' : 'robot'"
               nzTheme="outline"></i>
             <span class="message-role">{{ response.role === 'user' ? 'You' : agentInfo.name }}</span>
+            <!-- Revert: rewind the workflow + agent to before this turn -->
+            <button
+              *ngIf="response.role === 'user' && response.messageId !== 'initial' && canRevert()"
+              nz-button
+              nzType="text"
+              nzSize="small"
+              class="revert-button"
+              style="margin-left: auto"
+              nz-popconfirm
+              nzPopconfirmTitle="Revert the workflow to before this turn? This turn and any later turns leave the chat; Redo restores them until you send a new message."
+              (nzOnConfirm)="revertTurn(response.messageId)"
+              nz-tooltip
+              nzTooltipTitle="Revert to before this turn">
+              <i
+                nz-icon
+                nzType="undo"
+                nzTheme="outline"></i>
+            </button>
           </div>
 
           <!-- Message content with hover button -->

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.spec.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.spec.ts
@@ -46,6 +46,7 @@ class MockAgentService {
   public stepsSubject = new BehaviorSubject<ReActStep[]>([]);
   public headIdSubject = new BehaviorSubject<string | null>(null);
   public workflowSubject = new BehaviorSubject<Workflow | null>(null);
+  public canRedoSubject = new BehaviorSubject<boolean>(false);
   public scrollToStepSubject = new Subject<{ agentId: string; messageId: string; stepId: number }>();
   public scrollToStep$ = this.scrollToStepSubject.asObservable();
 
@@ -55,10 +56,13 @@ class MockAgentService {
   public getReActStepsObservable = vi.fn((): Observable<ReActStep[]> => this.stepsSubject.asObservable());
   public getHeadIdObservable = vi.fn((): Observable<string | null> => this.headIdSubject.asObservable());
   public getWorkflowObservable = vi.fn((): Observable<Workflow | null> => this.workflowSubject.asObservable());
+  public getCanRedoObservable = vi.fn((): Observable<boolean> => this.canRedoSubject.asObservable());
   public setHoveredMessage = vi.fn();
   public sendMessage = vi.fn();
   public stopGeneration = vi.fn();
   public clearMessages = vi.fn();
+  public revertTurn = vi.fn();
+  public redo = vi.fn();
   public getReActSteps = vi.fn((): Observable<ReActStep[]> => of([]));
   public getSystemInfo = vi.fn(
     (): Observable<{
@@ -850,6 +854,75 @@ describe("AgentChatComponent", () => {
       expect(agentService.clearMessages).toHaveBeenCalledWith(AGENT_ID);
     });
 
+    describe("revert and redo controls", () => {
+      // nz-popconfirm renders its confirmation buttons in the CDK overlay,
+      // which is attached to ApplicationRef rather than this fixture.
+      const flushOverlay = (): void => {
+        fixture.detectChanges();
+        TestBed.inject(ApplicationRef).tick();
+      };
+
+      const seedTurn = async (): Promise<void> => {
+        agentService.stepsSubject.next([
+          makeStep({ messageId: "m1", stepId: 0, role: "user", content: "add an operator" }),
+          makeStep({ messageId: "m1", stepId: 1, role: "agent", content: "done", isBegin: true }),
+        ]);
+        fixture.detectChanges();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        fixture.detectChanges();
+      };
+
+      it("reverts a user turn after confirming the popconfirm", async () => {
+        createComponent();
+        await seedTurn();
+
+        // Only the user turn gets a revert control.
+        const revertButtons = fixture.nativeElement.querySelectorAll(".revert-button");
+        expect(revertButtons.length).toBe(1);
+
+        (revertButtons[0] as HTMLButtonElement).click();
+        flushOverlay();
+        expect(document.body.textContent).toContain("Revert the workflow to before this turn?");
+        expect(agentService.revertTurn).not.toHaveBeenCalled();
+
+        const confirmButton = Array.from(
+          document.querySelectorAll<HTMLButtonElement>(".ant-popover-buttons button")
+        ).at(-1);
+        expect(confirmButton, "expected a popconfirm confirm button").toBeTruthy();
+        confirmButton!.click();
+        flushOverlay();
+
+        expect(agentService.revertTurn).toHaveBeenCalledWith(AGENT_ID, "m1");
+      });
+
+      it("hides the revert button while the agent is busy", async () => {
+        createComponent();
+        await seedTurn();
+        expect(fixture.nativeElement.querySelector(".revert-button")).toBeTruthy();
+
+        agentService.stateSubject.next(AgentState.GENERATING);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector(".revert-button")).toBeNull();
+      });
+
+      it("shows the redo button only when a redo is available, and clicking delegates to the service", () => {
+        createComponent();
+        expect(fixture.nativeElement.querySelector(".chat-toolbar .anticon-redo")).toBeNull();
+
+        agentService.canRedoSubject.next(true);
+        fixture.detectChanges();
+        const redoIcon = fixture.nativeElement.querySelector(".chat-toolbar .anticon-redo");
+        expect(redoIcon).toBeTruthy();
+
+        (redoIcon.closest("button") as HTMLButtonElement).click();
+        expect(agentService.redo).toHaveBeenCalledWith(AGENT_ID);
+
+        agentService.canRedoSubject.next(false);
+        fixture.detectChanges();
+        expect(fixture.nativeElement.querySelector(".chat-toolbar .anticon-redo")).toBeNull();
+      });
+    });
+
     describe("system-info modal", () => {
       // The modal body renders inside the CDK overlay, which is attached to
       // ApplicationRef rather than to this fixture — tick() re-renders it.
@@ -941,5 +1014,77 @@ describe("AgentChatComponent", () => {
         expect(document.body.textContent).toContain('No operators match "nomatch-xyz"');
       });
     });
+  });
+});
+
+describe("AgentChatComponent revert controls", () => {
+  let component: AgentChatComponent;
+  const revertTurn = vi.fn();
+  const redo = vi.fn();
+
+  beforeEach(async () => {
+    revertTurn.mockReset();
+    redo.mockReset();
+    // compileComponents validates the standalone component's template (including the
+    // new revert button + nz-popconfirm wiring). The component itself is then
+    // instantiated directly so the revert-helper logic can be exercised without
+    // standing up the full render-time DI graph (NzModalService, etc.).
+    await TestBed.configureTestingModule({
+      imports: [AgentChatComponent],
+      providers: [
+        { provide: AgentService, useValue: { revertTurn, redo } },
+        { provide: WorkflowActionService, useValue: {} },
+        { provide: NotificationService, useValue: { error: () => {}, success: () => {}, warning: () => {} } },
+        { provide: WorkflowPersistService, useValue: {} },
+        ...commonTestProviders,
+      ],
+    }).compileComponents();
+
+    component = new AgentChatComponent(
+      { revertTurn, redo } as unknown as AgentService,
+      {} as WorkflowActionService,
+      {} as NotificationService,
+      { detectChanges: () => {} } as any,
+      {} as WorkflowPersistService
+    );
+    component.agentInfo = { id: "agent-1", name: "Bob", modelType: "gpt-5-mini" } as any;
+  });
+
+  it("disallows reverting while generating or stopping, allows it otherwise", () => {
+    component.agentState = AgentState.GENERATING;
+    expect(component.canRevert()).toBe(false);
+
+    component.agentState = AgentState.STOPPING;
+    expect(component.canRevert()).toBe(false);
+
+    component.agentState = AgentState.AVAILABLE;
+    expect(component.canRevert()).toBe(true);
+  });
+
+  it("delegates revertTurn to the agent service with the agent id and turn", () => {
+    component.revertTurn("msg-7");
+    expect(revertTurn).toHaveBeenCalledWith("agent-1", "msg-7");
+  });
+
+  it("allows redo only when redo is available and not generating", () => {
+    component.canRedoValue = true;
+    component.agentState = AgentState.AVAILABLE;
+    expect(component.canRedo()).toBe(true);
+
+    component.agentState = AgentState.GENERATING;
+    expect(component.canRedo()).toBe(false);
+
+    component.agentState = AgentState.STOPPING;
+    component.canRedoValue = true;
+    expect(component.canRedo()).toBe(false);
+
+    component.agentState = AgentState.AVAILABLE;
+    component.canRedoValue = false;
+    expect(component.canRedo()).toBe(false);
+  });
+
+  it("delegates redo to the agent service", () => {
+    component.redo();
+    expect(redo).toHaveBeenCalledWith("agent-1");
   });
 });

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.ts
@@ -59,6 +59,7 @@ import { NzTabsComponent, NzTabComponent } from "ng-zorro-antd/tabs";
 import { NzInputNumberComponent } from "ng-zorro-antd/input-number";
 import { NzTagComponent } from "ng-zorro-antd/tag";
 import { NzSwitchComponent } from "ng-zorro-antd/switch";
+import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
 
 @UntilDestroy()
 @Component({
@@ -89,6 +90,7 @@ import { NzSwitchComponent } from "ng-zorro-antd/switch";
     NzInputGroupComponent,
     NzInputGroupWhitSuffixOrPrefixDirective,
     NzSwitchComponent,
+    NzPopconfirmDirective,
   ],
 })
 export class AgentChatComponent implements OnInit, AfterViewChecked, OnDestroy, OnChanges {
@@ -113,6 +115,8 @@ export class AgentChatComponent implements OnInit, AfterViewChecked, OnDestroy, 
 
   // Current HEAD step ID in the version tree
   public currentHeadId: string | null = null;
+
+  public canRedoValue = false;
 
   // System info modal state
   public settingsMaxCharLimit = 20000; // Default max characters for operator results
@@ -205,6 +209,14 @@ export class AgentChatComponent implements OnInit, AfterViewChecked, OnDestroy, 
       .subscribe(headId => {
         this.currentHeadId = headId;
         this.updateVisibleSteps();
+        this.cdr.detectChanges();
+      });
+
+    this.agentService
+      .getCanRedoObservable(this.agentInfo.id)
+      .pipe(untilDestroyed(this))
+      .subscribe(canRedo => {
+        this.canRedoValue = canRedo;
         this.cdr.detectChanges();
       });
 
@@ -484,6 +496,31 @@ export class AgentChatComponent implements OnInit, AfterViewChecked, OnDestroy, 
 
   public stopGeneration(): void {
     this.agentService.stopGeneration(this.agentInfo.id);
+  }
+
+  /**
+   * Whether a turn can be reverted right now. Reverting mid-generation would race
+   * the agent's own HEAD/workflow mutations, so it is disabled while generating.
+   */
+  public canRevert(): boolean {
+    return this.agentState !== AgentState.GENERATING && this.agentState !== AgentState.STOPPING;
+  }
+
+  /**
+   * Revert the workflow to the state before the given turn. The agent-service
+   * rewinds HEAD and pushes a head-change event, which reloads the canvas and
+   * collapses the chat history to before this turn.
+   */
+  public revertTurn(messageId: string): void {
+    this.agentService.revertTurn(this.agentInfo.id, messageId);
+  }
+
+  public canRedo(): boolean {
+    return this.canRedoValue && this.agentState !== AgentState.GENERATING && this.agentState !== AgentState.STOPPING;
+  }
+
+  public redo(): void {
+    this.agentService.redo(this.agentInfo.id);
   }
 
   public clearMessages(): void {

--- a/frontend/src/app/workspace/service/agent/agent.service.spec.ts
+++ b/frontend/src/app/workspace/service/agent/agent.service.spec.ts
@@ -738,15 +738,19 @@ describe("AgentService", () => {
   });
 
   describe("clearMessages", () => {
-    it("resets the step stream on success", () => {
+    it("resets the step stream and stale redo state on success", () => {
       seedAgent("agent-1");
       const tracking = (service as any).agentStateTracking.get("agent-1");
       tracking.reActStepsSubject.next([{ messageId: "m1" } as unknown as ReActStep]);
+      tracking.canRedoSubject.next(true);
 
       service.clearMessages("agent-1");
       httpMock.expectOne(r => r.method === "POST" && r.url === "/api/agents/agent-1/clear").flush({});
 
       expect(tracking.reActStepsSubject.getValue()).toEqual([]);
+      // The server's clearHistory() empties its redo stack without broadcasting,
+      // so a lingering Redo button would error with "Nothing to redo".
+      expect(tracking.canRedoSubject.getValue()).toBe(false);
     });
 
     it("keeps the steps when the clear request fails", () => {
@@ -963,6 +967,128 @@ describe("AgentService", () => {
       service.requestScrollToStep("agent-1", "m1", 4);
 
       expect(target).toEqual({ agentId: "agent-1", messageId: "m1", stepId: 4 });
+    });
+  });
+
+  describe("revertTurn", () => {
+    it("sends a revert command for the given turn over the websocket", () => {
+      const send = vi.fn();
+      (service as any).agentStateTracking.set("agent-1", {
+        websocket: { readyState: WebSocket.OPEN, send },
+      });
+
+      service.revertTurn("agent-1", "msg-7");
+
+      expect(send).toHaveBeenCalledWith(JSON.stringify({ type: "WsClientRevertCommand", messageId: "msg-7" }));
+    });
+
+    it("does not send when no websocket is open", () => {
+      const send = vi.fn();
+      (service as any).agentStateTracking.set("agent-1", {
+        websocket: { readyState: WebSocket.CLOSED, send },
+      });
+
+      service.revertTurn("agent-1", "msg-7");
+
+      expect(send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("redo", () => {
+    it("sends a redo command over the websocket", () => {
+      const send = vi.fn();
+      (service as any).agentStateTracking.set("agent-1", {
+        websocket: { readyState: WebSocket.OPEN, send },
+      });
+
+      service.redo("agent-1");
+
+      expect(send).toHaveBeenCalledWith(JSON.stringify({ type: "WsClientRedoCommand" }));
+    });
+  });
+
+  describe("sendMessage clears redo", () => {
+    it("resets canRedo when a new prompt is sent (mirrors the backend clearing its stack)", () => {
+      const send = vi.fn();
+      const tracking = (service as any).getOrCreateStateTracking("agent-1");
+      tracking.websocket = { readyState: WebSocket.OPEN, send };
+      tracking.canRedoSubject.next(true);
+      (service as any).agents.set("agent-1", { id: "agent-1", name: "Bob" });
+
+      service.sendMessage("agent-1", "hello");
+
+      expect(send).toHaveBeenCalled();
+      expect(tracking.canRedoSubject.getValue()).toBe(false);
+    });
+  });
+
+  describe("WsServerHeadChangeEvent handling", () => {
+    it("advances the head pointer and reloads the workflow on a revert", () => {
+      const tracking = (service as any).getOrCreateStateTracking("agent-1");
+      const oldContent = { operators: [{ operatorID: "op1" }], operatorPositions: {}, links: [] };
+      tracking.workflowSubject.next({ wid: 7, name: "my workflow", content: oldContent } as unknown as Workflow);
+      const content = { operators: [], operatorPositions: {}, links: [], commentBoxes: [], settings: {} };
+
+      (service as any).handleWebSocketMessage("agent-1", tracking, {
+        type: "WsServerHeadChangeEvent",
+        headId: "step-initial",
+        workflowContent: content,
+      });
+
+      expect(tracking.headIdSubject.getValue()).toEqual("step-initial");
+      const workflow = tracking.workflowSubject.getValue();
+      expect(workflow?.content).toEqual(content);
+      // The tracked workflow's identity must survive the content swap.
+      expect(workflow?.wid).toBe(7);
+      expect(workflow?.name).toBe("my workflow");
+      expect(tracking.wsWorkflowActive).toBe(true);
+    });
+
+    it("does not fabricate a metadata-less workflow when none is tracked yet", () => {
+      const tracking = (service as any).getOrCreateStateTracking("agent-1");
+      expect(tracking.workflowSubject.getValue()).toBeNull();
+
+      (service as any).handleWebSocketMessage("agent-1", tracking, {
+        type: "WsServerHeadChangeEvent",
+        headId: "step-initial",
+        workflowContent: { operators: [], operatorPositions: {}, links: [], commentBoxes: [], settings: {} },
+      });
+
+      // Applying content with no wid/name would let auto-persist create a
+      // duplicate workflow; the head pointer still advances.
+      expect(tracking.workflowSubject.getValue()).toBeNull();
+      expect(tracking.headIdSubject.getValue()).toEqual("step-initial");
+    });
+
+    it("applies workflowContent and canRedo from a snapshot when present", () => {
+      const tracking = (service as any).getOrCreateStateTracking("agent-1");
+      const content = { operators: [], operatorPositions: {}, links: [], commentBoxes: [], settings: {} };
+
+      (service as any).handleWebSocketMessage("agent-1", tracking, {
+        type: "WsServerSnapshotEvent",
+        state: "AVAILABLE",
+        steps: [],
+        headId: "step-initial",
+        workflowContent: content,
+        canRedo: true,
+      });
+
+      expect(tracking.headIdSubject.getValue()).toBe("step-initial");
+      expect(tracking.workflowSubject.getValue()?.content).toEqual(content);
+      expect(tracking.canRedoSubject.getValue()).toBe(true);
+    });
+
+    it("updates canRedo from the head-change event", () => {
+      const tracking = (service as any).getOrCreateStateTracking("agent-1");
+
+      (service as any).handleWebSocketMessage("agent-1", tracking, {
+        type: "WsServerHeadChangeEvent",
+        headId: "step-initial",
+        workflowContent: { operators: [], operatorPositions: {}, links: [], commentBoxes: [], settings: {} },
+        canRedo: true,
+      });
+
+      expect(tracking.canRedoSubject.getValue()).toBe(true);
     });
   });
 });

--- a/frontend/src/app/workspace/service/agent/agent.service.ts
+++ b/frontend/src/app/workspace/service/agent/agent.service.ts
@@ -172,6 +172,8 @@ interface AgentStateTracking {
   }>;
   /** Current HEAD step ID in the version tree */
   headIdSubject: BehaviorSubject<string | null>;
+  /** Whether a reverted turn can be redone (server-tracked redo stack) */
+  canRedoSubject: BehaviorSubject<boolean>;
   workflowSubject: BehaviorSubject<Workflow | null>;
   workflowId?: number;
   stopPolling$: Subject<void>;
@@ -364,6 +366,7 @@ export class AgentService {
           modifiedOperatorIds: string[];
         }>({ viewedOperatorIds: [], addedOperatorIds: [], modifiedOperatorIds: [] }),
         headIdSubject: new BehaviorSubject<string | null>(null),
+        canRedoSubject: new BehaviorSubject<boolean>(false),
         workflowSubject: new BehaviorSubject<Workflow | null>(null),
         workflowId,
         stopPolling$: new Subject<void>(),
@@ -462,6 +465,7 @@ export class AgentService {
         if (message.headId !== undefined) {
           tracking.headIdSubject.next(message.headId);
         }
+        tracking.canRedoSubject.next(message.canRedo === true);
         // Handle initial workflow content from agent service (ground truth)
         if (message.workflowContent) {
           tracking.wsWorkflowActive = true;
@@ -532,6 +536,24 @@ export class AgentService {
           this.notificationService.warning("Agent was removed (backend may have restarted)");
         } else {
           this.notificationService.error(message.error || "Agent error occurred");
+        }
+        break;
+
+      case "WsServerHeadChangeEvent":
+        // Revert/redo: advancing head recomputes visible steps; the workflow reloads the canvas.
+        if (message.headId !== undefined) {
+          tracking.headIdSubject.next(message.headId);
+        }
+        tracking.canRedoSubject.next(message.canRedo === true);
+        if (message.workflowContent !== undefined) {
+          const existingWorkflow = tracking.workflowSubject.getValue();
+          // Without a tracked workflow there is no wid/name to merge with; applying
+          // the content would fabricate a metadata-less workflow that auto-persist
+          // could save as a new duplicate. Skip and let backend polling catch up.
+          if (existingWorkflow) {
+            tracking.wsWorkflowActive = true;
+            tracking.workflowSubject.next({ ...existingWorkflow, content: message.workflowContent });
+          }
         }
         break;
 
@@ -877,6 +899,8 @@ export class AgentService {
 
     try {
       tracking.websocket.send(JSON.stringify(wsMessage));
+      // Only mirror the backend's redo-stack clear once the prompt actually went out.
+      tracking.canRedoSubject.next(false);
     } catch (error) {
       console.error("Failed to send message to agent:", error);
       this.notificationService.error("Failed to send message");
@@ -912,12 +936,56 @@ export class AgentService {
         const tracking = this.agentStateTracking.get(agentId);
         if (tracking) {
           tracking.reActStepsSubject.next([]);
+          // The server's clearHistory() empties its redo stack without broadcasting.
+          tracking.canRedoSubject.next(false);
         }
       },
       error: (error: unknown) => {
         console.error(`Error clearing messages for agent ${agentId}:`, error);
       },
     });
+  }
+
+  /**
+   * Revert the workflow to the state before the given turn. The agent-service
+   * rewinds its HEAD and replies with a WsServerHeadChangeEvent, which updates
+   * the head pointer (recomputing the visible steps) and reloads the canvas.
+   */
+  public revertTurn(agentId: string, messageId: string): void {
+    const tracking = this.agentStateTracking.get(agentId);
+    if (!tracking || !tracking.websocket || tracking.websocket.readyState !== WebSocket.OPEN) {
+      this.notificationService.error("WebSocket connection not available");
+      return;
+    }
+    try {
+      tracking.websocket.send(JSON.stringify({ type: "WsClientRevertCommand", messageId }));
+    } catch (error) {
+      console.error("Failed to send revert command:", error);
+      this.notificationService.error("Failed to revert");
+    }
+  }
+
+  /**
+   * Redo the most recent revert. The agent-service moves HEAD forward and replies
+   * with a WsServerHeadChangeEvent, which reloads the canvas and updates canRedo.
+   */
+  public redo(agentId: string): void {
+    const tracking = this.agentStateTracking.get(agentId);
+    if (!tracking || !tracking.websocket || tracking.websocket.readyState !== WebSocket.OPEN) {
+      this.notificationService.error("WebSocket connection not available");
+      return;
+    }
+    try {
+      tracking.websocket.send(JSON.stringify({ type: "WsClientRedoCommand" }));
+    } catch (error) {
+      console.error("Failed to send redo command:", error);
+      this.notificationService.error("Failed to redo");
+    }
+  }
+
+  /** Observable of whether a reverted turn can currently be redone. */
+  public getCanRedoObservable(agentId: string): Observable<boolean> {
+    return this.getOrCreateStateTracking(agentId).canRedoSubject.asObservable();
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this PR?
The Texera AI agent edits the user's **live workflow canvas** — its tools add, modify, and delete
operators, and the changes auto-persist. Until now there was no agent-aware way to back out a turn
that went wrong; the user had to manually undo a multi-operator change. This PR adds two controls:

- **Per-turn "Revert"** — rewinds the workflow (and the agent-service's `HEAD`) to the state
  *before* an agent turn.
- **"Redo"** — undoes the most recent revert; a redo stack supports multiple consecutive
  reverts→redos, and is cleared when a new prompt starts a new branch.

**How it works:** the agent-service already models a conversation as a version tree of ReAct steps
(`id`/`parentId` + `beforeWorkflowContent`/`afterWorkflowContent` snapshots + a `HEAD` pointer).
The missing primitive was moving `HEAD` backward:

- *Revert(turn T):* `HEAD ← parent(T)`, restore `T.beforeWorkflowContent`, push the old HEAD onto
  an in-memory redo stack (reverted steps stay in the tree — nothing is deleted).
- *Redo:* pop the stack, move `HEAD` forward, restore that step's `afterWorkflowContent`.
- A new prompt / clear-history clears the redo stack.

**Safety of the rewind:**
- Revert/redo and a prompt's startup section are **serialized through an internal history lock**
  (busy-state re-checked under the lock), so overlapping WebSocket frames cannot interleave HEAD
  moves, redo-stack edits, and backend writes.
- Reverts of turns **off the HEAD ancestor path are rejected**, so stale/duplicate clients cannot
  pollute the redo stack or teleport onto abandoned branches.
- The restored workflow is persisted to the backend
- The frontend only applies pushed workflow content when a workflow is already tracked, so a
  metadata-less duplicate workflow can never be auto-persisted.

**Protocol additions:** `WsClientRevertCommand { messageId }`, `WsClientRedoCommand`
(client→server); `WsServerHeadChangeEvent { headId, workflowContent, canRedo }` and a `canRedo`
field on `WsServerSnapshotEvent` (server→client).

No new persistence, no schema changes, no new services.

### Demo
Agent (gemini-2.5-flash) adds **CSV File Scan → Filter** to the canvas; each user turn has a
revert control:

<img width="1920" height="1080" alt="1-agent-turn-adds-operators" src="https://github.com/user-attachments/assets/170e102c-b7f7-450c-a8b7-fdc7e1401a27" />

Clicking revert asks for confirmation:
<img width="1920" height="1080" alt="2-revert-confirmation" src="https://github.com/user-attachments/assets/2e5fc751-5c15-4bcf-bbf7-91a21bed1497" />

After confirming, the canvas and the agent's HEAD rewind to before the turn; the reverted turn
leaves the chat and a **Redo** button appears in the toolbar:
<img width="1920" height="1080" alt="3-after-revert-redo-available" src="https://github.com/user-attachments/assets/078d0e04-5ac1-4906-8790-8a8d0265b746" />

Redo restores the operators and the chat turn:
<img width="1920" height="1080" alt="4-after-redo-restored" src="https://github.com/user-attachments/assets/467647d3-49d4-4bfc-b2af-84998765d3f3" />

### Any related issues, documentation, discussions?
Design discussion / RFC: https://github.com/apache/texera/discussions/6039 — this PR implements
the proposal from that thread (per-turn Revert + Redo stack) with the adjustments discussed there.

### How was this PR tested?
New automated tests, all suites passing:
- **agent-service (bun):** revert/redo over real `sendMessage()` turns — snapshot
  recording, HEAD round-trips, redo-stack clearing, errored-turn revertability, off-HEAD-path
  rejection, snapshot restoration when the workflow drifts after a turn; plus persistence &
  serialization tests with a mocked backend — rollback on failed persistence, overlapping
  revert/redo running strictly serialized, and a redo racing a prompt's startup being rejected
  instead of interleaving. WS-level tests cover the new frames end to end (reject-while-busy,
  unknown turn, off-path revert, nothing-to-redo, reconnect snapshot state).
- **frontend (vitest):** the `WsServerHeadChangeEvent` handler (HEAD + `canRedo` +
  canvas reload with workflow identity preserved, no metadata-less fabrication), `revertTurn`/
  `redo` senders, `clearMessages` resetting stale redo state, and rendered component tests that
  click through the revert popconfirm and redo button.
- **Manual (screenshots above):** full local deployment; agent adds operators → Revert rolls the
  canvas and chat back → Redo restores both → a new prompt clears Redo.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.8)