### PR TITLE
chore(pve, v1.2): hard-disable the Python Virtual Environment UI

### DIFF
--- a/frontend/src/app/common/app-setting.ts
+++ b/frontend/src/app/common/app-setting.ts
@@ -24,3 +24,7 @@ export class AppSettings {
     return environment.apiUrl;
   }
 }
+
+// Python Virtual Environments are hard-disabled on the 1.2 release line;
+// flip to re-enable the UI entry points.
+export const PVE_ENABLED = false;

--- a/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.html
+++ b/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.html
@@ -164,7 +164,7 @@
             nz-icon
             nzType="plus"
             nz-tooltip
-            *ngIf="unit.isOwner"
+            *ngIf="pveEnabled && unit.isOwner"
             [nzTooltipTitle]="'Python Environment'"
             (click)="selectedComputingUnit = unit; showPVEmodalVisible(); $event.stopPropagation()">
           </i>

--- a/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.ts
+++ b/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.ts
@@ -25,6 +25,7 @@ import {
   WorkflowComputingUnitType,
 } from "../../../common/type/workflow-computing-unit";
 import { NotificationService } from "../../../common/service/notification/notification.service";
+import { PVE_ENABLED } from "../../../common/app-setting";
 import { DEFAULT_WORKFLOW, WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { isDefined } from "../../../common/util/predicate";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -136,6 +137,7 @@ type PveDraft = {
   ],
 })
 export class ComputingUnitSelectionComponent implements OnInit {
+  protected readonly pveEnabled = PVE_ENABLED;
   // variables for creating a virtual environment
   pves: PveDraft[] = [];
   systemPackages: { name: string; version: string }[] = [];

--- a/frontend/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/frontend/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -36,6 +36,7 @@ import {
   hideTypes,
 } from "../../../types/custom-json-schema.interface";
 import { isDefined } from "../../../../common/util/predicate";
+import { PVE_ENABLED } from "../../../../common/app-setting";
 import { ExecutionState, OperatorState, OperatorStatistics } from "src/app/workspace/types/execute-workflow.interface";
 import { DynamicSchemaService } from "../../../service/dynamic-schema/dynamic-schema.service";
 import { WorkflowCompilingService } from "../../../service/compile-workflow/workflow-compiling.service";
@@ -204,6 +205,15 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
     }
   }
 
+  private hidePveFields(): void {
+    for (const key of ["defaultEnv", "envName"]) {
+      const field = this.formlyFields?.[0]?.fieldGroup?.find(f => f.key === key);
+      if (field) {
+        field.hide = true;
+      }
+    }
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
     this.currentOperatorId = changes.currentOperatorId?.currentValue;
     if (!this.currentOperatorId) {
@@ -281,13 +291,16 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
       this.currentOperatorSchema.operatorType === "PythonUDFV2" ||
       this.currentOperatorSchema.operatorType === "DualInputPortsPythonUDFV2" ||
       this.currentOperatorSchema.operatorType === "PythonUDFSourceV2";
-    if (isPythonUdf && this.formData.defaultEnv === undefined) {
+    if (isPythonUdf && (this.formData.defaultEnv === undefined || !PVE_ENABLED)) {
       this.formData.defaultEnv = true;
     }
 
     const baseSchema = cloneDeep(this.currentOperatorSchema.jsonSchema);
 
-    if (isPythonUdf) {
+    if (isPythonUdf && !PVE_ENABLED) {
+      this.setFormlyFormBinding(baseSchema);
+      this.hidePveFields();
+    } else if (isPythonUdf) {
       this.computingUnitStatusService
         .getSelectedComputingUnit()
         .pipe(


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR hard-disables the PVE UI behind a single constant (`PVE_ENABLED = false` in `app-setting.ts`) so the feature can be restored with a one-line flip:

- The "Python Environment" icon on computing unit rows is hidden, which removes the only entry to the PVE install modal.
- The Python UDF operator's `defaultEnv` / `envName` fields are hidden and `defaultEnv` is forced to `true` when the property panel opens, so every Python UDF runs on the default environment and the frontend no longer issues any `/api/pve` request.

The backend (`PveResource`, `PveManager`, routing) is untouched and stays dormant.

| Before | After |
|--------|-------|
| <img width="450" alt="UDF Before" src="https://github.com/user-attachments/assets/2ffadacc-f450-4d21-8fed-f5a5d26a6fb4" /> | <img width="450" alt="UDF After" src="https://github.com/user-attachments/assets/f3306aec-5586-4cd3-9bbb-19681f1fb379" /> |
| <img width="450" alt="Tab Before" src="https://github.com/user-attachments/assets/c81d5676-bbd6-4b68-bc99-8f450acd2ea3" /> | <img width="450" alt="Tab After" src="https://github.com/user-attachments/assets/a795605e-9b50-4c1b-ae52-0aa2ffab6070" /> |


### Any related issues, documentation, discussions?

Related to #6131 and #5963.

### How was this PR tested?

Existing auto tests passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)
