### PR TITLE
ci: add a texera-web boot smoke test in amber-integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -613,6 +613,32 @@ jobs:
           sbt scalafmtCheckAll \
               "scalafixAll --check" \
               "WorkflowExecutionService/test"
+      - name: Build amber dist for the texera-web boot test
+        # Boot smoke test for texera-web (mirrors platform-integration for the
+        # platform services): launch the packaged app and assert it reaches a
+        # listening state without a runtime classpath/linkage crash — the check
+        # that would have caught #6204 (Hadoop 3.4 -> Jersey NoClassDefFoundError)
+        # before merge. Self-build the dist here rather than pulling it in from
+        # the `amber` job as an artifact, so this job stays independent of
+        # `amber` and runs in parallel (as platform-integration does vs
+        # platform); the sbt compile is already warm from the integration-test
+        # run above. ubuntu-only: the boot is pure-JVM and OS-independent.
+        if: matrix.os == 'ubuntu-latest'
+        run: sbt "WorkflowExecutionService/dist"
+      - name: Unzip amber dist
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          mkdir -p /tmp/dists
+          unzip -q amber/target/universal/amber-*.zip -d /tmp/dists/
+      - name: Smoke-test texera-web boots
+        # texera-web boots on postgres only (TexeraWebApplication.run ->
+        # SqlServer.initConnection; no S3 / LakeFS), already provisioned above.
+        # It resolves its config via Utils.amberHomePath, which searches the
+        # working directory for a directory named `amber`; run from the checkout
+        # root (the default) that resolves to ./amber and reads
+        # amber/src/main/resources/web-config.yml (port 8080).
+        if: matrix.os == 'ubuntu-latest'
+        run: .github/scripts/smoke-boot.sh "/tmp/dists/amber-*/bin/texera-web-application" 8080
       - name: Run Python integration tests
         # --junit-xml feeds the Test Analytics upload below.
         run: |


### PR DESCRIPTION
### What changes were proposed in this PR?

Add a boot smoke test for `texera-web` to the `amber-integration` job: build the amber dist in-job and launch the packaged `bin/texera-web-application` via `.github/scripts/smoke-boot.sh` (from #6220), asserting it reaches a listening state (port 8080) without a runtime classpath/linkage crash.

`texera-web` was left out of #6274's `platform-integration` checks because it's built in the `amber` job, not `platform`; its boot check belongs in the infra-provisioned `amber-integration` job (mirroring how `platform-integration` hosts the platform boot checks).

- **Self-contained**: the dist is built in-job (`sbt WorkflowExecutionService/dist`), not shipped as an artifact — so `amber-integration` stays independent of `amber` and runs in parallel (the `platform-integration` ∥ `platform` shape from #6274). The compile is already warm from the integration-test run.
- **postgres-only**: `texera-web` boots via `TexeraWebApplication.run` → `SqlServer.initConnection` (+ `createAdminUser`); no S3 / LakeFS at boot, so `amber-integration`'s postgres suffices. Config resolves through `Utils.amberHomePath` (a working-dir search for a dir named `amber`), finding `./amber` from the checkout root and reading `amber/src/main/resources/web-config.yml`.
- **ubuntu-only**: the boot is pure-JVM and OS-independent, so it doesn't also run on the macOS leg.

Concrete regression it catches: #6204 (Hadoop 3.4 → Jersey `NoClassDefFoundError`) — compiled and unit-tested clean but crashed `texera-web` on boot.

### Any related issues, documentation, discussions?

Closes #6276. Boot script from #6220; mirrors the `platform-integration` boot checks in #6274.

### How was this PR tested?

- Verified `texera-web`'s boot path touches postgres only (`SqlServer.initConnection` + `AuthResource.createAdminUser`; no S3 / LakeFS / MinIO anywhere in the class).
- Confirmed `FileAssetsBundle("../../frontend/dist", …)` registers lazily (its `run()` only constructs + registers the servlet; the filesystem check is request-time), so the absent frontend build in CI doesn't block boot.
- Confirmed the launcher name (`bin/texera-web-application`, per the prod image `CMD`) and port (8080, per `web-config.yml`).
- Exercised end-to-end by this workflow's own `amber-integration` CI run (ubuntu leg).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-8)
