### PR TITLE
fix(frontend): add test coverage and null guard for extractErrorMessage

### DIFF
--- a/frontend/src/app/common/util/error.spec.ts
+++ b/frontend/src/app/common/util/error.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { extractErrorMessage } from "./error";
+
+describe("extractErrorMessage", () => {
+ it("should return the message from an Error instance", () => {
+   const testError = new Error("error instance");
+   const result = extractErrorMessage(testError);
+   expect(result).toBe(testError.message);
+ });
+
+ it("should return the error string when error is a plain string", () => {
+   const testError = {error : "boom"};
+   const result = extractErrorMessage(testError);
+   expect(result).toBe(testError.error);
+ });
+
+ it("should return the nested message when error is an object with a message", () => {
+    const testError = { error: { message: "nested" } };
+    const result = extractErrorMessage(testError);
+    expect(result).toBe(testError.error.message);
+  });
+
+  it("should return the fallback message for when error is null", () => {
+    const testError = null;
+    const result = extractErrorMessage(testError);
+    expect(result).toBe("An unknown error occurred.");
+  });
+
+  it("should return the fallback message when error is a number", () => {
+    const testError = 123;
+    const result = extractErrorMessage(testError);
+    expect(result).toBe("An unknown error occurred.");
+  });
+
+  it("should return the fallback message when error is an empty object", () => {
+    const testError = {};
+    const result = extractErrorMessage(testError);
+    expect(result).toBe("An unknown error occurred.");
+  });
+
+  it("should return the fallback message when error key value is neither a string nor an object with a message", () => {
+    const testError = {error : 123};
+    const result = extractErrorMessage(testError);
+    expect(result).toBe("An unknown error occurred.");
+  });
+});
+
+
+

--- a/frontend/src/app/common/util/error.spec.ts
+++ b/frontend/src/app/common/util/error.spec.ts
@@ -61,4 +61,10 @@ describe("extractErrorMessage", () => {
     const result = extractErrorMessage(testError);
     expect(result).toBe("An unknown error occurred.");
   });
+
+  it("should return the fallback message when error key value is null", () => {
+    const testError = { error: null };
+    const result = extractErrorMessage(testError);
+    expect(result).toBe("An unknown error occurred.");
+  });
 });

--- a/frontend/src/app/common/util/error.spec.ts
+++ b/frontend/src/app/common/util/error.spec.ts
@@ -20,19 +20,19 @@
 import { extractErrorMessage } from "./error";
 
 describe("extractErrorMessage", () => {
- it("should return the message from an Error instance", () => {
-   const testError = new Error("error instance");
-   const result = extractErrorMessage(testError);
-   expect(result).toBe(testError.message);
- });
+  it("should return the message from an Error instance", () => {
+    const testError = new Error("error instance");
+    const result = extractErrorMessage(testError);
+    expect(result).toBe(testError.message);
+  });
 
- it("should return the error string when error is a plain string", () => {
-   const testError = {error : "boom"};
-   const result = extractErrorMessage(testError);
-   expect(result).toBe(testError.error);
- });
+  it("should return the error string when error is a plain string", () => {
+    const testError = { error: "boom" };
+    const result = extractErrorMessage(testError);
+    expect(result).toBe(testError.error);
+  });
 
- it("should return the nested message when error is an object with a message", () => {
+  it("should return the nested message when error is an object with a message", () => {
     const testError = { error: { message: "nested" } };
     const result = extractErrorMessage(testError);
     expect(result).toBe(testError.error.message);
@@ -57,11 +57,8 @@ describe("extractErrorMessage", () => {
   });
 
   it("should return the fallback message when error key value is neither a string nor an object with a message", () => {
-    const testError = {error : 123};
+    const testError = { error: 123 };
     const result = extractErrorMessage(testError);
     expect(result).toBe("An unknown error occurred.");
   });
 });
-
-
-

--- a/frontend/src/app/common/util/error.ts
+++ b/frontend/src/app/common/util/error.ts
@@ -31,7 +31,7 @@ export function extractErrorMessage(err: unknown): string {
     if (typeof backendErr === "string") {
       return backendErr;
     }
-    if (typeof backendErr === "object" && "message" in backendErr) {
+    if (typeof backendErr === "object" && backendErr !== null && "message" in backendErr) {
       return backendErr.message;
     }
   }


### PR DESCRIPTION
### What changes were proposed in this PR?
Adds error.spec.ts to cover extractErrorMessage, a previously untested pure utility function in common/util/ that normalizes errors of unknown shape into a display-safe string. Covers all four behavior branches: a native Error instance, an object with a string error key, an object with a nested { error: { message } } shape, and fallback behavior for unrecognized shapes (null, number, empty object, malformed error key).

Also fixes a bug in error.ts: { error: null } caused a TypeError rather than falling back gracefully, since typeof null === "object" passes the object check before "message" in backendErr is evaluated on a null value. Added a backendErr !== null guard to fix this, along with a corresponding test case.


### Any related issues, documentation, discussions?
Closes #6254

### How was this PR tested?
Added 8 unit tests in error.spec.ts covering all branches described in the issue, plus the `{ error: null }` edge case caught in review. Ran locally via `npx ng test --include='**/error.spec.ts'`; all 8 pass.


### Was this PR authored or co-authored using generative AI tooling?
No.
