### PR TITLE
refactor(workflow-core): remove unused hadoop Iceberg catalog

### DIFF
--- a/common/config/src/main/resources/storage.conf
+++ b/common/config/src/main/resources/storage.conf
@@ -21,7 +21,7 @@ storage {
     # Configuration for Apache Iceberg, used for storing the workflow results & stats
     iceberg {
         catalog {
-            type = rest # either hadoop, rest, or postgres
+            type = rest # either rest or postgres
             type = ${?STORAGE_ICEBERG_CATALOG_TYPE}
 
             rest {

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/IcebergCatalogInstance.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/storage/IcebergCatalogInstance.scala
@@ -44,11 +44,6 @@ object IcebergCatalogInstance {
       case Some(catalog) => catalog
       case None =>
         val catalog = StorageConfig.icebergCatalogType match {
-          case "hadoop" =>
-            IcebergUtil.createHadoopCatalog(
-              "texera_iceberg",
-              StorageConfig.fileStorageDirectoryPath
-            )
           case "rest" =>
             IcebergUtil.createRestCatalog(
               "texera_iceberg",

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/util/IcebergUtil.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/util/IcebergUtil.scala
@@ -27,7 +27,7 @@ import org.apache.iceberg.catalog.{Catalog, SupportsNamespaces, TableIdentifier}
 import org.apache.iceberg.data.parquet.GenericParquetReaders
 import org.apache.iceberg.data.{GenericRecord, Record}
 import org.apache.iceberg.aws.s3.S3FileIO
-import org.apache.iceberg.hadoop.{HadoopCatalog, HadoopFileIO}
+import org.apache.iceberg.hadoop.HadoopFileIO
 import org.apache.iceberg.io.{CloseableIterator, InputFile}
 import org.apache.iceberg.jdbc.JdbcCatalog
 import org.apache.iceberg.parquet.{Parquet, ParquetValueReader}
@@ -84,34 +84,6 @@ object IcebergUtil {
       conf.setBoolean("fs.file.impl.disable.cache", true)
     }
     conf
-  }
-
-  /**
-    * Creates and initializes a HadoopCatalog with the given parameters.
-    * - Uses the Hadoop `Configuration` from [[newLocalHadoopConf]], meaning the local
-    * file system (or `file:/`) will be used by default instead of HDFS.
-    * - The `warehouse` parameter specifies the root directory for storing table data.
-    * - Sets the file I/O implementation to `HadoopFileIO`.
-    *
-    * @param catalogName the name of the catalog.
-    * @param warehouse   the root path for the warehouse where the tables are stored.
-    * @return the initialized HadoopCatalog instance.
-    */
-  def createHadoopCatalog(
-      catalogName: String,
-      warehouse: Path
-  ): HadoopCatalog = {
-    val catalog = new HadoopCatalog()
-    catalog.setConf(newLocalHadoopConf()) // Defaults to `file:/`, no HDFS
-    catalog.initialize(
-      catalogName,
-      Map(
-        "warehouse" -> warehouse.toString,
-        CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName
-      ).asJava
-    )
-
-    catalog
   }
 
   /**

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/DocumentFactorySpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/DocumentFactorySpec.scala
@@ -51,8 +51,8 @@ import java.util.UUID
   * The remaining groups exercise the scheme-dispatch surface of
   * `openReadonlyDocument` / `openDocument` / `createDocument` / `documentExists`:
   * the dataset / file / vfs scheme arms, the unsupported-scheme guards, and the
-  * vfs create/open/exists happy paths against a local Hadoop-backed Iceberg
-  * catalog installed via [[LocalHadoopIcebergCatalog]].
+  * vfs create/open/exists happy paths against a local in-memory Iceberg
+  * catalog installed via [[LocalInMemoryIcebergCatalog]].
   */
 class DocumentFactorySpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
 
@@ -61,7 +61,7 @@ class DocumentFactorySpec extends AnyFlatSpec with Matchers with BeforeAndAfterA
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    LocalHadoopIcebergCatalog.ensure()
+    LocalInMemoryIcebergCatalog.ensure()
   }
 
   // ---------------------------------------------------------------------------

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/LocalInMemoryIcebergCatalog.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/LocalInMemoryIcebergCatalog.scala
@@ -19,18 +19,19 @@
 
 package org.apache.texera.amber.core.storage
 
-import org.apache.texera.amber.util.IcebergUtil
+import org.apache.iceberg.inmemory.InMemoryCatalog
 
 import java.nio.file.{Files, Path}
 import java.util.Comparator
+import scala.jdk.CollectionConverters._
 
 /**
-  * Test-only helper that installs a local Hadoop-backed Iceberg catalog into the
+  * Test-only helper that installs a local in-memory Iceberg catalog into the
   * shared `IcebergCatalogInstance` singleton exactly once per JVM.
   *
   * The default configured catalog type is `rest`, which needs a live REST server;
-  * unit tests instead exercise Iceberg against a temp-directory `file:/` warehouse
-  * (via the merged winutils-free local filesystem on Windows).
+  * unit tests instead exercise Iceberg against a self-contained catalog backed by
+  * a temp-directory warehouse.
   *
   * `IcebergCatalogInstance` is a JVM-wide mutable singleton and ScalaTest runs
   * suites in the module in parallel within the same JVM, so every suite that needs
@@ -40,7 +41,7 @@ import java.util.Comparator
   * `replaceInstance`. Suites keep their tables disjoint via distinct namespaces and
   * unique (UUID) table names.
   */
-object LocalHadoopIcebergCatalog {
+object LocalInMemoryIcebergCatalog {
 
   private var initialized = false
 
@@ -57,9 +58,9 @@ object LocalHadoopIcebergCatalog {
             .forEach((p: Path) => Files.deleteIfExists(p))
           catch { case _: Throwable => () }
         }
-        IcebergCatalogInstance.replaceInstance(
-          IcebergUtil.createHadoopCatalog("wfcore-test", warehouse)
-        )
+        val catalog = new InMemoryCatalog()
+        catalog.initialize("wfcore-test", Map("warehouse" -> warehouse.toString).asJava)
+        IcebergCatalogInstance.replaceInstance(catalog)
         initialized = true
       }
     }

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergDocumentSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergDocumentSpec.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.amber.core.storage.result.iceberg
 
 import org.apache.texera.amber.core.storage.IcebergCatalogInstance
-import org.apache.texera.amber.core.storage.LocalHadoopIcebergCatalog
+import org.apache.texera.amber.core.storage.LocalInMemoryIcebergCatalog
 import org.apache.texera.amber.core.storage.model.VirtualDocument
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema, Tuple}
 import org.apache.texera.amber.util.IcebergUtil
@@ -37,9 +37,9 @@ import java.util.UUID
 import java.util.zip.ZipInputStream
 
 /**
-  * Unit-level tests for [[IcebergDocument]] running against a local Hadoop-backed
+  * Unit-level tests for [[IcebergDocument]] running against a local in-memory
   * Iceberg catalog (temp `file:/` warehouse) installed into the shared
-  * `IcebergCatalogInstance` singleton via [[LocalHadoopIcebergCatalog]].
+  * `IcebergCatalogInstance` singleton via [[LocalInMemoryIcebergCatalog]].
   *
   * `IcebergDocument` reads its catalog from `IcebergCatalogInstance.getInstance()`,
   * so the catalog must be installed before any document access. Each test creates a
@@ -64,7 +64,7 @@ class IcebergDocumentSpec extends AnyFlatSpec with Matchers with BeforeAndAfterA
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    LocalHadoopIcebergCatalog.ensure()
+    LocalInMemoryIcebergCatalog.ensure()
   }
 
   private def freshTableName(): String =

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergTableWriterSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/result/iceberg/IcebergTableWriterSpec.scala
@@ -23,6 +23,7 @@ import org.apache.texera.amber.core.tuple.{AttributeType, Schema, Tuple}
 import org.apache.texera.amber.util.IcebergUtil
 import org.apache.iceberg.catalog.Catalog
 import org.apache.iceberg.data.IcebergGenerics
+import org.apache.iceberg.inmemory.InMemoryCatalog
 import org.apache.iceberg.{Schema => IcebergSchema, Table}
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpec
@@ -45,7 +46,9 @@ class IcebergTableWriterSpec extends AnyFlatSpec with BeforeAndAfterAll {
 
   override def beforeAll(): Unit = {
     warehouseDir = Files.createTempDirectory("iceberg-table-writer-spec")
-    catalog = IcebergUtil.createHadoopCatalog("writer-spec", warehouseDir)
+    val testCatalog = new InMemoryCatalog()
+    testCatalog.initialize("writer-spec", Map("warehouse" -> warehouseDir.toString).asJava)
+    catalog = testCatalog
   }
 
   override def afterAll(): Unit = {

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/util/IcebergUtilSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/util/IcebergUtilSpec.scala
@@ -30,7 +30,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 import java.net.URI
 import java.nio.ByteBuffer
-import java.nio.file.Files
 import java.sql.Timestamp
 import java.time.{LocalDateTime, ZoneId}
 import scala.jdk.CollectionConverters._
@@ -316,28 +315,6 @@ class IcebergUtilSpec extends AnyFlatSpec {
     val conf = IcebergUtil.newLocalHadoopConf(useWinutilsFreeLocalFs = false)
     assert(conf.get("fs.file.impl") == null)
     assert(!conf.getBoolean("fs.file.impl.disable.cache", false))
-  }
-
-  it should "create and load tables via createHadoopCatalog in a local warehouse on every platform" in {
-    val warehouse = Files.createTempDirectory("iceberg-local-warehouse")
-    val catalog = IcebergUtil.createHadoopCatalog("local_test", warehouse)
-
-    // On Windows hosts without a winutils.exe installation, this used to fail with
-    // "Hadoop bin directory does not exist": Hadoop's default local file system
-    // shells out to winutils for chmod on every file/directory creation.
-    IcebergUtil.createTable(
-      catalog,
-      "test_namespace",
-      "test_table",
-      IcebergUtil.toIcebergSchema(Schema().add("id", AttributeType.INTEGER)),
-      overrideIfExists = true
-    )
-
-    assert(
-      Files.exists(warehouse.resolve("test_namespace").resolve("test_table").resolve("metadata")),
-      "table metadata must be written through the local file system"
-    )
-    assert(IcebergUtil.loadTableMetadata(catalog, "test_namespace", "test_table").nonEmpty)
   }
 
   it should "surface RESTException when createRestCatalog cannot reach the REST endpoint" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR removes the unused `hadoop` Iceberg catalog type.

Changes:
- Remove the `hadoop` catalog branch from `IcebergCatalogInstance`.
- Remove `IcebergUtil.createHadoopCatalog`.
- Remove the unused `HadoopCatalog` import while keeping `HadoopFileIO`.
- Replace test-only Hadoop catalogs with self-contained `InMemoryCatalog` instances, including the shared WorkflowCore test catalog introduced on current `main`.
- Rename the shared test helper from `LocalHadoopIcebergCatalog` to `LocalInMemoryIcebergCatalog`.
- Update the `storage.conf` catalog-type comment from `hadoop, rest, or postgres` to `rest or postgres`.

### Any related issues, documentation, discussions?

Closes #6150

### How was this PR tested?

- `sbt scalafmtCheckAll`
- `sbt "WorkflowCore / scalafixAll --check"`
- `sbt "WorkflowCore / compile"`
- `sbt "WorkflowCore / testOnly org.apache.texera.amber.core.storage.result.iceberg.IcebergTableWriterSpec org.apache.texera.amber.util.IcebergUtilSpec org.apache.texera.amber.core.storage.DocumentFactorySpec org.apache.texera.amber.core.storage.result.iceberg.IcebergDocumentSpec"` (57 tests passed across 4 suites)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex was used for planning, review assistance, and adapting the existing change to current `main`. I reviewed and tested the final code before submission.
