### PR TITLE
ci: add a computing-unit-master boot smoke test in amber-integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -639,6 +639,19 @@ jobs:
         # amber/src/main/resources/web-config.yml (port 8080).
         if: matrix.os == 'ubuntu-latest'
         run: .github/scripts/smoke-boot.sh "/tmp/dists/amber-*/bin/texera-web-application" 8080
+      - name: Smoke-test computing-unit-master boots
+        # computing-unit-master boots on postgres only, like texera-web: main
+        # starts a LOCAL Pekko actor master (clusterMode defaults to false with
+        # no --cluster arg, so no external seed/discovery and the cluster-only
+        # checkip.amazonaws.com lookup is never reached), then run() calls
+        # SqlServer.initConnection against the postgres provisioned above. The
+        # boot-time result-store cleanup is gated on
+        # ApplicationConfig.cleanupAllExecutionResults, which defaults to false,
+        # so no iceberg / S3 access. Config resolves via Utils.amberHomePath to
+        # amber/src/main/resources/computing-unit-master-config.yml (port 8085).
+        # Reuses the amber dist built + unzipped above for the texera-web boot.
+        if: matrix.os == 'ubuntu-latest'
+        run: .github/scripts/smoke-boot.sh "/tmp/dists/amber-*/bin/computing-unit-master" 8085
       - name: Run Python integration tests
         # --junit-xml feeds the Test Analytics upload below.
         run: |


### PR DESCRIPTION
### What changes were proposed in this PR?

`amber-integration` already builds and unzips the amber dist to boot-smoke-test `texera-web` (#6319), but `computing-unit-master` — the other server produced by the same `WorkflowExecutionService/dist` (`bin/computing-unit-master`, port 8085) — is not started anywhere in CI. It compiles and unit-tests clean, so a runtime classpath/linkage regression (the #6204 class of bug: `NoClassDefFoundError` from a dependency conflict that only manifests when the packaged launcher actually runs) would pass build and merge, surfacing only at deploy.

- Add one boot step to `amber-integration`, right after the `texera-web` boot, reusing the amber dist already built and unzipped there — no extra build. It launches `bin/computing-unit-master` via `.github/scripts/smoke-boot.sh` and asserts the process reaches a listening state on :8085 without crashing.

It boots on **postgres only**, which `amber-integration` already provisions:
- `main` starts a **local** Pekko actor master — `clusterMode` defaults to `false` (no `--cluster` arg), so `AmberRuntime.startActorMaster(false)` self-seeds a single node with no external discovery, and the cluster-only `getNodeIpAddress` (`checkip.amazonaws.com`) call is never reached — then `run()` calls `SqlServer.initConnection`.
- The boot-time result-store cleanup is gated on `ApplicationConfig.cleanupAllExecutionResults`, which defaults to `false` (asserted in `ApplicationConfigSpec`), so no iceberg/S3 access on boot.
- Config resolves via `Utils.amberHomePath` to `amber/src/main/resources/computing-unit-master-config.yml` (port 8085).

`ubuntu-latest` only, mirroring the `texera-web` step (the boot is pure-JVM and OS-independent).

### Any related issues, documentation, discussions?

Closes #6344. Mirrors the `texera-web` boot test from #6319 and the platform-service boot tests from #6274; smoke script from #6220. Suggested by @Yicong-Huang in the #6319 review.

### How was this PR tested?

- `amber-integration` (ubuntu-latest) runs the new step in this PR; `bin/computing-unit-master` boots and reaches LISTEN on :8085.
- Verified the boot needs no infra beyond the postgres the job already provisions, by reading `ComputingUnitMaster.main`/`run`: `clusterMode` default `false` → local actor master, `cleanupAllExecutionResults` default `false` → no result-store cleanup, `SqlServer.initConnection` → postgres only.
- The step is a faithful mirror of the existing `texera-web` boot (same dist, same `smoke-boot.sh`, same `ubuntu-only` guard).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-8)
