### PR TITLE
test(frontend): extend WorkflowPersistService unit test coverage

### DIFF
--- a/frontend/src/app/common/service/workflow-persist/workflow-persist.service.spec.ts
+++ b/frontend/src/app/common/service/workflow-persist/workflow-persist.service.spec.ts
@@ -19,9 +19,18 @@
 
 import { TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
-import { WorkflowPersistService } from "./workflow-persist.service";
+import {
+  WorkflowPersistService,
+  WORKFLOW_BASE_URL,
+  WORKFLOW_ID_URL,
+  WORKFLOW_OWNER_URL,
+  WORKFLOW_SEARCH_URL,
+} from "./workflow-persist.service";
 import { jsonCast } from "../../util/storage";
-import { WorkflowContent } from "../../type/workflow";
+import { Workflow, WorkflowContent } from "../../type/workflow";
+import { AppSettings } from "../../app-setting";
+import { DashboardWorkflow } from "../../../dashboard/type/dashboard-workflow.interface";
+import { SearchFilterParameters, toQueryStrings } from "../../../dashboard/type/search-filter-parameters";
 import { last } from "rxjs/operators";
 
 describe("WorkflowPersistService", () => {
@@ -76,5 +85,70 @@ describe("WorkflowPersistService", () => {
         expect(value.workflow.name).toEqual("testname_copy");
         expect(value.workflow.content).toEqual(jsonCast<WorkflowContent>(testContent));
       });
+  });
+
+  const API = AppSettings.getApiEndpoint();
+
+  it("retrieveWorkflow issues a GET and parses the workflow content", () => {
+    const raw = { wid: 5, name: "wf", content: '{"operators":[]}' } as unknown as Workflow;
+    let result: Workflow | undefined;
+    service.retrieveWorkflow(5).subscribe(w => (result = w));
+
+    const req = httpTestingController.expectOne(`${API}/${WORKFLOW_BASE_URL}/5`);
+    expect(req.request.method).toBe("GET");
+    req.flush(raw);
+
+    // parseWorkflowInfo turns the string content into a parsed object
+    expect(result?.content).toEqual({ operators: [] });
+  });
+
+  it("retrieveWorkflowIDs issues a GET to the workflow-ids url", () => {
+    let result: number[] | undefined;
+    service.retrieveWorkflowIDs().subscribe(ids => (result = ids));
+
+    const req = httpTestingController.expectOne(`${API}/${WORKFLOW_ID_URL}`);
+    expect(req.request.method).toBe("GET");
+    req.flush([1, 2, 3]);
+
+    expect(result).toEqual([1, 2, 3]);
+  });
+
+  it("retrieveOwners issues a GET to the owners url", () => {
+    let result: string[] | undefined;
+    service.retrieveOwners().subscribe(owners => (result = owners));
+
+    const req = httpTestingController.expectOne(`${API}/${WORKFLOW_OWNER_URL}`);
+    expect(req.request.method).toBe("GET");
+    req.flush(["alice@example.com", "bob@example.com"]);
+
+    expect(result).toEqual(["alice@example.com", "bob@example.com"]);
+  });
+
+  it("searchWorkflows issues a GET to the search url and maps each entry", () => {
+    const params: SearchFilterParameters = {
+      createDateStart: null,
+      createDateEnd: null,
+      modifiedDateStart: null,
+      modifiedDateEnd: null,
+      owners: [],
+      ids: [],
+      operators: [],
+      projectIds: [],
+    };
+    const keywords = ["test"];
+    const entry = { workflow: { wid: 1, name: "w", content: '{"operators":[]}' } } as unknown as DashboardWorkflow;
+
+    let result: DashboardWorkflow[] | undefined;
+    service.searchWorkflows(keywords, params).subscribe(r => (result = r));
+
+    const req = httpTestingController.expectOne(`${API}/${WORKFLOW_SEARCH_URL}?${toQueryStrings(keywords, params)}`);
+    expect(req.request.method).toBe("GET");
+    req.flush([entry]);
+
+    expect(result?.length).toBe(1);
+    // the mapping adds a `dashboardWorkflowEntry`; parseWorkflowInfo mutates the shared workflow
+    // in place, so the entry's own `workflow.content` is parsed too.
+    expect(result?.[0]).toHaveProperty("dashboardWorkflowEntry");
+    expect(result?.[0]?.workflow?.content).toEqual({ operators: [] });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing Vitest spec for `WorkflowPersistService`
(`frontend/src/app/common/service/workflow-persist/workflow-persist.service.ts`,
codecov ~43%). The existing spec only covered `createWorkflow`; this adds 4
tests for previously-untested GET methods, using `HttpClientTestingModule` +
`HttpTestingController` (no backend).

Each new test asserts the request method / URL (built from the service's
exported URL constants) and the mapped response:

- **`retrieveWorkflow`** — GET `workflow/{wid}`; `parseWorkflowInfo` parses the
  string `content` into an object.
- **`retrieveWorkflowIDs`** — GET `workflow/user-workflow-ids`; emits the id array.
- **`retrieveOwners`** — GET `workflow/user-workflow-owners`; emits the owner array.
- **`searchWorkflows`** — GET `workflow/search?<query>` (URL built via
  `toQueryStrings`); each entry gains a parsed `dashboardWorkflowEntry`.

The three existing tests are unchanged. No production code was changed.

### Any related issues, documentation, discussions?

Closes #6535

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking a URL assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/common/service/workflow-persist/workflow-persist.service.spec.ts
# Tests  7 passed (7)   (3 existing + 4 new)
eslint <spec>       # clean
prettier --check    # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
