### PR TITLE
test(frontend): add unit test coverage for HubService

### DIFF
--- a/frontend/src/app/hub/service/hub.service.spec.ts
+++ b/frontend/src/app/hub/service/hub.service.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import {
+  AccessResponse,
+  ActionType,
+  CountResponse,
+  EntityType,
+  HubService,
+  LikedStatus,
+  WORKFLOW_BASE_URL,
+} from "./hub.service";
+
+describe("HubService", () => {
+  let service: HubService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [HubService],
+    });
+    service = TestBed.inject(HubService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("getCount GETs /count with the entityType param and emits the count", () => {
+    let result: number | undefined;
+    service.getCount(EntityType.Workflow).subscribe(n => (result = n));
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/count`);
+    expect(req.request.method).toBe("GET");
+    expect(req.request.params.get("entityType")).toBe("workflow");
+
+    req.flush(5);
+    expect(result).toBe(5);
+  });
+
+  it("cloneWorkflow POSTs to /workflow/clone/:wid with a null body and emits the new wid", () => {
+    let result: number | undefined;
+    service.cloneWorkflow(42).subscribe(n => (result = n));
+
+    const req = httpMock.expectOne(`${WORKFLOW_BASE_URL}/clone/42`);
+    expect(req.request.method).toBe("POST");
+    expect(req.request.body).toBeNull();
+
+    req.flush(99);
+    expect(result).toBe(99);
+  });
+
+  it("isLiked GETs /isLiked appending every id and type, and emits the statuses", () => {
+    const statuses: LikedStatus[] = [
+      { entityId: 1, entityType: EntityType.Workflow, isLiked: true },
+      { entityId: 2, entityType: EntityType.Dataset, isLiked: false },
+    ];
+    let result: LikedStatus[] | undefined;
+    service.isLiked([1, 2], [EntityType.Workflow, EntityType.Dataset]).subscribe(s => (result = s));
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/isLiked`);
+    expect(req.request.method).toBe("GET");
+    expect(req.request.params.getAll("entityId")).toEqual(["1", "2"]);
+    expect(req.request.params.getAll("entityType")).toEqual(["workflow", "dataset"]);
+
+    req.flush(statuses);
+    expect(result).toEqual(statuses);
+  });
+
+  it("postLike POSTs /like with a json body and emits the boolean result", () => {
+    let result: boolean | undefined;
+    service.postLike(1, EntityType.Workflow).subscribe(b => (result = b));
+
+    const req = httpMock.expectOne(`${service.BASE_URL}/like`);
+    expect(req.request.method).toBe("POST");
+    expect(req.request.body).toEqual({ entityId: 1, entityType: EntityType.Workflow });
+    expect(req.request.headers.get("Content-Type")).toBe("application/json");
+
+    req.flush(true);
+    expect(result).toBe(true);
+  });
+
+  it("postUnlike POSTs /unlike with a json body and emits the boolean result", () => {
+    let result: boolean | undefined;
+    service.postUnlike(1, EntityType.Workflow).subscribe(b => (result = b));
+
+    const req = httpMock.expectOne(`${service.BASE_URL}/unlike`);
+    expect(req.request.method).toBe("POST");
+    expect(req.request.body).toEqual({ entityId: 1, entityType: EntityType.Workflow });
+
+    req.flush(false);
+    expect(result).toBe(false);
+  });
+
+  it("toggleLike likes (not currently liked) then re-fetches the like count", () => {
+    let result: { liked: boolean; likeCount: number } | undefined;
+    service.toggleLike(1, EntityType.Workflow, false).subscribe(r => (result = r));
+
+    // First request: the like POST carries the target entity.
+    const likeReq = httpMock.expectOne(r => r.url === `${service.BASE_URL}/like`);
+    expect(likeReq.request.method).toBe("POST");
+    expect(likeReq.request.body).toEqual({ entityId: 1, entityType: EntityType.Workflow });
+    likeReq.flush(true);
+
+    // Second request: the counts GET fired by switchMap re-queries the same entity for the like count.
+    const countsReq = httpMock.expectOne(r => r.url === `${service.BASE_URL}/counts`);
+    expect(countsReq.request.method).toBe("GET");
+    expect(countsReq.request.params.getAll("entityType")).toEqual(["workflow"]);
+    expect(countsReq.request.params.getAll("entityId")).toEqual(["1"]);
+    expect(countsReq.request.params.getAll("actionType")).toEqual(["like"]);
+    countsReq.flush([{ entityId: 1, entityType: EntityType.Workflow, counts: { like: 7 } }] as CountResponse[]);
+
+    expect(result).toEqual({ liked: true, likeCount: 7 });
+  });
+
+  it("toggleLike unlikes (currently liked) then re-fetches the like count", () => {
+    let result: { liked: boolean; likeCount: number } | undefined;
+    service.toggleLike(1, EntityType.Workflow, true).subscribe(r => (result = r));
+
+    const unlikeReq = httpMock.expectOne(r => r.url === `${service.BASE_URL}/unlike`);
+    expect(unlikeReq.request.method).toBe("POST");
+    expect(unlikeReq.request.body).toEqual({ entityId: 1, entityType: EntityType.Workflow });
+    unlikeReq.flush(true);
+
+    const countsReq = httpMock.expectOne(r => r.url === `${service.BASE_URL}/counts`);
+    expect(countsReq.request.method).toBe("GET");
+    expect(countsReq.request.params.getAll("entityType")).toEqual(["workflow"]);
+    expect(countsReq.request.params.getAll("entityId")).toEqual(["1"]);
+    expect(countsReq.request.params.getAll("actionType")).toEqual(["like"]);
+    countsReq.flush([{ entityId: 1, entityType: EntityType.Workflow, counts: { like: 3 } }] as CountResponse[]);
+
+    expect(result).toEqual({ liked: false, likeCount: 3 });
+  });
+
+  it("toggleLike keeps the current state when the action fails and defaults the count to 0", () => {
+    let result: { liked: boolean; likeCount: number } | undefined;
+    service.toggleLike(1, EntityType.Workflow, false).subscribe(r => (result = r));
+
+    const likeReq = httpMock.expectOne(r => r.url === `${service.BASE_URL}/like`);
+    expect(likeReq.request.method).toBe("POST");
+    expect(likeReq.request.body).toEqual({ entityId: 1, entityType: EntityType.Workflow });
+    likeReq.flush(false);
+
+    const countsReq = httpMock.expectOne(r => r.url === `${service.BASE_URL}/counts`);
+    expect(countsReq.request.method).toBe("GET");
+    expect(countsReq.request.params.getAll("entityId")).toEqual(["1"]);
+    countsReq.flush([] as CountResponse[]);
+
+    // action returned false -> liked stays at currentlyLiked (false); empty counts -> 0.
+    expect(result).toEqual({ liked: false, likeCount: 0 });
+  });
+
+  it("postView POSTs /view with a json body and emits the view count", () => {
+    let result: number | undefined;
+    service.postView(1, 7, EntityType.Workflow).subscribe(n => (result = n));
+
+    const req = httpMock.expectOne(`${service.BASE_URL}/view`);
+    expect(req.request.method).toBe("POST");
+    expect(req.request.body).toEqual({ entityId: 1, userId: 7, entityType: EntityType.Workflow });
+    expect(req.request.headers.get("Content-Type")).toBe("application/json");
+
+    req.flush(12);
+    expect(result).toBe(12);
+  });
+
+  it("getTops GETs /getTops with entityType, uid, limit and appended actionTypes", () => {
+    let result: Record<ActionType, unknown[]> | undefined;
+    service.getTops(EntityType.Workflow, [ActionType.Like, ActionType.Clone], 5, 3).subscribe(r => (result = r));
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/getTops`);
+    expect(req.request.method).toBe("GET");
+    expect(req.request.params.get("entityType")).toBe("workflow");
+    expect(req.request.params.get("uid")).toBe("5");
+    expect(req.request.params.get("limit")).toBe("3");
+    expect(req.request.params.getAll("actionTypes")).toEqual(["like", "clone"]);
+
+    const payload = { like: [], clone: [] } as unknown as Record<ActionType, unknown[]>;
+    req.flush(payload);
+    expect(result).toEqual(payload);
+  });
+
+  it("getTops defaults uid to -1 and omits limit when it is not provided", () => {
+    service.getTops(EntityType.Dataset, [ActionType.Like]).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/getTops`);
+    expect(req.request.params.get("uid")).toBe("-1");
+    expect(req.request.params.has("limit")).toBe(false);
+
+    req.flush({ like: [] });
+  });
+
+  it("getCounts GETs /counts appending types, ids and actionTypes", () => {
+    const counts: CountResponse[] = [{ entityId: 1, entityType: EntityType.Workflow, counts: { view: 3, like: 4 } }];
+    let result: CountResponse[] | undefined;
+    service
+      .getCounts([EntityType.Workflow, EntityType.Dataset], [1, 2], [ActionType.View, ActionType.Like])
+      .subscribe(r => (result = r));
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/counts`);
+    expect(req.request.method).toBe("GET");
+    expect(req.request.params.getAll("entityType")).toEqual(["workflow", "dataset"]);
+    expect(req.request.params.getAll("entityId")).toEqual(["1", "2"]);
+    expect(req.request.params.getAll("actionType")).toEqual(["view", "like"]);
+
+    req.flush(counts);
+    expect(result).toEqual(counts);
+  });
+
+  it("getCounts omits the actionType param when no actionTypes are given", () => {
+    service.getCounts([EntityType.Workflow], [1]).subscribe();
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/counts`);
+    expect(req.request.params.has("actionType")).toBe(false);
+
+    req.flush([]);
+  });
+
+  it("getUserAccess GETs /user-access appending types and ids, and emits the access list", () => {
+    const access: AccessResponse[] = [{ entityType: EntityType.Workflow, entityId: 1, userIds: [10, 20] }];
+    let result: AccessResponse[] | undefined;
+    service.getUserAccess([EntityType.Workflow], [1]).subscribe(r => (result = r));
+
+    const req = httpMock.expectOne(r => r.url === `${service.BASE_URL}/user-access`);
+    expect(req.request.method).toBe("GET");
+    expect(req.request.params.getAll("entityType")).toEqual(["workflow"]);
+    expect(req.request.params.getAll("entityId")).toEqual(["1"]);
+
+    req.flush(access);
+    expect(result).toEqual(access);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds a Vitest unit-test suite for `frontend/src/app/hub/service/hub.service.ts`
(`HubService`), which previously had no spec (~30% coverage). `HubService` is a
thin `HttpClient` wrapper with ~10 `Observable`-returning methods; the suite
asserts each issues the expected request (method, URL, query params / body,
headers) and maps the response, using `HttpClientTestingModule` +
`HttpTestingController` — no backend.

15 tests cover:

- `getCount` — GET `/count` with the `entityType` param → emits the count.
- `cloneWorkflow` — POST `/workflow/clone/:wid` with a null body → emits the new wid.
- `isLiked` — GET `/isLiked` appending every id/type → emits `LikedStatus[]`.
- `postLike` / `postUnlike` — POST `/like` / `/unlike` with the json body/header → emit the boolean.
- `toggleLike` — three cases: not-liked → likes then re-fetches the count; liked → unlikes then re-fetches; action returns `false` → state unchanged and the count defaults to 0.
- `postView` — POST `/view` with the json body → emits the view count.
- `getTops` — GET `/getTops` with `entityType`/`uid`/`limit`/appended `actionTypes`, plus the `uid` = -1 default and `limit`-omitted path.
- `getCounts` — GET `/counts` appending types/ids/actionTypes, plus the empty-`actionTypes` (param omitted) path.
- `getUserAccess` — GET `/user-access` appending types/ids → emits `AccessResponse[]`.

No production code was changed.

### Any related issues, documentation, discussions?

Closes #6387

### How was this PR tested?

New unit tests, run locally in `frontend/` (all green; the failure path was
verified by deliberately breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/hub/service/hub.service.spec.ts
# Test Files 1 passed (1) | Tests 15 passed (15)
prettier --write src/app/hub/service/hub.service.spec.ts   # unchanged
eslint  src/app/hub/service/hub.service.spec.ts            # clean
```

The suite uses `HttpClientTestingModule` / `HttpTestingController` (see
`frontend/TESTING.md` Recipe E), so it makes no real network calls.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
