### PR TITLE
test(frontend): extend OperatorPropertyEditFrameComponent coverage

### DIFF
--- a/frontend/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.spec.ts
+++ b/frontend/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.spec.ts
@@ -25,13 +25,15 @@ import {
   OperatorPropertyEditFrameComponent,
 } from "./operator-property-edit-frame.component";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
+import { WorkflowCompilingService } from "../../../service/compile-workflow/workflow-compiling.service";
+import { CustomJSONSchema7 } from "../../../types/custom-json-schema.interface";
 import { OperatorMetadataService } from "../../../service/operator-metadata/operator-metadata.service";
 import { StubOperatorMetadataService } from "../../../service/operator-metadata/stub-operator-metadata.service";
 import { FORM_DEBOUNCE_TIME_MS } from "../../../service/execute-workflow/execute-workflow.service";
 import { DatePipe } from "@angular/common";
 import { By } from "@angular/platform-browser";
 import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
-import { FormsModule, ReactiveFormsModule } from "@angular/forms";
+import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { FormlyFieldConfig, FormlyModule } from "@ngx-formly/core";
 import { TEXERA_FORMLY_CONFIG } from "../../../../common/formly/formly-config";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
@@ -1538,5 +1540,325 @@ describe("OperatorPropertyEditFrameComponent", () => {
     const field = getHfField("temperature");
     const hideFn = (field?.expressions as Record<string, Function>)?.["hide"];
     expect(hideFn({ model: {} } as FormlyFieldConfig)).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // attributeTypeRules validator (checkAttributeType) — the root-field validator
+  // added by setFormlyFormBinding when a schema declares attributeTypeRules.
+  // getOperatorInputAttributeType is stubbed on the (root-provided) compiling service.
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("attributeTypeRules validator (checkAttributeType)", () => {
+    let compiling: WorkflowCompilingService;
+
+    beforeEach(() => {
+      compiling = TestBed.inject(WorkflowCompilingService);
+      component.currentOperatorId = "attr-rules-op";
+    });
+
+    // Binds a crafted schema and returns the root field's checkAttributeType validator.
+    function bindSchema(schema: CustomJSONSchema7): any {
+      component.setFormlyFormBinding(schema);
+      return (component.formlyFields?.[0] as any)?.validators?.checkAttributeType;
+    }
+
+    function rootField(): FormlyFieldConfig {
+      return component.formlyFields![0];
+    }
+
+    it("enum rule fails when the input attribute type is not in the enum", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: { attr: { type: "string", autofillAttributeOnPort: 0 } },
+        attributeTypeRules: { attr: { enum: ["integer"] } },
+      });
+      const spy = vi.spyOn(compiling, "getOperatorInputAttributeType").mockReturnValue("string");
+      const field = rootField();
+      expect(validator.expression({ value: { attr: "colA" } } as any, field)).toBe(false);
+      expect((field as any).validators.checkAttributeType.message).toContain(
+        "is string, but it's expected to be integer"
+      );
+      expect(spy).toHaveBeenCalledWith("attr-rules-op", 0, "colA");
+    });
+
+    it("enum rule passes when the input attribute type matches the enum", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: { attr: { type: "string", autofillAttributeOnPort: 0 } },
+        attributeTypeRules: { attr: { enum: ["integer"] } },
+      });
+      vi.spyOn(compiling, "getOperatorInputAttributeType").mockReturnValue("integer");
+      expect(validator.expression({ value: { attr: "colA" } } as any, rootField())).toBe(true);
+    });
+
+    it("enum rule is skipped when the attribute type is undefined (attribute not selected)", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: { attr: { type: "string", autofillAttributeOnPort: 0 } },
+        attributeTypeRules: { attr: { enum: ["integer"] } },
+      });
+      vi.spyOn(compiling, "getOperatorInputAttributeType").mockReturnValue(undefined);
+      expect(validator.expression({ value: { attr: "" } } as any, rootField())).toBe(true);
+    });
+
+    it("const $data rule fails when the sibling attribute resolves to a different type", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: {
+          attr: { type: "string", autofillAttributeOnPort: 0 },
+          other: { type: "string", autofillAttributeOnPort: 0 },
+        },
+        attributeTypeRules: { attr: { const: { $data: "other" } } },
+      });
+      vi.spyOn(compiling, "getOperatorInputAttributeType").mockImplementation((_id, _port, name) =>
+        name === "colA" ? "string" : "integer"
+      );
+      const field = rootField();
+      expect(validator.expression({ value: { attr: "colA", other: "colB" } } as any, field)).toBe(false);
+      expect((field as any).validators.checkAttributeType.message).toContain("expected to be the same type as 'colB'");
+    });
+
+    it("const $data rule is skipped when the sibling attribute type is not yet resolved", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: {
+          attr: { type: "string", autofillAttributeOnPort: 0 },
+          other: { type: "string", autofillAttributeOnPort: 0 },
+        },
+        attributeTypeRules: { attr: { const: { $data: "other" } } },
+      });
+      vi.spyOn(compiling, "getOperatorInputAttributeType").mockImplementation((_id, _port, name) =>
+        name === "colA" ? "string" : undefined
+      );
+      expect(validator.expression({ value: { attr: "colA", other: "" } } as any, rootField())).toBe(true);
+    });
+
+    it("allOf if/then rule fails when the if-condition holds but the then-enum is violated", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: {
+          attr: { type: "string", autofillAttributeOnPort: 0 },
+          mode: { type: "string" },
+        },
+        attributeTypeRules: {
+          attr: { allOf: [{ if: { mode: { valEnum: ["strict"] } }, then: { enum: ["integer"] } }] },
+        },
+      });
+      vi.spyOn(compiling, "getOperatorInputAttributeType").mockReturnValue("string");
+      const field = rootField();
+      expect(validator.expression({ value: { attr: "colA", mode: "strict" } } as any, field)).toBe(false);
+      expect((field as any).validators.checkAttributeType.message).toContain("given that 'mode' is strict");
+    });
+
+    it("allOf if/then rule passes when the if-condition is not satisfied", () => {
+      const validator = bindSchema({
+        type: "object",
+        properties: {
+          attr: { type: "string", autofillAttributeOnPort: 0 },
+          mode: { type: "string" },
+        },
+        attributeTypeRules: {
+          attr: { allOf: [{ if: { mode: { valEnum: ["strict"] } }, then: { enum: ["integer"] } }] },
+        },
+      });
+      vi.spyOn(compiling, "getOperatorInputAttributeType").mockReturnValue("string");
+      expect(validator.expression({ value: { attr: "colA", mode: "loose" } } as any, rootField())).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Field-level validators / custom field-type mapping in setFormlyFormBinding
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("field-level validators and type mapping", () => {
+    function getField(key: string): FormlyFieldConfig | undefined {
+      return component.formlyFields?.[0]?.fieldGroup?.find(f => f.key === key);
+    }
+
+    it("adds an inEnum validator that rejects values no longer present in the schema enum", () => {
+      component.setFormlyFormBinding({
+        type: "object",
+        properties: { color: { type: "string", enum: ["red", "green"] } },
+      });
+      const validator = getField("color")?.validators?.["inEnum"];
+      expect(validator).toBeDefined();
+      expect(validator!.expression({ value: "blue" } as any)).toBe(false);
+      expect(validator!.expression({ value: "red" } as any)).toBe(true);
+      expect(validator!.message(null, { formControl: { value: "blue" } } as any)).toBe(
+        '"blue" is no longer a valid option'
+      );
+    });
+
+    it("maps datasetVersionPath to the datasetversionselector field type", () => {
+      component.setFormlyFormBinding({
+        type: "object",
+        properties: { datasetVersionPath: { type: "string" } },
+      });
+      expect(getField("datasetVersionPath")?.type).toBe("datasetversionselector");
+    });
+
+    it("maps a field described as 'Input your code here' to the codearea field type", () => {
+      component.setFormlyFormBinding({
+        type: "object",
+        properties: { code: { type: "string", description: "Input your code here" } },
+      });
+      expect(getField("code")?.type).toBe("codearea");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Operator-type-specific field behavior (FileScanOp hide, Projection reorder)
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("operator-type-specific field behavior", () => {
+    function getField(key: string): FormlyFieldConfig | undefined {
+      return component.formlyFields?.[0]?.fieldGroup?.find(f => f.key === key);
+    }
+
+    it("hides FileScanOp outputFileName unless extract is on or the type is a string/binary type", () => {
+      component.currentOperatorSchema = { operatorType: "FileScanOp" } as any;
+      component.setFormlyFormBinding({
+        type: "object",
+        properties: { outputFileName: { type: "string" } },
+      });
+      const hide = (getField("outputFileName")?.expressions as Record<string, Function>)["hide"];
+      expect(hide({ model: {} } as FormlyFieldConfig)).toBe(true);
+      expect(hide({ model: { extract: true } } as FormlyFieldConfig)).toBe(false);
+      expect(hide({ model: { attributeType: "single string" } } as FormlyFieldConfig)).toBe(false);
+      expect(hide({ model: { attributeType: "binary" } } as FormlyFieldConfig)).toBe(false);
+      expect(hide({ model: { attributeType: "large binary" } } as FormlyFieldConfig)).toBe(false);
+    });
+
+    it("maps Projection attributes to repeat-section-dnd and proxies reorder() to onFormChanges", () => {
+      component.currentOperatorSchema = { operatorType: "Projection" } as any;
+      component.formData = { attributes: ["colA"] };
+      component.setFormlyFormBinding({
+        type: "object",
+        properties: { attributes: { type: "array", items: { type: "string" } } },
+      });
+      const field = getField("attributes");
+      expect(field?.type).toBe("repeat-section-dnd");
+      const spy = vi.spyOn(component, "onFormChanges").mockImplementation(() => {});
+      (field?.props as any).reorder();
+      expect(spy).toHaveBeenCalledWith({ attributes: ["colA"] });
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // checkOperatorProperty — the guard used by the debounced form-change stream
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("checkOperatorProperty", () => {
+    it("returns false when no operator is being displayed", () => {
+      component.currentOperatorId = undefined;
+      expect(component.checkOperatorProperty({})).toBe(false);
+    });
+
+    it("returns true only when the form data differs from the stored operator properties", () => {
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      component.currentOperatorId = mockScanPredicate.operatorID;
+      // mockScanPredicate.operatorProperties is {}
+      expect(component.checkOperatorProperty({})).toBe(false);
+      expect(component.checkOperatorProperty({ tableName: "twitter" })).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // typeInferenceOnLambdaFunction — writes inferred attribute types back into
+  // the form data for PythonLambdaFunction operators.
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("typeInferenceOnLambdaFunction", () => {
+    it("does nothing for non-lambda operators", () => {
+      component.currentOperatorId = "ScanSource-op";
+      const formData = { lambdaAttributeUnits: [{ attributeName: "colA", attributeType: "keep" }] };
+      component.typeInferenceOnLambdaFunction(formData);
+      expect(formData.lambdaAttributeUnits[0].attributeType).toBe("keep");
+    });
+
+    it("infers attribute types from the input schema and clears empty 'Add New Column' units", () => {
+      const compiling = TestBed.inject(WorkflowCompilingService);
+      vi.spyOn(compiling, "getOperatorInputSchemaMap").mockReturnValue({
+        "0": [{ attributeName: "colA", attributeType: "integer" }],
+      } as any);
+      component.currentOperatorId = "PythonLambdaFunction-op";
+      const formData = {
+        lambdaAttributeUnits: [
+          { attributeName: "Add New Column", newAttributeName: "", attributeType: "stale" },
+          { attributeName: "colA", attributeType: "stale" },
+        ],
+      };
+      component.typeInferenceOnLambdaFunction(formData);
+      expect(formData.lambdaAttributeUnits[0].attributeType).toBe("");
+      expect(formData.lambdaAttributeUnits[1].attributeType).toBe("integer");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // setInteractivity — enable/disable the whole formly form group
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("setInteractivity", () => {
+    it("disables and re-enables every control in the form group", () => {
+      const group = new FormGroup({ a: new FormControl("x") });
+      component.formlyFormGroup = group;
+
+      component.setInteractivity(false);
+      expect(component.interactive).toBe(false);
+      expect(group.disabled).toBe(true);
+      expect(group.get("a")!.disabled).toBe(true);
+
+      component.setInteractivity(true);
+      expect(component.interactive).toBe(true);
+      expect(group.enabled).toBe(true);
+      expect(group.get("a")!.enabled).toBe(true);
+    });
+
+    it("only updates the interactive flag when there is no form group", () => {
+      component.formlyFormGroup = undefined;
+      expect(() => component.setInteractivity(true)).not.toThrow();
+      expect(component.interactive).toBe(true);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Python UDF environment schema patching
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("Python UDF environment schema patching", () => {
+    it("injects the environment list into the envName enum without mutating the original schema", () => {
+      const schema = { type: "object", properties: { envName: { type: "string" } } } as CustomJSONSchema7;
+      const patched = (component as any).patchPythonUdfEnvironmentSchema(schema, ["env-a", "env-b"]);
+      expect((patched.properties.envName as CustomJSONSchema7).enum).toEqual(["env-a", "env-b"]);
+      expect((schema.properties!.envName as CustomJSONSchema7).enum).toBeUndefined();
+    });
+
+    it("hides envName and makes it optional when the default environment is checked", () => {
+      component.setFormlyFormBinding({
+        type: "object",
+        properties: { envName: { type: "string" }, defaultEnv: { type: "boolean" } },
+      });
+      (component as any).hideEnvNameWhenDefaultEnvChecked();
+      const envField = component.formlyFields?.[0]?.fieldGroup?.find(f => f.key === "envName");
+      expect((envField?.expressions as any).hide).toBe("!!field.parent.model.defaultEnv");
+      expect((envField?.expressions as any)["props.required"]).toBe("!field.parent.model.defaultEnv");
+    });
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // registerOperatorPropertyChangeHandler — program-driven property changes
+  // refresh formData, guarded by listeningToChange to avoid an echo loop.
+  // ──────────────────────────────────────────────────────────────────────────
+  describe("registerOperatorPropertyChangeHandler loop guard", () => {
+    it("refreshes formData on graph property changes only while listeningToChange is true", () => {
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      component.ngOnChanges({
+        currentOperatorId: new SimpleChange(undefined, mockScanPredicate.operatorID, true),
+      });
+      fixture.detectChanges(); // runs ngOnInit, which registers the handler
+
+      // loop guard active: a change echoed while listeningToChange is false must not touch formData
+      component.listeningToChange = false;
+      workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, { marker: "blocked" });
+      expect(component.formData?.marker).toBeUndefined();
+
+      // normal program-driven change: formData is refreshed from the graph
+      component.listeningToChange = true;
+      workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, { marker: "allowed" });
+      expect(component.formData.marker).toBe("allowed");
+    });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the `OperatorPropertyEditFrameComponent` spec (was ~49% covered) to exercise the schema-driven validators and field-type mapping: `attributeTypeRules` enum/const-$data/allOf rules, `inEnum`, FileScanOp `outputFileName` hide, datasetversionselector/repeat-section-dnd/codearea mapping, `checkOperatorProperty`, `typeInferenceOnLambdaFunction`, Python-UDF env schema, `setInteractivity`, and the property-change loop guard.

### Any related issues, documentation, discussions?

Closes #6348.

### How was this PR tested?

Added 21 tests to the existing spec (now 154), reusing its StubOperatorMetadataService + jointjs-graph harness and a WorkflowCompilingService spy. Verified locally with Vitest (`ng test --watch=false --include=...`) and CI's `format:ci` gate (prettier-eslint + eslint) clean. Test-only change — no production code is modified.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])