### PR TITLE
fix(deps, v1.2): bump psutil from 5.9.0 to 7.2.2 in /amber

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -318,7 +318,7 @@ Python packages:
   - pandas==2.2.3
   - pg8000==1.31.5
   - protobuf==7.34.1
-  - psutil==5.9.0
+  - psutil==7.2.2
   - s3fs==2025.9.0
   - scikit-image==0.25.2
   - scikit-learn==1.5.0

--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -36,7 +36,7 @@ fs==2.4.16
 praw==7.6.1
 bidict==0.22.0
 cached_property==1.5.2
-psutil==5.9.0
+psutil==7.2.2
 tzlocal==2.1
 s3fs==2025.9.0
 aiobotocore==2.25.1


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of apache/texera#6230 to `release/v1.2`: bumps `psutil` from `5.9.0` to `7.2.2` in `/amber`.

`release/v1.2` still pinned `psutil==5.9.0` (a Dependabot security bump on `main`). This applies the same version bump on the release branch:

- `amber/requirements.txt`: `psutil==5.9.0` → `psutil==7.2.2`
- `amber/LICENSE-binary-python`: sync the direct-dep bullet to `7.2.2` so the binary-license drift check passes.

Hand-applied rather than cherry-picked, since #6230 has not merged to `main` yet (no squash commit to `-x`). `psutil` is a self-contained C-extension with no Python dependencies, so no transitive entries change and no full LICENSE-binary regeneration is needed — only the single version bullet.

### Any related issues, documentation, discussions?

Backport of apache/texera#6230.

### How was this PR tested?

Relies on the existing CI stack selected by the touched files (`amber/*`): `build / pyamber` runs `check_binary_deps.py`, which is the check that enforces direct-dep version agreement between `requirements.txt` and `LICENSE-binary-python`.

No `release/*` label is added — this PR *is* the backport.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
