### PR TITLE
fix(pyamber, v1.2): coerce numpy scalar types (np.integer / np.bool_) in cast_to_schema

### DIFF
--- a/amber/src/main/python/core/models/schema/attribute_type.py
+++ b/amber/src/main/python/core/models/schema/attribute_type.py
@@ -110,3 +110,12 @@ INTEGRAL_TYPE_RANGES = {
     AttributeType.INT: (-(2**31), 2**31 - 1),
     AttributeType.LONG: (-(2**53) + 1, 2**53 - 1),
 }
+
+# numpy integer scalars are exact (unlike integral floats, which lose
+# integer precision above 2**53), so they are bounded only by the target
+# Arrow integer width, not the float64 exact-integer window used by
+# INTEGRAL_TYPE_RANGES: INT -> int32, LONG -> int64.
+NUMPY_INTEGRAL_RANGES = {
+    AttributeType.INT: (-(2**31), 2**31 - 1),
+    AttributeType.LONG: (-(2**63), 2**63 - 1),
+}

--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import ctypes
+import numpy
 import pandas
 import pickle
 import pyarrow
@@ -32,6 +33,7 @@ from typing_extensions import Protocol, runtime_checkable
 from core.models.type.large_binary import largebinary
 from .schema.attribute_type import (
     INTEGRAL_TYPE_RANGES,
+    NUMPY_INTEGRAL_RANGES,
     TO_PYOBJECT_MAPPING,
     AttributeType,
 )
@@ -303,10 +305,12 @@ class Tuple:
         """
         Safely cast each field value to match the target schema.
         If failed, the value will stay not changed.
-        This current conducts three kinds of casts:
+        This method performs the following casts:
             1. cast NaN to None;
-            2. cast integral floats to int for INT/LONG fields;
-            3. cast any object to bytes (using pickle).
+            2. cast integral floats and numpy integer scalars to int for
+               INT/LONG fields;
+            3. cast numpy bool scalars to bool for BOOL fields;
+            4. cast any object to bytes (using pickle).
         :param schema: The target Schema that describes the target AttributeType to
             cast.
         :return:
@@ -320,30 +324,42 @@ class Tuple:
                     self[field_name] = None
                 elif field_value is not None:
                     field_type = schema.get_attr_type(field_name)
-                    if (
-                        field_type in INTEGRAL_TYPE_RANGES
-                        and isinstance(field_value, float)
-                        and field_value.is_integer()
+                    if field_type in INTEGRAL_TYPE_RANGES and (
+                        isinstance(field_value, numpy.integer)
+                        or (isinstance(field_value, float) and field_value.is_integer())
                     ):
-                        # pandas 2.2.3 promotes an int column holding nulls to
-                        # float64 (119 -> 119.0), so convert integral floats
-                        # destined for INT/LONG back to int — but only within
-                        # the safe range above; out-of-range floats are left
-                        # unchanged so validation still fails. Compare on the
-                        # int result to avoid float rounding at the endpoints.
-                        min_value, max_value = INTEGRAL_TYPE_RANGES[field_type]
+                        # Coerce numpy integer scalars and integral floats into
+                        # int for INT/LONG (pandas 2.2.3 promotes null-holding
+                        # int columns to float64, and reductions like .sum()
+                        # return numpy ints). Bounds differ by source: numpy
+                        # integers are exact, so only the target width applies
+                        # (LONG -> int64); integral floats stay within the
+                        # float64 exact-integer window (2**53). Out-of-range
+                        # values are left unchanged so validation still fails.
+                        if isinstance(field_value, numpy.integer):
+                            min_value, max_value = NUMPY_INTEGRAL_RANGES[field_type]
+                        else:
+                            min_value, max_value = INTEGRAL_TYPE_RANGES[field_type]
                         int_value = int(field_value)
                         if min_value <= int_value <= max_value:
                             self[field_name] = int_value
                         else:
                             logger.warning(
-                                f"Field '{field_name}': integral float "
+                                f"Field '{field_name}': integral value "
                                 f"{field_value} is outside the safely coercible "
                                 f"range of {field_type}; leaving it unchanged "
                                 f"(schema validation will fail). Consider "
                                 f"casting the column to STRING or DOUBLE (or "
                                 f"LONG for large integers in an INT field)."
                             )
+                    elif field_type == AttributeType.BOOL and isinstance(
+                        field_value, numpy.bool_
+                    ):
+                        # pandas reductions such as .any()/.all() and numpy
+                        # comparisons return numpy.bool_, which is not a Python
+                        # bool; convert it for BOOL fields. Gated on the BOOL
+                        # target type so a numpy integer never lands here.
+                        self[field_name] = bool(field_value)
                     elif field_type == AttributeType.BINARY and not isinstance(
                         field_value, bytes
                     ):

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -290,6 +290,176 @@ class TestTuple:
         tuple_.finalize(Schema(raw_schema={"payload": "BINARY"}))
         assert tuple_["payload"] is None
 
+    # Pandas-based operators also produce numpy scalar types very naturally:
+    # reductions such as df["x"].sum()/.max()/.count() return numpy.int64, and
+    # df["x"].any() or any numpy comparison returns numpy.bool_. These are NOT
+    # subclasses of Python int/bool, so finalize() must coerce them for INT/LONG
+    # and BOOL fields the same way it already coerces integral floats — while
+    # still rejecting numpy integers outside the target range and never crossing
+    # the bool<->int boundary.
+
+    @pytest.mark.parametrize(
+        "raw_value, attr_type, expected",
+        [
+            (np.int64(5), "INTEGER", 5),
+            (np.int32(5), "INTEGER", 5),
+            (np.int64(-7), "INTEGER", -7),
+            # int32 boundaries fit an INT field
+            (np.int64(2**31 - 1), "INTEGER", 2**31 - 1),
+            (np.int64(-(2**31)), "INTEGER", -(2**31)),
+            # an np.int64 that overflows int32 still fits a LONG field
+            (np.int64(3000000000), "LONG", 3000000000),
+        ],
+    )
+    def test_finalize_coerces_numpy_integer_to_int(
+        self, raw_value, attr_type, expected
+    ):
+        tuple_ = Tuple({"count": raw_value})
+        tuple_.finalize(Schema(raw_schema={"count": attr_type}))
+        assert tuple_["count"] == expected
+        assert type(tuple_["count"]) is int
+
+    @pytest.mark.parametrize(
+        "raw_value, expected",
+        [(np.bool_(True), True), (np.bool_(False), False)],
+    )
+    def test_finalize_coerces_numpy_bool_to_bool(self, raw_value, expected):
+        tuple_ = Tuple({"flag": raw_value})
+        tuple_.finalize(Schema(raw_schema={"flag": "BOOLEAN"}))
+        assert tuple_["flag"] == expected
+        assert type(tuple_["flag"]) is bool
+
+    def test_cast_to_schema_coerces_numpy_integer(self):
+        # The coercion must live in cast_to_schema(), mirroring the
+        # integral-float coercion.
+        tuple_ = Tuple({"count": np.int64(5)})
+        tuple_.cast_to_schema(Schema(raw_schema={"count": "INTEGER"}))
+        assert tuple_["count"] == 5
+        assert type(tuple_["count"]) is int
+
+    def test_cast_to_schema_coerces_numpy_bool(self):
+        tuple_ = Tuple({"flag": np.bool_(True)})
+        tuple_.cast_to_schema(Schema(raw_schema={"flag": "BOOLEAN"}))
+        assert tuple_["flag"] is True
+        assert type(tuple_["flag"]) is bool
+
+    @pytest.mark.parametrize(
+        "raw_value",
+        [np.int64(2**31), np.int64(-(2**31) - 1)],
+    )
+    def test_finalize_rejects_out_of_range_numpy_integer(self, raw_value):
+        # An np.int64 outside int32 range must be left unchanged so validation
+        # still fails; it must never silently overflow int32.
+        tuple_ = Tuple({"count": raw_value})
+        with pytest.raises(TypeError, match="Unmatched type"):
+            tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
+
+    def test_finalize_rejects_numpy_bool_in_int_field(self):
+        # Coercion must never cross the bool<->int boundary: np.bool_ is not
+        # np.integer, so it must not be coerced into an INT field.
+        tuple_ = Tuple({"count": np.bool_(True)})
+        with pytest.raises(TypeError, match="Unmatched type"):
+            tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
+
+    def test_finalize_keeps_plain_bool_in_int_field_unchanged(self):
+        # Pin the pre-existing behavior: a plain Python bool passes INT
+        # validation (bool subclasses int) and is left as a bool.
+        tuple_ = Tuple({"flag": True})
+        tuple_.finalize(Schema(raw_schema={"flag": "INTEGER"}))
+        assert tuple_["flag"] is True
+        assert type(tuple_["flag"]) is bool
+
+    def test_finalize_keeps_plain_bool_unchanged(self):
+        tuple_ = Tuple({"flag": True})
+        tuple_.finalize(Schema(raw_schema={"flag": "BOOLEAN"}))
+        assert tuple_["flag"] is True
+        assert type(tuple_["flag"]) is bool
+
+    def test_finalize_coerces_numpy_scalars_from_pandas_reduction(self):
+        # Mirrors idiomatic pandas UDF output: df["x"].sum() returns
+        # numpy.int64 and (df["x"] > n).any() returns numpy.bool_. Both must be
+        # accepted and stored as Python builtins.
+        df = pandas.DataFrame({"age": [20, 65, 70]})
+        tuple_ = Tuple(
+            {
+                "total_age": df["age"].sum(),
+                "has_senior": (df["age"] > 60).any(),
+            }
+        )
+        assert isinstance(tuple_["total_age"], np.integer)
+        assert isinstance(tuple_["has_senior"], np.bool_)
+        tuple_.finalize(
+            Schema(raw_schema={"total_age": "INTEGER", "has_senior": "BOOLEAN"})
+        )
+        assert type(tuple_["total_age"]) is int
+        assert tuple_["total_age"] == 155
+        assert type(tuple_["has_senior"]) is bool
+        assert tuple_["has_senior"] is True
+
+    @pytest.mark.parametrize("raw_value", [np.int64(1), np.int64(0)])
+    def test_finalize_rejects_numpy_integer_in_bool_field(self, raw_value):
+        # Symmetric guard to the bool<->int boundary: a numpy integer must
+        # never be coerced into a BOOLEAN field. The BOOL branch is gated on
+        # isinstance(v, numpy.bool_), and numpy.integer is not numpy.bool_.
+        tuple_ = Tuple({"flag": raw_value})
+        with pytest.raises(TypeError, match="Unmatched type"):
+            tuple_.finalize(Schema(raw_schema={"flag": "BOOLEAN"}))
+
+    @pytest.mark.parametrize(
+        "raw_value, expected",
+        [
+            (np.int64(2**53 - 1), 2**53 - 1),
+            (np.int64(-(2**53) + 1), -(2**53) + 1),
+            # beyond the float64 exact-integer window: numpy integers are
+            # exact, so unlike integral floats they are bounded only by the
+            # int64 width of LONG, not by the 2**53 window
+            (np.int64(2**53), 2**53),
+            (np.int64(-(2**53)), -(2**53)),
+            (np.int64(2**62), 2**62),
+            # int64 boundaries
+            (np.int64(2**63 - 1), 2**63 - 1),
+            (np.int64(-(2**63)), -(2**63)),
+            # an in-range uint64 is also a numpy.integer and must be accepted
+            (np.uint64(2**63 - 1), 2**63 - 1),
+        ],
+    )
+    def test_finalize_coerces_large_numpy_integer_to_long(self, raw_value, expected):
+        tuple_ = Tuple({"count": raw_value})
+        tuple_.finalize(Schema(raw_schema={"count": "LONG"}))
+        assert tuple_["count"] == expected
+        assert type(tuple_["count"]) is int
+
+    def test_finalize_coerces_large_id_numpy_integer_to_long(self):
+        # Real-world regression scenario: database/snowflake IDs (~10**18)
+        # arrive as np.int64 above 2**53 and must coerce to LONG instead of
+        # being rejected by the float64 exact-integer window.
+        tuple_ = Tuple({"id": np.int64(1234567890123456789)})
+        tuple_.finalize(Schema(raw_schema={"id": "LONG"}))
+        assert tuple_["id"] == 1234567890123456789
+        assert type(tuple_["id"]) is int
+
+    def test_finalize_coerces_unsigned_numpy_integer_to_int(self):
+        # Unsigned numpy integers are also numpy.integer, and int() is exact
+        # for them, so an in-range uint must be coerced to a Python int.
+        tuple_ = Tuple({"count": np.uint32(5)})
+        tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
+        assert tuple_["count"] == 5
+        assert type(tuple_["count"]) is int
+
+    def test_finalize_rejects_unsigned_numpy_integer_beyond_long_range(self):
+        # A uint64 above int64 max (2**63 - 1) cannot fit a LONG (Arrow int64)
+        # field, so it must be left unchanged and fail validation.
+        tuple_ = Tuple({"count": np.uint64(2**63)})
+        with pytest.raises(TypeError, match="Unmatched type"):
+            tuple_.finalize(Schema(raw_schema={"count": "LONG"}))
+
+    def test_finalize_rejects_numpy_bool_false_in_int_field(self):
+        # Complement to the np.bool_(True) guard: the falsy numpy bool must
+        # also never be coerced into an INT field.
+        tuple_ = Tuple({"count": np.bool_(False)})
+        with pytest.raises(TypeError, match="Unmatched type"):
+            tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
+
     def test_hash(self):
         schema = Schema(
             raw_schema={


### PR DESCRIPTION
### What changes were proposed in this PR?

Manual backport of #6278 to `release/v1.2` (the automated backport failed on merge conflicts in unrelated files such as `frontend/yarn.lock` and `amber/requirements.txt`, so only the actual changes are cherry-picked here).

The Python worker crashed with `TypeError: Unmatched type ...` when a Python operator output a numpy scalar into an INT/LONG or BOOLEAN field, because numpy's integer and bool scalar types are not subclasses of Python `int`/`bool` and failed the strict `isinstance` check in `validate_schema()`. Idiomatic pandas code produces these values naturally: `df["x"].sum()` returns `numpy.int64` and `(df["x"] > n).any()` returns `numpy.bool_`.

Changes, identical to #6278:

- `cast_to_schema()` in `amber/src/main/python/core/models/tuple.py`: coerce `numpy.integer` scalars to Python `int` for INT/LONG fields, and `numpy.bool_` to Python `bool` for BOOL fields in a separate branch gated on the target type, so `bool` and `int` never cross-coerce. Out-of-range values are left unchanged so validation still fails loudly.
- `amber/src/main/python/core/models/schema/attribute_type.py`: add `NUMPY_INTEGRAL_RANGES` (INT → int32, LONG → full int64 range). numpy integers are exact, so they are bounded only by the target Arrow width; integral floats keep the existing `INTEGRAL_TYPE_RANGES` cap at the float64 exact-integer window (2**53).
- `amber/src/test/python/core/models/test_tuple.py`: add the same unit tests as #6278 (coercion cases asserting the concrete Python type, range and bool↔int guards, int64/uint64 boundary cases, and a pandas-reduction integration case). `validate_schema()` is unchanged.

### Any related issues, documentation, discussions?

- Backport of #6278 (merged to `main`) to `release/v1.2`; same fix, no functional differences.
- Follow-up to #6053, whose `INTEGRAL_TYPE_RANGES` mechanism is already present on `release/v1.2`.

### How was this PR tested?

Same tests as #6278, applied on top of `release/v1.2`: `pytest src/test/python/core/models/test_tuple.py -q` passes with 87 passed (the 2-test difference from `main` comes from #5599's `as_dict` tests, which are not on `release/v1.2` and are unrelated to this fix), and `ruff check` / `ruff format --check` are clean on the three changed files. The backported `cast_to_schema()` and the numpy tests are identical to the merged #6278 version.

### Was this PR authored or co-authored using generative AI tooling?

Co-authored by: Claude Code (Claude Fable 5)
