### PR TITLE
fix(frontend): highlight active About and Feedback sidebar items

### DIFF
--- a/frontend/src/app/dashboard/component/dashboard.component.html
+++ b/frontend/src/app/dashboard/component/dashboard.component.html
@@ -204,6 +204,7 @@
         *ngIf="sidebarTabs.about_enabled"
         nz-menu-item
         nz-tooltip
+        nzMatchRouter="true"
         nzTooltipPlacement="right"
         [routerLink]="ABOUT">
         <span
@@ -216,6 +217,7 @@
         *ngIf="isLogin"
         nz-menu-item
         nz-tooltip
+        nzMatchRouter="true"
         nzTooltipPlacement="right"
         [routerLink]="USER_FEEDBACK">
         <span

--- a/frontend/src/app/dashboard/component/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/component/dashboard.component.spec.ts
@@ -286,4 +286,55 @@ describe("DashboardComponent", () => {
     // 7 "Your Work" links (incl. Python Venvs) + 4 admin links + 1 about link + 1 feedback link = 13
     expect(fixture.debugElement.queryAll(By.directive(RouterLink)).length).toBe(13);
   });
+
+  describe("sidebar active-route highlighting (#3490)", () => {
+    const fullSidebarTabs = {
+      hub_enabled: false,
+      home_enabled: true,
+      workflow_enabled: true,
+      dataset_enabled: true,
+      your_work_enabled: true,
+      projects_enabled: true,
+      workflows_enabled: true,
+      datasets_enabled: true,
+      compute_enabled: true,
+      quota_enabled: true,
+      forum_enabled: true,
+      about_enabled: true,
+    };
+
+    // Find a rendered nz-menu-item <li> by its visible label; componentInstance is the
+    // NzMenuItemComponent, whose nzMatchRouter input decides whether it gets the
+    // .ant-menu-item-selected highlight on its active route.
+    const menuItemByLabel = (label: string) =>
+      fixture.debugElement
+        .queryAll(By.css("li[nz-menu-item]"))
+        .find(de => (de.nativeElement.textContent || "").trim() === label);
+
+    beforeEach(() => {
+      (userServiceMock.isLogin as Mock).mockReturnValue(true);
+      component.isLogin = true;
+      component.isAdmin = true;
+      component.sidebarTabs = fullSidebarTabs;
+      fixture.detectChanges();
+    });
+
+    it("enables nzMatchRouter on the About item so it highlights when active", () => {
+      const about = menuItemByLabel("About");
+      expect(about).toBeTruthy();
+      expect(about!.componentInstance.nzMatchRouter).toBe(true);
+    });
+
+    it("enables nzMatchRouter on the Feedback item so it highlights when active", () => {
+      const feedback = menuItemByLabel("Feedback");
+      expect(feedback).toBeTruthy();
+      expect(feedback!.componentInstance.nzMatchRouter).toBe(true);
+    });
+
+    it("(reference) Your Work items already enable nzMatchRouter", () => {
+      const quota = menuItemByLabel("Quota");
+      expect(quota).toBeTruthy();
+      expect(quota!.componentInstance.nzMatchRouter).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Sidebar active-route highlighting was inconsistent (#3490). The **About** and **Feedback** items were plain `nz-menu-item`s with a `[routerLink]` but **no `nzMatchRouter`**, so — unlike Your Work / Admin / Hub — they never entered ng-zorro's `.ant-menu-item-selected` state and weren't highlighted when active. Added `nzMatchRouter="true"` to both, giving them the same background + blue text + right accent bar.

Note on the report: the issue also lists **Hub**, but the Hub items already have `nzMatchRouter` and route to real paths, so they already highlight correctly (confirmed on the running app) — no Hub change was needed.

<img width="1536" height="697" alt="image" src="https://github.com/user-attachments/assets/7814362b-1361-4d34-8363-0075298fee15" />

<img width="1536" height="697" alt="image" src="https://github.com/user-attachments/assets/21a3db41-baa2-4d81-bb19-24c34200694f" />

<img width="1536" height="702" alt="image" src="https://github.com/user-attachments/assets/8b84fc40-c255-40ba-a557-cdfa1dda6c69" />


### Any related issues, documentation, or discussions?

Closes #3490

### How was this PR tested?

Unit tests (Vitest) — added #3490 cases to `dashboard.component.spec.ts` asserting the About and Feedback items enable `nzMatchRouter` (with a Your Work item as a passing reference):

corepack yarn ng test --watch=false --include="**/dashboard.component.spec.ts"
→ **14/14 passing** (the 2 new About/Feedback cases were red before the fix).

Manual: `ng serve`, navigated to `/about` — About now shows the active highlight like Your Work; confirmed Hub items already highlight.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Yes, Alongside Claude Code