### PR TITLE
chore(licensing): refresh LICENSE-binary for transitive drift across services

### DIFF
--- a/access-control-service/LICENSE-binary
+++ b/access-control-service/LICENSE-binary
@@ -274,7 +274,7 @@ Scala/Java jars:
   - io.dropwizard.metrics.metrics-json-4.2.25.jar
   - io.dropwizard.metrics.metrics-jvm-4.2.25.jar
   - io.dropwizard.metrics.metrics-logback-4.2.25.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - org.apache.commons.commons-lang3-3.13.0.jar

--- a/amber/LICENSE-binary-java
+++ b/amber/LICENSE-binary-java
@@ -230,10 +230,10 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jdk8-2.11.4.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-joda-2.9.10.jar
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.18.6.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.18.6.jar
   - com.fasterxml.jackson.module.jackson-module-afterburner-2.9.10.jar
-  - com.fasterxml.jackson.module.jackson-module-jaxb-annotations-2.12.7.jar
+  - com.fasterxml.jackson.module.jackson-module-jaxb-annotations-2.18.6.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-no-ctor-deser-2.18.8.jar
   - com.fasterxml.jackson.module.jackson-module-parameter-names-2.9.10.jar
@@ -260,8 +260,8 @@ Scala/Java jars:
   - com.google.http-client.google-http-client-1.42.3.jar
   - com.google.http-client.google-http-client-apache-v2-1.42.3.jar
   - com.google.http-client.google-http-client-gson-1.42.3.jar
-  - com.google.inject.extensions.guice-servlet-4.2.3.jar
-  - com.google.inject.guice-4.2.3.jar
+  - com.google.inject.extensions.guice-servlet-5.1.0.jar
+  - com.google.inject.guice-5.1.0.jar
   - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.google.oauth-client.google-oauth-client-1.34.1.jar
   - com.google.oauth-client.google-oauth-client-java6-1.34.1.jar
@@ -363,7 +363,7 @@ Scala/Java jars:
   - io.opencensus.opencensus-api-0.31.1.jar
   - io.opencensus.opencensus-contrib-http-util-0.31.1.jar
   - io.perfmark.perfmark-api-0.27.0.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - io.reactivex.rxjava3.rxjava-3.1.12.jar
   - javax.inject.javax.inject-1.jar
   - javax.validation.validation-api-2.0.1.Final.jar
@@ -450,30 +450,30 @@ Scala/Java jars:
   - org.apache.pekko.pekko-slf4j_2.13-1.6.0.jar
   - org.apache.pekko.pekko-stream_2.13-1.6.0.jar
   - org.apache.yetus.audience-annotations-0.12.0.jar
-  - org.apache.zookeeper.zookeeper-3.8.4.jar
-  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-3.8.6.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.6.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
   - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-annotations-9.4.18.v20190429.jar
-  - org.eclipse.jetty.jetty-client-9.4.57.v20241219.jar
+  - org.eclipse.jetty.jetty-client-9.4.58.v20250814.jar
   - org.eclipse.jetty.jetty-continuation-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-http-9.4.20.v20190813.jar
-  - org.eclipse.jetty.jetty-io-9.4.57.v20241219.jar
+  - org.eclipse.jetty.jetty-io-9.4.58.v20250814.jar
   - org.eclipse.jetty.jetty-jndi-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-plus-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-security-9.4.20.v20190813.jar
   - org.eclipse.jetty.jetty-server-9.4.20.v20190813.jar
   - org.eclipse.jetty.jetty-servlet-9.4.20.v20190813.jar
   - org.eclipse.jetty.jetty-servlets-9.4.18.v20190429.jar
-  - org.eclipse.jetty.jetty-util-9.4.57.v20241219.jar
+  - org.eclipse.jetty.jetty-util-9.4.58.v20250814.jar
   - org.eclipse.jetty.jetty-webapp-9.4.18.v20190429.jar
   - org.eclipse.jetty.jetty-xml-9.4.18.v20190429.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.3.jar
   - org.eclipse.jetty.websocket.javax-websocket-client-impl-9.4.18.v20190429.jar
   - org.eclipse.jetty.websocket.javax-websocket-server-impl-9.4.18.v20190429.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.58.v20250814.jar
   - org.eclipse.jetty.websocket.websocket-server-9.4.18.v20190429.jar
   - org.eclipse.jetty.websocket.websocket-servlet-9.4.18.v20190429.jar
   - org.ehcache.sizeof-0.4.4.jar
@@ -489,8 +489,8 @@ Scala/Java jars:
   - org.jheaps.jheaps-0.11.jar
   - org.joda.joda-convert-2.2.2.jar
   - org.jooq.jooq-3.19.36.jar
-  - org.json4s.json4s-ast_2.13-4.0.1.jar
-  - org.json4s.json4s-jackson-core_2.13-4.0.1.jar
+  - org.json4s.json4s-ast_2.13-4.0.6.jar
+  - org.json4s.json4s-jackson-core_2.13-4.0.6.jar
   - org.lz4.lz4-java-1.8.0.jar
   - org.objenesis.objenesis-3.4.jar
   - org.openapitools.jackson-databind-nullable-0.2.6.jar
@@ -567,8 +567,8 @@ Scala/Java jars:
   - com.liveperson.dropwizard-websockets-1.3.14.jar
   - io.github.classgraph.classgraph-4.8.184.jar
   - net.sourceforge.argparse4j.argparse4j-0.8.1.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
-  - org.checkerframework.checker-qual-3.52.0.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
+  - org.checkerframework.checker-qual-3.55.1.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar
   - org.reactivestreams.reactive-streams-1.0.4.jar
@@ -690,8 +690,8 @@ Dependencies under the Eclipse Distribution License, Version 1.0
 --------------------------------------------------------------------------------
 
 Scala/Java jars:
-  - jakarta.activation.jakarta.activation-api-1.2.1.jar
-  - jakarta.xml.bind.jakarta.xml.bind-api-3.0.0.jar
+  - jakarta.activation.jakarta.activation-api-1.2.2.jar
+  - jakarta.xml.bind.jakarta.xml.bind-api-2.3.3.jar
   - org.eclipse.jgit.org.eclipse.jgit-5.13.0.202109080827-r.jar
 
 --------------------------------------------------------------------------------

--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -218,7 +218,7 @@ Python packages:
   - botocore==1.42.90
   - frozenlist==1.8.0
   - hf-xet==1.5.1
-  - huggingface-hub==1.20.1
+  - huggingface-hub==1.23.0
   - multidict==6.7.1
   - overrides==7.7.0
   - packaging==26.2
@@ -227,14 +227,14 @@ Python packages:
   - pyiceberg==0.11.1
   - pympler==1.1
   - python-dateutil==2.8.2
-  - regex==2026.5.9
+  - regex==2026.7.10
   - requests==2.34.2
   - s3transfer==0.16.1
   - safetensors==0.8.0
   - tenacity==8.5.0
   - tokenizers==0.22.2
   - transformers==5.3.0
-  - tzdata==2026.2
+  - tzdata==2026.3
   - websocket-client==1.9.0
   - yarl==1.24.2
 
@@ -246,17 +246,17 @@ Python packages:
   - aioitertools==0.13.0
   - annotated-doc==0.0.4
   - annotated-types==0.7.0
-  - anyio==4.14.1
+  - anyio==4.14.2
   - appdirs==1.4.4
   - asn1crypto==1.5.1
   - attrs==26.1.0
   - betterproto==2.0.0b7
   - cachetools==6.2.6
-  - charset-normalizer==3.4.7
-  - filelock==3.29.4
+  - charset-normalizer==3.4.9
+  - filelock==3.29.7
   - fonttools==4.63.0
   - fs==2.4.16
-  - greenlet==3.5.2
+  - greenlet==3.5.3
   - h11==0.16.0
   - h2==4.3.0
   - hpack==4.2.0
@@ -276,11 +276,11 @@ Python packages:
   - pyyaml==6.0.3
   - readerwriterlock==1.0.9
   - rich==14.3.4
-  - scramp==1.4.9
+  - scramp==1.4.12
   - six==1.17.0
   - sqlalchemy==2.0.51
   - strictyaml==1.7.3
-  - typer==0.25.1
+  - typer==0.26.8
   - typing-inspection==0.4.2
   - tzlocal==2.1
   - urllib3==2.7.0
@@ -347,14 +347,14 @@ Dependencies under the Mozilla Public License, Version 2.0
 Python packages:
   - bidict==0.22.0
   - certifi==2026.6.17
-  - tqdm==4.68.3
+  - tqdm==4.68.4
 
 --------------------------------------------------------------------------------
 Dependencies under the Python Software Foundation License
 --------------------------------------------------------------------------------
 
 Python packages:
-  - aiohappyeyeballs==2.6.2
+  - aiohappyeyeballs==2.7.1
   - matplotlib==3.11.0
   - typing-extensions==4.14.1
 

--- a/computing-unit-managing-service/LICENSE-binary
+++ b/computing-unit-managing-service/LICENSE-binary
@@ -231,8 +231,8 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.18.6.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.18.6.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
@@ -252,8 +252,8 @@ Scala/Java jars:
   - com.google.guava.failureaccess-1.0.3.jar
   - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  - com.google.inject.extensions.guice-servlet-4.2.3.jar
-  - com.google.inject.guice-4.2.3.jar
+  - com.google.inject.extensions.guice-servlet-5.1.0.jar
+  - com.google.inject.guice-5.1.0.jar
   - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
@@ -370,7 +370,7 @@ Scala/Java jars:
   - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
   - org.jspecify.jspecify-1.0.0.jar
   - io.perfmark.perfmark-api-0.27.0.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - io.swagger.swagger-annotations-1.6.14.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
@@ -437,8 +437,8 @@ Scala/Java jars:
   - org.apache.parquet.parquet-hadoop-1.15.2.jar
   - org.apache.parquet.parquet-jackson-1.15.2.jar
   - org.apache.yetus.audience-annotations-0.12.0.jar
-  - org.apache.zookeeper.zookeeper-3.8.4.jar
-  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-3.8.6.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.6.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
   - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-http-11.0.20.jar
@@ -450,9 +450,9 @@ Scala/Java jars:
   - org.eclipse.jetty.jetty-util-11.0.20.jar
   - org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api-5.0.2.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.4.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.58.v20250814.jar
   - org.ehcache.sizeof-0.4.3.jar
   - org.hibernate.validator.hibernate-validator-7.0.5.Final.jar
   - org.javassist.javassist-3.30.2-GA.jar

--- a/config-service/LICENSE-binary
+++ b/config-service/LICENSE-binary
@@ -274,7 +274,7 @@ Scala/Java jars:
   - io.dropwizard.metrics.metrics-json-4.2.25.jar
   - io.dropwizard.metrics.metrics-jvm-4.2.25.jar
   - io.dropwizard.metrics.metrics-logback-4.2.25.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - org.apache.commons.commons-lang3-3.13.0.jar

--- a/file-service/LICENSE-binary
+++ b/file-service/LICENSE-binary
@@ -231,8 +231,8 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.18.6.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.18.6.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
@@ -252,8 +252,8 @@ Scala/Java jars:
   - com.google.guava.failureaccess-1.0.3.jar
   - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  - com.google.inject.extensions.guice-servlet-4.2.3.jar
-  - com.google.inject.guice-4.2.3.jar
+  - com.google.inject.extensions.guice-servlet-5.1.0.jar
+  - com.google.inject.guice-5.1.0.jar
   - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
@@ -335,7 +335,7 @@ Scala/Java jars:
   - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
   - org.jspecify.jspecify-1.0.0.jar
   - io.perfmark.perfmark-api-0.27.0.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
@@ -401,8 +401,8 @@ Scala/Java jars:
   - org.apache.parquet.parquet-hadoop-1.15.2.jar
   - org.apache.parquet.parquet-jackson-1.15.2.jar
   - org.apache.yetus.audience-annotations-0.12.0.jar
-  - org.apache.zookeeper.zookeeper-3.8.4.jar
-  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-3.8.6.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.6.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
   - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-http-11.0.20.jar
@@ -414,9 +414,9 @@ Scala/Java jars:
   - org.eclipse.jetty.jetty-util-11.0.20.jar
   - org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api-5.0.2.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.4.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.58.v20250814.jar
   - org.ehcache.sizeof-0.4.3.jar
   - org.hibernate.validator.hibernate-validator-7.0.5.Final.jar
   - org.javassist.javassist-3.30.2-GA.jar
@@ -496,7 +496,7 @@ Source files derived from third-party MIT-licensed projects:
 
 Scala/Java jars:
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar

--- a/notebook-migration-service/LICENSE-binary
+++ b/notebook-migration-service/LICENSE-binary
@@ -274,7 +274,7 @@ Scala/Java jars:
   - io.dropwizard.metrics.metrics-json-4.2.25.jar
   - io.dropwizard.metrics.metrics-jvm-4.2.25.jar
   - io.dropwizard.metrics.metrics-logback-4.2.25.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - org.apache.commons.commons-lang3-3.13.0.jar

--- a/workflow-compiling-service/LICENSE-binary
+++ b/workflow-compiling-service/LICENSE-binary
@@ -231,8 +231,8 @@ Scala/Java jars:
   - com.fasterxml.jackson.datatype.jackson-datatype-jsr310-2.21.0.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base-2.16.1.jar
   - com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider-2.16.1.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.12.7.jar
-  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.12.7.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-base-2.18.6.jar
+  - com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider-2.18.6.jar
   - com.fasterxml.jackson.module.jackson-module-blackbird-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jakarta-xmlbind-annotations-2.16.1.jar
   - com.fasterxml.jackson.module.jackson-module-jsonSchema-2.18.8.jar
@@ -253,8 +253,8 @@ Scala/Java jars:
   - com.google.guava.failureaccess-1.0.3.jar
   - com.google.guava.guava-33.5.0-android.jar
   - com.google.guava.listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  - com.google.inject.extensions.guice-servlet-4.2.3.jar
-  - com.google.inject.guice-4.2.3.jar
+  - com.google.inject.extensions.guice-servlet-5.1.0.jar
+  - com.google.inject.guice-5.1.0.jar
   - com.google.j2objc.j2objc-annotations-3.1.jar
   - com.googlecode.javaewah.JavaEWAH-1.1.12.jar
   - com.helger.profiler-1.1.1.jar
@@ -337,7 +337,7 @@ Scala/Java jars:
   - io.netty.netty-transport-native-unix-common-4.2.15.Final.jar
   - org.jspecify.jspecify-1.0.0.jar
   - io.perfmark.perfmark-api-0.27.0.jar
-  - io.r2dbc.r2dbc-spi-0.9.0.RELEASE.jar
+  - io.r2dbc.r2dbc-spi-1.0.0.RELEASE.jar
   - jakarta.inject.jakarta.inject-api-2.0.1.jar
   - jakarta.validation.jakarta.validation-api-3.0.2.jar
   - javax.inject.javax.inject-1.jar
@@ -412,8 +412,8 @@ Scala/Java jars:
   - org.apache.parquet.parquet-hadoop-1.15.2.jar
   - org.apache.parquet.parquet-jackson-1.15.2.jar
   - org.apache.yetus.audience-annotations-0.12.0.jar
-  - org.apache.zookeeper.zookeeper-3.8.4.jar
-  - org.apache.zookeeper.zookeeper-jute-3.8.4.jar
+  - org.apache.zookeeper.zookeeper-3.8.6.jar
+  - org.apache.zookeeper.zookeeper-jute-3.8.6.jar
   - org.bitbucket.b_c.jose4j-0.9.6.jar
   - org.codehaus.jettison.jettison-1.5.4.jar
   - org.eclipse.jetty.jetty-http-11.0.20.jar
@@ -425,9 +425,9 @@ Scala/Java jars:
   - org.eclipse.jetty.jetty-util-11.0.20.jar
   - org.eclipse.jetty.toolchain.jetty-jakarta-servlet-api-5.0.2.jar
   - org.eclipse.jetty.toolchain.setuid.jetty-setuid-java-1.0.4.jar
-  - org.eclipse.jetty.websocket.websocket-api-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-client-9.4.57.v20241219.jar
-  - org.eclipse.jetty.websocket.websocket-common-9.4.57.v20241219.jar
+  - org.eclipse.jetty.websocket.websocket-api-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-client-9.4.58.v20250814.jar
+  - org.eclipse.jetty.websocket.websocket-common-9.4.58.v20250814.jar
   - org.ehcache.sizeof-0.4.3.jar
   - org.hibernate.validator.hibernate-validator-7.0.5.Final.jar
   - org.javassist.javassist-3.30.2-GA.jar
@@ -507,7 +507,7 @@ Scala/Java jars:
   - com.konghq.unirest-java-3.14.2.jar
   - io.github.classgraph.classgraph-4.8.157.jar
   - net.sourceforge.argparse4j.argparse4j-0.9.0.jar
-  - org.bouncycastle.bcprov-jdk18on-1.82.jar
+  - org.bouncycastle.bcprov-jdk18on-1.84.jar
   - org.checkerframework.checker-qual-3.52.0.jar
   - org.codehaus.mojo.animal-sniffer-annotations-1.26.jar
   - org.projectlombok.lombok-1.18.24.jar


### PR DESCRIPTION
### What changes were proposed in this PR?

Refreshes the per-module `LICENSE-binary` files on `main` to match the versions actually bundled, clearing the drift reported by the nightly license-binary checker ([run 29248239204](https://github.com/apache/texera/actions/runs/29248239204), 2026-07-13). Version-only edits; license groupings unchanged.

**JVM** — transitive jars pulled in by recent dependency bumps (hadoop/iceberg/etc.), applied per service to match each service's own bundle:
- `amber/LICENSE-binary-java` (20): jackson-jaxrs 2.12.7→2.18.6 (×3), guice/guice-servlet 4.2.3→5.1.0, zookeeper/-jute 3.8.4→3.8.6, jetty-client/io/util + websocket-api/client/common 9.4.57→9.4.58, json4s-ast/-jackson-core 4.0.1→4.0.6, r2dbc-spi 0.9.0→1.0.0, checker-qual 3.52.0→3.55.1, jakarta.activation-api 1.2.1→1.2.2, jakarta.xml.bind-api 3.0.0→2.3.3, bcprov 1.82→1.84
- `computing-unit-managing-service` (10), `file-service` (11, +bcprov), `workflow-compiling-service` (11, +bcprov): the subset each actually bundles
- `config-service`, `access-control-service`, `notebook-migration-service` (1 each): r2dbc-spi 0.9.0→1.0.0 only

**Python** — `amber/LICENSE-binary-python` (11): aiohappyeyeballs 2.6.2→2.7.1, anyio 4.14.1→4.14.2, charset-normalizer 3.4.7→3.4.9, filelock 3.29.4→3.29.7, greenlet 3.5.2→3.5.3, huggingface-hub 1.20.1→1.23.0, regex 2026.5.9→2026.7.10, scramp 1.4.9→1.4.12, tqdm 4.68.3→4.68.4, typer 0.25.1→0.26.8, tzdata 2026.2→2026.3

Only the entries the checker reported per file were changed; e.g. `json4s` / `checker-qual` in the service files were left as-is because those services bundle the older versions (no drift).

### Any related issues, documentation, discussions?

Closes #5889.

### How was this PR tested?

Version-only metadata change, verified against nightly run 29248239204. Transitive versions float with PyPI/Maven resolution, so a re-run may surface newer drift.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
