### PR TITLE
test(frontend): cover ShareAccessService

### DIFF
--- a/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
@@ -18,17 +18,24 @@
  */
 
 
-import {ShareAccessService} from "./share-access.service";
-import {HttpTestingController} from "@angular/common/http/testing";
+import {BASE, ShareAccessService} from "./share-access.service";
+import {HttpClientTestingModule, HttpTestingController} from "@angular/common/http/testing";
 import {TestBed} from "@angular/core/testing";
+import {ShareAccess} from "../../../type/share-access.interface";
 
 describe('ShareAccessService', () => {
   let service: ShareAccessService
   let httpMock: HttpTestingController
 
+  const type : string = 'resource'
+  const id : number = 42
+  const email : string = 'johnDoe@gmail.com'
+  const privilege : string = 'write'
+  const username : string = "johnDaBeast1999"
+
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpTestingController],
+      imports: [HttpClientTestingModule],
       providers: [ShareAccessService]
     })
     service = TestBed.inject(ShareAccessService);
@@ -37,5 +44,60 @@ describe('ShareAccessService', () => {
 
   afterEach(() => {
     httpMock.verify();
+  })
+
+  it("grantAccess composes the correct PUT url", () => {
+    service.grantAccess(type, id, email, privilege).subscribe()
+
+    const req = httpMock.expectOne(
+      `${BASE}/${type}/grant/${id}/${email}/${privilege}`
+    )
+
+    expect(req.request.method).toBe('PUT')
+    req.flush(null)
+  })
+
+  it("revokeAccess composes the correct DELETE url", () => {
+    service.revokeAccess(type, id, username).subscribe()
+
+    const req = httpMock.expectOne(
+      `${BASE}/${type}/revoke/${id}/${username}`
+    )
+
+    expect(req.request.method).toBe('DELETE')
+    req.flush(null)
+  })
+
+  it("getOwner should respond with type text", () => {
+    service.getOwner(type, id).subscribe()
+
+    const req = httpMock.expectOne(
+      `${BASE}/${type}/owner/${id}`
+    )
+
+    expect(req.request.method).toBe('GET')
+    expect(req.request.responseType).toBe('text')
+    req.flush(null)
+  })
+
+  it("getAccessList should resolve to an array", () => {
+    const mockList = [
+      { username: 'JohnDaBeast1999', privilege: 'write' },
+      { username: 'alice', privilege: 'read' },
+    ];
+
+    let result : ReadonlyArray<ShareAccess> | undefined
+    service.getAccessList(type, id).subscribe(res => {
+      result = res
+    })
+
+    const req = httpMock.expectOne(
+      `${BASE}/${type}/list/${id}`
+    )
+
+    expect(req.request.method).toBe('GET')
+    req.flush(mockList)
+
+    expect(result).toBe(mockList)
   })
 });

--- a/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
@@ -17,87 +17,78 @@
  * under the License.
  */
 
+import { BASE, ShareAccessService } from "./share-access.service";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { TestBed } from "@angular/core/testing";
+import { ShareAccess } from "../../../type/share-access.interface";
 
-import {BASE, ShareAccessService} from "./share-access.service";
-import {HttpClientTestingModule, HttpTestingController} from "@angular/common/http/testing";
-import {TestBed} from "@angular/core/testing";
-import {ShareAccess} from "../../../type/share-access.interface";
+describe("ShareAccessService", () => {
+  let service: ShareAccessService;
+  let httpMock: HttpTestingController;
 
-describe('ShareAccessService', () => {
-  let service: ShareAccessService
-  let httpMock: HttpTestingController
-
-  const type : string = 'resource'
-  const id : number = 42
-  const email : string = 'johnDoe@gmail.com'
-  const privilege : string = 'write'
-  const username : string = "johnDaBeast1999"
+  const type: string = "resource";
+  const id: number = 42;
+  const email: string = "johnDoe@gmail.com";
+  const privilege: string = "write";
+  const username: string = "johnDaBeast1999";
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [ShareAccessService]
-    })
+      providers: [ShareAccessService],
+    });
     service = TestBed.inject(ShareAccessService);
     httpMock = TestBed.inject(HttpTestingController);
   });
 
   afterEach(() => {
     httpMock.verify();
-  })
+  });
 
   it("grantAccess composes the correct PUT url", () => {
-    service.grantAccess(type, id, email, privilege).subscribe()
+    service.grantAccess(type, id, email, privilege).subscribe();
 
-    const req = httpMock.expectOne(
-      `${BASE}/${type}/grant/${id}/${email}/${privilege}`
-    )
+    const req = httpMock.expectOne(`${BASE}/${type}/grant/${id}/${email}/${privilege}`);
 
-    expect(req.request.method).toBe('PUT')
-    req.flush(null)
-  })
+    expect(req.request.method).toBe("PUT");
+    req.flush(null);
+  });
 
   it("revokeAccess composes the correct DELETE url", () => {
-    service.revokeAccess(type, id, username).subscribe()
+    service.revokeAccess(type, id, username).subscribe();
 
-    const req = httpMock.expectOne(
-      `${BASE}/${type}/revoke/${id}/${username}`
-    )
+    const req = httpMock.expectOne(`${BASE}/${type}/revoke/${id}/${username}`);
 
-    expect(req.request.method).toBe('DELETE')
-    req.flush(null)
-  })
+    expect(req.request.method).toBe("DELETE");
+    req.flush(null);
+  });
 
   it("getOwner should respond with type text", () => {
-    service.getOwner(type, id).subscribe()
+    service.getOwner(type, id).subscribe();
 
-    const req = httpMock.expectOne(
-      `${BASE}/${type}/owner/${id}`
-    )
+    const req = httpMock.expectOne(`${BASE}/${type}/owner/${id}`);
 
-    expect(req.request.method).toBe('GET')
-    expect(req.request.responseType).toBe('text')
-    req.flush(null)
-  })
+    expect(req.request.method).toBe("GET");
+    expect(req.request.responseType).toBe("text");
+    req.flush(null);
+  });
 
   it("getAccessList should resolve to an array", () => {
     const mockList = [
-      { username: 'JohnDaBeast1999', privilege: 'write' },
-      { username: 'alice', privilege: 'read' },
+      { username: "JohnDaBeast1999", privilege: "write" },
+      { username: "alice", privilege: "read" },
     ];
 
-    let result : ReadonlyArray<ShareAccess> | undefined
+    let result: ReadonlyArray<ShareAccess> | undefined;
     service.getAccessList(type, id).subscribe(res => {
-      result = res
-    })
+      result = res;
+    });
 
-    const req = httpMock.expectOne(
-      `${BASE}/${type}/list/${id}`
-    )
+    const req = httpMock.expectOne(`${BASE}/${type}/list/${id}`);
 
-    expect(req.request.method).toBe('GET')
-    req.flush(mockList)
+    expect(req.request.method).toBe("GET");
+    req.flush(mockList);
 
-    expect(result).toBe(mockList)
-  })
+    expect(result).toBe(mockList);
+  });
 });

--- a/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
@@ -20,7 +20,7 @@
 import { BASE, ShareAccessService } from "./share-access.service";
 import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { TestBed } from "@angular/core/testing";
-import { ShareAccess } from "../../../type/share-access.interface";
+import { Privilege, ShareAccess } from "../../../type/share-access.interface";
 
 describe("ShareAccessService", () => {
   let service: ShareAccessService;
@@ -64,19 +64,22 @@ describe("ShareAccessService", () => {
   });
 
   it("getOwner should respond with type text", () => {
-    service.getOwner(type, id).subscribe();
-
+    let owner: string | undefined;
+    service.getOwner(type, id).subscribe(res => {
+      owner = res;
+    });
     const req = httpMock.expectOne(`${BASE}/${type}/owner/${id}`);
 
     expect(req.request.method).toBe("GET");
     expect(req.request.responseType).toBe("text");
-    req.flush(null);
+    req.flush("owner@example.com");
+    expect(owner).toBe("owner@example.com");
   });
 
   it("getAccessList should resolve to an array", () => {
-    const mockList = [
-      { username: "JohnDaBeast1999", privilege: "write" },
-      { username: "alice", privilege: "read" },
+    const mockList: ReadonlyArray<ShareAccess> = [
+      { email: "JohnDaBeast1999@example.com", name: "John", privilege: Privilege.READ },
+      { email: "alice@example.com", name: "Alice", privilege: Privilege.WRITE },
     ];
 
     let result: ReadonlyArray<ShareAccess> | undefined;
@@ -89,6 +92,6 @@ describe("ShareAccessService", () => {
     expect(req.request.method).toBe("GET");
     req.flush(mockList);
 
-    expect(result).toBe(mockList);
+    expect(result).toEqual(mockList);
   });
 });

--- a/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/share-access/share-access.service.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import {ShareAccessService} from "./share-access.service";
+import {HttpTestingController} from "@angular/common/http/testing";
+import {TestBed} from "@angular/core/testing";
+
+describe('ShareAccessService', () => {
+  let service: ShareAccessService
+  let httpMock: HttpTestingController
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpTestingController],
+      providers: [ShareAccessService]
+    })
+    service = TestBed.inject(ShareAccessService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  })
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
Adds a unit test spec for ShareAccessService, the REST client for grant/revoke/owner/list of resource share-access endpoints (no production code changes). Covers grantAccess, revokeAccess, getOwner, and getAccessList, using Angular's HttpTestingController to pin exact URL composition and HTTP method per endpoint.

### Any related issues, documentation, discussions?
Closes #6261. 

### How was this PR tested?
`share-access.service.spec.ts` passes locally via ng test (Vitest runner, happy-dom, TestBed + HttpTestingController — no real network calls), along with `yarn format:fix` and `yarn lint`.

### Was this PR authored or co-authored using generative AI tooling?
No.