### PR TITLE
chore(pylsp): upgrade container to Python 3.12

### DIFF
--- a/bin/pylsp/Dockerfile
+++ b/bin/pylsp/Dockerfile
@@ -25,13 +25,13 @@
 # has yet to be fully endorsed by the ASF.
 
 # Use an official Python runtime as a parent image
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
 # Install pylsp
-RUN pip install python-lsp-server[all]==1.5.0 python-lsp-server[websockets] pylint==2.15.10
+RUN pip install python-lsp-server[all]==1.14.0 python-lsp-server[websockets] pylint==4.0.6
 RUN apt update
 RUN apt install -y htop
 RUN apt update && apt install -y --no-install-recommends bash htop


### PR DESCRIPTION
### What changes were proposed in this PR?

Upgrade the pyright language-service container (`bin/pylsp/Dockerfile`) to Python 3.12. This container is an environment we build and fully control — it isn't bound to the amber Python support matrix — so it's better to run a newer Python than the support floor.

Bumping the base image alone isn't enough: `python-lsp-server 1.5.0` imports `pkg_resources` at startup, which Python 3.12 no longer ships, so the pinned tools are also bumped to versions with native 3.12 support:

| | before | after |
| --- | --- | --- |
| base image | `python:3.11-slim` | `python:3.12-slim` |
| python-lsp-server | 1.5.0 | 1.14.0 (drops the `pkg_resources` dependency) |
| pylint | 2.15.10 | 4.0.6 |

(base image was `python:3.10-slim` before #6270 landed the 3.11 bump)

### Any related issues, documentation, discussions?

Closes #6282. Raised by @Yicong-Huang in review of #6270 ([comment](https://github.com/apache/texera/pull/6270#discussion_r3546170451)).

#6270 (drop Python 3.10) has merged and moved this line to `3.11-slim`; this branch has been rebased on top, so the diff is now a clean `3.11-slim → 3.12-slim`.

### How was this PR tested?

The pylsp service has no CI stack. The Docker daemon wasn't available locally to build the image, so I verified the substance of the change — that the pinned tools install and run on Python 3.12 — in a clean Python 3.12 environment:

- With the **old** pins, `pylsp` fails to start on 3.12: `ModuleNotFoundError: No module named 'pkg_resources'` (this is the bug the version bumps fix).
- With the **new** pins (pylsp 1.14.0, pylint 4.0.6, astroid 4.0.4, jedi 0.19.2): install succeeds, `pylsp` imports/starts, `pylint` runs, and the pylsp pylint plugin produces diagnostics end-to-end (`pylsp_lint` → C0114/C0116/W0611). The pylint plugin no longer uses the `epylint` entry point that pylint 3.0+ removed.
- The container entrypoint invocation (`pylsp --ws --port 3000 --verbose` in `run_pylsp.sh`) uses flags present in both versions, so it's unchanged.

A maintainer with Docker available may want to confirm the full `docker build` once more before merging.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
