### PR TITLE
fix(licensing, v1.2): refresh LICENSE-binary for bcprov and transitive Python deps

### DIFF
--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -566,7 +566,7 @@ Scala/Java jars:
   - com.liveperson.dropwizard-websockets-1.3.14.jar
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.8.1.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar

--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -246,7 +246,7 @@ Python packages:
   - aioitertools==0.13.0
   - annotated-doc==0.0.4
   - annotated-types==0.7.0
-  - anyio==4.14.1
+  - anyio==4.14.2
   - appdirs==1.4.4
   - asn1crypto==1.5.1
   - attrs==26.1.0

--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -218,7 +218,7 @@ Python packages:
   - botocore==1.40.53
   - frozenlist==1.8.0
   - hf-xet==1.5.1
-  - huggingface-hub==1.20.1
+  - huggingface-hub==1.23.0
   - multidict==6.7.1
   - overrides==7.4.0
   - packaging==26.2
@@ -227,14 +227,14 @@ Python packages:
   - pyiceberg==0.11.1
   - pympler==1.1
   - python-dateutil==2.8.2
-  - regex==2026.5.9
+  - regex==2026.7.10
   - requests==2.34.0
   - s3transfer==0.14.0
   - safetensors==0.8.0
   - tenacity==8.5.0
   - tokenizers==0.22.2
   - transformers==5.3.0
-  - tzdata==2026.2
+  - tzdata==2026.3
   - websocket-client==1.9.0
   - yarl==1.24.2
 
@@ -252,12 +252,12 @@ Python packages:
   - attrs==26.1.0
   - betterproto==2.0.0b7
   - cachetools==6.2.6
-  - charset-normalizer==3.4.7
+  - charset-normalizer==3.4.9
   - deprecated==1.2.14
-  - filelock==3.29.4
+  - filelock==3.29.7
   - fonttools==4.63.0
   - fs==2.4.16
-  - greenlet==3.5.2
+  - greenlet==3.5.3
   - h11==0.16.0
   - h2==4.3.0
   - hpack==4.2.0
@@ -283,11 +283,11 @@ Python packages:
   - readerwriterlock==1.0.9
   - rich==14.3.4
   - ruff==0.14.7
-  - scramp==1.4.9
+  - scramp==1.4.12
   - six==1.17.0
   - sqlalchemy==2.0.37
   - strictyaml==1.7.3
-  - typer==0.25.1
+  - typer==0.26.8
   - typing-inspection==0.4.2
   - tzlocal==2.1
   - urllib3==2.7.0
@@ -356,14 +356,14 @@ Dependencies under the Mozilla Public License, Version 2.0
 Python packages:
   - bidict==0.22.0
   - certifi==2026.6.17
-  - tqdm==4.68.3
+  - tqdm==4.68.4
 
 --------------------------------------------------------------------------------
 Dependencies under the Python Software Foundation License
 --------------------------------------------------------------------------------
 
 Python packages:
-  - aiohappyeyeballs==2.6.2
+  - aiohappyeyeballs==2.7.1
   - matplotlib==3.11.0
   - typing-extensions==4.14.1
 

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -495,7 +495,7 @@ Source files derived from third-party MIT-licensed projects:
 
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -506,7 +506,7 @@ Scala/Java jars:
   - com.konghq.unirest-java-3.14.2.jar
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar


### PR DESCRIPTION
### What changes were proposed in this PR?

Refreshes the per-module `LICENSE-binary` files on `release/v1.2` to match the versions actually bundled, clearing the drift reported by the license-binary checker (verified against dispatch [run 29286968845](https://github.com/apache/texera/actions/runs/29286968845)). Version-only edits; license groupings unchanged.

**JVM — `org.bouncycastle.bcprov-jdk18on` 1.82 → 1.84** in the three files that bundle it: `amber/LICENSE-binary-java`, `file-service/LICENSE-binary`, `workflow-compiling-service/LICENSE-binary`. Completes #6316 (the CVE-2025-14813 bump pinned the override to 1.84 but left these lines at 1.82).

**Python — `amber/LICENSE-binary-python` (11):** transitive packages, version-only bumps to match the freshly-resolved bundle:
`aiohappyeyeballs` 2.6.2→2.7.1, `anyio` 4.14.1→4.14.2, `charset-normalizer` 3.4.7→3.4.9, `filelock` 3.29.4→3.29.7, `greenlet` 3.5.2→3.5.3, `huggingface-hub` 1.20.1→1.23.0, `regex` 2026.5.9→2026.7.10, `scramp` 1.4.9→1.4.12, `tqdm` 4.68.3→4.68.4, `typer` 0.25.1→0.26.8, `tzdata` 2026.2→2026.3.

License groupings are unchanged; only version strings were updated.

### Any related issues, documentation, discussions?

Closes #6372. Follow-up to #6316.

### How was this PR tested?

Version-only metadata change, verified against license-binary checker dispatch on `release/v1.2` (run 29286968845). Note: the Python entries are transitive and float with PyPI, so the check must be re-run immediately before tagging RC3 and topped up if any newer drift has appeared by then.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
