### PR TITLE
fix(frontend, v1.2): virtualize dataset version file tree

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.browser.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Browser-mode companion to user-dataset-version-filetree.component.spec.ts.
+// jsdom does no layout — getBoundingClientRect() is all zeros — so the
+// virtual scroll measures a 0-height viewport and renders zero rows there.
+// These tests run in vitest's Playwright/Chromium browser mode to pin the
+// behaviors that need real geometry.
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
+import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+import { FILE_COUNT, makeFlatFileNodes } from "./user-dataset-version-filetree.test-utils";
+
+describe("UserDatasetVersionFiletreeComponent (browser)", () => {
+  let fixture: ComponentFixture<UserDatasetVersionFiletreeComponent>;
+  let component: UserDatasetVersionFiletreeComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UserDatasetVersionFiletreeComponent],
+    });
+    fixture = TestBed.createComponent(UserDatasetVersionFiletreeComponent);
+    component = fixture.componentInstance;
+  });
+
+  // Assign inside the Angular zone, as a host binding would, so whenStable
+  // waits for the viewport-measure timers; the second detectChanges renders
+  // the measured window.
+  async function renderTree(nodes: DatasetFileNode[]): Promise<void> {
+    if (fixture.ngZone) {
+      fixture.ngZone.run(() => (component.fileTreeNodes = nodes));
+    } else {
+      component.fileTreeNodes = nodes;
+    }
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it("renders a non-empty virtualized window of rows for a large tree", async () => {
+    await renderTree(makeFlatFileNodes(FILE_COUNT));
+
+    const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
+    expect(renderedRows).toBeGreaterThan(0);
+    expect(renderedRows).toBeLessThan(FILE_COUNT / 5);
+  });
+
+  it("renders rows at exactly the virtual-scroll node height", async () => {
+    await renderTree(makeFlatFileNodes(FILE_COUNT));
+
+    const row = fixture.nativeElement.querySelector(".node-content-wrapper") as HTMLElement;
+    expect(row).not.toBeNull();
+    expect(row.getBoundingClientRect().height).toBe(component.TREE_NODE_HEIGHT_PX);
+  });
+
+  it("keeps row action buttons inside the fixed-height row", async () => {
+    component.isTreeNodeDeletable = true;
+    await renderTree(makeFlatFileNodes(5));
+
+    const row = fixture.nativeElement.querySelector(".node-content-wrapper") as HTMLElement;
+    const button = row.querySelector("button.icon-button") as HTMLElement;
+    expect(button).not.toBeNull();
+
+    const rowRect = row.getBoundingClientRect();
+    const buttonRect = button.getBoundingClientRect();
+    expect(buttonRect.height).toBeLessThanOrEqual(rowRect.height);
+    expect(buttonRect.top).toBeGreaterThanOrEqual(rowRect.top);
+    expect(buttonRect.bottom).toBeLessThanOrEqual(rowRect.bottom);
+  });
+
+  // Both hosts create the tree empty and fill it when data arrives; the
+  // height change must trigger a viewport re-measure or the 0px initial
+  // measurement sticks and the tree stays blank.
+  it("renders rows when files arrive after an initially-empty tree", async () => {
+    await renderTree([]);
+    await renderTree(makeFlatFileNodes(FILE_COUNT));
+
+    const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
+    expect(renderedRows).toBeGreaterThan(0);
+  });
+
+  it("lays out the container at content height for small trees", async () => {
+    await renderTree(makeFlatFileNodes(3));
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    // 3 rows x 26px pitch + 2px leading drop slot.
+    expect(container.getBoundingClientRect().height).toBe(80);
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.html
@@ -17,7 +17,10 @@
  under the License.
 -->
 
-<div class="file-tree-container">
+<div
+  class="file-tree-container"
+  [style.height.px]="fileTreeContainerHeightPx"
+  [style.--tree-node-height.px]="TREE_NODE_HEIGHT_PX">
   <tree-root
     #tree
     [nodes]="fileTreeNodes"

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.scss
@@ -21,32 +21,43 @@
   width: 20px;
 }
 
-/* Styles for the delete button */
+/* Delete / set-cover buttons: ng-zorro's .ant-btn defaults to 32px tall,
+   which would bleed into the neighboring fixed-height row. */
 .icon-button {
   width: 15px;
   margin-left: 5px;
+  height: var(--tree-node-height);
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
-/* Allow text selection so users can copy file/folder names */
+/* Names stay selectable for copying and on a single line — a wrapped line
+   would paint over the next fixed-height row. */
 :host ::ng-deep tree-node-content span {
   user-select: text;
+  white-space: nowrap;
 }
 
-/* Styles for the file tree container */
+/* The virtual scroll needs a definite viewport height: the template binds
+   min(content, 200px), tree-root fills it, and the lib's tree-viewport
+   (height: 100%, overflow: auto) scrolls. */
 .file-tree-container {
-  max-height: 200px; /* Adjust the max-height as needed */
-  overflow-y: auto; /* Enables vertical scrolling when content exceeds max-height */
-  overflow-x: auto; /* Prevents horizontal scrolling */
+  overflow: hidden;
+
+  tree-root {
+    display: block;
+    height: 100%;
+  }
 }
 
-//tree-root .fa-file {
-//  //padding-left: 4%; /* Adjust the value as needed */
-//}
-//
-//tree-root span {
-//  display: inline-block;
-//  max-width: 100%; /* Adjust the width as needed */
-//  text-overflow: ellipsis;
-//  white-space: nowrap;
-//  overflow: hidden;
-//}
+/* Rows must stay exactly nodeHeight tall for the virtual scroll to position
+   them; --tree-node-height is bound from the same constant. */
+:host ::ng-deep .file-tree-container .node-content-wrapper {
+  height: var(--tree-node-height);
+  padding-top: 0;
+  padding-bottom: 0;
+  display: flex;
+  align-items: center;
+}

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { UserDatasetVersionFiletreeComponent } from "./user-dataset-version-filetree.component";
+import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+import { FILE_COUNT, makeFlatFileNodes } from "./user-dataset-version-filetree.test-utils";
+
+describe("UserDatasetVersionFiletreeComponent", () => {
+  let fixture: ComponentFixture<UserDatasetVersionFiletreeComponent>;
+  let component: UserDatasetVersionFiletreeComponent;
+
+  function makeFolderNode(fileCount: number): DatasetFileNode {
+    return {
+      name: "dir",
+      type: "directory",
+      parentDir: "/owner/dataset/v1",
+      children: makeFlatFileNodes(fileCount),
+    };
+  }
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [UserDatasetVersionFiletreeComponent],
+    });
+    fixture = TestBed.createComponent(UserDatasetVersionFiletreeComponent);
+    component = fixture.componentInstance;
+  });
+
+  // Regression tests for the freeze on versions with hundreds of files: the
+  // tree must virtualize instead of rendering one component per file.
+  it("enables virtual scrolling with the 24px node height the row styles pin", () => {
+    expect(component.fileTreeDisplayOptions.useVirtualScroll).toBe(true);
+    // 24 is the single design value; the SCSS consumes it via --tree-node-height.
+    expect(component.fileTreeDisplayOptions.nodeHeight).toBe(24);
+  });
+
+  it("keeps the full tree in the model without one DOM row per file", async () => {
+    component.fileTreeNodes = makeFlatFileNodes(FILE_COUNT);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.tree.treeModel.roots.length).toBe(FILE_COUNT);
+    const renderedRows = fixture.nativeElement.querySelectorAll("tree-node").length;
+    expect(renderedRows).toBeLessThan(FILE_COUNT / 5);
+  });
+
+  // The container hugs small trees and caps at 200px; heights follow the
+  // tree's 26px row pitch plus a 2px leading drop slot.
+  it("collapses the container when there are no files", () => {
+    component.fileTreeNodes = [];
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("0px");
+  });
+
+  it("sizes the container to its content for small trees", () => {
+    component.fileTreeNodes = makeFlatFileNodes(3);
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("80px"); // 3 rows x 26px pitch + 2px leading drop slot
+  });
+
+  it("caps the container height at 200px for large trees", () => {
+    component.fileTreeNodes = makeFlatFileNodes(FILE_COUNT);
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("200px");
+  });
+
+  it("counts nested folder contents when sizing the container", () => {
+    component.fileTreeNodes = [makeFolderNode(2)]; // 1 folder + 2 files = 3 rows when expanded
+    fixture.detectChanges();
+
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("80px");
+  });
+
+  it("treats a missing files input as an empty tree", () => {
+    component.fileTreeNodes = undefined as unknown as DatasetFileNode[];
+    fixture.detectChanges();
+
+    expect(component.fileTreeNodes).toEqual([]);
+    const container = fixture.nativeElement.querySelector(".file-tree-container") as HTMLElement;
+    expect(container.style.height).toBe("0px");
+  });
+
+  it("expands all folders after view init when isExpandAllAfterViewInit is set", () => {
+    component.isExpandAllAfterViewInit = true;
+    component.fileTreeNodes = [makeFolderNode(2)];
+    fixture.detectChanges();
+
+    expect(component.tree.treeModel.roots[0].isExpanded).toBe(true);
+  });
+
+  it("toggles expansion without emitting selectedTreeNode when a folder is clicked", () => {
+    const emitted: DatasetFileNode[] = [];
+    component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
+
+    // The folder branch delegates to TOGGLE_EXPANDED, which only calls
+    // node.toggleExpanded().
+    let toggleCalls = 0;
+    const onClick = component.fileTreeDisplayOptions.actionMapping!.mouse!.click!;
+    const folderNode = {
+      hasChildren: true,
+      toggleExpanded: () => {
+        toggleCalls++;
+      },
+      data: { name: "dir", type: "directory", parentDir: "/owner/dataset/v1" },
+    } as never;
+    onClick(undefined as never, folderNode, undefined as never);
+
+    expect(toggleCalls).toBe(1);
+    expect(emitted).toEqual([]);
+  });
+
+  it("emits selectedTreeNode when a leaf node is clicked", () => {
+    component.fileTreeNodes = makeFlatFileNodes(1);
+    const emitted: DatasetFileNode[] = [];
+    component.selectedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
+
+    // The handler only reads hasChildren and data; tree and $event are unused.
+    const onClick = component.fileTreeDisplayOptions.actionMapping!.mouse!.click!;
+    const leafNode = { hasChildren: false, data: component.fileTreeNodes[0] } as never;
+    onClick(undefined as never, leafNode, undefined as never);
+
+    expect(emitted).toEqual([component.fileTreeNodes[0]]);
+  });
+
+  it("emits deletedTreeNode when a node deletion is requested", () => {
+    component.fileTreeNodes = makeFlatFileNodes(1);
+    const emitted: DatasetFileNode[] = [];
+    component.deletedTreeNode.subscribe((n: DatasetFileNode) => emitted.push(n));
+
+    component.onNodeDeleted(component.fileTreeNodes[0]);
+
+    expect(emitted).toEqual([component.fileTreeNodes[0]]);
+  });
+
+  it("identifies image files by extension, case-insensitively", () => {
+    expect(component.isImageFile("photo.PNG")).toBe(true);
+    expect(component.isImageFile("data.csv")).toBe(false);
+  });
+
+  it("emits the file's dataset-relative path when set as cover", () => {
+    const emitted: string[] = [];
+    component.setCoverImage.subscribe((path: string) => emitted.push(path));
+
+    // parentDir has exactly the three stripped segments (owner/dataset/version),
+    // so the relative path is just the file name.
+    component.onSetCover({ name: "photo.png", type: "file", parentDir: "/owner/dataset/v1" });
+
+    expect(emitted).toEqual(["photo.png"]);
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
@@ -33,6 +33,23 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 
 const IMAGE_EXTENSIONS = [".jpg", ".jpeg", ".png", ".gif", ".webp"] as const;
 
+// The library adds a 2px drop slot after every row, plus one extra leading
+// slot before the first row.
+const TREE_DROP_SLOT_HEIGHT_PX = 2;
+
+// Container height cap; matches the pre-virtualization max-height.
+const MAX_FILE_TREE_CONTAINER_HEIGHT_PX = 200;
+
+// The library throttles viewport re-measures to one per 17ms, leading-edge
+// only — a call inside the window is dropped and never re-fired, so
+// re-measures must wait out the window.
+const TREE_VIEWPORT_REMEASURE_DELAY_MS = 25;
+
+// Total node count across the whole tree, including collapsed descendants.
+function countNodes(nodes: DatasetFileNode[]): number {
+  return nodes.reduce((count, node) => count + 1 + countNodes(node.children ?? []), 0);
+}
+
 @UntilDestroy()
 @Component({
   selector: "texera-user-dataset-version-filetree",
@@ -53,7 +70,23 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   public isTreeNodeDeletable: boolean = false;
 
   @Input()
-  public fileTreeNodes: DatasetFileNode[] = [];
+  public set fileTreeNodes(nodes: DatasetFileNode[]) {
+    this._fileTreeNodes = nodes ?? [];
+    const newHeight = this.computeContainerHeightPx();
+    if (newHeight !== this.fileTreeContainerHeightPx) {
+      this.fileTreeContainerHeightPx = newHeight;
+      // The tree measures its viewport once after init and again only on
+      // scroll, so a height change must trigger a re-measure (delayed past
+      // the throttle) — otherwise a tree that starts empty stays blank. For
+      // the same reason, a host that creates this component hidden must call
+      // tree.sizeChanged() on reveal.
+      setTimeout(() => this.tree?.sizeChanged(), TREE_VIEWPORT_REMEASURE_DELAY_MS);
+    }
+  }
+  public get fileTreeNodes(): DatasetFileNode[] {
+    return this._fileTreeNodes;
+  }
+  private _fileTreeNodes: DatasetFileNode[] = [];
 
   @Input()
   public isExpandAllAfterViewInit = false;
@@ -63,9 +96,21 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   @Output()
   setCoverImage = new EventEmitter<string>();
 
+  // Row height used by the virtual scroll; the template binds it as
+  // --tree-node-height so the SCSS row rules stay in sync with nodeHeight.
+  public readonly TREE_NODE_HEIGHT_PX = 24;
+
+  // min(content, 200px); bound in the template so small trees hug their
+  // content while the virtual scroll keeps a definite viewport.
+  public fileTreeContainerHeightPx = 0;
+
+  // useVirtualScroll keeps only the visible rows in the DOM; without it,
+  // hundreds of files freeze the page for seconds to minutes.
   public fileTreeDisplayOptions: ITreeOptions = {
     displayField: "name",
     hasChildrenField: "children",
+    useVirtualScroll: true,
+    nodeHeight: this.TREE_NODE_HEIGHT_PX,
     actionMapping: {
       mouse: {
         click: (tree: any, node: any, $event: any) => {
@@ -88,7 +133,6 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   constructor() {}
 
   onNodeDeleted(node: DatasetFileNode): void {
-    // look up for the DatasetVersionFileTreeNode
     this.deletedTreeNode.emit(node);
   }
 
@@ -100,6 +144,18 @@ export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
 
   isImageFile(fileName: string): boolean {
     return IMAGE_EXTENSIONS.some(ext => fileName.toLowerCase().endsWith(ext));
+  }
+
+  // countNodes includes collapsed descendants, so a partially collapsed tree
+  // may get a slightly taller container — still bounded by the cap.
+  private computeContainerHeightPx(): number {
+    const nodeCount = countNodes(this._fileTreeNodes);
+    if (nodeCount === 0) {
+      return 0;
+    }
+    const contentHeightPx =
+      nodeCount * (this.TREE_NODE_HEIGHT_PX + TREE_DROP_SLOT_HEIGHT_PX) + TREE_DROP_SLOT_HEIGHT_PX;
+    return Math.min(contentHeightPx, MAX_FILE_TREE_CONTAINER_HEIGHT_PX);
   }
 
   onSetCover(nodeData: DatasetFileNode): void {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.test-utils.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.test-utils.ts
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Fixtures shared by the filetree component's jsdom and browser specs so the
+ * two cannot drift.
+ */
+
+import { DatasetFileNode } from "../../../../../../common/type/datasetVersionFileTree";
+
+export const FILE_COUNT = 1000;
+
+export function makeFlatFileNodes(count: number): DatasetFileNode[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `file_${String(i + 1).padStart(4, "0")}.txt`,
+    type: "file",
+    parentDir: "/owner/dataset/v1",
+    size: 1,
+  }));
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6285 to `release/v1.2` (cherry-pick of `134bbbd5`, applied cleanly with no conflicts).

This fixes the frontend issue where opening a dataset whose selected version contains hundreds of files freezes the frontend for tens of seconds to minutes. The version file tree rendered every file as a full tree-node component with virtualization disabled; this change enables virtual scroll so only visible rows are rendered. See #6285 for the root-cause analysis and before/after measurements (400-file dataset: page usable in 24.5 s → 1.3 s).

### Any related issues, documentation, discussions?

Backport of #6285. Related to #6281 (fixed on `main` by the original PR).

### How was this PR tested?

The cherry-pick applied without conflicts and the resulting diff is identical to the original (6 files, +408/−20). The component unit tests that ship with the fix were run on this branch (`ng test --include '**/user-dataset-version-filetree/user-dataset-version-filetree.component.spec.ts'`): 13/13 passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code, Claude Fable 5
