### PR TITLE
chore(ci): drop Python 3.10 support, raise floor to 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -752,7 +752,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     services:
       postgres:

--- a/amber/pyproject.toml
+++ b/amber/pyproject.toml
@@ -17,7 +17,7 @@
 
 [tool.ruff]
 line-length = 88
-target-version = "py310"
+target-version = "py311"
 extend-exclude = ["proto"]
 
 [tool.ruff.lint]

--- a/bin/local-dev/main.sh
+++ b/bin/local-dev/main.sh
@@ -1124,7 +1124,7 @@ _install_hint() {
             printf "  or set JAVA_HOME=/path/to/jdk-17 explicitly\n"
             ;;
         python)
-            printf "  ${BOLD}install Python 3.10+ and the TUI deps:${RESET}\n"
+            printf "  ${BOLD}install Python 3.11+ and the TUI deps:${RESET}\n"
             printf "    macOS:   brew install python@3.12\n"
             printf "    Linux:   apt install python3 python3-pip\n"
             printf "    then:    python3 -m pip install -r %s/amber/dev-requirements.txt\n" "$REPO_ROOT"

--- a/bin/pylsp/Dockerfile
+++ b/bin/pylsp/Dockerfile
@@ -25,7 +25,7 @@
 # has yet to be fully endorsed by the ASF.
 
 # Use an official Python runtime as a parent image
-FROM python:3.10-slim
+FROM python:3.11-slim
 
 # Set the working directory in the container
 WORKDIR /usr/src/app

--- a/docs/contribution-guidelines/guide-for-developers.md
+++ b/docs/contribution-guidelines/guide-for-developers.md
@@ -18,9 +18,9 @@ export JAVA_HOME=$(/usr/libexec/java_home -v 17)
 ```
 On Windows, add a system environment variable called `JAVA_HOME` that points to the JDK directory.
 
-#### Python@3.12/3.11/3.10
+#### Python@3.12/3.11
 
-Install Python 3.12 (or 3.11/3.10) from the official site or your preferred package manager.
+Install Python 3.12 (or 3.11) from the official site or your preferred package manager.
 
 #### **Git**
 

--- a/docs/tutorials/guide-to-enable-llm-agent.md
+++ b/docs/tutorials/guide-to-enable-llm-agent.md
@@ -7,7 +7,7 @@ This guide explains how to enable the AI agent feature in Texera. For detailed e
 
 ## Prerequisites
 - Already know how to setup Texera
-- Python 3.10+
+- Python 3.11+
 - API key from a supported LLM provider (e.g., Anthropic, OpenAI)
 
 ## Step 1: Install LiteLLM


### PR DESCRIPTION
### What changes were proposed in this PR?

Python 3.10 reaches **end of life in October 2026** (already security-only per the [Python devguide](https://devguide.python.org/versions/)), and the scientific-Python ecosystem is dropping it (numpy 2.3+ requires ≥3.11, 2.5+ requires ≥3.12). Keeping 3.10 in the matrix forces us to cap each scientific dependency to its last 3.10-compatible release — most recently numpy in #6231.

This drops Python 3.10 and makes **3.11** the new floor (3.11 is supported until Oct 2027):

| File | Change |
| ---- | ------ |
| `.github/workflows/build.yml` | pyamber matrix `["3.10","3.11","3.12","3.13"]` → `["3.11","3.12","3.13"]` |
| `amber/pyproject.toml` | Ruff `target-version` `py310` → `py311` |
| `bin/pylsp/Dockerfile` | base image `python:3.10-slim` → `python:3.11-slim` |
| `docs/contribution-guidelines/guide-for-developers.md` | drop 3.10 from setup instructions |
| `docs/tutorials/guide-to-enable-llm-agent.md` | `Python 3.10+` → `Python 3.11+` |

### Any related issues, documentation, discussions?

Closes #6269. Proposed in discussion #6247. Motivating case: #6231 (numpy capped at 2.2.6 to stay 3.10-compatible).

### How was this PR tested?

CI: the `pyamber` and `amber-integration` jobs now run on Python 3.11/3.12/3.13. There are no source changes — the amber module already built and tested on 3.11, which was an existing matrix leg. Verified locally that `amber/requirements.txt` + `amber/operator-requirements.txt` resolve on Python 3.11 (`uv pip compile ... --python-version 3.11` → 112 packages, no conflicts).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
