### PR TITLE
fix(amber): log betterproto stderr as info to avoid false IDE build failures

### DIFF
--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -224,7 +224,7 @@ genPythonProto := {
         "Install protoc and `pip install betterproto[compiler]` before launching a Python worker or running pytest."
     )
   } else {
-    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.error(line))
+    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.info(line))
     val exit = scala.sys.process.Process(Seq("bash", script.getAbsolutePath), repoRoot).!(procLogger)
     if (exit != 0) sys.error(s"python-proto-gen.sh failed with exit code $exit")
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Log the `genPythonProto` subprocess's stderr at `info` instead of `error` (`amber/build.sbt`).

`genPythonProto` runs `bin/python-proto-gen.sh`, which invokes betterproto as a `protoc` plugin. A `protoc` plugin's stdout is reserved for the binary `CodeGeneratorResponse` sent back to `protoc`, so betterproto writes its normal progress (`Writing __init__.py`, `Writing org/…/__init__.py`, …) to stderr. The task routed that stderr to sbt's `error` level, so a fully successful generation printed a wall of `[error]` lines and still ended in `[success]`.

A command-line `sbt compile` is unaffected, but IDEs that delegate the build to sbt (e.g. IntelliJ IDEA with "Build and run using: sbt") parse those `[error]` lines as a build failure. This fails the "Build" before-launch step of the amber-based run configurations — `TexeraWebApplication`, `ComputingUnitMaster`, `ComputingUnitWorker` — so those services never launch, while non-amber services (which do not depend on `genPythonProto`) start normally.

**The change.** `ProcessLogger` takes two callbacks, one for the subprocess's stdout and one for its stderr; only the stderr callback is changed, from `log.error` to `log.info`, in the `genPythonProto` task in `amber/build.sbt`:

```diff
-    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.error(line))
+    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.info(line))
```

Nothing else changes. Real failures are still detected via the script's exit code on the next line (`if (exit != 0) sys.error(...)`), which is untouched, so this only stops benign stderr from being labeled as an error.

### Any related issues, documentation, or discussions?

Follow-up to #5358

Closes: https://github.com/apache/texera/issues/6243

### How was this PR tested?

- Ran `sbt "WorkflowExecutionService/genPythonProto"` with `protoc` and `protoc-gen-python_betterproto` on `PATH`: the betterproto progress lines now appear as `[info] Writing …` (previously `[error] Writing …`), and the task still ends in `[success]`.
- Confirmed failure detection is unchanged: the exit-code check on the following line still fails the build when the script exits non-zero, so real failures are still surfaced.
- Confirmed the diff is limited to a single line in `amber/build.sbt`.
- `sbt scalafmtCheckAll` passed.
- `sbt "scalafixAll --check"` passed.
- `sbt test` (backend): all tests unrelated to external infrastructure passed. 

### Was this PR authored or co-authored using generative AI tooling?

Co-authored by Claude Fable 5.
