### PR TITLE
test(frontend): add unit test coverage for calculateTotalTranslate3d

### DIFF
--- a/frontend/src/app/common/util/panel-dock.spec.ts
+++ b/frontend/src/app/common/util/panel-dock.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { calculateTotalTranslate3d } from "./panel-dock";
+
+describe("calculateTotalTranslate3d", () => {
+  it("should parse a single translate3d fragment", () => {
+    expect(calculateTotalTranslate3d("translate3d(10px, -5px, 0px)")).toEqual([10, -5, 0]);
+  });
+
+  it("should parse two translate3d fragments by summing", () => {
+    expect(calculateTotalTranslate3d("translate3d(10px, 20px, 0px) translate3d(5px, -8px, 3px)")).toEqual([15, 12, 3]);
+  });
+
+  it("should parse decimal values in translate3d fragment", () => {
+    expect(calculateTotalTranslate3d("translate3d(1.5px, 2.25px, 0px)")).toEqual([1.5, 2.25, 0]);
+  });
+
+  it("should parse negative values in translate3d fragment", () => {
+    expect(calculateTotalTranslate3d("translate3d(-10px, -20px, -3px)")).toEqual([-10, -20, -3]);
+  });
+
+  it("should return [0, 0, 0] when no translate3d pattern exists", () => {
+    expect(calculateTotalTranslate3d("")).toEqual([0, 0, 0]);
+    expect(calculateTotalTranslate3d("rotate(45deg)")).toEqual([0, 0, 0]);
+  });
+
+  it("should treat a translate3d fragment without px units as [0, 0, 0]", () => {
+    expect(calculateTotalTranslate3d("translate3d(10, 20, 0)")).toEqual([0, 0, 0]);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
Adds unit test coverage for the calculateTotalTranslate3d function in [frontend/src/app/common/util/panel-dock.ts](vscode-webview://1epki5h79lmkghv36u4evg54fuvmk17ndjca203mcg7opnnd5sg9/frontend/src/app/common/util/panel-dock.ts), which was previously untested. This is a pure function that parses one or more CSS translate3d(...) fragments from a string and returns the component-wise sum of their x/y/z offsets.

A new spec file, frontend/src/app/common/util/panel-dock.spec.ts, was created following the testing style of size-formatter.util.spec.ts. It covers:
- Parsing a single translate3d(...) fragment
- Summing multiple concatenated fragments component-wise
- Decimal pixel values
- Negative pixel values
- Returning [0, 0, 0] when no translate3d(...) pattern is present
- A fragment missing px units, which does not match the parser and contributes [0, 0, 0]

### Any related issues, documentation, discussions?
Closes #6255

### How was this PR tested?
Added 6 unit tests in the new spec file, all passing via ng test:
cd frontend && npx ng test --watch=false --include='**/panel-dock.spec.ts'
src/app/common/util/panel-dock.spec.ts (6 tests) 3ms
 Test Files - 1, passed (1)
      Tests - 6, passed (6)

### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF