### PR TITLE
test(frontend): extend OperatorMenuService coverage

### DIFF
--- a/frontend/src/app/workspace/service/operator-menu/operator-menu.service.spec.ts
+++ b/frontend/src/app/workspace/service/operator-menu/operator-menu.service.spec.ts
@@ -32,8 +32,11 @@ import {
   mockPoint,
   mockResultPredicate,
   mockScanPredicate,
+  mockScanSentimentLink,
   mockSentimentPredicate,
 } from "../workflow-graph/model/mock-workflow-data";
+import { NotificationService } from "../../../common/service/notification/notification.service";
+import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
 import { Subscription } from "rxjs";
 
 describe("OperatorMenuService", () => {
@@ -61,6 +64,10 @@ describe("OperatorMenuService", () => {
   });
 
   afterEach(() => subs.unsubscribe());
+
+  // drains both the microtask queue (Promise .then/.catch) and the macrotask queue so the
+  // clipboard-driven flows (writeText/readText promises) settle before assertions run.
+  const flushAsync = () => new Promise<void>(resolve => setTimeout(resolve, 0));
 
   it("should be created", () => {
     expect(service).toBeTruthy();
@@ -182,6 +189,259 @@ describe("OperatorMenuService", () => {
       workflowActionService.setViewOperatorResults([mockScanPredicate.operatorID, mockSentimentPredicate.operatorID]);
       // both highlighted non-sinks are now viewing results → next click should toggle off.
       expect(service.isToViewResult).toBe(false);
+    });
+  });
+
+  describe("operator action callbacks", () => {
+    beforeEach(() => {
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      workflowActionService.getJointGraphWrapper().highlightOperators(mockScanPredicate.operatorID);
+    });
+
+    it("disables then re-enables the highlighted operators based on isDisableOperator", () => {
+      const texeraGraph = workflowActionService.getTexeraGraph();
+      // fresh non-disabled operator → the button is in "disable" mode.
+      expect(service.isDisableOperator).toBe(true);
+
+      service.disableHighlightedOperators();
+      expect(texeraGraph.isOperatorDisabled(mockScanPredicate.operatorID)).toBe(true);
+      // recompute flips the toggle so the next click re-enables.
+      expect(service.isDisableOperator).toBe(false);
+
+      service.disableHighlightedOperators();
+      expect(texeraGraph.isOperatorDisabled(mockScanPredicate.operatorID)).toBe(false);
+    });
+
+    it("sets then unsets view-result on the highlighted non-sink operators", () => {
+      const texeraGraph = workflowActionService.getTexeraGraph();
+      expect(service.isToViewResult).toBe(true);
+
+      service.viewResultHighlightedOperators();
+      expect(texeraGraph.isViewingResult(mockScanPredicate.operatorID)).toBe(true);
+      expect(service.isToViewResult).toBe(false);
+
+      service.viewResultHighlightedOperators();
+      expect(texeraGraph.isViewingResult(mockScanPredicate.operatorID)).toBe(false);
+    });
+
+    it("marks then unmarks the highlighted non-sink operators for reuse", () => {
+      const texeraGraph = workflowActionService.getTexeraGraph();
+      expect(service.isMarkForReuse).toBe(true);
+
+      service.reuseResultHighlightedOperator();
+      expect(texeraGraph.isMarkedForReuseResult(mockScanPredicate.operatorID)).toBe(true);
+      expect(service.isMarkForReuse).toBe(false);
+
+      service.reuseResultHighlightedOperator();
+      expect(texeraGraph.isMarkedForReuseResult(mockScanPredicate.operatorID)).toBe(false);
+    });
+  });
+
+  describe("executeUpToOperator", () => {
+    it("errors and does not execute when zero operators are highlighted", () => {
+      const notificationService = TestBed.inject(NotificationService);
+      const executeWorkflowService = TestBed.inject(ExecuteWorkflowService);
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+      const executeSpy = vi.spyOn(executeWorkflowService, "executeWorkflow").mockImplementation(() => undefined);
+
+      service.executeUpToOperator();
+
+      expect(errorSpy).toHaveBeenCalledWith("Can only execute to exactly one target operator.");
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it("errors and does not execute when more than one operator is highlighted", () => {
+      const notificationService = TestBed.inject(NotificationService);
+      const executeWorkflowService = TestBed.inject(ExecuteWorkflowService);
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+      const executeSpy = vi.spyOn(executeWorkflowService, "executeWorkflow").mockImplementation(() => undefined);
+      workflowActionService.addOperatorsAndLinks(
+        [
+          { op: mockScanPredicate, pos: mockPoint },
+          { op: mockSentimentPredicate, pos: mockPoint },
+        ],
+        []
+      );
+      const wrapper = workflowActionService.getJointGraphWrapper();
+      wrapper.unhighlightOperators(...wrapper.getCurrentHighlightedOperatorIDs());
+      wrapper.setMultiSelectMode(true);
+      wrapper.highlightOperators(mockScanPredicate.operatorID, mockSentimentPredicate.operatorID);
+
+      service.executeUpToOperator();
+
+      expect(errorSpy).toHaveBeenCalledWith("Can only execute to exactly one target operator.");
+      expect(executeSpy).not.toHaveBeenCalled();
+    });
+
+    it("executes the workflow up to the single highlighted operator", () => {
+      const executeWorkflowService = TestBed.inject(ExecuteWorkflowService);
+      const executeSpy = vi.spyOn(executeWorkflowService, "executeWorkflow").mockImplementation(() => undefined);
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      workflowActionService.getJointGraphWrapper().highlightOperators(mockScanPredicate.operatorID);
+
+      service.executeUpToOperator();
+
+      expect(executeSpy).toHaveBeenCalledWith("", mockScanPredicate.operatorID);
+    });
+  });
+
+  describe("saveHighlightedElements", () => {
+    let originalClipboard: PropertyDescriptor | undefined;
+    let writeText: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      writeText = vi.fn().mockResolvedValue(undefined);
+      Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+    });
+
+    afterEach(() => {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        delete (navigator as any).clipboard;
+      }
+    });
+
+    it("serializes the highlighted operators, links, and comment boxes to the clipboard", () => {
+      // give the comment box a distinct ID: operators and comment boxes share the joint-graph
+      // cell namespace, and mockCommentBox reuses operator ID "1".
+      const commentBox = { ...mockCommentBox, commentBoxID: "comment-box-a" };
+      workflowActionService.addOperatorsAndLinks(
+        [
+          { op: mockScanPredicate, pos: mockPoint },
+          { op: mockSentimentPredicate, pos: mockPoint },
+        ],
+        [mockScanSentimentLink]
+      );
+      workflowActionService.addCommentBox(commentBox);
+      const wrapper = workflowActionService.getJointGraphWrapper();
+      // start from a clean highlight state, then multi-select every element we want copied.
+      wrapper.unhighlightOperators(...wrapper.getCurrentHighlightedOperatorIDs());
+      wrapper.setMultiSelectMode(true);
+      wrapper.highlightOperators(mockScanPredicate.operatorID, mockSentimentPredicate.operatorID);
+      wrapper.highlightLinks(mockScanSentimentLink.linkID);
+      wrapper.highlightCommentBoxes(commentBox.commentBoxID);
+
+      service.saveHighlightedElements();
+
+      expect(writeText).toHaveBeenCalledTimes(1);
+      const serialized = JSON.parse(writeText.mock.calls[0][0]);
+      expect(serialized.operators.map((op: any) => op.operatorID).sort()).toEqual(["1", "2"]);
+      expect(Object.keys(serialized.operatorPositions).sort()).toEqual(["1", "2"]);
+      // the serialized position mirrors what the graph reports for that operator.
+      expect(serialized.operatorPositions[mockScanPredicate.operatorID]).toEqual(
+        wrapper.getElementPosition(mockScanPredicate.operatorID)
+      );
+      expect(serialized.links.map((link: any) => link.linkID)).toEqual([mockScanSentimentLink.linkID]);
+      expect(serialized.commentBoxes.map((box: any) => box.commentBoxID)).toEqual([commentBox.commentBoxID]);
+    });
+
+    it("notifies the user when writing to the clipboard is rejected", async () => {
+      writeText.mockRejectedValue(new Error("no permission"));
+      const notificationService = TestBed.inject(NotificationService);
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      workflowActionService.getJointGraphWrapper().highlightOperators(mockScanPredicate.operatorID);
+
+      service.saveHighlightedElements();
+      await flushAsync();
+
+      expect(errorSpy).toHaveBeenCalledWith("Copy failed. You don't have the permission to write to the clipboard.");
+    });
+  });
+
+  describe("performPasteOperation", () => {
+    let originalClipboard: PropertyDescriptor | undefined;
+    let readText: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+      readText = vi.fn();
+      Object.defineProperty(navigator, "clipboard", { value: { readText }, configurable: true });
+    });
+
+    afterEach(() => {
+      if (originalClipboard) {
+        Object.defineProperty(navigator, "clipboard", originalClipboard);
+      } else {
+        delete (navigator as any).clipboard;
+      }
+    });
+
+    it("pastes operators, links, and comment boxes with fresh IDs and non-overlapping positions", async () => {
+      // both operators share the same clipboard position, so pasting the second one must be
+      // shifted by the getNonOverlappingPosition loop to avoid landing on the first.
+      const clipboard = {
+        operators: [mockScanPredicate, mockSentimentPredicate],
+        operatorPositions: {
+          [mockScanPredicate.operatorID]: { x: 100, y: 100 },
+          [mockSentimentPredicate.operatorID]: { x: 100, y: 100 },
+        },
+        links: [mockScanSentimentLink],
+        commentBoxes: [mockCommentBox],
+      };
+      readText.mockResolvedValue(JSON.stringify(clipboard));
+      const texeraGraph = workflowActionService.getTexeraGraph();
+
+      service.performPasteOperation();
+      await flushAsync();
+
+      const pastedOperators = texeraGraph.getAllOperators();
+      expect(pastedOperators.length).toBe(2);
+      // fresh IDs are assigned; none of the originals are reused.
+      expect(pastedOperators.map(op => op.operatorID)).not.toContain(mockScanPredicate.operatorID);
+      expect(pastedOperators.map(op => op.operatorID)).not.toContain(mockSentimentPredicate.operatorID);
+      expect(texeraGraph.getAllLinks().length).toBe(1);
+      expect(texeraGraph.getAllCommentBoxes().length).toBe(1);
+      // the pasted comment box is a distinct copy, not the original.
+      expect(texeraGraph.getAllCommentBoxes()[0].commentBoxID).not.toBe(mockCommentBox.commentBoxID);
+    });
+
+    it("notifies the user when the clipboard holds no pasteable elements", async () => {
+      readText.mockResolvedValue("{}");
+      const notificationService = TestBed.inject(NotificationService);
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+
+      service.performPasteOperation();
+      await flushAsync();
+
+      expect(errorSpy).toHaveBeenCalledWith("You haven't copied any element yet.");
+      expect(workflowActionService.getTexeraGraph().getAllOperators().length).toBe(0);
+    });
+
+    it("notifies the user when reading the clipboard is rejected", async () => {
+      readText.mockRejectedValue(new Error("blocked"));
+      const notificationService = TestBed.inject(NotificationService);
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+
+      service.performPasteOperation();
+      await flushAsync();
+
+      expect(errorSpy).toHaveBeenCalledWith("Paste failed. This site has been blocked from reading the clipboard.");
+    });
+
+    it("warns when adding the pasted operators and links fails", async () => {
+      const clipboard = {
+        operators: [mockScanPredicate],
+        operatorPositions: { [mockScanPredicate.operatorID]: { x: 100, y: 100 } },
+        links: [],
+        commentBoxes: [],
+      };
+      readText.mockResolvedValue(JSON.stringify(clipboard));
+      const notificationService = TestBed.inject(NotificationService);
+      const infoSpy = vi.spyOn(notificationService, "info").mockImplementation(() => {});
+      vi.spyOn(workflowActionService, "addOperatorsAndLinks").mockImplementation(() => {
+        throw new Error("dangling link");
+      });
+
+      service.performPasteOperation();
+      await flushAsync();
+
+      expect(infoSpy).toHaveBeenCalledWith(
+        "Some of the links that you selected don't have operators attached to both ends of them. " +
+          "These links won't be pasted, since links can't exist without operators."
+      );
     });
   });
 });

--- a/frontend/src/app/workspace/service/operator-menu/operator-menu.service.spec.ts
+++ b/frontend/src/app/workspace/service/operator-menu/operator-menu.service.spec.ts
@@ -51,6 +51,14 @@ describe("OperatorMenuService", () => {
       providers: [
         { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
         { provide: ComputingUnitStatusService, useClass: MockComputingUnitStatusService },
+        // Stub the two collaborators OperatorMenuService only calls into (executeWorkflow,
+        // error/info toasts) so the spec doesn't boot the real execution/notification stacks
+        // (websocket heartbeats, NgZorro notification overlays).
+        { provide: ExecuteWorkflowService, useValue: { executeWorkflow: vi.fn() } },
+        {
+          provide: NotificationService,
+          useValue: { error: vi.fn(), info: vi.fn(), success: vi.fn(), warning: vi.fn() },
+        },
         ...commonTestProviders,
       ],
       imports: [HttpClientTestingModule],
@@ -327,8 +335,9 @@ describe("OperatorMenuService", () => {
 
       expect(writeText).toHaveBeenCalledTimes(1);
       const serialized = JSON.parse(writeText.mock.calls[0][0]);
-      expect(serialized.operators.map((op: any) => op.operatorID).sort()).toEqual(["1", "2"]);
-      expect(Object.keys(serialized.operatorPositions).sort()).toEqual(["1", "2"]);
+      const copiedIds = [mockScanPredicate.operatorID, mockSentimentPredicate.operatorID].sort();
+      expect(serialized.operators.map((op: any) => op.operatorID).sort()).toEqual(copiedIds);
+      expect(Object.keys(serialized.operatorPositions).sort()).toEqual(copiedIds);
       // the serialized position mirrors what the graph reports for that operator.
       expect(serialized.operatorPositions[mockScanPredicate.operatorID]).toEqual(
         wrapper.getElementPosition(mockScanPredicate.operatorID)
@@ -392,6 +401,11 @@ describe("OperatorMenuService", () => {
       // fresh IDs are assigned; none of the originals are reused.
       expect(pastedOperators.map(op => op.operatorID)).not.toContain(mockScanPredicate.operatorID);
       expect(pastedOperators.map(op => op.operatorID)).not.toContain(mockSentimentPredicate.operatorID);
+      // both clipboard entries carried the same position, so getNonOverlappingPosition must have
+      // shifted the second paste off the first: the two pasted elements end up at distinct spots.
+      const wrapper = workflowActionService.getJointGraphWrapper();
+      const [posA, posB] = pastedOperators.map(op => wrapper.getElementPosition(op.operatorID));
+      expect(posA).not.toEqual(posB);
       expect(texeraGraph.getAllLinks().length).toBe(1);
       expect(texeraGraph.getAllCommentBoxes().length).toBe(1);
       // the pasted comment box is a distinct copy, not the original.


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the `OperatorMenuService` spec (was ~30% covered): disable/view/reuse toggle callbacks, `executeUpToOperator` (none/one/many highlighted), `saveHighlightedElements` clipboard serialization (success + rejection), and `performPasteOperation` (paste + copy + position/overlap, empty clipboard, read rejection, add-failure).

### Any related issues, documentation, discussions?

Closes #6367.

### How was this PR tested?

Added 12 tests (now 23) reusing the workflow-graph harness (StubOperatorMetadataService + WorkflowActionService/TexeraGraph); clipboard is stubbed and restored in afterEach. Verified locally with Vitest and CI's `format:ci` gate clean. Test-only change — no production code is modified.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])