### PR TITLE
test(agent-service): add unit test coverage for compileWorkflowAsync

### DIFF
--- a/agent-service/src/api/compile-api.spec.ts
+++ b/agent-service/src/api/compile-api.spec.ts
@@ -42,7 +42,7 @@ describe("compileWorkflowAsync", () => {
     expect(result).toEqual(compilation);
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
-    expect(url).toContain("/api/compile");
+    expect(url).toMatch(/\/api\/compile$/);
     expect(init.method).toBe("POST");
     expect(init.headers).toEqual({ "Content-Type": "application/json" });
     expect(JSON.parse(init.body as string)).toEqual({

--- a/agent-service/src/api/compile-api.spec.ts
+++ b/agent-service/src/api/compile-api.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { compileWorkflowAsync, type WorkflowCompilationResponse } from "./compile-api";
+import type { LogicalPlan } from "../types/workflow";
+
+const plan = {
+  operators: [{ operatorID: "opX" }],
+  links: [],
+} as unknown as LogicalPlan;
+
+describe("compileWorkflowAsync", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test("POSTs the plan to the compile endpoint and returns the parsed response on ok", async () => {
+    const compilation: WorkflowCompilationResponse = { operatorOutputSchemas: {}, operatorErrors: {} };
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify(compilation), { status: 200 })
+    );
+
+    const result = await compileWorkflowAsync(plan);
+
+    expect(result).toEqual(compilation);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/compile");
+    expect(init.method).toBe("POST");
+    expect(init.headers).toEqual({ "Content-Type": "application/json" });
+    expect(JSON.parse(init.body as string)).toEqual({
+      operators: [{ operatorID: "opX" }],
+      links: [],
+      opsToReuseResult: [],
+      opsToViewResult: [],
+    });
+  });
+
+  test("returns null on a non-ok response", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(new Response("boom", { status: 500 }));
+    expect(await compileWorkflowAsync(plan)).toBeNull();
+  });
+
+  test("returns null when fetch rejects", async () => {
+    spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    expect(await compileWorkflowAsync(plan)).toBeNull();
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?

Add unit test coverage for `compileWorkflowAsync` in `agent-service/src/api/compile-api.ts` — a `fetch`-based client returning `WorkflowCompilationResponse | null`. A `bun test` `.spec.ts` that mocks the global `fetch`. No production-code changes.

### Any related issues, documentation, discussions?

Closes #6376.

### How was this PR tested?

```
bun test src/api/compile-api.spec.ts
```

3 pass. `bun run typecheck` and `bun run format:check` are clean. The spec mocks `globalThis.fetch` (`spyOn` + `mock.restore()` between cases) and covers: the `POST` request shape (`/api/compile`, method, `Content-Type`, and the serialized `{ operators, links, opsToReuseResult, opsToViewResult }` body); the ok path returning the parsed `WorkflowCompilationResponse`; and both `null` fallbacks — a non-ok response and a rejected `fetch`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
