### PR TITLE
test(frontend): add unit tests for PanelService

### DIFF
--- a/frontend/src/app/workspace/service/panel/panel.service.spec.ts
+++ b/frontend/src/app/workspace/service/panel/panel.service.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { PanelService } from "./panel.service";
+
+describe("PanelService", () => {
+  let service: PanelService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [PanelService] });
+    service = TestBed.inject(PanelService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("resetPanels() emits on resetPanelStream", () => {
+    const next = vi.fn();
+    service.resetPanelStream.subscribe(next);
+
+    service.resetPanels();
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("closePanels() emits on closePanelStream", () => {
+    const next = vi.fn();
+    service.closePanelStream.subscribe(next);
+
+    service.closePanels();
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the reset and close streams independent of each other", () => {
+    const onReset = vi.fn();
+    const onClose = vi.fn();
+    service.resetPanelStream.subscribe(onReset);
+    service.closePanelStream.subscribe(onClose);
+
+    service.resetPanels();
+
+    expect(onReset).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("delivers each emission to every current subscriber", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    service.closePanelStream.subscribe(first);
+    service.closePanelStream.subscribe(second);
+
+    service.closePanels();
+    service.closePanels();
+
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not replay past emissions to a late subscriber (Subject semantics)", () => {
+    service.resetPanels();
+
+    const late = vi.fn();
+    service.resetPanelStream.subscribe(late);
+
+    expect(late).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/workspace/service/panel/panel.service.spec.ts
+++ b/frontend/src/app/workspace/service/panel/panel.service.spec.ts
@@ -60,6 +60,11 @@ describe("PanelService", () => {
 
     expect(onReset).toHaveBeenCalledTimes(1);
     expect(onClose).not.toHaveBeenCalled();
+
+    service.closePanels();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onReset).toHaveBeenCalledTimes(1);
   });
 
   it("delivers each emission to every current subscriber", () => {
@@ -75,12 +80,16 @@ describe("PanelService", () => {
     expect(second).toHaveBeenCalledTimes(2);
   });
 
-  it("does not replay past emissions to a late subscriber (Subject semantics)", () => {
+  it("does not replay past emissions to a late subscriber but still forwards future ones (Subject semantics)", () => {
     service.resetPanels();
 
     const late = vi.fn();
     service.resetPanelStream.subscribe(late);
 
     expect(late).not.toHaveBeenCalled();
+
+    service.resetPanels();
+
+    expect(late).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?
- Adds panel.service.spec.ts covering PanelService; no production code changed.
- Verifies resetPanels and closePanels emit on their streams and that the streams stay independent.
- Covers multi-subscriber delivery and Subject no-replay semantics for a late subscriber.
### Any related issues, documentation, discussions?
Closes: #6449
### How was this PR tested?
- Run `cd frontend && npx nx test gui --include="**/panel.service.spec.ts"`, expect 6 passed.
- Full frontend suite runs in CI via `yarn test:ci`, selected by the auto-applied `frontend` label.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF