### PR TITLE
test(computing-unit-managing-service): add unit test coverage for KubernetesClient.generatePodName

### DIFF
--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/util/KubernetesClientSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/util/KubernetesClientSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.service.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class KubernetesClientSpec extends AnyFlatSpec with Matchers {
+
+  "generatePodName" should "prefix the cuid with computing-unit" in {
+    KubernetesClient.generatePodName(42) shouldBe "computing-unit-42"
+  }
+
+  it should "handle a cuid of 0" in {
+    KubernetesClient.generatePodName(0) shouldBe "computing-unit-0"
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add unit test coverage for `KubernetesClient.generatePodName`, a pure string helper (`computing-unit-<cuid>`) that needs no cluster. Covers the base case and the `cuid=0` boundary. No production-code changes.

The client-backed methods (`getPodByName`, `createPod`, …) and `generatePodURI` (which embeds `KubernetesConfig` values) need a fabric8 mock / config control and stay out of scope, per the issue.

### Any related issues, documentation, discussions?

Closes #6327.

### How was this PR tested?

```
sbt "ComputingUnitManagingService/testOnly *KubernetesClientSpec"
```

All 2 pass. `scalafmt` and `scalafix --check` are clean. The spec touches no cluster — `generatePodName` is a pure string helper, and loading `object KubernetesClient` builds the fabric8 client offline (config resolved from the classpath, no connection).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
