### PR TITLE
refactor(amber): remove dead WorkflowWorker.handleActorCommand

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -129,7 +129,7 @@ class WorkflowWorker(
 
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
     super.preRestart(reason, message)
-    logger.error(s"Encountered fatal error, worker is shutting done.", reason)
+    logger.error(s"Encountered fatal error, worker is shutting down.", reason)
     postStop()
   }
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -127,11 +127,6 @@ class WorkflowWorker(
       t.closure(this)
   }
 
-  def handleActorCommand: Receive = {
-    case c: ActorCommand =>
-      println(c)
-  }
-
   override def preRestart(reason: Throwable, message: Option[Any]): Unit = {
     super.preRestart(reason, message)
     logger.error(s"Encountered fatal error, worker is shutting done.", reason)


### PR DESCRIPTION
### What changes were proposed in this PR?

Removes the dead `handleActorCommand` method from `WorkflowWorker`. It is a `Receive` whose body is a bare `println(c)`, it is not part of the actor's `receive` chain (`receive = super.receive orElse handleDirectInvocation orElse handleTriggerClosure`), and it has no callers — the live `handleActorCommand` is a separate method on `DPThread`. Deleting it removes a debug leftover and raises coverage by removal rather than cementing dead code with a test.

### Any related issues, documentation, discussions?

Closes #6304. Follow-up to a review comment by @mengw15 on #6289.

### How was this PR tested?

No new tests — this only deletes unreachable code. Verified locally (Java 17): the amber module compiles, `WorkerSpec` (which exercises `WorkflowWorker`) passes, and `scalafixAll --check` is clean (the `ActorCommand` import remains used via `ActorCommandElement`).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])