### PR TITLE
feat(frontend): type-to-search the dataset picker in the workflow file selector

### DIFF
--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.spec.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.spec.ts
@@ -86,4 +86,9 @@ describe("filterDatasetOption", () => {
     expect(filterDatasetOption("", emptyOption)).toBe(true); // empty query → matches all
     expect(filterDatasetOption("iris", emptyOption)).toBe(false); // no data → no match, no throw
   });
+
+  it("treats a null/undefined query as an empty query (matches everything)", () => {
+    expect(filterDatasetOption(null as unknown as string, optionFor("iris", 17))).toBe(true);
+    expect(filterDatasetOption(undefined as unknown as string, optionFor("iris", 17))).toBe(true);
+  });
 });

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.spec.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NzSelectItemInterface } from "ng-zorro-antd/select";
+import { datasetMatchesQuery, filterDatasetOption } from "./dataset-search.util";
+
+describe("datasetMatchesQuery", () => {
+  it("matches by name, case-insensitively", () => {
+    expect(datasetMatchesQuery("iris", 17, "iris")).toBe(true);
+    expect(datasetMatchesQuery("iris", 17, "IR")).toBe(true);
+    expect(datasetMatchesQuery("iris", 17, "ris")).toBe(true); // substring
+  });
+
+  it("matches by numeric id", () => {
+    expect(datasetMatchesQuery("iris", 17, "17")).toBe(true);
+    expect(datasetMatchesQuery("iris", 17, "1")).toBe(true); // substring of id
+  });
+
+  it("does not match when neither name nor id contains the query", () => {
+    expect(datasetMatchesQuery("iris", 17, "test")).toBe(false);
+    expect(datasetMatchesQuery("iris", 17, "99")).toBe(false);
+  });
+
+  it("treats an empty or whitespace query as matching everything", () => {
+    expect(datasetMatchesQuery("iris", 17, "")).toBe(true);
+    expect(datasetMatchesQuery("iris", 17, "   ")).toBe(true);
+  });
+
+  it("trims and lowercases the query", () => {
+    expect(datasetMatchesQuery("Iris", 17, "  IRIS  ")).toBe(true);
+  });
+
+  it("handles missing name or id safely", () => {
+    expect(datasetMatchesQuery(null, 17, "17")).toBe(true);
+    expect(datasetMatchesQuery(undefined, null, "iris")).toBe(false);
+    expect(datasetMatchesQuery("iris", null, "iris")).toBe(true);
+    expect(datasetMatchesQuery("iris", undefined, "3")).toBe(false);
+  });
+
+  it("matches when the query appears in the name but not the id (and vice versa)", () => {
+    expect(datasetMatchesQuery("customers", 42, "cust")).toBe(true); // name only
+    expect(datasetMatchesQuery("customers", 42, "42")).toBe(true); // id only
+  });
+
+  it("does not partially match across the name/id boundary", () => {
+    // "s4" is not a substring of the name "iris" nor of the id "3"
+    expect(datasetMatchesQuery("iris", 3, "s4")).toBe(false);
+  });
+});
+
+describe("filterDatasetOption", () => {
+  // Build an nz-select option carrying a DashboardDataset-shaped value, like the real
+  // dropdown does. Only the fields the filter reads (name, did) matter here.
+  const optionFor = (name: string, did: number): NzSelectItemInterface =>
+    ({ nzLabel: name, nzValue: { dataset: { name, did } } }) as unknown as NzSelectItemInterface;
+
+  it("matches by dataset name pulled from the option value", () => {
+    expect(filterDatasetOption("iris", optionFor("iris", 17))).toBe(true);
+    expect(filterDatasetOption("IR", optionFor("iris", 17))).toBe(true);
+    expect(filterDatasetOption("test", optionFor("iris", 17))).toBe(false);
+  });
+
+  it("matches by dataset #id pulled from the option value", () => {
+    expect(filterDatasetOption("17", optionFor("iris", 17))).toBe(true);
+    expect(filterDatasetOption("99", optionFor("iris", 17))).toBe(false);
+  });
+
+  it("is safe (and matches only on empty query) when the option has no value", () => {
+    const emptyOption = { nzLabel: null, nzValue: null } as unknown as NzSelectItemInterface;
+    expect(filterDatasetOption("", emptyOption)).toBe(true); // empty query → matches all
+    expect(filterDatasetOption("iris", emptyOption)).toBe(false); // no data → no match, no throw
+  });
+});

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.spec.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.spec.ts
@@ -32,6 +32,13 @@ describe("datasetMatchesQuery", () => {
     expect(datasetMatchesQuery("iris", 17, "1")).toBe(true); // substring of id
   });
 
+  it("matches the id typed with the leading # shown in the dropdown label", () => {
+    expect(datasetMatchesQuery("iris", 17, "#17")).toBe(true);
+    expect(datasetMatchesQuery("iris", 17, "#1")).toBe(true); // prefix of the displayed #17
+    expect(datasetMatchesQuery("iris", 17, "#99")).toBe(false);
+    expect(datasetMatchesQuery(null, 17, "#17")).toBe(true); // id-only match still works
+  });
+
   it("does not match when neither name nor id contains the query", () => {
     expect(datasetMatchesQuery("iris", 17, "test")).toBe(false);
     expect(datasetMatchesQuery("iris", 17, "99")).toBe(false);
@@ -79,6 +86,11 @@ describe("filterDatasetOption", () => {
   it("matches by dataset #id pulled from the option value", () => {
     expect(filterDatasetOption("17", optionFor("iris", 17))).toBe(true);
     expect(filterDatasetOption("99", optionFor("iris", 17))).toBe(false);
+  });
+
+  it("matches the #<id> form typed as displayed in the UI label", () => {
+    expect(filterDatasetOption("#17", optionFor("iris", 17))).toBe(true);
+    expect(filterDatasetOption("#99", optionFor("iris", 17))).toBe(false);
   });
 
   it("is safe (and matches only on empty query) when the option has no value", () => {

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.ts
@@ -23,8 +23,8 @@ import { DashboardDataset } from "../../../dashboard/type/dashboard-dataset.inte
 /**
  * Whether a dataset matches a type-to-search query in the dataset picker.
  *
- * Matches against both the dataset name and its numeric id (shown as `#<id>` in the
- * dropdown), case-insensitively, so typing either `iris` or `17` finds `#17 iris`
+ * Matches against both the dataset name and its id as displayed in the dropdown
+ * (`#<id>`), case-insensitively, so typing `iris`, `17`, or `#17` finds `#17 iris`
  * (per the design decision on the proposal). An empty/whitespace query matches
  * everything.
  */

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.ts
@@ -38,7 +38,7 @@ export function datasetMatchesQuery(
     return true;
   }
   const nameMatches = (name ?? "").toLowerCase().includes(q);
-  const idMatches = did !== null && did !== undefined && String(did).includes(q);
+  const idMatches = did !== null && did !== undefined && `#${did}`.includes(q);
   return nameMatches || idMatches;
 }
 

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-search.util.ts
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { NzSelectItemInterface } from "ng-zorro-antd/select";
+import { DashboardDataset } from "../../../dashboard/type/dashboard-dataset.interface";
+
+/**
+ * Whether a dataset matches a type-to-search query in the dataset picker.
+ *
+ * Matches against both the dataset name and its numeric id (shown as `#<id>` in the
+ * dropdown), case-insensitively, so typing either `iris` or `17` finds `#17 iris`
+ * (per the design decision on the proposal). An empty/whitespace query matches
+ * everything.
+ */
+export function datasetMatchesQuery(
+  name: string | null | undefined,
+  did: number | null | undefined,
+  query: string
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (q === "") {
+    return true;
+  }
+  const nameMatches = (name ?? "").toLowerCase().includes(q);
+  const idMatches = did !== null && did !== undefined && String(did).includes(q);
+  return nameMatches || idMatches;
+}
+
+/**
+ * ng-zorro `nzFilterOption` adapter for the dataset dropdown: pulls the dataset off the
+ * option's value and matches the typed query against its name and #id via
+ * {@link datasetMatchesQuery}. Safe when the option has no value.
+ */
+export function filterDatasetOption(input: string, option: NzSelectItemInterface): boolean {
+  const dataset = option.nzValue as DashboardDataset | undefined;
+  return datasetMatchesQuery(dataset?.dataset?.name, dataset?.dataset?.did, input ?? "");
+}

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-selection-modal.component.html
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-selection-modal.component.html
@@ -23,6 +23,8 @@
   <nz-select
     nz-col
     nzFlex="auto"
+    nzShowSearch
+    [nzFilterOption]="datasetFilterOption"
     nzPlaceHolder="Select dataset"
     [(ngModel)]="selectedDataset"
     (ngModelChange)="onDatasetChange()">
@@ -41,6 +43,7 @@
   <nz-select
     nz-col
     nzFlex="130px"
+    nzShowSearch
     nzPlaceHolder="Select version"
     [(ngModel)]="selectedVersion"
     (ngModelChange)="onVersionChange()">

--- a/frontend/src/app/workspace/component/dataset-selection-modal/dataset-selection-modal.component.ts
+++ b/frontend/src/app/workspace/component/dataset-selection-modal/dataset-selection-modal.component.ts
@@ -33,6 +33,7 @@ import { UserDatasetVersionFiletreeComponent } from "../../../dashboard/componen
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
+import { filterDatasetOption } from "./dataset-search.util";
 
 @UntilDestroy()
 @Component({
@@ -69,6 +70,10 @@ export class DatasetSelectionModalComponent implements OnInit {
     private modalRef: NzModalRef,
     private datasetService: DatasetService
   ) {}
+
+  // Search filter for the dataset dropdown: matches the typed text against both the
+  // dataset name and its numeric id (shown as `#<id>`). See filterDatasetOption.
+  datasetFilterOption = filterDatasetOption;
 
   ngOnInit() {
     this.datasetService


### PR DESCRIPTION

<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->
Implements the dataset/version picker search discussed and approved in #6241.

In the file-selection dialog (the "Select File" dialog on operators like CSV File Scan),
the dataset and version dropdowns were scroll-and-click only. This turns on ng-zorro's
built-in `nzShowSearch` on both so users can type to filter. The dataset filter matches
both the dataset **name** and its **#id** (e.g. typing `17` finds `#17 iris`).

Frontend-only — it filters the list already loaded in the dialog; no backend change.


### Any related issues, documentation, discussions?
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->
Per #6241: dropdowns only. 

### How was this PR tested?
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->
- Unit tests for the match logic and the option-filter adapter (`dataset-search.util.spec.ts`).
- A full production build passes.
- Manually verified in the UI: typing a name or an id filters the dataset dropdown.


### Was this PR authored or co-authored using generative AI tooling?
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
Generated-by: Claude Code (Claude Opus 4.8)