### PR TITLE
test(agent-service): add unit test coverage for the metadata formatters

### DIFF
--- a/agent-service/src/agent/util/workflow-system-metadata.spec.ts
+++ b/agent-service/src/agent/util/workflow-system-metadata.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { formatValidationErrors, formatCompactSchemaForError } from "./workflow-system-metadata";
+
+describe("formatValidationErrors", () => {
+  test("returns an empty string for a valid result", () => {
+    expect(formatValidationErrors({ isValid: true })).toBe("");
+  });
+
+  test("joins each message as 'key: msg' with '; '", () => {
+    expect(formatValidationErrors({ isValid: false, messages: { a: "x", b: "y" } })).toBe("a: x; b: y");
+  });
+});
+
+describe("formatCompactSchemaForError", () => {
+  test("lists required keys and JSON-stringifies only the present required properties", () => {
+    expect(formatCompactSchemaForError({ required: ["a", "b"], properties: { a: { type: "string" } } })).toBe(
+      'required: [a, b], properties: {"a":{"type":"string"}}'
+    );
+  });
+
+  test("renders empty required and properties", () => {
+    expect(formatCompactSchemaForError({ required: [], properties: {} })).toBe("required: [], properties: {}");
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?

Add unit test coverage for the two pure string formatters in `agent-service/src/agent/util/workflow-system-metadata.ts` — `formatValidationErrors` and `formatCompactSchemaForError`. A `bun test` `.spec.ts` sits next to the source. No production-code changes.

`fetchOperatorMetadata` in the same file hits the backend and is out of scope for this unit issue.

### Any related issues, documentation, discussions?

Closes #6335.

### How was this PR tested?

```
bun test src/agent/util/workflow-system-metadata.spec.ts
```

4 pass. `bun run typecheck` and `bun run format:check` are clean. The spec is pure — it calls the formatters with in-process literals and covers: a valid result → `""`; invalid messages joined as `key: msg` with `"; "`; a compact schema rendering its required keys plus the JSON-stringified present required properties; and the empty required/properties case.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
