### PR TITLE
fix(deps, v1.2): upgrade bouncycastle to fix CVE-2025-14813

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,8 +57,20 @@ lazy val universalJvmFlagsSettings = Seq(
 // See project/AddMetaInfLicenseFiles.scala.
 // Dist-producing modules additionally override Universal / mappings in their own
 // build.sbt (not here) — see AddMetaInfLicenseFiles.distMappings.
-lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
-lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings ++ coverageReportSettings ++ universalJvmFlagsSettings
+val bouncyCastleVersion = "1.84"
+
+lazy val bouncyCastleOverrides = Seq(
+  "org.bouncycastle" % "bcpkix-jdk18on" % bouncyCastleVersion,
+  "org.bouncycastle" % "bcprov-jdk18on" % bouncyCastleVersion,
+  "org.bouncycastle" % "bcutil-jdk18on" % bouncyCastleVersion
+)
+
+lazy val commonDependencyOverrides = Seq(
+  dependencyOverrides ++= bouncyCastleOverrides
+)
+
+lazy val asfLicensingSettings = AddMetaInfLicenseFiles.defaultSettings ++ coverageReportSettings ++ universalJvmFlagsSettings ++ commonDependencyOverrides
+lazy val asfLicensingSettingsWithVendored = AddMetaInfLicenseFiles.workflowOperatorSettings ++ coverageReportSettings ++ universalJvmFlagsSettings ++ commonDependencyOverrides
 
 val jacksonVersion = "2.18.8"
 

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -530,9 +530,9 @@ Source files derived from third-party MIT-licensed projects:
 
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
-  - org.bouncycastle.bcpkix-jdk18on-1.78.1.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
-  - org.bouncycastle.bcutil-jdk18on-1.78.1.jar
+  - org.bouncycastle.bcpkix-jdk18on-1.84.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
+  - org.bouncycastle.bcutil-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6286 to `release/v1.2`.

Pins the Bouncy Castle JDK 18 artifacts to `1.84` through shared sbt `dependencyOverrides`:

| Artifact | Version |
| --- | --- |
| `org.bouncycastle:bcpkix-jdk18on` | `1.84` |
| `org.bouncycastle:bcprov-jdk18on` | `1.84` |
| `org.bouncycastle:bcutil-jdk18on` | `1.84` |

It also updates `computing-unit-managing-service/LICENSE-binary` to match the resolved bundled jar versions.

**Adaptation note:** `main` has a refactored `build.sbt` with a `commonModuleSettings` aggregate that #6286 hooked into. `release/v1.2` has no such aggregate — every module applies `asfLicensingSettings` / `asfLicensingSettingsWithVendored` directly — so the overrides are appended to those two instead. Functionally equivalent.

### Any related issues, documentation, discussions?

Related security report: https://github.com/apache/texera/security/dependabot/782

### How was this PR tested?

```bash
JAVA_HOME=$(/usr/libexec/java_home -v 17) sbt 'show ComputingUnitManagingService / dependencyOverrides' 'show ComputingUnitManagingService / update' | rg 'bouncycastle|bcprov|bcpkix|bcutil|\[success\]|\[error\]'
```

Confirmed `bcpkix-jdk18on`, `bcprov-jdk18on`, and `bcutil-jdk18on` all resolve to `1.84`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude (Opus 4.8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)