### PR TITLE
fix(deps): upgrade bouncycastle to fix CVE-2025-14813

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -60,11 +60,25 @@ lazy val universalJvmFlagsSettings = Seq(
 lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings
 lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings
 
+val bouncyCastleVersion = "1.84"
+
+lazy val bouncyCastleOverrides = Seq(
+  "org.bouncycastle" % "bcpkix-jdk18on" % bouncyCastleVersion,
+  "org.bouncycastle" % "bcprov-jdk18on" % bouncyCastleVersion,
+  "org.bouncycastle" % "bcutil-jdk18on" % bouncyCastleVersion
+)
+
+lazy val commonDependencyOverrides = Seq(
+  dependencyOverrides ++= bouncyCastleOverrides
+)
+
 // Aggregate of the settings every module shares. These are independent
 // concerns — ASF licensing, jacoco XML coverage, and universal JVM flags —
 // grouped only so each module can apply them with a single .settings(...) call.
-lazy val commonModuleSettings = asfLicensingSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
-lazy val commonModuleSettingsWithVendored = asfLicensingSettingsWithVendored ++ coverageReportSettings ++ universalJvmFlagsSettings
+lazy val commonModuleSettings =
+  asfLicensingSettings ++ coverageReportSettings ++ universalJvmFlagsSettings ++ commonDependencyOverrides
+lazy val commonModuleSettingsWithVendored =
+  asfLicensingSettingsWithVendored ++ coverageReportSettings ++ universalJvmFlagsSettings ++ commonDependencyOverrides
 
 val jacksonVersion = "2.18.8"
 

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -530,9 +530,9 @@ Source files derived from third-party MIT-licensed projects:
 
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
-  - org.bouncycastle.bcpkix-jdk18on-1.78.1.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
-  - org.bouncycastle.bcutil-jdk18on-1.78.1.jar
+  - org.bouncycastle.bcpkix-jdk18on-1.84.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
+  - org.bouncycastle.bcutil-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR pins the Bouncy Castle JDK 18 artifacts to `1.84` through shared sbt `dependencyOverrides`:

| Artifact | Version |
| --- | --- |
| `org.bouncycastle:bcpkix-jdk18on` | `1.84` |
| `org.bouncycastle:bcprov-jdk18on` | `1.84` |
| `org.bouncycastle:bcutil-jdk18on` | `1.84` |

It also updates `computing-unit-managing-service/LICENSE-binary` to match the resolved bundled jar versions.

### Any related issues, documentation, discussions?

Related security report: https://github.com/apache/texera/security/dependabot/782

### How was this PR tested?

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) sbt 'show ComputingUnitManagingService / dependencyOverrides' 'show ComputingUnitManagingService / update' | rg 'bouncycastle|bcprov|bcpkix|bcutil|\[success\]|\[error\]'
```

Confirmed `bcpkix-jdk18on`, `bcprov-jdk18on`, and `bcutil-jdk18on` all resolve to `1.84`.


### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)

