### PR TITLE
fix(sync): handle missing position events without breaking sync stream

### DIFF
--- a/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
@@ -818,4 +818,45 @@ describe("JointGraphWrapperService", () => {
       expect(emitted).toEqual([false, true, false]);
     });
   });
+
+  it(
+    "should ignore position change events when old position is missing and continue emitting future events",
+    marbles(m => {
+      const operator = jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint);
+      jointGraph.addCell(operator);
+
+      const events: any[] = [];
+      const subscription = jointGraphWrapper
+        .getElementPositionChangeEvent()
+        .subscribe(event => events.push(event));
+
+      // remove operator position from the internal map to force bug condition
+      (jointGraphWrapper as any).elementPositions.delete(mockScanPredicate.operatorID);
+
+      // trigger position change with missing oldPosition
+      operator.position(100, 100);
+
+      // restore position tracking
+      (jointGraphWrapper as any).elementPositions.set(
+        mockScanPredicate.operatorID,
+        {
+          currPos: { x: 100, y: 100 },
+          lastPos: undefined,
+        }
+      );
+
+      // trigger another valid position change
+      operator.position(200, 200);
+
+      // the first event should be skipped,but the second event should still emit
+      expect(events.length).toBe(1);
+      expect(events[0].elementID).toBe(mockScanPredicate.operatorID);
+      expect(events[0].newPosition).toEqual({
+        x: 200,
+        y: 200,
+      });
+
+      subscription.unsubscribe();
+    })
+  );
 });

--- a/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
@@ -832,7 +832,7 @@ describe("JointGraphWrapperService", () => {
       (jointGraphWrapper as any).elementPositions.delete(mockScanPredicate.operatorID);
 
       // trigger position change with missing oldPosition
-      operator.position(100, 100);
+      operator.position(150, 150);
 
       // restore position tracking
       (jointGraphWrapper as any).elementPositions.set(mockScanPredicate.operatorID, {

--- a/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
@@ -826,9 +826,7 @@ describe("JointGraphWrapperService", () => {
       jointGraph.addCell(operator);
 
       const events: any[] = [];
-      const subscription = jointGraphWrapper
-        .getElementPositionChangeEvent()
-        .subscribe(event => events.push(event));
+      const subscription = jointGraphWrapper.getElementPositionChangeEvent().subscribe(event => events.push(event));
 
       // remove operator position from the internal map to force bug condition
       (jointGraphWrapper as any).elementPositions.delete(mockScanPredicate.operatorID);
@@ -837,13 +835,10 @@ describe("JointGraphWrapperService", () => {
       operator.position(100, 100);
 
       // restore position tracking
-      (jointGraphWrapper as any).elementPositions.set(
-        mockScanPredicate.operatorID,
-        {
-          currPos: { x: 100, y: 100 },
-          lastPos: undefined,
-        }
-      );
+      (jointGraphWrapper as any).elementPositions.set(mockScanPredicate.operatorID, {
+        currPos: { x: 100, y: 100 },
+        lastPos: undefined,
+      });
 
       // trigger another valid position change
       operator.position(200, 200);

--- a/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -307,7 +307,7 @@ export class JointGraphWrapper {
         const oldPosition = this.elementPositions.get(elementID);
         const newPosition = { x: e[1].x, y: e[1].y };
         if (!oldPosition) {
-          throw new Error(`internal error: cannot find element position for ${elementID}`);
+          return undefined;
         }
         if (
           !oldPosition.lastPos ||
@@ -325,7 +325,11 @@ export class JointGraphWrapper {
           oldPosition: oldPosition.lastPos,
           newPosition: newPosition,
         };
-      })
+      }),
+      filter(
+        (event): event is { elementID: string; oldPosition: Point; newPosition: Point } =>
+          event !== undefined
+      )
     );
   }
 

--- a/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -326,10 +326,7 @@ export class JointGraphWrapper {
           newPosition: newPosition,
         };
       }),
-      filter(
-        (event): event is { elementID: string; oldPosition: Point; newPosition: Point } =>
-          event !== undefined
-      )
+      filter((event): event is { elementID: string; oldPosition: Point; newPosition: Point } => event !== undefined)
     );
   }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR fixes an issue where a missing position entry could break the position synchronization stream during collaborative editing.

Instead of allowing an `undefined` old position to propagate, the position change event is filtered out so the stream continues processing future valid events.

Before (simulated missing position scenario):
If a position change event was received for an operator whose position was missing from `elementPositions`, the stream could error out and stop processing future position updates, breaking synchronization.

<img width="2866" height="1110" alt="image" src="https://github.com/user-attachments/assets/3c782b1d-c740-4a36-9438-16cff8ea8386" />

After:
Position change events with missing position information are ignored, allowing the stream to continue processing subsequent valid position updates and preserving synchronization.

<img width="1433" height="718" alt="Screenshot 2026-07-17 at 1 23 31 AM" src="https://github.com/user-attachments/assets/0ce72c41-49a6-4517-b0a1-80abc86d38f1" />

### Any related issues, documentation, discussions?

Closes #6420

### How was this PR tested?

Manual test:
- Opened two browser tabs with two different users
- Simulated the missing-position scenario by removing the position entry
- Verified that position sync continued after the bad event
- Confirmed add/delete operations still worked independently

Added a unit test that simulates a missing position entry by removing an operator's position from the internal position map before triggering a position change. The test verifies that the invalid event is ignored and that subsequent valid position change events are still emitted correctly.

Ran:

```bash
yarn test --include=src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: ChatGPT (GPT-5.5 mini)