### PR TITLE
fix(deps, v1.2): upgrade Apache Iceberg to 1.9.2 to resolve parquet-avro CVEs

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -297,7 +297,7 @@ Scala/Java jars:
   - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
-  - io.airlift.aircompressor-0.27.jar
+  - io.airlift.aircompressor-2.0.2.jar
   - io.altoo.pekko-kryo-serialization_2.13-1.3.0.jar
   - io.altoo.scala-kryo-serialization_2.13-1.3.0.jar
   - io.dropwizard-bundles.dropwizard-redirect-bundle-1.0.5.jar
@@ -394,21 +394,21 @@ Scala/Java jars:
   - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
-  - org.apache.httpcomponents.client5.httpclient5-5.4.jar
-  - org.apache.httpcomponents.core5.httpcore5-5.3.jar
-  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
+  - org.apache.httpcomponents.client5.httpclient5-5.4.3.jar
+  - org.apache.httpcomponents.core5.httpcore5-5.3.4.jar
+  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.4.jar
   - org.apache.httpcomponents.httpasyncclient-4.1.5.jar
   - org.apache.httpcomponents.httpclient-4.5.14.jar
   - org.apache.httpcomponents.httpcore-4.4.16.jar
   - org.apache.httpcomponents.httpcore-nio-4.4.13.jar
   - org.apache.httpcomponents.httpmime-4.5.13.jar
-  - org.apache.iceberg.iceberg-api-1.7.1.jar
-  - org.apache.iceberg.iceberg-aws-1.7.1.jar
-  - org.apache.iceberg.iceberg-bundled-guava-1.7.1.jar
-  - org.apache.iceberg.iceberg-common-1.7.1.jar
-  - org.apache.iceberg.iceberg-core-1.7.1.jar
-  - org.apache.iceberg.iceberg-data-1.7.1.jar
-  - org.apache.iceberg.iceberg-parquet-1.7.1.jar
+  - org.apache.iceberg.iceberg-api-1.9.2.jar
+  - org.apache.iceberg.iceberg-aws-1.9.2.jar
+  - org.apache.iceberg.iceberg-bundled-guava-1.9.2.jar
+  - org.apache.iceberg.iceberg-common-1.9.2.jar
+  - org.apache.iceberg.iceberg-core-1.9.2.jar
+  - org.apache.iceberg.iceberg-data-1.9.2.jar
+  - org.apache.iceberg.iceberg-parquet-1.9.2.jar
   - org.apache.kerby.kerb-core-2.0.3.jar
   - org.apache.kerby.kerb-crypto-2.0.3.jar
   - org.apache.kerby.kerb-util-2.0.3.jar
@@ -425,15 +425,15 @@ Scala/Java jars:
   - org.apache.lucene.lucene-queries-8.7.0.jar
   - org.apache.lucene.lucene-queryparser-8.7.0.jar
   - org.apache.lucene.lucene-sandbox-8.7.0.jar
-  - org.apache.orc.orc-core-1.9.4-nohive.jar
-  - org.apache.orc.orc-shims-1.9.4.jar
-  - org.apache.parquet.parquet-avro-1.13.1.jar
-  - org.apache.parquet.parquet-column-1.13.1.jar
-  - org.apache.parquet.parquet-common-1.13.1.jar
-  - org.apache.parquet.parquet-encoding-1.13.1.jar
-  - org.apache.parquet.parquet-format-structures-1.13.1.jar
-  - org.apache.parquet.parquet-hadoop-1.13.1.jar
-  - org.apache.parquet.parquet-jackson-1.13.1.jar
+  - org.apache.orc.orc-core-1.9.5-nohive.jar
+  - org.apache.orc.orc-shims-1.9.5.jar
+  - org.apache.parquet.parquet-avro-1.15.2.jar
+  - org.apache.parquet.parquet-column-1.15.2.jar
+  - org.apache.parquet.parquet-common-1.15.2.jar
+  - org.apache.parquet.parquet-encoding-1.15.2.jar
+  - org.apache.parquet.parquet-format-structures-1.15.2.jar
+  - org.apache.parquet.parquet-hadoop-1.15.2.jar
+  - org.apache.parquet.parquet-jackson-1.15.2.jar
   - org.apache.pekko.pekko-actor_2.13-1.2.1.jar
   - org.apache.pekko.pekko-cluster-metrics_2.13-1.2.1.jar
   - org.apache.pekko.pekko-cluster-tools_2.13-1.2.1.jar
@@ -445,7 +445,7 @@ Scala/Java jars:
   - org.apache.pekko.pekko-remote_2.13-1.2.1.jar
   - org.apache.pekko.pekko-slf4j_2.13-1.2.1.jar
   - org.apache.pekko.pekko-stream_2.13-1.2.1.jar
-  - org.apache.yetus.audience-annotations-0.13.0.jar
+  - org.apache.yetus.audience-annotations-0.12.0.jar
   - org.apache.zookeeper.zookeeper-3.8.4.jar
   - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
@@ -502,7 +502,7 @@ Scala/Java jars:
   - org.typelevel.cats-effect-std_2.13-3.6.3.jar
   - org.typelevel.cats-effect_2.13-3.6.3.jar
   - org.typelevel.cats-mtl_2.13-1.3.1.jar
-  - org.xerial.snappy.snappy-java-1.1.10.4.jar
+  - org.xerial.snappy.snappy-java-1.1.10.7.jar
   - org.yaml.snakeyaml-1.23.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -603,7 +603,7 @@ Dependencies under the BSD 2-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.github.luben.zstd-jni-1.5.0-1.jar
+  - com.github.luben.zstd-jni-1.5.6-6.jar
   - com.github.marianobarrios.lbmq-0.6.0.jar
   - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar

--- a/amber/NOTICE-binary
+++ b/amber/NOTICE-binary
@@ -217,7 +217,7 @@ org.apache.iceberg
 --------------------------------------------------------------------------------
 
 Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
+Copyright 2017-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -862,6 +862,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.parquet.parquet-jackson
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
@@ -1161,27 +1238,6 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.parquet.parquet-avro
---------------------------------------------------------------------------------
-
-Apache Parquet MR (Incubating)
-Copyright 2014-2015 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Avro, which includes the following in
-its NOTICE file:
-
-  Apache Avro
-  Copyright 2010-2015 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
 org.apache.arrow.arrow-format
 --------------------------------------------------------------------------------
 
@@ -1465,6 +1521,16 @@ This project leverages the following third party content.
 JUnit (4.12)
 
 * License: Eclipse Public License
+
+--------------------------------------------------------------------------------
+com.google.guava.guava
+--------------------------------------------------------------------------------
+
+Apache Iceberg
+Copyright 2017-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.apache.pekko.pekko-protobuf-v3_2.13
@@ -1810,28 +1876,6 @@ Copyright 2016 AddThis
 This product includes software developed by AddThis.
 
 --------------------------------------------------------------------------------
-org.apache.parquet.parquet-jackson
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
 org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
@@ -1850,6 +1894,27 @@ Java ClassMate library was originally written by Tatu Saloranta (tatu.saloranta@
 Other developers who have contributed code are:
 
 * Brian Langel
+
+--------------------------------------------------------------------------------
+org.apache.parquet.parquet-avro
+--------------------------------------------------------------------------------
+
+Apache Parquet Avro
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.core.jackson-core
@@ -2125,16 +2190,6 @@ org.apache.arrow.flight-core
 
 Arrow Flight Core
 Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.guava.guava
---------------------------------------------------------------------------------
-
-Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/common/workflow-core/build.sbt
+++ b/common/workflow-core/build.sbt
@@ -158,22 +158,25 @@ val excludeJackson = ExclusionRule(organization = "com.fasterxml.jackson.core")
 val excludeJacksonModule = ExclusionRule(organization = "com.fasterxml.jackson.module")
 val excludeNetty = ExclusionRule(organization = "io.netty")
 val log4jVersion = "2.26.1"
+// Iceberg 1.9.2 pairs with parquet 1.15.2, clearing the parquet-avro CVEs
+// (CVE-2025-30065, CVE-2025-46762) pulled in transitively by older releases.
+val icebergVersion = "1.9.2"
 
 libraryDependencies ++= Seq(
-  "org.apache.iceberg" % "iceberg-api" % "1.7.1",
-  "org.apache.iceberg" % "iceberg-parquet" % "1.7.1" excludeAll(
+  "org.apache.iceberg" % "iceberg-api" % icebergVersion,
+  "org.apache.iceberg" % "iceberg-parquet" % icebergVersion excludeAll(
     excludeJackson,
     excludeJacksonModule
   ),
-  "org.apache.iceberg" % "iceberg-core" % "1.7.1" excludeAll(
+  "org.apache.iceberg" % "iceberg-core" % icebergVersion excludeAll(
     excludeJackson,
     excludeJacksonModule
   ),
-  "org.apache.iceberg" % "iceberg-data" % "1.7.1" excludeAll(
+  "org.apache.iceberg" % "iceberg-data" % icebergVersion excludeAll(
     excludeJackson,
     excludeJacksonModule
   ),
-  "org.apache.iceberg" % "iceberg-aws" % "1.7.1" excludeAll(
+  "org.apache.iceberg" % "iceberg-aws" % icebergVersion excludeAll(
     excludeJackson,
     excludeJacksonModule
   ),

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergTableWriter.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergTableWriter.scala
@@ -28,6 +28,7 @@ import org.apache.iceberg.data.parquet.GenericParquetWriter
 import org.apache.iceberg.io.{DataWriter, OutputFile}
 import org.apache.iceberg.parquet.Parquet
 import org.apache.iceberg.{Schema, Table}
+import org.apache.parquet.schema.MessageType
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -115,7 +116,9 @@ private[storage] class IcebergTableWriter[T](
       val dataWriter: DataWriter[Record] = Parquet
         .writeData(outputFile)
         .forTable(table)
-        .createWriterFunc(GenericParquetWriter.buildWriter)
+        .createWriterFunc((schema: Schema, messageType: MessageType) =>
+          GenericParquetWriter.create(schema, messageType)
+        )
         .overwrite()
         .build()
       // Write each buffered item to the data file

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergTableWriterSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergTableWriterSpec.scala
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.core.storage.result.iceberg
+
+import org.apache.texera.amber.core.tuple.{AttributeType, Schema, Tuple}
+import org.apache.texera.amber.util.IcebergUtil
+import org.apache.iceberg.catalog.Catalog
+import org.apache.iceberg.data.IcebergGenerics
+import org.apache.iceberg.{Schema => IcebergSchema, Table}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.nio.file.{Files, Path}
+import java.util.UUID
+import scala.jdk.CollectionConverters._
+
+class IcebergTableWriterSpec extends AnyFlatSpec with BeforeAndAfterAll {
+
+  private val tableNamespace = "writer_spec"
+  private var warehouseDir: Path = _
+  private var catalog: Catalog = _
+
+  private val amberSchema: Schema = Schema()
+    .add("id", AttributeType.INTEGER)
+    .add("name", AttributeType.STRING)
+
+  private val icebergSchema: IcebergSchema = IcebergUtil.toIcebergSchema(amberSchema)
+
+  override def beforeAll(): Unit = {
+    warehouseDir = Files.createTempDirectory("iceberg-table-writer-spec")
+    catalog = IcebergUtil.createHadoopCatalog("writer-spec", warehouseDir)
+  }
+
+  override def afterAll(): Unit = {
+    catalog match {
+      case closeable: AutoCloseable => closeable.close()
+      case _                        =>
+    }
+  }
+
+  private def tuple(id: Int): Tuple =
+    Tuple
+      .builder(amberSchema)
+      .addSequentially(Array(Int.box(id), s"name-$id"))
+      .build()
+
+  private def createWriter(tableName: String, writerIdentifier: String = "writer_0") = {
+    IcebergUtil.createTable(
+      catalog,
+      tableNamespace,
+      tableName,
+      icebergSchema,
+      overrideIfExists = true
+    )
+    new IcebergTableWriter[Tuple](
+      writerIdentifier,
+      catalog,
+      tableNamespace,
+      tableName,
+      icebergSchema,
+      IcebergUtil.toGenericRecord
+    )
+  }
+
+  private def loadTable(tableName: String): Table =
+    IcebergUtil.loadTableMetadata(catalog, tableNamespace, tableName).get
+
+  private def readTuples(tableName: String): List[Tuple] = {
+    val records = IcebergGenerics.read(loadTable(tableName)).build()
+    try {
+      records.iterator().asScala.map(IcebergUtil.fromRecord(_, amberSchema)).toList
+    } finally {
+      records.close()
+    }
+  }
+
+  private def freshTableName(): String =
+    s"table_${UUID.randomUUID().toString.replace("-", "")}"
+
+  "IcebergTableWriter" should "flush remaining buffered tuples to the table on close" in {
+    val tableName = freshTableName()
+    val writer = createWriter(tableName)
+    writer.open()
+    val tuples = (0 until 10).map(tuple)
+    tuples.foreach(writer.putOne)
+
+    // Nothing is committed until the buffer fills or the writer closes
+    assert(readTuples(tableName).isEmpty)
+
+    writer.close()
+    assert(readTuples(tableName).sortBy(_.getField[Int]("id")) == tuples.toList)
+  }
+
+  it should "auto-flush when the buffer reaches the configured batch size" in {
+    val tableName = freshTableName()
+    val writer = createWriter(tableName)
+    val batchSize = writer.bufferSize
+    writer.open()
+    (0 until batchSize).foreach(i => writer.putOne(tuple(i)))
+
+    // The full batch is committed without an explicit close
+    assert(readTuples(tableName).size == batchSize)
+
+    writer.putOne(tuple(batchSize))
+    writer.close()
+    val tuples = readTuples(tableName)
+    assert(tuples.size == batchSize + 1)
+    // Each flush creates its own data file
+    assert(loadTable(tableName).snapshots().asScala.size == 2)
+  }
+
+  it should "not write tuples removed from the buffer before a flush" in {
+    val tableName = freshTableName()
+    val writer = createWriter(tableName)
+    writer.open()
+    val kept = tuple(1)
+    val removed = tuple(2)
+    writer.putOne(kept)
+    writer.putOne(removed)
+    writer.removeOne(removed)
+    writer.close()
+
+    assert(readTuples(tableName) == List(kept))
+  }
+
+  it should "prefix created data files with the writer identifier" in {
+    val tableName = freshTableName()
+    val writer = createWriter(tableName, writerIdentifier = "worker_42")
+    writer.open()
+    writer.putOne(tuple(1))
+    writer.close()
+
+    val table = loadTable(tableName)
+    val dataFiles = table
+      .currentSnapshot()
+      .addedDataFiles(table.io())
+      .asScala
+      .map(_.location())
+      .toList
+    assert(dataFiles.nonEmpty)
+    assert(dataFiles.forall(_.contains("worker_42_")))
+  }
+}

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -281,7 +281,7 @@ Scala/Java jars:
   - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
-  - io.airlift.aircompressor-0.27.jar
+  - io.airlift.aircompressor-2.0.2.jar
   - io.dropwizard.dropwizard-auth-4.0.7.jar
   - io.dropwizard.dropwizard-configuration-4.0.7.jar
   - io.dropwizard.dropwizard-core-4.0.7.jar
@@ -402,18 +402,18 @@ Scala/Java jars:
   - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
-  - org.apache.httpcomponents.client5.httpclient5-5.4.jar
-  - org.apache.httpcomponents.core5.httpcore5-5.3.jar
-  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
+  - org.apache.httpcomponents.client5.httpclient5-5.4.3.jar
+  - org.apache.httpcomponents.core5.httpcore5-5.3.4.jar
+  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.4.jar
   - org.apache.httpcomponents.httpclient-4.5.13.jar
   - org.apache.httpcomponents.httpcore-4.4.16.jar
-  - org.apache.iceberg.iceberg-api-1.7.1.jar
-  - org.apache.iceberg.iceberg-aws-1.7.1.jar
-  - org.apache.iceberg.iceberg-bundled-guava-1.7.1.jar
-  - org.apache.iceberg.iceberg-common-1.7.1.jar
-  - org.apache.iceberg.iceberg-core-1.7.1.jar
-  - org.apache.iceberg.iceberg-data-1.7.1.jar
-  - org.apache.iceberg.iceberg-parquet-1.7.1.jar
+  - org.apache.iceberg.iceberg-api-1.9.2.jar
+  - org.apache.iceberg.iceberg-aws-1.9.2.jar
+  - org.apache.iceberg.iceberg-bundled-guava-1.9.2.jar
+  - org.apache.iceberg.iceberg-common-1.9.2.jar
+  - org.apache.iceberg.iceberg-core-1.9.2.jar
+  - org.apache.iceberg.iceberg-data-1.9.2.jar
+  - org.apache.iceberg.iceberg-parquet-1.9.2.jar
   - org.apache.kerby.kerb-core-2.0.3.jar
   - org.apache.kerby.kerb-crypto-2.0.3.jar
   - org.apache.kerby.kerb-util-2.0.3.jar
@@ -424,16 +424,16 @@ Scala/Java jars:
   - org.apache.logging.log4j.log4j-1.2-api-2.26.1.jar
   - org.apache.logging.log4j.log4j-api-2.26.1.jar
   - org.apache.logging.log4j.log4j-to-slf4j-2.26.1.jar
-  - org.apache.orc.orc-core-1.9.4-nohive.jar
-  - org.apache.orc.orc-shims-1.9.4.jar
-  - org.apache.parquet.parquet-avro-1.13.1.jar
-  - org.apache.parquet.parquet-column-1.13.1.jar
-  - org.apache.parquet.parquet-common-1.13.1.jar
-  - org.apache.parquet.parquet-encoding-1.13.1.jar
-  - org.apache.parquet.parquet-format-structures-1.13.1.jar
-  - org.apache.parquet.parquet-hadoop-1.13.1.jar
-  - org.apache.parquet.parquet-jackson-1.13.1.jar
-  - org.apache.yetus.audience-annotations-0.13.0.jar
+  - org.apache.orc.orc-core-1.9.5-nohive.jar
+  - org.apache.orc.orc-shims-1.9.5.jar
+  - org.apache.parquet.parquet-avro-1.15.2.jar
+  - org.apache.parquet.parquet-column-1.15.2.jar
+  - org.apache.parquet.parquet-common-1.15.2.jar
+  - org.apache.parquet.parquet-encoding-1.15.2.jar
+  - org.apache.parquet.parquet-format-structures-1.15.2.jar
+  - org.apache.parquet.parquet-hadoop-1.15.2.jar
+  - org.apache.parquet.parquet-jackson-1.15.2.jar
+  - org.apache.yetus.audience-annotations-0.12.0.jar
   - org.apache.zookeeper.zookeeper-3.8.4.jar
   - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
@@ -471,7 +471,7 @@ Scala/Java jars:
   - org.slf4j.jcl-over-slf4j-2.0.12.jar
   - org.slf4j.log4j-over-slf4j-2.0.12.jar
   - org.snakeyaml.snakeyaml-engine-2.7.jar
-  - org.xerial.snappy.snappy-java-1.1.10.4.jar
+  - org.xerial.snappy.snappy-java-1.1.10.7.jar
   - org.yaml.snakeyaml-2.2.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -555,7 +555,7 @@ Dependencies under the BSD 2-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.github.luben.zstd-jni-1.5.0-1.jar
+  - com.github.luben.zstd-jni-1.5.6-6.jar
   - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar

--- a/computing-unit-managing-service/NOTICE-binary
+++ b/computing-unit-managing-service/NOTICE-binary
@@ -176,7 +176,7 @@ org.apache.iceberg
 --------------------------------------------------------------------------------
 
 Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
+Copyright 2017-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -758,6 +758,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.parquet.parquet-jackson
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
@@ -1097,27 +1174,6 @@ Copyright 2001-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.parquet.parquet-avro
---------------------------------------------------------------------------------
-
-Apache Parquet MR (Incubating)
-Copyright 2014-2015 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Avro, which includes the following in
-its NOTICE file:
-
-  Apache Avro
-  Copyright 2010-2015 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.glassfish.jersey.ext.jersey-bean-validation
@@ -1595,6 +1651,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+com.google.guava.guava
+--------------------------------------------------------------------------------
+
+Apache Iceberg
+Copyright 2017-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -1859,28 +1925,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.parquet.parquet-jackson
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
 org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
@@ -1889,6 +1933,27 @@ Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.parquet.parquet-avro
+--------------------------------------------------------------------------------
+
+Apache Parquet Avro
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.core.jackson-core
@@ -2276,16 +2341,6 @@ org.apache.arrow.flight-core
 
 Arrow Flight Core
 Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.guava.guava
---------------------------------------------------------------------------------
-
-Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -275,7 +275,7 @@ Scala/Java jars:
   - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
-  - io.airlift.aircompressor-0.27.jar
+  - io.airlift.aircompressor-2.0.2.jar
   - io.dropwizard.dropwizard-auth-4.0.7.jar
   - io.dropwizard.dropwizard-configuration-4.0.7.jar
   - io.dropwizard.dropwizard-core-4.0.7.jar
@@ -366,18 +366,18 @@ Scala/Java jars:
   - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
-  - org.apache.httpcomponents.client5.httpclient5-5.4.jar
-  - org.apache.httpcomponents.core5.httpcore5-5.3.jar
-  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
+  - org.apache.httpcomponents.client5.httpclient5-5.4.3.jar
+  - org.apache.httpcomponents.core5.httpcore5-5.3.4.jar
+  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.4.jar
   - org.apache.httpcomponents.httpclient-4.5.13.jar
   - org.apache.httpcomponents.httpcore-4.4.16.jar
-  - org.apache.iceberg.iceberg-api-1.7.1.jar
-  - org.apache.iceberg.iceberg-aws-1.7.1.jar
-  - org.apache.iceberg.iceberg-bundled-guava-1.7.1.jar
-  - org.apache.iceberg.iceberg-common-1.7.1.jar
-  - org.apache.iceberg.iceberg-core-1.7.1.jar
-  - org.apache.iceberg.iceberg-data-1.7.1.jar
-  - org.apache.iceberg.iceberg-parquet-1.7.1.jar
+  - org.apache.iceberg.iceberg-api-1.9.2.jar
+  - org.apache.iceberg.iceberg-aws-1.9.2.jar
+  - org.apache.iceberg.iceberg-bundled-guava-1.9.2.jar
+  - org.apache.iceberg.iceberg-common-1.9.2.jar
+  - org.apache.iceberg.iceberg-core-1.9.2.jar
+  - org.apache.iceberg.iceberg-data-1.9.2.jar
+  - org.apache.iceberg.iceberg-parquet-1.9.2.jar
   - org.apache.kerby.kerb-core-2.0.3.jar
   - org.apache.kerby.kerb-crypto-2.0.3.jar
   - org.apache.kerby.kerb-util-2.0.3.jar
@@ -388,16 +388,16 @@ Scala/Java jars:
   - org.apache.logging.log4j.log4j-1.2-api-2.26.1.jar
   - org.apache.logging.log4j.log4j-api-2.26.1.jar
   - org.apache.logging.log4j.log4j-to-slf4j-2.26.1.jar
-  - org.apache.orc.orc-core-1.9.4-nohive.jar
-  - org.apache.orc.orc-shims-1.9.4.jar
-  - org.apache.parquet.parquet-avro-1.13.1.jar
-  - org.apache.parquet.parquet-column-1.13.1.jar
-  - org.apache.parquet.parquet-common-1.13.1.jar
-  - org.apache.parquet.parquet-encoding-1.13.1.jar
-  - org.apache.parquet.parquet-format-structures-1.13.1.jar
-  - org.apache.parquet.parquet-hadoop-1.13.1.jar
-  - org.apache.parquet.parquet-jackson-1.13.1.jar
-  - org.apache.yetus.audience-annotations-0.13.0.jar
+  - org.apache.orc.orc-core-1.9.5-nohive.jar
+  - org.apache.orc.orc-shims-1.9.5.jar
+  - org.apache.parquet.parquet-avro-1.15.2.jar
+  - org.apache.parquet.parquet-column-1.15.2.jar
+  - org.apache.parquet.parquet-common-1.15.2.jar
+  - org.apache.parquet.parquet-encoding-1.15.2.jar
+  - org.apache.parquet.parquet-format-structures-1.15.2.jar
+  - org.apache.parquet.parquet-hadoop-1.15.2.jar
+  - org.apache.parquet.parquet-jackson-1.15.2.jar
+  - org.apache.yetus.audience-annotations-0.12.0.jar
   - org.apache.zookeeper.zookeeper-3.8.4.jar
   - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
@@ -436,7 +436,7 @@ Scala/Java jars:
   - org.scala-lang.scala-reflect-2.13.18.jar
   - org.slf4j.jcl-over-slf4j-2.0.12.jar
   - org.slf4j.log4j-over-slf4j-2.0.12.jar
-  - org.xerial.snappy.snappy-java-1.1.10.4.jar
+  - org.xerial.snappy.snappy-java-1.1.10.7.jar
   - org.yaml.snakeyaml-2.2.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -518,7 +518,7 @@ Dependencies under the BSD 2-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.github.luben.zstd-jni-1.5.0-1.jar
+  - com.github.luben.zstd-jni-1.5.6-6.jar
   - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar

--- a/file-service/NOTICE-binary
+++ b/file-service/NOTICE-binary
@@ -176,7 +176,7 @@ org.apache.iceberg
 --------------------------------------------------------------------------------
 
 Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
+Copyright 2017-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -758,6 +758,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.parquet.parquet-jackson
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
@@ -1097,27 +1174,6 @@ Copyright 2001-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.parquet.parquet-avro
---------------------------------------------------------------------------------
-
-Apache Parquet MR (Incubating)
-Copyright 2014-2015 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Avro, which includes the following in
-its NOTICE file:
-
-  Apache Avro
-  Copyright 2010-2015 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.glassfish.jersey.ext.jersey-bean-validation
@@ -1595,6 +1651,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+com.google.guava.guava
+--------------------------------------------------------------------------------
+
+Apache Iceberg
+Copyright 2017-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -1812,28 +1878,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.parquet.parquet-jackson
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
 org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
@@ -1842,6 +1886,27 @@ Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.parquet.parquet-avro
+--------------------------------------------------------------------------------
+
+Apache Parquet Avro
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.core.jackson-core
@@ -2272,16 +2337,6 @@ org.apache.arrow.flight-core
 
 Arrow Flight Core
 Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.guava.guava
---------------------------------------------------------------------------------
-
-Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -277,7 +277,7 @@ Scala/Java jars:
   - commons-net.commons-net-3.9.0.jar
   - commons-pool.commons-pool-1.6.jar
   - dev.failsafe.failsafe-3.3.2.jar
-  - io.airlift.aircompressor-0.27.jar
+  - io.airlift.aircompressor-2.0.2.jar
   - io.dropwizard.dropwizard-auth-4.0.7.jar
   - io.dropwizard.dropwizard-configuration-4.0.7.jar
   - io.dropwizard.dropwizard-core-4.0.7.jar
@@ -368,21 +368,21 @@ Scala/Java jars:
   - org.apache.hadoop.hadoop-yarn-common-3.4.3.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-guava-1.5.0.jar
   - org.apache.hadoop.thirdparty.hadoop-shaded-protobuf_3_25-1.5.0.jar
-  - org.apache.httpcomponents.client5.httpclient5-5.4.jar
-  - org.apache.httpcomponents.core5.httpcore5-5.3.jar
-  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.jar
+  - org.apache.httpcomponents.client5.httpclient5-5.4.3.jar
+  - org.apache.httpcomponents.core5.httpcore5-5.3.4.jar
+  - org.apache.httpcomponents.core5.httpcore5-h2-5.3.4.jar
   - org.apache.httpcomponents.httpasyncclient-4.1.5.jar
   - org.apache.httpcomponents.httpclient-4.5.13.jar
   - org.apache.httpcomponents.httpcore-4.4.16.jar
   - org.apache.httpcomponents.httpcore-nio-4.4.13.jar
   - org.apache.httpcomponents.httpmime-4.5.13.jar
-  - org.apache.iceberg.iceberg-api-1.7.1.jar
-  - org.apache.iceberg.iceberg-aws-1.7.1.jar
-  - org.apache.iceberg.iceberg-bundled-guava-1.7.1.jar
-  - org.apache.iceberg.iceberg-common-1.7.1.jar
-  - org.apache.iceberg.iceberg-core-1.7.1.jar
-  - org.apache.iceberg.iceberg-data-1.7.1.jar
-  - org.apache.iceberg.iceberg-parquet-1.7.1.jar
+  - org.apache.iceberg.iceberg-api-1.9.2.jar
+  - org.apache.iceberg.iceberg-aws-1.9.2.jar
+  - org.apache.iceberg.iceberg-bundled-guava-1.9.2.jar
+  - org.apache.iceberg.iceberg-common-1.9.2.jar
+  - org.apache.iceberg.iceberg-core-1.9.2.jar
+  - org.apache.iceberg.iceberg-data-1.9.2.jar
+  - org.apache.iceberg.iceberg-parquet-1.9.2.jar
   - org.apache.kerby.kerb-core-2.0.3.jar
   - org.apache.kerby.kerb-crypto-2.0.3.jar
   - org.apache.kerby.kerb-util-2.0.3.jar
@@ -399,16 +399,16 @@ Scala/Java jars:
   - org.apache.lucene.lucene-queries-8.7.0.jar
   - org.apache.lucene.lucene-queryparser-8.7.0.jar
   - org.apache.lucene.lucene-sandbox-8.7.0.jar
-  - org.apache.orc.orc-core-1.9.4-nohive.jar
-  - org.apache.orc.orc-shims-1.9.4.jar
-  - org.apache.parquet.parquet-avro-1.13.1.jar
-  - org.apache.parquet.parquet-column-1.13.1.jar
-  - org.apache.parquet.parquet-common-1.13.1.jar
-  - org.apache.parquet.parquet-encoding-1.13.1.jar
-  - org.apache.parquet.parquet-format-structures-1.13.1.jar
-  - org.apache.parquet.parquet-hadoop-1.13.1.jar
-  - org.apache.parquet.parquet-jackson-1.13.1.jar
-  - org.apache.yetus.audience-annotations-0.13.0.jar
+  - org.apache.orc.orc-core-1.9.5-nohive.jar
+  - org.apache.orc.orc-shims-1.9.5.jar
+  - org.apache.parquet.parquet-avro-1.15.2.jar
+  - org.apache.parquet.parquet-column-1.15.2.jar
+  - org.apache.parquet.parquet-common-1.15.2.jar
+  - org.apache.parquet.parquet-encoding-1.15.2.jar
+  - org.apache.parquet.parquet-format-structures-1.15.2.jar
+  - org.apache.parquet.parquet-hadoop-1.15.2.jar
+  - org.apache.parquet.parquet-jackson-1.15.2.jar
+  - org.apache.yetus.audience-annotations-0.12.0.jar
   - org.apache.zookeeper.zookeeper-3.8.4.jar
   - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
@@ -445,7 +445,7 @@ Scala/Java jars:
   - org.scala-lang.scala-reflect-2.13.18.jar
   - org.slf4j.jcl-over-slf4j-2.0.12.jar
   - org.slf4j.log4j-over-slf4j-2.0.12.jar
-  - org.xerial.snappy.snappy-java-1.1.10.4.jar
+  - org.xerial.snappy.snappy-java-1.1.10.7.jar
   - org.yaml.snakeyaml-2.2.jar
   - software.amazon.awssdk.annotations-2.29.51.jar
   - software.amazon.awssdk.apache-client-2.29.51.jar
@@ -529,7 +529,7 @@ Dependencies under the BSD 2-Clause License
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - com.github.luben.zstd-jni-1.5.0-1.jar
+  - com.github.luben.zstd-jni-1.5.6-6.jar
   - dnsjava.dnsjava-3.6.1.jar
   - org.codehaus.woodstox.stax2-api-4.2.1.jar
   - org.postgresql.postgresql-42.7.10.jar

--- a/workflow-compiling-service/NOTICE-binary
+++ b/workflow-compiling-service/NOTICE-binary
@@ -176,7 +176,7 @@ org.apache.iceberg
 --------------------------------------------------------------------------------
 
 Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
+Copyright 2017-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -1186,6 +1186,83 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+org.apache.parquet.parquet-jackson
+--------------------------------------------------------------------------------
+
+# Jackson JSON processor
+
+Jackson is a high-performance, Free/Open Source JSON processing library.
+It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
+been in development since 2007.
+It is currently developed by a community of developers.
+
+## Copyright
+
+Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
+
+## Licensing
+
+Jackson 2.x core and extension components are licensed under Apache License 2.0
+To find the details that apply to this artifact see the accompanying LICENSE file.
+
+## Credits
+
+A list of contributors may be found from CREDITS(-2.x) file, which is included
+in some artifacts (usually source distributions); but is always available
+from the source code management (SCM) system project uses.
+
+## FastDoubleParser
+
+jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+under the following copyright.
+
+Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+
+See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+and the licenses and copyrights that apply to that code.
+
+# FastDoubleParser
+
+This is a Java port of Daniel Lemire's fast_float project.
+This project provides parsers for double, float, BigDecimal and BigInteger values.
+
+## Copyright
+
+Copyright © 2024 Werner Randelshofer, Switzerland.
+
+## Licensing
+
+This code is licensed under MIT License.
+https://github.com/wrandelshofer/FastDoubleParser/blob/522be16e145f43308c43b23094e31d5efcaa580e/LICENSE
+(The file 'LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+Some portions of the code have been derived from other projects.
+All these projects require that we include a copyright notice, and some require that we also include some text of their
+license file.
+
+fast_double_parser, Copyright (c) 2022 Daniel Lemire. BSL License.
+https://github.com/lemire/fast_double_parser
+https://github.com/lemire/fast_double_parser/blob/07d9189a8fb815fe800cb15ca022e7a07093236e/LICENSE.BSL
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+fast_float, Copyright (c) 2021 The fast_float authors. MIT License.
+https://github.com/fastfloat/fast_float
+https://github.com/fastfloat/fast_float/blob/cc1e01e9eee74128e48d51488a6b1df4a767a810/LICENSE-MIT
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+bigint, Copyright 2020 Tim Buktu. 2-clause BSD License.
+https://github.com/tbuktu/bigint/tree/floatfft
+https://github.com/tbuktu/bigint/blob/617c8cd8a7c5e4fb4d919c6a4d11e2586107f029/LICENSE
+https://github.com/wrandelshofer/FastDoubleParser/blob/39e123b15b71f29a38a087d16a0bc620fc879aa6/bigint-LICENSE
+(We only use those portions of the bigint project that can be licensed under 2-clause BSD License.)
+(The file 'thirdparty-LICENSE' is included in the sources and classes Jar files that are released by this project
+- as is required by that license.)
+
+--------------------------------------------------------------------------------
 org.apache.curator.curator-recipes
 --------------------------------------------------------------------------------
 
@@ -1535,27 +1612,6 @@ Copyright 2001-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
-
---------------------------------------------------------------------------------
-org.apache.parquet.parquet-avro
---------------------------------------------------------------------------------
-
-Apache Parquet MR (Incubating)
-Copyright 2014-2015 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-
-This product includes code from Apache Avro, which includes the following in
-its NOTICE file:
-
-  Apache Avro
-  Copyright 2010-2015 The Apache Software Foundation
-
-  This product includes software developed at
-  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 org.glassfish.jersey.ext.jersey-bean-validation
@@ -2033,6 +2089,16 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
+com.google.guava.guava
+--------------------------------------------------------------------------------
+
+Apache Iceberg
+Copyright 2017-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
 commons-pool.commons-pool
 --------------------------------------------------------------------------------
 
@@ -2250,28 +2316,6 @@ This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
-org.apache.parquet.parquet-jackson
---------------------------------------------------------------------------------
-
-# Jackson JSON processor
-
-Jackson is a high-performance, Free/Open Source JSON processing library.
-It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
-been in development since 2007.
-It is currently developed by a community of developers.
-
-## Licensing
-
-Jackson 2.x core and extension components are licensed under Apache License 2.0
-To find the details that apply to this artifact see the accompanying LICENSE file.
-
-## Credits
-
-A list of contributors may be found from CREDITS(-2.x) file, which is included
-in some artifacts (usually source distributions); but is always available
-from the source code management (SCM) system project uses.
-
---------------------------------------------------------------------------------
 org.apache.kerby.kerby-util
 --------------------------------------------------------------------------------
 
@@ -2280,6 +2324,27 @@ Copyright 2014-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+org.apache.parquet.parquet-avro
+--------------------------------------------------------------------------------
+
+Apache Parquet Avro
+Copyright 2014-2024 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Avro, which includes the following in
+its NOTICE file:
+
+  Apache Avro
+  Copyright 2010-2015 The Apache Software Foundation
+
+  This product includes software developed at
+  The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 com.fasterxml.jackson.core.jackson-core
@@ -2720,16 +2785,6 @@ org.apache.arrow.flight-core
 
 Arrow Flight Core
 Copyright 2024 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
---------------------------------------------------------------------------------
-com.google.guava.guava
---------------------------------------------------------------------------------
-
-Apache Iceberg
-Copyright 2017-2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#6208 to `release/v1.2`: upgrade Apache Iceberg from 1.7.1 to 1.9.2 in `common/workflow-core`.

Iceberg 1.7.1 transitively pulls `org.apache.parquet:parquet-avro` 1.13.1, flagged by two open Dependabot alerts:
- **CVE-2025-30065** (critical): schema parsing in the parquet-avro module allows arbitrary code execution; fixed in parquet 1.15.1.
- **CVE-2025-46762** (high): fixed in parquet 1.15.2.

Iceberg 1.9.2 is the smallest Iceberg release whose official dependency set pairs with parquet 1.15.2. As on `main`, one source change was required: Iceberg 1.9 added a `BiFunction` overload to `Parquet.DataWriteBuilder#createWriterFunc` and deprecated `GenericParquetWriter.buildWriter(MessageType)`, so `IcebergTableWriter.flushBuffer` now uses the replacement API `GenericParquetWriter.create(Schema, MessageType)` via an explicit lambda. The new `IcebergTableWriterSpec` is included as well.

Cherry-pick of db00f9416 with conflicts resolved:
- The source changes (`build.sbt`, `IcebergTableWriter.scala`, `IcebergTableWriterSpec.scala`) apply cleanly.
- The manifest changes conflicted (this is also why the automated backport pre-check on the original PR failed) and the `LICENSE-binary`(-java) / `NOTICE-binary` sets were instead **regenerated from freshly built `release/v1.2` dists** rather than taken from `main`, because `main`'s manifests reflect a dependency tree this branch does not have (e.g. jackson 2.21, guava 33.5.0-android, grpc 1.79, protobuf 4.33 are `main`-only). The iceberg/parquet drift itself is the same 23-entry set as on `main` (iceberg 1.9.2, parquet 1.15.2, zstd-jni, aircompressor, httpclient5/httpcore5, orc, audience-annotations, snappy-java). `NOTICE-binary` files were regenerated with `generate_notice_binary.py` (amber with `--extras amber/NOTICE-binary-python`).

### Any related issues, documentation, discussions?

Backports apache/texera#6208 (merged to `main`), which resolves #6207. Dependabot alerts: [#714](https://github.com/apache/texera/security/dependabot/714), [#716](https://github.com/apache/texera/security/dependabot/716). No `release/*` label is added — this PR *is* the backport.

### How was this PR tested?

- Built the four affected dists on this branch and ran `check_binary_deps.py` (strict mode) and `generate_notice_binary.py` against each unzipped dist — all pass, and the bundled parquet family resolves to 1.15.2.
- `sbt WorkflowCore/test`: all tests pass on this branch, including the Iceberg integration specs and the new `IcebergTableWriterSpec`. (The `S3StorageClientSpec`/`LargeBinary*`/`IcebergDocumentConsoleMessagesSpec` suite aborts are environmental — missing external MinIO and a stale local iceberg-catalog entry — and reproduce identically on unmodified `release/v1.2`.)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)
