### PR TITLE
fix(deps, v1.2): upgrade Apache Arrow to 19.0.0 and Netty to 4.2.15.Final

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -222,14 +222,14 @@ Dependencies under the Apache License, Version 2.0
 Scala/Java jars:
   - ch.qos.reload4j.reload4j-1.2.18.3.jar
   - com.fasterxml.classmate-1.3.1.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.21.jar
   - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
   - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.9.10.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.9.10.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.11.4.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-joda-2.9.10.jar
-  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.16.0.jar
+  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.10.5.jar
   - com.fasterxml.jackson.module.jackson-module-afterburner-2.9.10.jar
@@ -250,20 +250,20 @@ Scala/Java jars:
   - com.github.tototoshi.scala-csv_2.13-1.3.10.jar
   - com.google.android.annotations-4.1.1.4.jar
   - com.google.api-client.google-api-client-2.2.0.jar
-  - com.google.api.grpc.proto-google-common-protos-2.29.0.jar
+  - com.google.api.grpc.proto-google-common-protos-2.63.2.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
-  - com.google.code.gson.gson-2.10.1.jar
-  - com.google.errorprone.error_prone_annotations-2.23.0.jar
-  - com.google.flatbuffers.flatbuffers-java-23.5.26.jar
-  - com.google.guava.failureaccess-1.0.2.jar
-  - com.google.guava.guava-33.0.0-jre.jar
+  - com.google.code.gson.gson-2.12.1.jar
+  - com.google.errorprone.error_prone_annotations-2.45.0.jar
+  - com.google.flatbuffers.flatbuffers-java-25.2.10.jar
+  - com.google.guava.failureaccess-1.0.3.jar
+  - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
   - com.google.http-client.google-http-client-1.42.3.jar
   - com.google.http-client.google-http-client-apache-v2-1.42.3.jar
   - com.google.http-client.google-http-client-gson-1.42.3.jar
   - com.google.inject.extensions.guice-servlet-4.0.jar
   - com.google.inject.guice-4.0.jar
-  - com.google.j2objc.j2objc-annotations-2.8.jar
+  - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.google.oauth-client.google-oauth-client-1.34.1.jar
   - com.google.oauth-client.google-oauth-client-java6-1.34.1.jar
   - com.google.oauth-client.google-oauth-client-jetty-1.34.1.jar
@@ -294,7 +294,7 @@ Scala/Java jars:
   - com.zaxxer.HikariCP-5.1.0.jar
   - commons-beanutils.commons-beanutils-1.9.4.jar
   - commons-cli.commons-cli-1.2.jar
-  - commons-codec.commons-codec-1.17.1.jar
+  - commons-codec.commons-codec-1.21.0.jar
   - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
   - commons-logging.commons-logging-1.2.jar
@@ -331,38 +331,41 @@ Scala/Java jars:
   - io.dropwizard.metrics.metrics-logback-4.0.5.jar
   - io.dropwizard.metrics.metrics-servlets-4.0.5.jar
   - io.github.kostaskougios.cloning-1.10.3.jar
-  - io.grpc.grpc-api-1.62.2.jar
-  - io.grpc.grpc-context-1.62.2.jar
-  - io.grpc.grpc-core-1.62.2.jar
-  - io.grpc.grpc-netty-1.60.0.jar
-  - io.grpc.grpc-protobuf-1.62.2.jar
-  - io.grpc.grpc-protobuf-lite-1.62.2.jar
-  - io.grpc.grpc-stub-1.62.2.jar
+  - io.grpc.grpc-api-1.79.0.jar
+  - io.grpc.grpc-context-1.79.0.jar
+  - io.grpc.grpc-core-1.79.0.jar
+  - io.grpc.grpc-netty-1.79.0.jar
+  - io.grpc.grpc-protobuf-1.79.0.jar
+  - io.grpc.grpc-protobuf-lite-1.79.0.jar
+  - io.grpc.grpc-stub-1.79.0.jar
+  - io.grpc.grpc-util-1.79.0.jar
   - io.gsonfire.gson-fire-1.8.5.jar
   - io.kamon.sigar-loader-1.6.6-rev002.jar
   - io.lakefs.sdk-1.51.0.jar
   - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.96.Final.jar
-  - io.netty.netty-codec-4.1.96.Final.jar
-  - io.netty.netty-codec-http-4.1.96.Final.jar
-  - io.netty.netty-codec-http2-4.1.96.Final.jar
-  - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.96.Final.jar
-  - io.netty.netty-handler-4.1.96.Final.jar
-  - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.96.Final.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
-  - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.96.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.96.Final.jar
+  - io.netty.netty-buffer-4.2.15.Final.jar
+  - io.netty.netty-codec-http-4.2.15.Final.jar
+  - io.netty.netty-codec-base-4.2.15.Final.jar
+  - io.netty.netty-codec-compression-4.2.15.Final.jar
+  - io.netty.netty-codec-http2-4.2.15.Final.jar
+  - io.netty.netty-codec-socks-4.2.15.Final.jar
+  - io.netty.netty-common-4.2.15.Final.jar
+  - io.netty.netty-handler-4.2.15.Final.jar
+  - io.netty.netty-handler-proxy-4.2.15.Final.jar
+  - io.netty.netty-resolver-4.2.15.Final.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-windows-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final.jar
+  - io.netty.netty-tcnative-classes-2.0.74.Final.jar
+  - io.netty.netty-transport-4.2.15.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
+  - org.jspecify.jspecify-1.0.0.jar
   - io.opencensus.opencensus-api-0.31.1.jar
   - io.opencensus.opencensus-contrib-http-util-0.31.1.jar
-  - io.perfmark.perfmark-api-0.26.0.jar
+  - io.perfmark.perfmark-api-0.27.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - io.reactivex.rxjava3.rxjava-3.1.6.jar
   - javax.inject.javax.inject-1.jar
@@ -372,12 +375,12 @@ Scala/Java jars:
   - net.minidev.accessors-smart-2.4.7.jar
   - net.minidev.json-smart-2.4.7.jar
   - org.agrona.agrona-1.22.0.jar
-  - org.apache.arrow.arrow-format-15.0.2.jar
-  - org.apache.arrow.arrow-memory-core-15.0.2.jar
-  - org.apache.arrow.arrow-memory-netty-15.0.2.jar
-  - org.apache.arrow.arrow-vector-15.0.2.jar
-  - org.apache.arrow.flight-core-15.0.2.jar
-  - org.apache.arrow.flight-grpc-15.0.2.jar
+  - org.apache.arrow.arrow-format-19.0.0.jar
+  - org.apache.arrow.arrow-memory-core-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-19.0.0.jar
+  - org.apache.arrow.arrow-vector-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-buffer-patch-19.0.0.jar
+  - org.apache.arrow.flight-core-19.0.0.jar
   - org.apache.avro.avro-1.12.0.jar
   - org.apache.commons.commons-collections4-4.2.jar
   - org.apache.commons.commons-compress-1.27.1.jar
@@ -574,7 +577,7 @@ Scala/Java jars:
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.8.1.jar
   - org.checkerframework.checker-qual-3.52.0.jar
-  - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
+  - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jcl-over-slf4j-1.7.26.jar
@@ -594,7 +597,8 @@ Scala/Java jars:
   - com.esotericsoftware.kryo5-5.6.0.jar
   - com.esotericsoftware.minlog-1.3.1.jar
   - com.esotericsoftware.reflectasm-1.11.9.jar
-  - com.google.protobuf.protobuf-java-3.25.8.jar
+  - com.google.protobuf.protobuf-java-4.33.4.jar
+  - com.google.protobuf.protobuf-java-util-4.33.4.jar
   - com.google.re2j.re2j-1.1.jar
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
@@ -697,8 +701,6 @@ Scala/Java jars:
   - com.sun.activation.jakarta.activation-2.0.0.jar
   - jakarta.activation.jakarta.activation-api-1.2.1.jar
   - jakarta.xml.bind.jakarta.xml.bind-api-3.0.0.jar
-  - org.eclipse.collections.eclipse-collections-11.1.0.jar
-  - org.eclipse.collections.eclipse-collections-api-11.1.0.jar
   - org.eclipse.jgit.org.eclipse.jgit-5.13.0.202109080827-r.jar
 
 --------------------------------------------------------------------------------

--- a/amber/NOTICE-binary
+++ b/amber/NOTICE-binary
@@ -282,18 +282,10 @@ This product contains the Maven wrapper scripts from 'Maven Wrapper', that provi
   * HOMEPAGE:
     * https://github.com/takari/maven-wrapper
 
-This product contains small piece of code to support AIX, taken from netbsd.
-
-  * LICENSE:
-    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-  * HOMEPAGE:
-    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
-
-
 This product contains code from boringssl.
 
-  * LICENSE (Combination ISC and OpenSSL license)
-    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
+  * LICENSE
+    * license/LICENSE.boringssl.txt (Apache License 2.0)
   * HOMEPAGE:
     * https://boringssl.googlesource.com/boringssl/
 
@@ -912,6 +904,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty-buffer-patch
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty Buffer
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.jasypt.jasypt
 --------------------------------------------------------------------------------
 
@@ -1006,14 +1009,15 @@ promote the sale, use or other dealings in this Software
 without prior written authorization of the copyright holder.
 
 --------------------------------------------------------------------------------
-commons-codec.commons-codec
+org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
-Apache Commons Codec
-Copyright 2002-2024 The Apache Software Foundation
+Arrow Flight Core
+Copyright 2026 The Apache Software Foundation
+
 
 This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.pekko.pekko-actor_2.13
@@ -1250,16 +1254,6 @@ its NOTICE file:
   The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.arrow-format
---------------------------------------------------------------------------------
-
-Arrow Format
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.commons.commons-vfs2
 --------------------------------------------------------------------------------
 
@@ -1270,21 +1264,12 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-grpc
+org.apache.arrow.arrow-memory-core
 --------------------------------------------------------------------------------
 
-Arrow Flight GRPC
-Copyright 2024 The Apache Software Foundation
+Arrow Memory - Core
+Copyright 2026 The Apache Software Foundation
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-vector
---------------------------------------------------------------------------------
-
-Arrow Vectors
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1320,6 +1305,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+commons-codec.commons-codec
+--------------------------------------------------------------------------------
+
+Apache Commons Codec
+Copyright 2002-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.commons.commons-text
 --------------------------------------------------------------------------------
 
@@ -1335,16 +1330,6 @@ org.apache.kerby.kerb-core
 
 Kerby-kerb core
 Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-core
---------------------------------------------------------------------------------
-
-Arrow Memory - Core
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1548,6 +1533,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-format
+--------------------------------------------------------------------------------
+
+Arrow Format
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -1629,16 +1625,6 @@ org.apache.avro.avro
 Apache Avro
 Copyright 2009-2024 The Apache Software Foundation
 
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-netty
---------------------------------------------------------------------------------
-
-Arrow Memory - Netty
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1835,6 +1821,17 @@ Copyright 2002-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.arrow.arrow-vector
+--------------------------------------------------------------------------------
+
+Arrow Vectors
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.orc.orc-shims
@@ -2264,21 +2261,22 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-core
---------------------------------------------------------------------------------
-
-Arrow Flight Core
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.google.guava.guava
 --------------------------------------------------------------------------------
 
 Apache Iceberg
 Copyright 2017-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty
+Copyright 2026 The Apache Software Foundation
+
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,35 @@ lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOpera
 
 val jacksonVersion = "2.18.8"
 
+// Netty must be pinned as a single coordinated family: Apache Arrow's
+// arrow-memory-netty accesses Netty allocator internals, so a split across the
+// 4.1/4.2 line breaks it (NoClassDefFoundError: ThreadAwareExecutor). Arrow
+// 19.0.0 targets the Netty 4.2 line, so the whole family is held at 4.2.x here
+// and in common/workflow-core/build.sbt.
+val nettyVersion = "4.2.15.Final"
+
+// The full Netty family pinned to nettyVersion. Applied to every module whose
+// dist bundles Arrow Flight (amber + the Arrow-carrying platform services), so
+// the 4.1/4.2 line can never split — arrow-memory-netty reaches into Netty
+// allocator internals and a split breaks it. Kept in sync with the same list
+// in common/workflow-core/build.sbt (which can't see this val).
+val nettyDependencyOverrides = Seq(
+  "io.netty" % "netty-all" % nettyVersion,
+  "io.netty" % "netty-buffer" % nettyVersion,
+  "io.netty" % "netty-codec" % nettyVersion,
+  "io.netty" % "netty-codec-http" % nettyVersion,
+  "io.netty" % "netty-codec-http2" % nettyVersion,
+  "io.netty" % "netty-codec-socks" % nettyVersion,
+  "io.netty" % "netty-common" % nettyVersion,
+  "io.netty" % "netty-handler" % nettyVersion,
+  "io.netty" % "netty-handler-proxy" % nettyVersion,
+  "io.netty" % "netty-resolver" % nettyVersion,
+  "io.netty" % "netty-transport" % nettyVersion,
+  "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
+  "io.netty" % "netty-transport-native-epoll" % nettyVersion,
+  "io.netty" % "netty-transport-native-unix-common" % nettyVersion
+)
+
 lazy val DAO = (project in file("common/dao")).settings(asfLicensingSettings)
 lazy val Config = (project in file("common/config")).settings(asfLicensingSettings)
 lazy val Auth = (project in file("common/auth"))
@@ -106,8 +135,14 @@ lazy val ComputingUnitManagingService = (project in file("computing-unit-managin
   .settings(
     dependencyOverrides ++= Seq(
       // override it as io.dropwizard 4 require 2.16.1 or higher
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion
-    )
+      "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
+      // Arrow 19 (via WorkflowCore) evicts jackson-databind up to 2.21.0, past
+      // the 2.18 range jackson-module-scala allows; pin it back to jacksonVersion
+      // so the Scala module can initialize (else the service aborts at startup
+      // with "Scala module 2.18.8 requires Jackson Databind version >= 2.18.0
+      // and < 2.19.0 - Found jackson-databind version 2.21.0").
+      "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion
+    ) ++ nettyDependencyOverrides
   )
 lazy val FileService = (project in file("file-service"))
   .settings(asfLicensingSettings)
@@ -120,7 +155,7 @@ lazy val FileService = (project in file("file-service"))
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "org.glassfish.jersey.core" % "jersey-common" % "3.0.12"
-    )
+    ) ++ nettyDependencyOverrides
   )
 
 lazy val WorkflowOperator = (project in file("common/workflow-operator")).settings(asfLicensingSettingsWithVendored).dependsOn(WorkflowCore)
@@ -133,7 +168,7 @@ lazy val WorkflowCompilingService = (project in file("workflow-compiling-service
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
       "org.glassfish.jersey.core" % "jersey-common" % "3.0.12"
-    )
+    ) ++ nettyDependencyOverrides
   )
 
 lazy val WorkflowExecutionService = (project in file("amber"))
@@ -147,20 +182,8 @@ lazy val WorkflowExecutionService = (project in file("amber"))
       "org.slf4j" % "slf4j-api" % "1.7.26",
       "org.eclipse.jetty" % "jetty-server" % "9.4.20.v20190813",
       "org.eclipse.jetty" % "jetty-servlet" % "9.4.20.v20190813",
-      "org.eclipse.jetty" % "jetty-http" % "9.4.20.v20190813",
-      // Netty dependency overrides to ensure compatibility with Arrow 14.0.1
-      // Arrow requires Netty 4.1.96.Final to avoid NoSuchFieldError: chunkSize
-      "io.netty" % "netty-all" % "4.1.96.Final",
-      "io.netty" % "netty-buffer" % "4.1.96.Final",
-      "io.netty" % "netty-codec" % "4.1.96.Final",
-      "io.netty" % "netty-codec-http" % "4.1.96.Final",
-      "io.netty" % "netty-codec-http2" % "4.1.96.Final",
-      "io.netty" % "netty-common" % "4.1.96.Final",
-      "io.netty" % "netty-handler" % "4.1.96.Final",
-      "io.netty" % "netty-resolver" % "4.1.96.Final",
-      "io.netty" % "netty-transport" % "4.1.96.Final",
-      "io.netty" % "netty-transport-native-unix-common" % "4.1.96.Final"
-    ),
+      "org.eclipse.jetty" % "jetty-http" % "9.4.20.v20190813"
+    ) ++ nettyDependencyOverrides,
     libraryDependencies ++= Seq(
       "com.squareup.okhttp3" % "okhttp" % "4.10.0" force () // Force usage of OkHttp 4.10.0
     )

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -111,20 +111,22 @@ libraryDependencies ++= Seq(
 
 /////////////////////////////////////////////////////////////////////////////
 // Arrow related
-val arrowVersion = "15.0.2"
-val nettyVersion = "4.1.96.Final"
+val arrowVersion = "19.0.0"
+val nettyVersion = "4.2.15.Final"
 val arrowDependencies = Seq(
-  // https://mvnrepository.com/artifact/org.apache.arrow/flight-grpc
-  "org.apache.arrow" % "flight-grpc" % arrowVersion,
+  // flight-core bundles the gRPC transport since Arrow 16; the standalone
+  // flight-grpc artifact was discontinued after 15.0.2.
   // https://mvnrepository.com/artifact/org.apache.arrow/flight-core
   "org.apache.arrow" % "flight-core" % arrowVersion
 )
 
 libraryDependencies ++= arrowDependencies
 
-// Netty dependency overrides to ensure compatibility with Arrow
-// Arrow 14.0.1 requires Netty 4.1.96.Final for proper memory allocation
-// The chunkSize field issue occurs when Netty versions are mismatched
+// Netty dependency overrides to ensure compatibility with Arrow 19.0.0, which
+// targets the Netty 4.2 line. The whole family must be pinned to one version:
+// arrow-memory-netty reaches into Netty allocator internals, so a 4.1/4.2 split
+// breaks it (NoClassDefFoundError: ThreadAwareExecutor). Kept in sync with the
+// same list in the root build.sbt (amber module).
 dependencyOverrides ++= Seq(
   "io.netty" % "netty-all" % nettyVersion,
   "io.netty" % "netty-buffer" % nettyVersion,
@@ -139,7 +141,15 @@ dependencyOverrides ++= Seq(
   "io.netty" % "netty-transport" % nettyVersion,
   "io.netty" % "netty-transport-classes-epoll" % nettyVersion,
   "io.netty" % "netty-transport-native-epoll" % nettyVersion,
-  "io.netty" % "netty-transport-native-unix-common" % nettyVersion
+  "io.netty" % "netty-transport-native-unix-common" % nettyVersion,
+  // Arrow 19's transitive deps pull jackson-databind past the 2.18 line that
+  // jackson-module-scala is pinned to; force the Jackson core family back to
+  // jacksonVersion so the Scala module can initialize (else Test aborts with
+  // "Scala module 2.18.x requires Jackson Databind version >= 2.18.0 and
+  // < 2.19.0").
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
 )
 
 /////////////////////////////////////////////////////////////////////////////

--- a/common/workflow-operator/build.sbt
+++ b/common/workflow-operator/build.sbt
@@ -98,6 +98,15 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.module" % "jackson-module-no-ctor-deser" % jacksonVersion,
 )
 
+// Arrow 19's transitive deps pull jackson-databind past the 2.18 line that
+// jackson-module-scala is pinned to; force the Jackson core family back to
+// jacksonVersion so the Scala module can initialize.
+dependencyOverrides ++= Seq(
+  "com.fasterxml.jackson.core" % "jackson-core" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion
+)
+
 /////////////////////////////////////////////////////////////////////////////
 // Additional Dependencies
 /////////////////////////////////////////////////////////////////////////////

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -221,13 +221,13 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.21.jar
+  - com.fasterxml.jackson.core.jackson-core-2.21.0.jar
   - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.17.0.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
-  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.17.0.jar
+  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
@@ -244,17 +244,17 @@ Scala/Java jars:
   - com.github.sisyphsu.retree-1.0.4.jar
   - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.google.android.annotations-4.1.1.4.jar
-  - com.google.api.grpc.proto-google-common-protos-2.22.0.jar
+  - com.google.api.grpc.proto-google-common-protos-2.63.2.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
-  - com.google.code.gson.gson-2.11.0.jar
-  - com.google.errorprone.error_prone_annotations-2.27.0.jar
-  - com.google.flatbuffers.flatbuffers-java-23.5.26.jar
-  - com.google.guava.failureaccess-1.0.2.jar
-  - com.google.guava.guava-33.0.0-jre.jar
+  - com.google.code.gson.gson-2.12.1.jar
+  - com.google.errorprone.error_prone_annotations-2.45.0.jar
+  - com.google.flatbuffers.flatbuffers-java-25.2.10.jar
+  - com.google.guava.failureaccess-1.0.3.jar
+  - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
   - com.google.inject.extensions.guice-servlet-4.0.jar
   - com.google.inject.guice-4.0.jar
-  - com.google.j2objc.j2objc-annotations-2.8.jar
+  - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
   - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
@@ -277,7 +277,7 @@ Scala/Java jars:
   - com.zaxxer.HikariCP-5.1.0.jar
   - commons-beanutils.commons-beanutils-1.9.4.jar
   - commons-cli.commons-cli-1.2.jar
-  - commons-codec.commons-codec-1.17.1.jar
+  - commons-codec.commons-codec-1.21.0.jar
   - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
   - commons-logging.commons-logging-1.2.jar
@@ -337,39 +337,41 @@ Scala/Java jars:
   - io.fabric8.kubernetes-model-scheduling-6.12.1.jar
   - io.fabric8.kubernetes-model-storageclass-6.12.1.jar
   - io.fabric8.zjsonpatch-0.3.0.jar
-  - io.grpc.grpc-api-1.60.0.jar
-  - io.grpc.grpc-context-1.60.0.jar
-  - io.grpc.grpc-core-1.60.0.jar
-  - io.grpc.grpc-netty-1.60.0.jar
-  - io.grpc.grpc-protobuf-1.60.0.jar
-  - io.grpc.grpc-protobuf-lite-1.60.0.jar
-  - io.grpc.grpc-stub-1.60.0.jar
-  - io.grpc.grpc-util-1.60.0.jar
+  - io.grpc.grpc-api-1.79.0.jar
+  - io.grpc.grpc-context-1.79.0.jar
+  - io.grpc.grpc-core-1.79.0.jar
+  - io.grpc.grpc-netty-1.79.0.jar
+  - io.grpc.grpc-protobuf-1.79.0.jar
+  - io.grpc.grpc-protobuf-lite-1.79.0.jar
+  - io.grpc.grpc-stub-1.79.0.jar
+  - io.grpc.grpc-util-1.79.0.jar
   - io.gsonfire.gson-fire-1.9.0.jar
   - io.kubernetes.client-java-21.0.0.jar
   - io.kubernetes.client-java-api-21.0.0.jar
   - io.kubernetes.client-java-proto-21.0.0.jar
   - io.lakefs.sdk-1.51.0.jar
   - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.104.Final.jar
-  - io.netty.netty-codec-4.1.104.Final.jar
-  - io.netty.netty-codec-http-4.1.100.Final.jar
-  - io.netty.netty-codec-http2-4.1.100.Final.jar
-  - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.104.Final.jar
-  - io.netty.netty-handler-4.1.104.Final.jar
-  - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.104.Final.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
-  - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.104.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.104.Final.jar
-  - io.perfmark.perfmark-api-0.26.0.jar
+  - io.netty.netty-buffer-4.2.15.Final.jar
+  - io.netty.netty-codec-http-4.2.15.Final.jar
+  - io.netty.netty-codec-base-4.2.15.Final.jar
+  - io.netty.netty-codec-compression-4.2.15.Final.jar
+  - io.netty.netty-codec-http2-4.2.15.Final.jar
+  - io.netty.netty-codec-socks-4.2.15.Final.jar
+  - io.netty.netty-common-4.2.15.Final.jar
+  - io.netty.netty-handler-4.2.15.Final.jar
+  - io.netty.netty-handler-proxy-4.2.15.Final.jar
+  - io.netty.netty-resolver-4.2.15.Final.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-windows-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final.jar
+  - io.netty.netty-tcnative-classes-2.0.74.Final.jar
+  - io.netty.netty-transport-4.2.15.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
+  - io.perfmark.perfmark-api-0.27.0.jar
+  - org.jspecify.jspecify-1.0.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - io.swagger.swagger-annotations-1.6.14.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
@@ -379,12 +381,12 @@ Scala/Java jars:
   - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.2.jar
   - net.minidev.json-smart-2.4.2.jar
-  - org.apache.arrow.arrow-format-15.0.2.jar
-  - org.apache.arrow.arrow-memory-core-15.0.2.jar
-  - org.apache.arrow.arrow-memory-netty-15.0.2.jar
-  - org.apache.arrow.arrow-vector-15.0.2.jar
-  - org.apache.arrow.flight-core-15.0.2.jar
-  - org.apache.arrow.flight-grpc-15.0.2.jar
+  - org.apache.arrow.arrow-format-19.0.0.jar
+  - org.apache.arrow.arrow-memory-core-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-19.0.0.jar
+  - org.apache.arrow.arrow-vector-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-buffer-patch-19.0.0.jar
+  - org.apache.arrow.flight-core-19.0.0.jar
   - org.apache.avro.avro-1.12.0.jar
   - org.apache.commons.commons-collections4-4.4.jar
   - org.apache.commons.commons-compress-1.26.2.jar
@@ -542,18 +544,19 @@ Scala/Java jars:
   - org.bouncycastle.bcprov-jdk18on-1.78.1.jar
   - org.bouncycastle.bcutil-jdk18on-1.78.1.jar
   - org.checkerframework.checker-qual-3.52.0.jar
-  - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
+  - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jul-to-slf4j-2.0.12.jar
-  - org.slf4j.slf4j-api-2.0.16.jar
+  - org.slf4j.slf4j-api-2.0.17.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the BSD 3-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.google.protobuf.protobuf-java-4.27.1.jar
+  - com.google.protobuf.protobuf-java-4.33.4.jar
+  - com.google.protobuf.protobuf-java-util-4.33.4.jar
   - com.google.re2j.re2j-1.1.jar
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
@@ -636,8 +639,6 @@ Scala/Java jars:
   - com.sun.activation.jakarta.activation-2.0.1.jar
   - jakarta.activation.jakarta.activation-api-2.1.0.jar
   - jakarta.xml.bind.jakarta.xml.bind-api-3.0.1.jar
-  - org.eclipse.collections.eclipse-collections-11.1.0.jar
-  - org.eclipse.collections.eclipse-collections-api-11.1.0.jar
   - org.eclipse.jgit.org.eclipse.jgit-5.13.0.202109080827-r.jar
 
 --------------------------------------------------------------------------------

--- a/computing-unit-managing-service/NOTICE-binary
+++ b/computing-unit-managing-service/NOTICE-binary
@@ -201,6 +201,54 @@ the following copyright notice:
 | limitations under the License.
 
 --------------------------------------------------------------------------------
+io.netty.netty-tcnative-boringssl-static
+--------------------------------------------------------------------------------
+
+The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2016 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+This product contains a forked and modified version of Tomcat Native
+
+  * LICENSE:
+    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org/native-doc/
+    * https://svn.apache.org/repos/asf/tomcat/native/
+
+This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+  * LICENSE:
+    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/takari/maven-wrapper
+
+This product contains code from boringssl.
+
+  * LICENSE
+    * license/LICENSE.boringssl.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/
+
+--------------------------------------------------------------------------------
 org.glassfish.jersey
 --------------------------------------------------------------------------------
 
@@ -317,62 +365,6 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
-
---------------------------------------------------------------------------------
-io.netty.netty-tcnative-boringssl-static
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2016 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
--------------------------------------------------------------------------------
-This product contains a forked and modified version of Tomcat Native
-
-  * LICENSE:
-    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://tomcat.apache.org/native-doc/
-    * https://svn.apache.org/repos/asf/tomcat/native/
-
-This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
-
-  * LICENSE:
-    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/takari/maven-wrapper
-
-This product contains small piece of code to support AIX, taken from netbsd.
-
-  * LICENSE:
-    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-  * HOMEPAGE:
-    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
-
-
-This product contains code from boringssl.
-
-  * LICENSE (Combination ISC and OpenSSL license)
-    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
-  * HOMEPAGE:
-    * https://boringssl.googlesource.com/boringssl/
 
 --------------------------------------------------------------------------------
 org.glassfish.hk2
@@ -768,6 +760,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -788,6 +857,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty-buffer-patch
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty Buffer
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 log4j.log4j
 --------------------------------------------------------------------------------
 
@@ -798,14 +878,15 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-codec.commons-codec
+org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
-Apache Commons Codec
-Copyright 2002-2024 The Apache Software Foundation
+Arrow Flight Core
+Copyright 2026 The Apache Software Foundation
+
 
 This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-admin
@@ -1354,16 +1435,6 @@ W3.org documents
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
 
 --------------------------------------------------------------------------------
-org.apache.arrow.arrow-format
---------------------------------------------------------------------------------
-
-Arrow Format
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.commons.commons-vfs2
 --------------------------------------------------------------------------------
 
@@ -1446,21 +1517,12 @@ None
 None
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-grpc
+org.apache.arrow.arrow-memory-core
 --------------------------------------------------------------------------------
 
-Arrow Flight GRPC
-Copyright 2024 The Apache Software Foundation
+Arrow Memory - Core
+Copyright 2026 The Apache Software Foundation
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-vector
---------------------------------------------------------------------------------
-
-Arrow Vectors
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1486,21 +1548,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+commons-codec.commons-codec
+--------------------------------------------------------------------------------
+
+Apache Commons Codec
+Copyright 2002-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
 Kerby-kerb core
 Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-core
---------------------------------------------------------------------------------
-
-Arrow Memory - Core
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1648,6 +1710,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-format
+--------------------------------------------------------------------------------
+
+Arrow Format
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -1729,16 +1802,6 @@ org.apache.avro.avro
 Apache Avro
 Copyright 2009-2024 The Apache Software Foundation
 
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-netty
---------------------------------------------------------------------------------
-
-Arrow Memory - Netty
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1921,6 +1984,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-vector
+--------------------------------------------------------------------------------
+
+Arrow Vectors
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.orc.orc-shims
 --------------------------------------------------------------------------------
 
@@ -1981,53 +2055,6 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
-included in FastDoubleParser and the licenses and copyrights that apply to that code.
-
-## Schubfach
-
-jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
-That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
-under the following copyright.
-
-Copyright 2018-2020 Raffaello Giulietti
-
-See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io
@@ -2415,16 +2442,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-core
---------------------------------------------------------------------------------
-
-Arrow Flight Core
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.google.guava.guava
 --------------------------------------------------------------------------------
 
@@ -2443,6 +2460,17 @@ Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-net.commons-net

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -221,13 +221,13 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.21.jar
+  - com.fasterxml.jackson.core.jackson-core-2.21.0.jar
   - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
-  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.16.1.jar
+  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
@@ -244,17 +244,17 @@ Scala/Java jars:
   - com.github.sisyphsu.retree-1.0.4.jar
   - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.google.android.annotations-4.1.1.4.jar
-  - com.google.api.grpc.proto-google-common-protos-2.22.0.jar
+  - com.google.api.grpc.proto-google-common-protos-2.63.2.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
-  - com.google.code.gson.gson-2.10.1.jar
-  - com.google.errorprone.error_prone_annotations-2.25.0.jar
-  - com.google.flatbuffers.flatbuffers-java-23.5.26.jar
-  - com.google.guava.failureaccess-1.0.2.jar
-  - com.google.guava.guava-33.0.0-jre.jar
+  - com.google.code.gson.gson-2.12.1.jar
+  - com.google.errorprone.error_prone_annotations-2.45.0.jar
+  - com.google.flatbuffers.flatbuffers-java-25.2.10.jar
+  - com.google.guava.failureaccess-1.0.3.jar
+  - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
   - com.google.inject.extensions.guice-servlet-4.0.jar
   - com.google.inject.guice-4.0.jar
-  - com.google.j2objc.j2objc-annotations-2.8.jar
+  - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
   - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
@@ -271,7 +271,7 @@ Scala/Java jars:
   - com.zaxxer.HikariCP-5.1.0.jar
   - commons-beanutils.commons-beanutils-1.9.4.jar
   - commons-cli.commons-cli-1.2.jar
-  - commons-codec.commons-codec-1.17.1.jar
+  - commons-codec.commons-codec-1.21.0.jar
   - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
   - commons-logging.commons-logging-1.2.jar
@@ -305,36 +305,38 @@ Scala/Java jars:
   - io.dropwizard.metrics.metrics-json-4.2.25.jar
   - io.dropwizard.metrics.metrics-jvm-4.2.25.jar
   - io.dropwizard.metrics.metrics-logback-4.2.25.jar
-  - io.grpc.grpc-api-1.60.0.jar
-  - io.grpc.grpc-context-1.60.0.jar
-  - io.grpc.grpc-core-1.60.0.jar
-  - io.grpc.grpc-netty-1.60.0.jar
-  - io.grpc.grpc-protobuf-1.60.0.jar
-  - io.grpc.grpc-protobuf-lite-1.60.0.jar
-  - io.grpc.grpc-stub-1.60.0.jar
-  - io.grpc.grpc-util-1.60.0.jar
+  - io.grpc.grpc-api-1.79.0.jar
+  - io.grpc.grpc-context-1.79.0.jar
+  - io.grpc.grpc-core-1.79.0.jar
+  - io.grpc.grpc-netty-1.79.0.jar
+  - io.grpc.grpc-protobuf-1.79.0.jar
+  - io.grpc.grpc-protobuf-lite-1.79.0.jar
+  - io.grpc.grpc-stub-1.79.0.jar
+  - io.grpc.grpc-util-1.79.0.jar
   - io.gsonfire.gson-fire-1.8.5.jar
   - io.lakefs.sdk-1.51.0.jar
   - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.104.Final.jar
-  - io.netty.netty-codec-4.1.104.Final.jar
-  - io.netty.netty-codec-http-4.1.100.Final.jar
-  - io.netty.netty-codec-http2-4.1.100.Final.jar
-  - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.104.Final.jar
-  - io.netty.netty-handler-4.1.104.Final.jar
-  - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.104.Final.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
-  - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.104.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.104.Final.jar
-  - io.perfmark.perfmark-api-0.26.0.jar
+  - io.netty.netty-buffer-4.2.15.Final.jar
+  - io.netty.netty-codec-http-4.2.15.Final.jar
+  - io.netty.netty-codec-base-4.2.15.Final.jar
+  - io.netty.netty-codec-compression-4.2.15.Final.jar
+  - io.netty.netty-codec-http2-4.2.15.Final.jar
+  - io.netty.netty-codec-socks-4.2.15.Final.jar
+  - io.netty.netty-common-4.2.15.Final.jar
+  - io.netty.netty-handler-4.2.15.Final.jar
+  - io.netty.netty-handler-proxy-4.2.15.Final.jar
+  - io.netty.netty-resolver-4.2.15.Final.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-windows-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final.jar
+  - io.netty.netty-tcnative-classes-2.0.74.Final.jar
+  - io.netty.netty-transport-4.2.15.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
+  - io.perfmark.perfmark-api-0.27.0.jar
+  - org.jspecify.jspecify-1.0.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
@@ -343,12 +345,12 @@ Scala/Java jars:
   - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.2.jar
   - net.minidev.json-smart-2.4.2.jar
-  - org.apache.arrow.arrow-format-15.0.2.jar
-  - org.apache.arrow.arrow-memory-core-15.0.2.jar
-  - org.apache.arrow.arrow-memory-netty-15.0.2.jar
-  - org.apache.arrow.arrow-vector-15.0.2.jar
-  - org.apache.arrow.flight-core-15.0.2.jar
-  - org.apache.arrow.flight-grpc-15.0.2.jar
+  - org.apache.arrow.arrow-format-19.0.0.jar
+  - org.apache.arrow.arrow-memory-core-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-19.0.0.jar
+  - org.apache.arrow.arrow-vector-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-buffer-patch-19.0.0.jar
+  - org.apache.arrow.flight-core-19.0.0.jar
   - org.apache.avro.avro-1.12.0.jar
   - org.apache.commons.commons-compress-1.26.2.jar
   - org.apache.commons.commons-configuration2-2.1.1.jar
@@ -503,18 +505,19 @@ Source files derived from third-party MIT-licensed projects:
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
   - org.checkerframework.checker-qual-3.52.0.jar
-  - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
+  - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jul-to-slf4j-2.0.12.jar
-  - org.slf4j.slf4j-api-2.0.16.jar
+  - org.slf4j.slf4j-api-2.0.17.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the BSD 3-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.google.protobuf.protobuf-java-3.25.8.jar
+  - com.google.protobuf.protobuf-java-4.33.4.jar
+  - com.google.protobuf.protobuf-java-util-4.33.4.jar
   - com.google.re2j.re2j-1.1.jar
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
@@ -597,8 +600,6 @@ Scala/Java jars:
   - com.sun.activation.jakarta.activation-2.0.1.jar
   - jakarta.activation.jakarta.activation-api-2.1.0.jar
   - jakarta.xml.bind.jakarta.xml.bind-api-3.0.1.jar
-  - org.eclipse.collections.eclipse-collections-11.1.0.jar
-  - org.eclipse.collections.eclipse-collections-api-11.1.0.jar
   - org.eclipse.jgit.org.eclipse.jgit-5.13.0.202109080827-r.jar
 
 --------------------------------------------------------------------------------

--- a/file-service/NOTICE-binary
+++ b/file-service/NOTICE-binary
@@ -201,6 +201,54 @@ the following copyright notice:
 | limitations under the License.
 
 --------------------------------------------------------------------------------
+io.netty.netty-tcnative-boringssl-static
+--------------------------------------------------------------------------------
+
+The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2016 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+This product contains a forked and modified version of Tomcat Native
+
+  * LICENSE:
+    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org/native-doc/
+    * https://svn.apache.org/repos/asf/tomcat/native/
+
+This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+  * LICENSE:
+    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/takari/maven-wrapper
+
+This product contains code from boringssl.
+
+  * LICENSE
+    * license/LICENSE.boringssl.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/
+
+--------------------------------------------------------------------------------
 org.glassfish.jersey
 --------------------------------------------------------------------------------
 
@@ -317,62 +365,6 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
-
---------------------------------------------------------------------------------
-io.netty.netty-tcnative-boringssl-static
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2016 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
--------------------------------------------------------------------------------
-This product contains a forked and modified version of Tomcat Native
-
-  * LICENSE:
-    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://tomcat.apache.org/native-doc/
-    * https://svn.apache.org/repos/asf/tomcat/native/
-
-This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
-
-  * LICENSE:
-    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/takari/maven-wrapper
-
-This product contains small piece of code to support AIX, taken from netbsd.
-
-  * LICENSE:
-    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-  * HOMEPAGE:
-    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
-
-
-This product contains code from boringssl.
-
-  * LICENSE (Combination ISC and OpenSSL license)
-    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
-  * HOMEPAGE:
-    * https://boringssl.googlesource.com/boringssl/
 
 --------------------------------------------------------------------------------
 org.glassfish.hk2
@@ -768,6 +760,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -788,6 +857,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty-buffer-patch
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty Buffer
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 log4j.log4j
 --------------------------------------------------------------------------------
 
@@ -798,14 +878,15 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-codec.commons-codec
+org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
-Apache Commons Codec
-Copyright 2002-2024 The Apache Software Foundation
+Arrow Flight Core
+Copyright 2026 The Apache Software Foundation
+
 
 This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-admin
@@ -1354,16 +1435,6 @@ W3.org documents
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
 
 --------------------------------------------------------------------------------
-org.apache.arrow.arrow-format
---------------------------------------------------------------------------------
-
-Arrow Format
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.commons.commons-vfs2
 --------------------------------------------------------------------------------
 
@@ -1446,21 +1517,12 @@ None
 None
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-grpc
+org.apache.arrow.arrow-memory-core
 --------------------------------------------------------------------------------
 
-Arrow Flight GRPC
-Copyright 2024 The Apache Software Foundation
+Arrow Memory - Core
+Copyright 2026 The Apache Software Foundation
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-vector
---------------------------------------------------------------------------------
-
-Arrow Vectors
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1486,21 +1548,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+commons-codec.commons-codec
+--------------------------------------------------------------------------------
+
+Apache Commons Codec
+Copyright 2002-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
 Kerby-kerb core
 Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-core
---------------------------------------------------------------------------------
-
-Arrow Memory - Core
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1638,6 +1700,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-format
+--------------------------------------------------------------------------------
+
+Arrow Format
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -1719,16 +1792,6 @@ org.apache.avro.avro
 Apache Avro
 Copyright 2009-2024 The Apache Software Foundation
 
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-netty
---------------------------------------------------------------------------------
-
-Arrow Memory - Netty
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1864,6 +1927,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-vector
+--------------------------------------------------------------------------------
+
+Arrow Vectors
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.orc.orc-shims
 --------------------------------------------------------------------------------
 
@@ -1924,53 +1998,6 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
-included in FastDoubleParser and the licenses and copyrights that apply to that code.
-
-## Schubfach
-
-jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
-That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
-under the following copyright.
-
-Copyright 2018-2020 Raffaello Giulietti
-
-See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io
@@ -2401,16 +2428,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-core
---------------------------------------------------------------------------------
-
-Arrow Flight Core
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.google.guava.guava
 --------------------------------------------------------------------------------
 
@@ -2429,6 +2446,17 @@ Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-net.commons-net

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -221,13 +221,13 @@ Dependencies under the Apache License, Version 2.0
 
 Scala/Java jars:
   - com.fasterxml.classmate-1.7.0.jar
-  - com.fasterxml.jackson.core.jackson-annotations-2.18.8.jar
-  - com.fasterxml.jackson.core.jackson-core-2.18.8.jar
+  - com.fasterxml.jackson.core.jackson-annotations-2.21.jar
+  - com.fasterxml.jackson.core.jackson-core-2.21.0.jar
   - com.fasterxml.jackson.core.jackson-databind-2.18.8.jar
   - com.fasterxml.jackson.dataformat.jackson-dataformat-yaml-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-guava-2.16.1.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.16.1.jar
-  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.16.1.jar
+  - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
   - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.10.5.jar
@@ -245,17 +245,17 @@ Scala/Java jars:
   - com.github.stephenc.jcip.jcip-annotations-1.0-1.jar
   - com.github.tototoshi.scala-csv_2.13-1.3.10.jar
   - com.google.android.annotations-4.1.1.4.jar
-  - com.google.api.grpc.proto-google-common-protos-2.22.0.jar
+  - com.google.api.grpc.proto-google-common-protos-2.63.2.jar
   - com.google.code.findbugs.jsr305-3.0.2.jar
-  - com.google.code.gson.gson-2.10.1.jar
-  - com.google.errorprone.error_prone_annotations-2.25.0.jar
-  - com.google.flatbuffers.flatbuffers-java-23.5.26.jar
-  - com.google.guava.failureaccess-1.0.2.jar
-  - com.google.guava.guava-33.0.0-jre.jar
+  - com.google.code.gson.gson-2.12.1.jar
+  - com.google.errorprone.error_prone_annotations-2.45.0.jar
+  - com.google.flatbuffers.flatbuffers-java-25.2.10.jar
+  - com.google.guava.failureaccess-1.0.3.jar
+  - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
   - com.google.inject.extensions.guice-servlet-4.0.jar
   - com.google.inject.guice-4.0.jar
-  - com.google.j2objc.j2objc-annotations-2.8.jar
+  - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
   - com.nimbusds.nimbus-jose-jwt-9.8.1.jar
@@ -273,7 +273,7 @@ Scala/Java jars:
   - com.univocity.univocity-parsers-2.9.1.jar
   - commons-beanutils.commons-beanutils-1.9.4.jar
   - commons-cli.commons-cli-1.2.jar
-  - commons-codec.commons-codec-1.17.1.jar
+  - commons-codec.commons-codec-1.21.0.jar
   - commons-collections.commons-collections-3.2.2.jar
   - commons-io.commons-io-2.16.1.jar
   - commons-logging.commons-logging-1.2.jar
@@ -307,36 +307,38 @@ Scala/Java jars:
   - io.dropwizard.metrics.metrics-json-4.2.25.jar
   - io.dropwizard.metrics.metrics-jvm-4.2.25.jar
   - io.dropwizard.metrics.metrics-logback-4.2.25.jar
-  - io.grpc.grpc-api-1.60.0.jar
-  - io.grpc.grpc-context-1.60.0.jar
-  - io.grpc.grpc-core-1.60.0.jar
-  - io.grpc.grpc-netty-1.60.0.jar
-  - io.grpc.grpc-protobuf-1.60.0.jar
-  - io.grpc.grpc-protobuf-lite-1.60.0.jar
-  - io.grpc.grpc-stub-1.60.0.jar
-  - io.grpc.grpc-util-1.60.0.jar
+  - io.grpc.grpc-api-1.79.0.jar
+  - io.grpc.grpc-context-1.79.0.jar
+  - io.grpc.grpc-core-1.79.0.jar
+  - io.grpc.grpc-netty-1.79.0.jar
+  - io.grpc.grpc-protobuf-1.79.0.jar
+  - io.grpc.grpc-protobuf-lite-1.79.0.jar
+  - io.grpc.grpc-stub-1.79.0.jar
+  - io.grpc.grpc-util-1.79.0.jar
   - io.gsonfire.gson-fire-1.8.5.jar
   - io.lakefs.sdk-1.51.0.jar
   - io.netty.netty-3.10.6.Final.jar
-  - io.netty.netty-buffer-4.1.104.Final.jar
-  - io.netty.netty-codec-4.1.104.Final.jar
-  - io.netty.netty-codec-http-4.1.100.Final.jar
-  - io.netty.netty-codec-http2-4.1.100.Final.jar
-  - io.netty.netty-codec-socks-4.1.100.Final.jar
-  - io.netty.netty-common-4.1.104.Final.jar
-  - io.netty.netty-handler-4.1.104.Final.jar
-  - io.netty.netty-handler-proxy-4.1.100.Final.jar
-  - io.netty.netty-resolver-4.1.104.Final.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-linux-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-aarch_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-osx-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final-windows-x86_64.jar
-  - io.netty.netty-tcnative-boringssl-static-2.0.61.Final.jar
-  - io.netty.netty-tcnative-classes-2.0.61.Final.jar
-  - io.netty.netty-transport-4.1.104.Final.jar
-  - io.netty.netty-transport-native-unix-common-4.1.104.Final.jar
-  - io.perfmark.perfmark-api-0.26.0.jar
+  - io.netty.netty-buffer-4.2.15.Final.jar
+  - io.netty.netty-codec-http-4.2.15.Final.jar
+  - io.netty.netty-codec-base-4.2.15.Final.jar
+  - io.netty.netty-codec-compression-4.2.15.Final.jar
+  - io.netty.netty-codec-http2-4.2.15.Final.jar
+  - io.netty.netty-codec-socks-4.2.15.Final.jar
+  - io.netty.netty-common-4.2.15.Final.jar
+  - io.netty.netty-handler-4.2.15.Final.jar
+  - io.netty.netty-handler-proxy-4.2.15.Final.jar
+  - io.netty.netty-resolver-4.2.15.Final.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-linux-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-aarch_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-osx-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final-windows-x86_64.jar
+  - io.netty.netty-tcnative-boringssl-static-2.0.74.Final.jar
+  - io.netty.netty-tcnative-classes-2.0.74.Final.jar
+  - io.netty.netty-transport-4.2.15.Final.jar
+  - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
+  - io.perfmark.perfmark-api-0.27.0.jar
+  - org.jspecify.jspecify-1.0.0.jar
   - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
@@ -345,12 +347,12 @@ Scala/Java jars:
   - log4j.log4j-1.2.17.jar
   - net.minidev.accessors-smart-2.4.2.jar
   - net.minidev.json-smart-2.4.2.jar
-  - org.apache.arrow.arrow-format-15.0.2.jar
-  - org.apache.arrow.arrow-memory-core-15.0.2.jar
-  - org.apache.arrow.arrow-memory-netty-15.0.2.jar
-  - org.apache.arrow.arrow-vector-15.0.2.jar
-  - org.apache.arrow.flight-core-15.0.2.jar
-  - org.apache.arrow.flight-grpc-15.0.2.jar
+  - org.apache.arrow.arrow-format-19.0.0.jar
+  - org.apache.arrow.arrow-memory-core-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-19.0.0.jar
+  - org.apache.arrow.arrow-vector-19.0.0.jar
+  - org.apache.arrow.arrow-memory-netty-buffer-patch-19.0.0.jar
+  - org.apache.arrow.flight-core-19.0.0.jar
   - org.apache.avro.avro-1.12.0.jar
   - org.apache.commons.commons-compress-1.27.1.jar
   - org.apache.commons.commons-configuration2-2.1.1.jar
@@ -514,18 +516,19 @@ Scala/Java jars:
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
   - org.checkerframework.checker-qual-3.52.0.jar
-  - org.codehaus.mojo.animal-sniffer-annotations-1.23.jar
+  - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
   - org.slf4j.jul-to-slf4j-2.0.12.jar
-  - org.slf4j.slf4j-api-2.0.16.jar
+  - org.slf4j.slf4j-api-2.0.17.jar
 
 --------------------------------------------------------------------------------
 Dependencies under the BSD 3-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.google.protobuf.protobuf-java-3.25.8.jar
+  - com.google.protobuf.protobuf-java-4.33.4.jar
+  - com.google.protobuf.protobuf-java-util-4.33.4.jar
   - com.google.re2j.re2j-1.1.jar
   - com.jcraft.jsch-0.1.55.jar
   - com.thoughtworks.paranamer.paranamer-2.8.jar
@@ -608,8 +611,6 @@ Scala/Java jars:
   - com.sun.activation.jakarta.activation-2.0.1.jar
   - jakarta.activation.jakarta.activation-api-2.1.0.jar
   - jakarta.xml.bind.jakarta.xml.bind-api-3.0.1.jar
-  - org.eclipse.collections.eclipse-collections-11.1.0.jar
-  - org.eclipse.collections.eclipse-collections-api-11.1.0.jar
   - org.eclipse.jgit.org.eclipse.jgit-5.13.0.202109080827-r.jar
 
 --------------------------------------------------------------------------------

--- a/workflow-compiling-service/NOTICE-binary
+++ b/workflow-compiling-service/NOTICE-binary
@@ -201,6 +201,54 @@ the following copyright notice:
 | limitations under the License.
 
 --------------------------------------------------------------------------------
+io.netty.netty-tcnative-boringssl-static
+--------------------------------------------------------------------------------
+
+The Netty Project
+                            =================
+
+Please visit the Netty web site for more information:
+
+  * http://netty.io/
+
+Copyright 2016 The Netty Project
+
+The Netty Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+-------------------------------------------------------------------------------
+This product contains a forked and modified version of Tomcat Native
+
+  * LICENSE:
+    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * http://tomcat.apache.org/native-doc/
+    * https://svn.apache.org/repos/asf/tomcat/native/
+
+This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
+
+  * LICENSE:
+    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://github.com/takari/maven-wrapper
+
+This product contains code from boringssl.
+
+  * LICENSE
+    * license/LICENSE.boringssl.txt (Apache License 2.0)
+  * HOMEPAGE:
+    * https://boringssl.googlesource.com/boringssl/
+
+--------------------------------------------------------------------------------
 org.glassfish.jersey
 --------------------------------------------------------------------------------
 
@@ -317,62 +365,6 @@ org.glassfish.jersey.server.internal.monitoring.core
 W3.org documents
 * License: W3C License
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
-
---------------------------------------------------------------------------------
-io.netty.netty-tcnative-boringssl-static
---------------------------------------------------------------------------------
-
-The Netty Project
-                            =================
-
-Please visit the Netty web site for more information:
-
-  * http://netty.io/
-
-Copyright 2016 The Netty Project
-
-The Netty Project licenses this file to you under the Apache License,
-version 2.0 (the "License"); you may not use this file except in compliance
-with the License. You may obtain a copy of the License at:
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
-License for the specific language governing permissions and limitations
-under the License.
-
--------------------------------------------------------------------------------
-This product contains a forked and modified version of Tomcat Native
-
-  * LICENSE:
-    * license/LICENSE.tomcat-native.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * http://tomcat.apache.org/native-doc/
-    * https://svn.apache.org/repos/asf/tomcat/native/
-
-This product contains the Maven wrapper scripts from 'Maven Wrapper', that provides an easy way to ensure a user has everything necessary to run the Maven build.
-
-  * LICENSE:
-    * license/LICENSE.mvn-wrapper.txt (Apache License 2.0)
-  * HOMEPAGE:
-    * https://github.com/takari/maven-wrapper
-
-This product contains small piece of code to support AIX, taken from netbsd.
-
-  * LICENSE:
-    * license/LICENSE.aix-netbsd.txt (OpenSSL License)
-  * HOMEPAGE:
-    * https://ftp.netbsd.org/pub/NetBSD/NetBSD-current/src/crypto/external/bsd/openssl/dist
-
-
-This product contains code from boringssl.
-
-  * LICENSE (Combination ISC and OpenSSL license)
-    * license/LICENSE.boringssl.txt (Combination ISC and OpenSSL license)
-  * HOMEPAGE:
-    * https://boringssl.googlesource.com/boringssl/
 
 --------------------------------------------------------------------------------
 org.glassfish.hk2
@@ -1196,6 +1188,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+com.fasterxml.jackson.core.jackson-core
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.zookeeper.zookeeper
 --------------------------------------------------------------------------------
 
@@ -1226,6 +1295,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty-buffer-patch
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty Buffer
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 log4j.log4j
 --------------------------------------------------------------------------------
 
@@ -1236,14 +1316,15 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-commons-codec.commons-codec
+org.apache.arrow.flight-core
 --------------------------------------------------------------------------------
 
-Apache Commons Codec
-Copyright 2002-2024 The Apache Software Foundation
+Arrow Flight Core
+Copyright 2026 The Apache Software Foundation
+
 
 This product includes software developed at
-The Apache Software Foundation (https://www.apache.org/).
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.kerby.kerb-admin
@@ -1782,16 +1863,6 @@ W3.org documents
 * Copyright: Copyright (c) 1994-2001 World Wide Web Consortium, (Massachusetts Institute of Technology, Institut National de Recherche en Informatique et en Automatique, Keio University). All Rights Reserved. http://www.w3.org/Consortium/Legal/
 
 --------------------------------------------------------------------------------
-org.apache.arrow.arrow-format
---------------------------------------------------------------------------------
-
-Arrow Format
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.commons.commons-vfs2
 --------------------------------------------------------------------------------
 
@@ -1874,21 +1945,12 @@ None
 None
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-grpc
+org.apache.arrow.arrow-memory-core
 --------------------------------------------------------------------------------
 
-Arrow Flight GRPC
-Copyright 2024 The Apache Software Foundation
+Arrow Memory - Core
+Copyright 2026 The Apache Software Foundation
 
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-vector
---------------------------------------------------------------------------------
-
-Arrow Vectors
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1914,21 +1976,21 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+commons-codec.commons-codec
+--------------------------------------------------------------------------------
+
+Apache Commons Codec
+Copyright 2002-2026 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.kerby.kerb-core
 --------------------------------------------------------------------------------
 
 Kerby-kerb core
 Copyright 2014-2017 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-core
---------------------------------------------------------------------------------
-
-Arrow Memory - Core
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2066,6 +2128,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-format
+--------------------------------------------------------------------------------
+
+Arrow Format
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -2147,16 +2220,6 @@ org.apache.avro.avro
 Apache Avro
 Copyright 2009-2024 The Apache Software Foundation
 
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.arrow.arrow-memory-netty
---------------------------------------------------------------------------------
-
-Arrow Memory - Netty
-Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -2292,6 +2355,17 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.arrow.arrow-vector
+--------------------------------------------------------------------------------
+
+Arrow Vectors
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 org.apache.orc.orc-shims
 --------------------------------------------------------------------------------
 
@@ -2352,53 +2426,6 @@ Copyright 2014-2017 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.fasterxml.jackson.core.jackson-core
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Copyright
-
-Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
-## FastDoubleParser
-
-jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
-That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
-under the following copyright.
-
-Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
-
-See FastDoubleParser-LICENSE and also FastDoubleParser-ThirdParty-LICENSE for details of other source code
-included in FastDoubleParser and the licenses and copyrights that apply to that code.
-
-## Schubfach
-
-jackson-core bundles a copy of the Schubfach number writing code <https://github.com/c4f7fcce9cb06515/Schubfach>.
-That code is available under an MIT license <https://github.com/c4f7fcce9cb06515/Schubfach/blob/master/todec/LICENSE>
-under the following copyright.
-
-Copyright 2018-2020 Raffaello Giulietti
-
-See Schubfach-LICENSE.
 
 --------------------------------------------------------------------------------
 commons-io.commons-io
@@ -2849,16 +2876,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.arrow.flight-core
---------------------------------------------------------------------------------
-
-Arrow Flight Core
-Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 com.google.guava.guava
 --------------------------------------------------------------------------------
 
@@ -2877,6 +2894,17 @@ Copyright 2014-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.arrow.arrow-memory-netty
+--------------------------------------------------------------------------------
+
+Arrow Memory - Netty
+Copyright 2026 The Apache Software Foundation
+
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 commons-net.commons-net


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#6185 to `release/v1.2`: upgrade Apache Arrow `15.0.2 → 19.0.0` and the Netty family `4.1.x → 4.2.15.Final` as one coordinated move. `arrow-memory-netty` reaches into Netty's allocator internals, so the 4.1/4.2 line cannot split — a split throws `NoClassDefFoundError: io/netty/util/concurrent/ThreadAwareExecutor` on the Arrow Flight transport to the Python workers. Arrow 19 is the first release targeting the Netty 4.2 line, so the two move together. The standalone `flight-grpc` artifact (discontinued after 15.0.2) is dropped — its gRPC transport now lives inside `flight-core`. The Netty family is extracted into a shared `nettyDependencyOverrides` val applied to amber and the three Arrow-bundling platform services, and the Jackson core family is pinned to `2.18.8` in `workflow-core`/`workflow-operator` (Arrow 19 otherwise evicts `jackson-databind` past the `>= 2.18.0, < 2.19.0` range `jackson-module-scala` allows).

**Update:** this PR also folds in the `computing-unit-managing-service` startup fix from apache/texera#6209 (issue #6206), so the Arrow upgrade lands on `release/v1.2` without ever breaking that service's startup. #6185 pinned `jackson-databind` in `workflow-core`/`workflow-operator` and in `file-service`/`workflow-compiling-service`, but not in `computing-unit-managing-service`, whose dist consequently bundled `jackson-databind-2.21.0.jar` next to `jackson-module-scala 2.18.8` and aborted at boot with `Scala module 2.18.8 requires Jackson Databind version >= 2.18.0 and < 2.19.0 - Found jackson-databind version 2.21.0`. The fix adds the `jackson-databind` override to that service too (matching `file-service`/`workflow-compiling-service`).

Notes on how the backport was produced:

- **Source changes were hand-applied, not cherry-picked.** `release/v1.2`'s `build.sbt` is structurally different from `main`'s (no `Resource` module or `NotebookMigrationService`, `asfLicensingSettings` rather than `commonModuleSettings`, hadoop 3.3.1, no log4j-2 bridges), so a raw cherry-pick of #6185's squash would drag in unrelated structure. Only the Arrow/Netty/Jackson semantics from #6185 + #6209 were ported; the `common/workflow-operator/build.sbt` hunk is byte-identical to #6185's.
- **The 8 `LICENSE-binary`(-java) / `NOTICE-binary` manifests were regenerated from `release/v1.2`'s own resolved runtime classpath**, not copied from `main`. `main`'s manifests reflect deps this branch does not have (hadoop 3.4.3, the log4j-2 bridges), so their transitive tails differ. On this branch the cascade resolves to grpc `1.62 → 1.79.0`, protobuf-java `3.25 → 4.33.4` (+ new `protobuf-java-util`), the netty `netty-codec → netty-codec-base`/`netty-codec-compression` split, new `arrow-memory-netty-buffer-patch` and `org.jspecify:jspecify 1.0.0`, `guava → 33.5.0-android`; `flight-grpc` and `eclipse-collections` drop out.

### Any related issues, documentation, discussions?

Backports apache/texera#6185 (merged to `main`). Also includes the fix from apache/texera#6209 for #6206 (startup regression introduced by #6185). No `release/*` label is added — this PR *is* the backport.

### How was this PR tested?

The binary-licensing manifests were verified the same way CI checks them, against each module's resolved `Runtime/managedClasspath` on this branch (which equals the dist's third-party jar set):

- `check_binary_deps.py jar --license-binary <manifest> <lib>` passes for all four services in both strict (nightly) mode and `--ignore-transitive-version` (PR) mode: `OK: 407 / 311 / 323 / 350 JVM jars match LICENSE-binary` for amber / file-service / workflow-compiling-service / computing-unit-managing-service.
- `generate_notice_binary.py` reproduces each committed `NOTICE-binary` byte-for-byte (regenerate-and-diff is clean for all four), matching the CI NOTICE check.
- `sbt export <Service>/Runtime/managedClasspath` resolves cleanly for all four services with Arrow 19 + Netty 4.2 (no eviction or resolution errors); `computing-unit-managing-service` now resolves `jackson-databind-2.18.8.jar` (was `2.21.0`).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
