### PR TITLE
test(computing-unit-managing-service): add unit test coverage for ComputingUnitHelpers

### DIFF
--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/util/ComputingUnitHelpersSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/util/ComputingUnitHelpersSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.service.util
+
+import org.apache.texera.dao.jooq.generated.enums.WorkflowComputingUnitTypeEnum
+import org.apache.texera.dao.jooq.generated.tables.pojos.WorkflowComputingUnit
+import org.apache.texera.service.resource.ComputingUnitManagingResource.WorkflowComputingUnitMetrics
+import org.apache.texera.service.resource.ComputingUnitState.{Pending, Running}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class ComputingUnitHelpersSpec extends AnyFlatSpec with Matchers {
+
+  private def localUnit(): WorkflowComputingUnit = {
+    val unit = new WorkflowComputingUnit()
+    unit.setType(WorkflowComputingUnitTypeEnum.local)
+    unit
+  }
+
+  // WorkflowComputingUnitTypeEnum only defines `local` and `kubernetes`, so an
+  // untyped unit (getType == null) is what exercises the pure "unknown" branch.
+  private def untypedUnit(): WorkflowComputingUnit = new WorkflowComputingUnit()
+
+  "getComputingUnitStatus" should "return Running for a local unit" in {
+    ComputingUnitHelpers.getComputingUnitStatus(localUnit()) shouldBe Running
+  }
+
+  it should "return Pending for an unknown (untyped) unit" in {
+    ComputingUnitHelpers.getComputingUnitStatus(untypedUnit()) shouldBe Pending
+  }
+
+  "getComputingUnitMetrics" should "return NaN metrics for a local unit" in {
+    ComputingUnitHelpers.getComputingUnitMetrics(localUnit()) shouldBe
+      WorkflowComputingUnitMetrics("NaN", "NaN")
+  }
+
+  it should "return NaN metrics for an unknown (untyped) unit" in {
+    ComputingUnitHelpers.getComputingUnitMetrics(untypedUnit()) shouldBe
+      WorkflowComputingUnitMetrics("NaN", "NaN")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add unit test coverage for `ComputingUnitHelpers.getComputingUnitStatus` and `getComputingUnitMetrics`, on their pure `local` and unknown-type branches. Each constructs the jOOQ `WorkflowComputingUnit` pojo via `setType` (no DB). No production-code changes.

The `kubernetes` branch calls the static `KubernetesClient` (`getPodByName` / `getPodMetrics`) and needs a mock seam — out of scope here, per the issue. (`WorkflowComputingUnitTypeEnum` defines only `local` and `kubernetes`, so an untyped unit exercises the `unknown` branch.)

### Any related issues, documentation, discussions?

Closes #6326.

### How was this PR tested?

```
sbt "ComputingUnitManagingService/testOnly *ComputingUnitHelpersSpec"
```

All 4 pass. `scalafmt` and `scalafix --check` are clean. The spec touches no cluster or DB — it constructs pojos and exercises only the pure `local` / unknown branches.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
