### PR TITLE
test(frontend): add unit test coverage for replaceOneImmutable

### DIFF
--- a/frontend/src/app/common/util/array-utils.spec.ts
+++ b/frontend/src/app/common/util/array-utils.spec.ts
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { replaceOneImmutable } from "./array-utils";
+
+describe("replaceOneImmutable", () => {
+  it("should return a new array reference with the matched element replaced", () => {
+    const input = [1, 2, 3];
+    const result = replaceOneImmutable(input, x => x === 2, 20);
+
+    expect(result).not.toBe(input);
+    expect(result).toEqual([1, 20, 3]);
+  });
+
+  it("should not mutate the original input array", () => {
+    const input = [1, 2, 3];
+    replaceOneImmutable(input, x => x === 2, 20);
+
+    expect(input).toEqual([1, 2, 3]);
+  });
+
+  it("should return the same array reference when the predicate matches nothing", () => {
+    const input = [1, 2, 3];
+    const result = replaceOneImmutable(input, x => x === 999, 20);
+
+    expect(result).toBe(input);
+  });
+
+  it("should pass the element index as the second argument to the predicate", () => {
+    const input = ["a", "b", "c"];
+    const seenIndices: number[] = [];
+
+    replaceOneImmutable(
+      input,
+      (t, idx) => {
+        seenIndices.push(idx);
+        return t === "b";
+      },
+      "z"
+    );
+
+    expect(seenIndices).toEqual([0, 1]);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
Adds `array-utils.spec.ts` to cover `replaceOneImmutable`, a previously untested generic utility function in `common/util/` that returns a new array with the first predicate-matching element replaced, without mutating the original array. Covers all four behavior contracts: returns a new array reference when a match is found, leaves the original array unmutated, returns the same array reference (identity) when no match is found, and passes the element's index as the second argument to the predicate.

No production code was changed.


### Any related issues, documentation, discussions?
Closes #6256


### How was this PR tested?
Added 4 new unit tests in array-utils.spec.ts covering all behavior contracts described in the issue. Ran locally via `npx ng test --include='**/array-utils.spec.ts'`; all 4 pass.


### Was this PR authored or co-authored using generative AI tooling?
Co-authored using Claude (Anthropic).
