### PR TITLE
fix(frontend): virtualize dataset version file tree

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Browser-mode companion to user-dataset-version-filetree.component.spec.ts.
+// jsdom performs no layout — getBoundingClientRect() is all zeros there — so
+// the tree's virtual scroll measures a 0-height viewport and renders zero
+// rows, and the jsdom spec can only assert an upper bound on rendered rows.
+// These tests run in vitest's Playwright/Chromium browser mode, where the
+// container really lays out, to pin the behaviors that need real geometry:
+// virtualization renders a non-empty window of rows, rows stay exactly
+// TREE_NODE_HEIGHT_PX tall, per-row action buttons fit inside the row, and
+// the container hugs small trees.
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
+import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+
+describe("UserDatasetVersionFiletreeComponent (browser)", () => {
+  let fixture: ComponentFixture<UserDatasetVersionFiletreeComponent>;
+  let component: UserDatasetVersionFiletreeComponent;
+
+  const FILE_COUNT = 1000;
+  function makeFlatFileNodes(count: number): DatasetFileNode[] {
+    return Array.from({ length: count }, (_, i) => ({
+      name: `file_${String(i + 1).padStart(4, "0")}.txt`,
+      type: "file" as const,
+      parentDir: "/owner/dataset/v1",
+      size: 1,
+    }));
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UserDatasetVersionFiletreeComponent],
+    });
+    fixture = TestBed.createComponent(UserDatasetVersionFiletreeComponent);
+    component = fixture.componentInstance;
+  });
+
+  // whenStable flushes the tree-viewport's setTimeout that measures the
+  // viewport height; the second detectChanges renders the measured window.
+  // The input is assigned inside the Angular zone, as a host template binding
+  // would be, so whenStable also waits for the re-measure timer the
+  // fileTreeNodes setter schedules.
+  async function renderTree(nodes: DatasetFileNode[]): Promise<void> {
+    if (fixture.ngZone) {
+      fixture.ngZone.run(() => (component.fileTreeNodes = nodes));
+    } else {
+      component.fileTreeNodes = nodes;
+    }
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it("renders a non-empty virtualized window of rows for a large tree", async () => {
+    await renderTree(makeFlatFileNodes(FILE_COUNT));
+
+    const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
+    expect(renderedRows).toBeGreaterThan(0);
+    expect(renderedRows).toBeLessThan(FILE_COUNT / 5);
+  });
+
+  it("renders rows at exactly the virtual-scroll node height", async () => {
+    await renderTree(makeFlatFileNodes(FILE_COUNT));
+
+    const row = fixture.nativeElement.querySelector(".node-content-wrapper") as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.getBoundingClientRect().height).toBe(component.TREE_NODE_HEIGHT_PX);
+  });
+
+  it("keeps row action buttons inside the fixed-height row", async () => {
+    component.isTreeNodeDeletable = true;
+    await renderTree(makeFlatFileNodes(5));
+
+    const row = fixture.nativeElement.querySelector(".node-content-wrapper") as HTMLElement;
+    const button = row.querySelector("button.icon-button") as HTMLElement;
+    expect(button).not.toBeNull();
+
+    const rowRect = row.getBoundingClientRect();
+    const buttonRect = button.getBoundingClientRect();
+    expect(buttonRect.height).toBeLessThanOrEqual(rowRect.height);
+    expect(buttonRect.top).toBeGreaterThanOrEqual(rowRect.top);
+    expect(buttonRect.bottom).toBeLessThanOrEqual(rowRect.bottom);
+  });
+
+  // The tree measures its viewport height once after init (and again only on
+  // scroll). Both hosts create this component with an empty tree and fill it
+  // when data arrives, so a container sized to content must trigger a
+  // re-measure when its height changes — otherwise the 0px initial
+  // measurement sticks and the tree stays blank forever.
+  it("renders rows when files arrive after an initially-empty tree", async () => {
+    await renderTree([]);
+    await renderTree(makeFlatFileNodes(FILE_COUNT));
+
+    const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
+    expect(renderedRows).toBeGreaterThan(0);
+  });
+
+  it("lays out the container at content height for small trees", async () => {
+    await renderTree(makeFlatFileNodes(3));
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    // 3 rows x 26px pitch + 2px leading drop slot.
+    expect(container.getBoundingClientRect().height).toBe(80);
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
@@ -26,20 +26,11 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
 import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+import { FILE_COUNT, makeFlatFileNodes } from "./user-dataset-version-filetree.test-utils";
 
 describe("UserDatasetVersionFiletreeComponent (browser)", () => {
   let fixture: ComponentFixture<UserDatasetVersionFiletreeComponent>;
   let component: UserDatasetVersionFiletreeComponent;
-
-  const FILE_COUNT = 1000;
-  function makeFlatFileNodes(count: number): DatasetFileNode[] {
-    return Array.from({ length: count }, (_, i) => ({
-      name: `file_${String(i + 1).padStart(4, "0")}.txt`,
-      type: "file",
-      parentDir: "/owner/dataset/v1",
-      size: 1,
-    }));
-  }
 
   beforeEach(() => {
     TestBed.configureTestingModule({

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
@@ -18,14 +18,10 @@
  */
 
 // Browser-mode companion to user-dataset-version-filetree.component.spec.ts.
-// jsdom performs no layout — getBoundingClientRect() is all zeros there — so
-// the tree's virtual scroll measures a 0-height viewport and renders zero
-// rows, and the jsdom spec can only assert an upper bound on rendered rows.
-// These tests run in vitest's Playwright/Chromium browser mode, where the
-// container really lays out, to pin the behaviors that need real geometry:
-// virtualization renders a non-empty window of rows, rows stay exactly
-// TREE_NODE_HEIGHT_PX tall, per-row action buttons fit inside the row, and
-// the container hugs small trees.
+// jsdom does no layout — getBoundingClientRect() is all zeros — so the
+// virtual scroll measures a 0-height viewport and renders zero rows there.
+// These tests run in vitest's Playwright/Chromium browser mode to pin the
+// behaviors that need real geometry.
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
@@ -53,11 +49,9 @@ describe("UserDatasetVersionFiletreeComponent (browser)", () => {
     component = fixture.componentInstance;
   });
 
-  // whenStable flushes the tree-viewport's setTimeout that measures the
-  // viewport height; the second detectChanges renders the measured window.
-  // The input is assigned inside the Angular zone, as a host template binding
-  // would be, so whenStable also waits for the re-measure timer the
-  // fileTreeNodes setter schedules.
+  // Assign inside the Angular zone, as a host binding would, so whenStable
+  // waits for the viewport-measure timers; the second detectChanges renders
+  // the measured window.
   async function renderTree(nodes: DatasetFileNode[]): Promise<void> {
     if (fixture.ngZone) {
       fixture.ngZone.run(() => (component.fileTreeNodes = nodes));
@@ -100,11 +94,9 @@ describe("UserDatasetVersionFiletreeComponent (browser)", () => {
     expect(buttonRect.bottom).toBeLessThanOrEqual(rowRect.bottom);
   });
 
-  // The tree measures its viewport height once after init (and again only on
-  // scroll). Both hosts create this component with an empty tree and fill it
-  // when data arrives, so a container sized to content must trigger a
-  // re-measure when its height changes — otherwise the 0px initial
-  // measurement sticks and the tree stays blank forever.
+  // Both hosts create the tree empty and fill it when data arrives; the
+  // height change must trigger a viewport re-measure or the 0px initial
+  // measurement sticks and the tree stays blank.
   it("renders rows when files arrive after an initially-empty tree", async () => {
     await renderTree([]);
     await renderTree(makeFlatFileNodes(FILE_COUNT));

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
@@ -39,7 +39,7 @@ describe("UserDatasetVersionFiletreeComponent (browser)", () => {
   function makeFlatFileNodes(count: number): DatasetFileNode[] {
     return Array.from({ length: count }, (_, i) => ({
       name: `file_${String(i + 1).padStart(4, "0")}.txt`,
-      type: "file" as const,
+      type: "file",
       parentDir: "/owner/dataset/v1",
       size: 1,
     }));

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.html
@@ -17,7 +17,10 @@
  under the License.
 -->
 
-<div class="file-tree-container">
+<div
+  class="file-tree-container"
+  [style.height.px]="fileTreeContainerHeightPx"
+  [style.--tree-node-height.px]="TREE_NODE_HEIGHT_PX">
   <tree-root
     #tree
     [nodes]="fileTreeNodes"

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
@@ -32,11 +32,27 @@
   user-select: text;
 }
 
-/* Styles for the file tree container */
+/* Styles for the file tree container. The tree's virtual scroll needs a
+   definite viewport height: the container is fixed at 200px, tree-root fills
+   it, and the lib's tree-viewport (height: 100%, overflow: auto) scrolls. */
 .file-tree-container {
-  max-height: 200px; /* Adjust the max-height as needed */
-  overflow-y: auto; /* Enables vertical scrolling when content exceeds max-height */
-  overflow-x: auto; /* Prevents horizontal scrolling */
+  height: 200px;
+  overflow: hidden;
+
+  tree-root {
+    display: block;
+    height: 100%;
+  }
+}
+
+/* Each row must stay exactly TREE_NODE_HEIGHT_PX tall so the virtual scroll
+   positions rows correctly. */
+:host ::ng-deep .file-tree-container .node-content-wrapper {
+  height: 24px;
+  padding-top: 0;
+  padding-bottom: 0;
+  display: flex;
+  align-items: center;
 }
 
 //tree-root .fa-file {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
@@ -21,22 +21,33 @@
   width: 20px;
 }
 
-/* Styles for the delete button */
+/* Styles for the delete / set-cover buttons. ng-zorro's .ant-btn is 32px
+   tall by default, which would bleed out of the fixed-height rows into the
+   neighboring virtualized row (and mis-route clicks near row boundaries). */
 .icon-button {
   width: 15px;
   margin-left: 5px;
+  height: var(--tree-node-height);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-/* Allow text selection so users can copy file/folder names */
+/* Allow text selection so users can copy file/folder names. Keep names on a
+   single line: rows are pinned to the virtual-scroll row height, so a wrapped
+   second line would paint over the next row; long names scroll horizontally
+   inside the tree viewport instead (the title tooltip shows the full name). */
 :host ::ng-deep tree-node-content span {
   user-select: text;
+  white-space: nowrap;
 }
 
 /* Styles for the file tree container. The tree's virtual scroll needs a
-   definite viewport height: the container is fixed at 200px, tree-root fills
-   it, and the lib's tree-viewport (height: 100%, overflow: auto) scrolls. */
+   definite viewport height: the template binds the container height to
+   min(content, 200px) (fileTreeContainerHeightPx), tree-root fills it, and
+   the lib's tree-viewport (height: 100%, overflow: auto) scrolls. */
 .file-tree-container {
-  height: 200px;
   overflow: hidden;
 
   tree-root {
@@ -45,24 +56,13 @@
   }
 }
 
-/* Each row must stay exactly TREE_NODE_HEIGHT_PX tall so the virtual scroll
-   positions rows correctly. */
+/* Each row must stay exactly as tall as the tree's nodeHeight so the virtual
+   scroll positions rows correctly; --tree-node-height is bound in the
+   template from the same TREE_NODE_HEIGHT_PX constant that feeds nodeHeight. */
 :host ::ng-deep .file-tree-container .node-content-wrapper {
-  height: 24px;
+  height: var(--tree-node-height);
   padding-top: 0;
   padding-bottom: 0;
   display: flex;
   align-items: center;
 }
-
-//tree-root .fa-file {
-//  //padding-left: 4%; /* Adjust the value as needed */
-//}
-//
-//tree-root span {
-//  display: inline-block;
-//  max-width: 100%; /* Adjust the width as needed */
-//  text-overflow: ellipsis;
-//  white-space: nowrap;
-//  overflow: hidden;
-//}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
@@ -21,9 +21,8 @@
   width: 20px;
 }
 
-/* Styles for the delete / set-cover buttons. ng-zorro's .ant-btn is 32px
-   tall by default, which would bleed out of the fixed-height rows into the
-   neighboring virtualized row (and mis-route clicks near row boundaries). */
+/* Delete / set-cover buttons: ng-zorro's .ant-btn defaults to 32px tall,
+   which would bleed into the neighboring fixed-height row. */
 .icon-button {
   width: 15px;
   margin-left: 5px;
@@ -34,19 +33,16 @@
   justify-content: center;
 }
 
-/* Allow text selection so users can copy file/folder names. Keep names on a
-   single line: rows are pinned to the virtual-scroll row height, so a wrapped
-   second line would paint over the next row; long names scroll horizontally
-   inside the tree viewport instead (the title tooltip shows the full name). */
+/* Names stay selectable for copying and on a single line — a wrapped line
+   would paint over the next fixed-height row. */
 :host ::ng-deep tree-node-content span {
   user-select: text;
   white-space: nowrap;
 }
 
-/* Styles for the file tree container. The tree's virtual scroll needs a
-   definite viewport height: the template binds the container height to
-   min(content, 200px) (fileTreeContainerHeightPx), tree-root fills it, and
-   the lib's tree-viewport (height: 100%, overflow: auto) scrolls. */
+/* The virtual scroll needs a definite viewport height: the template binds
+   min(content, 200px), tree-root fills it, and the lib's tree-viewport
+   (height: 100%, overflow: auto) scrolls. */
 .file-tree-container {
   overflow: hidden;
 
@@ -56,9 +52,8 @@
   }
 }
 
-/* Each row must stay exactly as tall as the tree's nodeHeight so the virtual
-   scroll positions rows correctly; --tree-node-height is bound in the
-   template from the same TREE_NODE_HEIGHT_PX constant that feeds nodeHeight. */
+/* Rows must stay exactly nodeHeight tall for the virtual scroll to position
+   them; --tree-node-height is bound from the same constant. */
 :host ::ng-deep .file-tree-container .node-content-wrapper {
   height: var(--tree-node-height);
   padding-top: 0;

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -20,20 +20,11 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
 import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+import { FILE_COUNT, makeFlatFileNodes } from "./user-dataset-version-filetree.test-utils";
 
 describe("UserDatasetVersionFiletreeComponent", () => {
   let fixture: ComponentFixture<UserDatasetVersionFiletreeComponent>;
   let component: UserDatasetVersionFiletreeComponent;
-
-  const FILE_COUNT = 1000;
-  function makeFlatFileNodes(count: number): DatasetFileNode[] {
-    return Array.from({ length: count }, (_, i) => ({
-      name: `file_${String(i + 1).padStart(4, "0")}.txt`,
-      type: "file",
-      parentDir: "/owner/dataset/v1",
-      size: 1,
-    }));
-  }
 
   function makeFolderNode(fileCount: number): DatasetFileNode {
     return {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
+import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+
+describe("UserDatasetVersionFiletreeComponent", () => {
+  let fixture: ComponentFixture<UserDatasetVersionFiletreeComponent>;
+  let component: UserDatasetVersionFiletreeComponent;
+
+  const FILE_COUNT = 1000;
+  function makeFlatFileNodes(count: number): DatasetFileNode[] {
+    return Array.from({ length: count }, (_, i) => ({
+      name: `file_${String(i + 1).padStart(4, "0")}.txt`,
+      type: "file" as const,
+      parentDir: "/owner/dataset/v1",
+      size: 1,
+    }));
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UserDatasetVersionFiletreeComponent],
+    });
+    fixture = TestBed.createComponent(UserDatasetVersionFiletreeComponent);
+    component = fixture.componentInstance;
+  });
+
+  // Regression tests for the frontend freeze when a dataset version has
+  // hundreds of files: the tree must virtualize its rows instead of creating
+  // one component per file.
+  it("enables virtual scrolling with a fixed node height", () => {
+    expect(component.fileTreeDisplayOptions.useVirtualScroll).toBe(true);
+    expect(typeof component.fileTreeDisplayOptions.nodeHeight).toBe("number");
+  });
+
+  it("keeps the full tree in the model without one DOM row per file", async () => {
+    component.fileTreeNodes = makeFlatFileNodes(FILE_COUNT);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.tree.treeModel.roots.length).toBe(FILE_COUNT);
+    const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
+    expect(renderedRows).toBeLessThan(FILE_COUNT / 5);
+  });
+
+  it("emits selectedTreeNode when a leaf node is clicked", () => {
+    component.fileTreeNodes = makeFlatFileNodes(1);
+    const emitted: DatasetFileNode[] = [];
+    component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
+
+    // Invoke the tree's real click handler with a stub leaf node; the handler
+    // only reads hasChildren and data, so tree and $event are unused.
+    const onClick = component.fileTreeDisplayOptions.actionMapping!.mouse!.click!;
+    const leafNode = { hasChildren: false, data: component.fileTreeNodes[0] } as never;
+    onClick(undefined as never, leafNode, undefined as never);
+
+    expect(emitted).toEqual([component.fileTreeNodes[0]]);
+  });
+
+  it("emits deletedTreeNode when a node deletion is requested", () => {
+    component.fileTreeNodes = makeFlatFileNodes(1);
+    const emitted: DatasetFileNode[] = [];
+    component.deletedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
+
+    component.onNodeDeleted(component.fileTreeNodes[0]);
+
+    expect(emitted).toEqual([component.fileTreeNodes[0]]);
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -43,13 +43,11 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     component = fixture.componentInstance;
   });
 
-  // Regression tests for the frontend freeze when a dataset version has
-  // hundreds of files: the tree must virtualize its rows instead of creating
-  // one component per file.
+  // Regression tests for the freeze on versions with hundreds of files: the
+  // tree must virtualize instead of rendering one component per file.
   it("enables virtual scrolling with the 24px node height the row styles pin", () => {
     expect(component.fileTreeDisplayOptions.useVirtualScroll).toBe(true);
-    // The SCSS row height consumes --tree-node-height, which the template
-    // binds from the same constant, so 24 here is the single design value.
+    // 24 is the single design value; the SCSS consumes it via --tree-node-height.
     expect(component.fileTreeDisplayOptions.nodeHeight).toBe(24);
   });
 
@@ -65,10 +63,8 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     expect(renderedRows).toBeLessThan(FILE_COUNT / 5);
   });
 
-  // The container must hug small trees (the pre-virtualization behavior)
-  // while giving the virtual scroll a definite, capped viewport for large
-  // ones. Content height follows the tree's row pitch: nodeHeight plus a 2px
-  // drop slot per row, plus one extra leading 2px drop slot on the first row.
+  // The container hugs small trees and caps at 200px; heights follow the
+  // tree's 26px row pitch plus a 2px leading drop slot.
   it("collapses the container when there are no files", () => {
     component.fileTreeNodes = [];
     fixture.detectChanges();
@@ -97,8 +93,8 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     const emitted: DatasetFileNode[] = [];
     component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
 
-    // The folder branch of the click handler delegates to the tree action
-    // TOGGLE_EXPANDED, which only calls node.toggleExpanded().
+    // The folder branch delegates to TOGGLE_EXPANDED, which only calls
+    // node.toggleExpanded().
     let toggleCalls = 0;
     const onClick = component.fileTreeDisplayOptions.actionMapping!.mouse!.click!;
     const folderNode = {
@@ -119,8 +115,7 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     const emitted: DatasetFileNode[] = [];
     component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
 
-    // Invoke the tree's real click handler with a stub leaf node; the handler
-    // only reads hasChildren and data, so tree and $event are unused.
+    // The handler only reads hasChildren and data; tree and $event are unused.
     const onClick = component.fileTreeDisplayOptions.actionMapping!.mouse!.click!;
     const leafNode = { hasChildren: false, data: component.fileTreeNodes[0] } as never;
     onClick(undefined as never, leafNode, undefined as never);

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -29,7 +29,7 @@ describe("UserDatasetVersionFiletreeComponent", () => {
   function makeFlatFileNodes(count: number): DatasetFileNode[] {
     return Array.from({ length: count }, (_, i) => ({
       name: `file_${String(i + 1).padStart(4, "0")}.txt`,
-      type: "file" as const,
+      type: "file",
       parentDir: "/owner/dataset/v1",
       size: 1,
     }));
@@ -106,7 +106,7 @@ describe("UserDatasetVersionFiletreeComponent", () => {
       toggleExpanded: () => {
         toggleCalls++;
       },
-      data: { name: "dir", type: "directory" as const, parentDir: "/owner/dataset/v1" },
+      data: { name: "dir", type: "directory", parentDir: "/owner/dataset/v1" },
     } as never;
     onClick(undefined as never, folderNode, undefined as never);
 

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -35,6 +35,15 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     }));
   }
 
+  function makeFolderNode(fileCount: number): DatasetFileNode {
+    return {
+      name: "dir",
+      type: "directory",
+      parentDir: "/owner/dataset/v1",
+      children: makeFlatFileNodes(fileCount),
+    };
+  }
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [UserDatasetVersionFiletreeComponent],
@@ -89,6 +98,31 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     expect(container.style.height).toBe("200px");
   });
 
+  it("counts nested folder contents when sizing the container", () => {
+    component.fileTreeNodes = [makeFolderNode(2)]; // 1 folder + 2 files = 3 rows when expanded
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("80px");
+  });
+
+  it("treats a missing files input as an empty tree", () => {
+    component.fileTreeNodes = undefined as unknown as DatasetFileNode[];
+    fixture.detectChanges();
+
+    expect(component.fileTreeNodes).toEqual([]);
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("0px");
+  });
+
+  it("expands all folders after view init when isExpandAllAfterViewInit is set", () => {
+    component.isExpandAllAfterViewInit = true;
+    component.fileTreeNodes = [makeFolderNode(2)];
+    fixture.detectChanges();
+
+    expect(component.tree.treeModel.roots[0].isExpanded).toBe(true);
+  });
+
   it("toggles expansion without emitting selectedTreeNode when a folder is clicked", () => {
     const emitted: DatasetFileNode[] = [];
     component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
@@ -131,5 +165,21 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     component.onNodeDeleted(component.fileTreeNodes[0]);
 
     expect(emitted).toEqual([component.fileTreeNodes[0]]);
+  });
+
+  it("identifies image files by extension, case-insensitively", () => {
+    expect(component.isImageFile("photo.PNG")).toBe(true);
+    expect(component.isImageFile("data.csv")).toBe(false);
+  });
+
+  it("emits the file's dataset-relative path when set as cover", () => {
+    const emitted: string[] = [];
+    component.setCoverImage.subscribe((path: string) => emitted.push(path));
+
+    // parentDir has exactly the three stripped segments (owner/dataset/version),
+    // so the relative path is just the file name.
+    component.onSetCover({ name: "photo.png", type: "file", parentDir: "/owner/dataset/v1" });
+
+    expect(emitted).toEqual(["photo.png"]);
   });
 });

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -46,9 +46,11 @@ describe("UserDatasetVersionFiletreeComponent", () => {
   // Regression tests for the frontend freeze when a dataset version has
   // hundreds of files: the tree must virtualize its rows instead of creating
   // one component per file.
-  it("enables virtual scrolling with a fixed node height", () => {
+  it("enables virtual scrolling with the 24px node height the row styles pin", () => {
     expect(component.fileTreeDisplayOptions.useVirtualScroll).toBe(true);
-    expect(typeof component.fileTreeDisplayOptions.nodeHeight).toBe("number");
+    // The SCSS row height consumes --tree-node-height, which the template
+    // binds from the same constant, so 24 here is the single design value.
+    expect(component.fileTreeDisplayOptions.nodeHeight).toBe(24);
   });
 
   it("keeps the full tree in the model without one DOM row per file", async () => {
@@ -61,6 +63,55 @@ describe("UserDatasetVersionFiletreeComponent", () => {
     expect(component.tree.treeModel.roots.length).toBe(FILE_COUNT);
     const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
     expect(renderedRows).toBeLessThan(FILE_COUNT / 5);
+  });
+
+  // The container must hug small trees (the pre-virtualization behavior)
+  // while giving the virtual scroll a definite, capped viewport for large
+  // ones. Content height follows the tree's row pitch: nodeHeight plus a 2px
+  // drop slot per row, plus one extra leading 2px drop slot on the first row.
+  it("collapses the container when there are no files", () => {
+    component.fileTreeNodes = [];
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("0px");
+  });
+
+  it("sizes the container to its content for small trees", () => {
+    component.fileTreeNodes = makeFlatFileNodes(3);
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("80px"); // 3 rows x 26px pitch + 2px leading drop slot
+  });
+
+  it("caps the container height at 200px for large trees", () => {
+    component.fileTreeNodes = makeFlatFileNodes(FILE_COUNT);
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("200px");
+  });
+
+  it("toggles expansion without emitting selectedTreeNode when a folder is clicked", () => {
+    const emitted: DatasetFileNode[] = [];
+    component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
+
+    // The folder branch of the click handler delegates to the tree action
+    // TOGGLE_EXPANDED, which only calls node.toggleExpanded().
+    let toggleCalls = 0;
+    const onClick = component.fileTreeDisplayOptions.actionMapping!.mouse!.click!;
+    const folderNode = {
+      hasChildren: true,
+      toggleExpanded: () => {
+        toggleCalls++;
+      },
+      data: { name: "dir", type: "directory" as const, parentDir: "/owner/dataset/v1" },
+    } as never;
+    onClick(undefined as never, folderNode, undefined as never);
+
+    expect(toggleCalls).toBe(1);
+    expect(emitted).toEqual([]);
   });
 
   it("emits selectedTreeNode when a leaf node is clicked", () => {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
@@ -42,6 +42,19 @@ const TREE_DROP_SLOT_HEIGHT_PX = 2;
 // before virtualization.
 const MAX_FILE_TREE_CONTAINER_HEIGHT_PX = 200;
 
+// The library throttles viewport re-measures (TreeViewportComponent's
+// setViewport) to one per 17ms, leading-edge only: a call landing inside the
+// window is dropped and never re-fired. A re-measure scheduled on the next
+// macrotask can land within 17ms of the tree's own post-init measurement and
+// be silently swallowed (leaving a permanently blank tree), so wait out the
+// throttle window before asking for one.
+const TREE_VIEWPORT_REMEASURE_DELAY_MS = 25;
+
+// Total node count across the whole tree, including collapsed descendants.
+function countNodes(nodes: DatasetFileNode[]): number {
+  return nodes.reduce((count, node) => count + 1 + countNodes(node.children ?? []), 0);
+}
+
 @UntilDestroy()
 @Component({
   selector: "texera-user-dataset-version-filetree",
@@ -71,11 +84,13 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
       // on scroll. Both hosts create this component with an empty tree and
       // fill it when data arrives, so ask the tree to re-measure once change
       // detection has applied the new container height — otherwise the 0px
-      // initial measurement sticks and the tree renders blank. The same
-      // one-shot measurement means a host must never instantiate this
-      // component inside a hidden (display: none) container without calling
-      // tree.sizeChanged() on reveal.
-      setTimeout(() => this.tree?.sizeChanged());
+      // initial measurement sticks and the tree renders blank. The delay must
+      // clear the library's re-measure throttle (see
+      // TREE_VIEWPORT_REMEASURE_DELAY_MS). The same one-shot measurement means
+      // a host must never instantiate this component inside a hidden
+      // (display: none) container without calling tree.sizeChanged() on
+      // reveal.
+      setTimeout(() => this.tree?.sizeChanged(), TREE_VIEWPORT_REMEASURE_DELAY_MS);
     }
   }
   public get fileTreeNodes(): DatasetFileNode[] {
@@ -146,26 +161,18 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
     return IMAGE_EXTENSIONS.some(ext => fileName.toLowerCase().endsWith(ext));
   }
 
-  // Content height for the whole tree at the library's row pitch. The count
+  // Content height for the whole tree at the library's row pitch. countNodes
   // includes collapsed descendants, so a partially collapsed folder tree may
   // get a container slightly taller than its visible rows — still bounded by
   // the cap, and exact for the flat file lists both hosts show.
   private computeContainerHeightPx(): number {
-    const nodeCount = UserDatasetVersionFiletreeComponent.countNodes(this._fileTreeNodes);
+    const nodeCount = countNodes(this._fileTreeNodes);
     if (nodeCount === 0) {
       return 0;
     }
     const contentHeightPx =
       nodeCount * (this.TREE_NODE_HEIGHT_PX + TREE_DROP_SLOT_HEIGHT_PX) + TREE_DROP_SLOT_HEIGHT_PX;
     return Math.min(contentHeightPx, MAX_FILE_TREE_CONTAINER_HEIGHT_PX);
-  }
-
-  private static countNodes(nodes: DatasetFileNode[]): number {
-    let count = 0;
-    for (const node of nodes) {
-      count += 1 + (node.children ? UserDatasetVersionFiletreeComponent.countNodes(node.children) : 0);
-    }
-    return count;
   }
 
   onSetCover(nodeData: DatasetFileNode): void {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
@@ -63,9 +63,18 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   @Output()
   setCoverImage = new EventEmitter<string>();
 
+  // Row height (px) used by the tree's virtual scroll to position rows; must
+  // match the row height pinned in the SCSS.
+  public readonly TREE_NODE_HEIGHT_PX = 24;
+
+  // useVirtualScroll keeps only the visible rows in the DOM; without it a
+  // version with hundreds of files renders one component per file and every
+  // change-detection pass freezes the page for seconds to minutes.
   public fileTreeDisplayOptions: ITreeOptions = {
     displayField: "name",
     hasChildrenField: "children",
+    useVirtualScroll: true,
+    nodeHeight: this.TREE_NODE_HEIGHT_PX,
     actionMapping: {
       mouse: {
         click: (tree: any, node: any, $event: any) => {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
@@ -33,6 +33,15 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 
 const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".webp"] as const;
 
+// The tree library lays rows out on a fixed pitch: nodeHeight plus a 2px drop
+// slot after every row (its default dropSlotHeight), with one extra leading
+// drop slot before the first row.
+const TREE_DROP_SLOT_HEIGHT_PX = 2;
+
+// Cap on the container height; matches the max-height the container had
+// before virtualization.
+const MAX_FILE_TREE_CONTAINER_HEIGHT_PX = 200;
+
 @UntilDestroy()
 @Component({
   selector: "texera-user-dataset-version-filetree",
@@ -53,7 +62,26 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   public isTreeNodeDeletable: boolean = false;
 
   @Input()
-  public fileTreeNodes: DatasetFileNode[] = [];
+  public set fileTreeNodes(nodes: DatasetFileNode[]) {
+    this._fileTreeNodes = nodes ?? [];
+    const newHeight = this.computeContainerHeightPx();
+    if (newHeight !== this.fileTreeContainerHeightPx) {
+      this.fileTreeContainerHeightPx = newHeight;
+      // The tree measures its viewport height once after init and again only
+      // on scroll. Both hosts create this component with an empty tree and
+      // fill it when data arrives, so ask the tree to re-measure once change
+      // detection has applied the new container height — otherwise the 0px
+      // initial measurement sticks and the tree renders blank. The same
+      // one-shot measurement means a host must never instantiate this
+      // component inside a hidden (display: none) container without calling
+      // tree.sizeChanged() on reveal.
+      setTimeout(() => this.tree?.sizeChanged());
+    }
+  }
+  public get fileTreeNodes(): DatasetFileNode[] {
+    return this._fileTreeNodes;
+  }
+  private _fileTreeNodes: DatasetFileNode[] = [];
 
   @Input()
   public isExpandAllAfterViewInit = false;
@@ -63,9 +91,16 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   @Output()
   setCoverImage = new EventEmitter<string>();
 
-  // Row height (px) used by the tree's virtual scroll to position rows; must
-  // match the row height pinned in the SCSS.
+  // Row height (px) used by the tree's virtual scroll to position rows. The
+  // template binds it onto the container as --tree-node-height, which the
+  // SCSS row rules consume, so rows can never drift from the nodeHeight the
+  // tree positions them with.
   public readonly TREE_NODE_HEIGHT_PX = 24;
+
+  // Container height bound in the template: hugs the content for small trees
+  // (the pre-virtualization behavior) and caps at 200px for large ones so the
+  // virtual scroll has a definite, bounded viewport.
+  public fileTreeContainerHeightPx = 0;
 
   // useVirtualScroll keeps only the visible rows in the DOM; without it a
   // version with hundreds of files renders one component per file and every
@@ -109,6 +144,28 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
 
   isImageFile(fileName: string): boolean {
     return IMAGE_EXTENSIONS.some(ext => fileName.toLowerCase().endsWith(ext));
+  }
+
+  // Content height for the whole tree at the library's row pitch. The count
+  // includes collapsed descendants, so a partially collapsed folder tree may
+  // get a container slightly taller than its visible rows — still bounded by
+  // the cap, and exact for the flat file lists both hosts show.
+  private computeContainerHeightPx(): number {
+    const nodeCount = UserDatasetVersionFiletreeComponent.countNodes(this._fileTreeNodes);
+    if (nodeCount === 0) {
+      return 0;
+    }
+    const contentHeightPx =
+      nodeCount * (this.TREE_NODE_HEIGHT_PX + TREE_DROP_SLOT_HEIGHT_PX) + TREE_DROP_SLOT_HEIGHT_PX;
+    return Math.min(contentHeightPx, MAX_FILE_TREE_CONTAINER_HEIGHT_PX);
+  }
+
+  private static countNodes(nodes: DatasetFileNode[]): number {
+    let count = 0;
+    for (const node of nodes) {
+      count += 1 + (node.children ? UserDatasetVersionFiletreeComponent.countNodes(node.children) : 0);
+    }
+    return count;
   }
 
   onSetCover(nodeData: DatasetFileNode): void {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
@@ -33,21 +33,16 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 
 const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".webp"] as const;
 
-// The tree library lays rows out on a fixed pitch: nodeHeight plus a 2px drop
-// slot after every row (its default dropSlotHeight), with one extra leading
-// drop slot before the first row.
+// The library adds a 2px drop slot after every row, plus one extra leading
+// slot before the first row.
 const TREE_DROP_SLOT_HEIGHT_PX = 2;
 
-// Cap on the container height; matches the max-height the container had
-// before virtualization.
+// Container height cap; matches the pre-virtualization max-height.
 const MAX_FILE_TREE_CONTAINER_HEIGHT_PX = 200;
 
-// The library throttles viewport re-measures (TreeViewportComponent's
-// setViewport) to one per 17ms, leading-edge only: a call landing inside the
-// window is dropped and never re-fired. A re-measure scheduled on the next
-// macrotask can land within 17ms of the tree's own post-init measurement and
-// be silently swallowed (leaving a permanently blank tree), so wait out the
-// throttle window before asking for one.
+// The library throttles viewport re-measures to one per 17ms, leading-edge
+// only — a call inside the window is dropped and never re-fired, so
+// re-measures must wait out the window.
 const TREE_VIEWPORT_REMEASURE_DELAY_MS = 25;
 
 // Total node count across the whole tree, including collapsed descendants.
@@ -80,16 +75,11 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
     const newHeight = this.computeContainerHeightPx();
     if (newHeight !== this.fileTreeContainerHeightPx) {
       this.fileTreeContainerHeightPx = newHeight;
-      // The tree measures its viewport height once after init and again only
-      // on scroll. Both hosts create this component with an empty tree and
-      // fill it when data arrives, so ask the tree to re-measure once change
-      // detection has applied the new container height — otherwise the 0px
-      // initial measurement sticks and the tree renders blank. The delay must
-      // clear the library's re-measure throttle (see
-      // TREE_VIEWPORT_REMEASURE_DELAY_MS). The same one-shot measurement means
-      // a host must never instantiate this component inside a hidden
-      // (display: none) container without calling tree.sizeChanged() on
-      // reveal.
+      // The tree measures its viewport once after init and again only on
+      // scroll, so a height change must trigger a re-measure (delayed past
+      // the throttle) — otherwise a tree that starts empty stays blank. For
+      // the same reason, a host that creates this component hidden must call
+      // tree.sizeChanged() on reveal.
       setTimeout(() => this.tree?.sizeChanged(), TREE_VIEWPORT_REMEASURE_DELAY_MS);
     }
   }
@@ -106,20 +96,16 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   @Output()
   setCoverImage = new EventEmitter<string>();
 
-  // Row height (px) used by the tree's virtual scroll to position rows. The
-  // template binds it onto the container as --tree-node-height, which the
-  // SCSS row rules consume, so rows can never drift from the nodeHeight the
-  // tree positions them with.
+  // Row height used by the virtual scroll; the template binds it as
+  // --tree-node-height so the SCSS row rules stay in sync with nodeHeight.
   public readonly TREE_NODE_HEIGHT_PX = 24;
 
-  // Container height bound in the template: hugs the content for small trees
-  // (the pre-virtualization behavior) and caps at 200px for large ones so the
-  // virtual scroll has a definite, bounded viewport.
+  // min(content, 200px); bound in the template so small trees hug their
+  // content while the virtual scroll keeps a definite viewport.
   public fileTreeContainerHeightPx = 0;
 
-  // useVirtualScroll keeps only the visible rows in the DOM; without it a
-  // version with hundreds of files renders one component per file and every
-  // change-detection pass freezes the page for seconds to minutes.
+  // useVirtualScroll keeps only the visible rows in the DOM; without it,
+  // hundreds of files freeze the page for seconds to minutes.
   public fileTreeDisplayOptions: ITreeOptions = {
     displayField: "name",
     hasChildrenField: "children",
@@ -147,7 +133,6 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   constructor() {}
 
   onNodeDeleted(node: DatasetFileNode): void {
-    // look up for the DatasetVersionFileTreeNode
     this.deletedTreeNode.emit(node);
   }
 
@@ -161,10 +146,8 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
     return IMAGE_EXTENSIONS.some(ext => fileName.toLowerCase().endsWith(ext));
   }
 
-  // Content height for the whole tree at the library's row pitch. countNodes
-  // includes collapsed descendants, so a partially collapsed folder tree may
-  // get a container slightly taller than its visible rows — still bounded by
-  // the cap, and exact for the flat file lists both hosts show.
+  // countNodes includes collapsed descendants, so a partially collapsed tree
+  // may get a slightly taller container — still bounded by the cap.
   private computeContainerHeightPx(): number {
     const nodeCount = countNodes(this._fileTreeNodes);
     if (nodeCount === 0) {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.test-utils.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.test-utils.ts
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Shared fixtures for UserDatasetVersionFiletreeComponent specs.
+ *
+ * The filetree has two spec files that drive the same component:
+ *   - user-dataset-version-filetree.component.spec.ts          (jsdom test target)
+ *   - user-dataset-version-filetree.component.browser.spec.ts  (test-browser target,
+ *                                                               for the virtual scroll
+ *                                                               paths that need real
+ *                                                               geometry)
+ *
+ * Both specs build the same flat file trees. Exporting the factory here
+ * keeps them from drifting over time.
+ */
+
+import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+
+export const FILE_COUNT = 1000;
+
+export function makeFlatFileNodes(count: number): DatasetFileNode[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `file_${String(i + 1).padStart(4, "0")}.txt`,
+    type: "file",
+    parentDir: "/owner/dataset/v1",
+    size: 1,
+  }));
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.test-utils.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.test-utils.ts
@@ -18,17 +18,8 @@
  */
 
 /**
- * Shared fixtures for UserDatasetVersionFiletreeComponent specs.
- *
- * The filetree has two spec files that drive the same component:
- *   - user-dataset-version-filetree.component.spec.ts          (jsdom test target)
- *   - user-dataset-version-filetree.component.browser.spec.ts  (test-browser target,
- *                                                               for the virtual scroll
- *                                                               paths that need real
- *                                                               geometry)
- *
- * Both specs build the same flat file trees. Exporting the factory here
- * keeps them from drifting over time.
+ * Fixtures shared by the filetree component's jsdom and browser specs so the
+ * two cannot drift.
  */
 
 import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR fixes the frontend issue where opening a dataset whose selected version contains hundreds of files freezes the frontend for tens of seconds to minutes. 

Root cause: the version file tree renders every file as a full tree-node component (`@ali-hm/angular-tree-component` with virtualization disabled), and each row's `nz-button` re-reads layout after every change-detection pass.

Measured on the local dev stack (`ng serve`, Chrome, Long Tasks API), datasets of N one-byte files:

| N files | Page usable after (before → after) | Main thread blocked (before → after) | DOM rows (before → after) |
|---|---|---|---|
| 400 | 24.5 s → 1.3 s | 22.2 s → 0.2 s | 400 → 28 |

### Any related issues, documentation, discussions?

Closes #6281. Related to #5586 (same unbounded-rendering pattern in the upload lists).

### How was this PR tested?

https://github.com/user-attachments/assets/702b6ffa-7ac3-479e-9ac0-f1f186aa4739

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code, Claude Fable 5

