### PR TITLE
test(frontend): extend UserDatasetFileRendererComponent coverage

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
@@ -24,6 +24,7 @@ import { DatasetService } from "../../../../../service/user/dataset/dataset.serv
 import { NotificationService } from "../../../../../../common/service/notification/notification.service";
 import { DomSanitizer } from "@angular/platform-browser";
 import { commonTestProviders } from "../../../../../../common/testing/test-utils";
+import { of } from "rxjs";
 
 describe("UserDatasetFileRendererComponent", () => {
   let component: UserDatasetFileRendererComponent;
@@ -53,5 +54,115 @@ describe("UserDatasetFileRendererComponent", () => {
     const unsupportedMimeType = "application/unknown"; // Example of an unsupported MIME type
     const result = component.isPreviewSupported(unsupportedMimeType);
     expect(result).toBe(false);
+  });
+
+  describe("reloadFileContent", () => {
+    it("flags an unsupported file type and does not hit the backend", () => {
+      const spy = vi.spyOn(TestBed.inject(DatasetService), "retrieveDatasetVersionSingleFile");
+      // did/dvid are set so the early-return is what stops the request, not the missing ids.
+      component.did = 1;
+      component.dvid = 2;
+      component.filePath = "archive.bin"; // -> OCTET_STREAM -> unsupported
+
+      component.reloadFileContent();
+
+      expect(component.isFileTypePreviewUnsupported).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("flags an oversized file and does not hit the backend", () => {
+      const spy = vi.spyOn(TestBed.inject(DatasetService), "retrieveDatasetVersionSingleFile");
+      component.did = 1;
+      component.dvid = 2;
+      component.filePath = "notes.txt"; // TXT limit is 1 MB
+      component.fileSize = 5 * 1024 * 1024;
+
+      component.reloadFileContent();
+
+      expect(component.isFileSizeUnloadable).toBe(true);
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("retrieves a supported file and switches on the matching display", () => {
+      const datasetService = TestBed.inject(DatasetService);
+      const blob = new Blob(["hello"], { type: "text/plain" });
+      const spy = vi.spyOn(datasetService, "retrieveDatasetVersionSingleFile").mockReturnValue(of(blob));
+      component.did = 1;
+      component.dvid = 2;
+      component.filePath = "notes.txt";
+      component.isLogin = true;
+      component.fileSize = 100;
+
+      component.reloadFileContent();
+
+      expect(spy).toHaveBeenCalledWith("notes.txt", true);
+      expect(component.displayPlainText).toBe(true);
+      expect(component.isLoading).toBe(false);
+    });
+  });
+
+  describe("error handlers", () => {
+    it("onFileLoadingError sets the loading-error state and clears displays", () => {
+      component.displayCSV = true;
+
+      component.onFileLoadingError();
+
+      expect(component.isFileLoadingError).toBe(true);
+      expect(component.displayCSV).toBe(false);
+    });
+
+    it("onFileSizeNotLoadable sets the size-unloadable state", () => {
+      component.onFileSizeNotLoadable();
+
+      expect(component.isFileSizeUnloadable).toBe(true);
+    });
+
+    it("onFileTypePreviewUnsupported sets the unsupported-type state", () => {
+      component.onFileTypePreviewUnsupported();
+
+      expect(component.isFileTypePreviewUnsupported).toBe(true);
+    });
+  });
+
+  describe("display toggles", () => {
+    it("toggleImageModal flips showImageModal", () => {
+      expect(component.showImageModal).toBe(false);
+
+      component.toggleImageModal();
+      expect(component.showImageModal).toBe(true);
+
+      component.toggleImageModal();
+      expect(component.showImageModal).toBe(false);
+    });
+
+    it("turnOffAllDisplay resets every display and error flag", () => {
+      component.displayCSV = true;
+      component.displayXlsx = true;
+      component.displayImage = true;
+      component.displayPlainText = true;
+      component.displayMarkdown = true;
+      component.displayJson = true;
+      component.displayMP4 = true;
+      component.displayMP3 = true;
+      component.isLoading = true;
+      component.isFileLoadingError = true;
+      component.isFileSizeUnloadable = true;
+      component.isFileTypePreviewUnsupported = true;
+
+      component.turnOffAllDisplay();
+
+      expect(component.displayCSV).toBe(false);
+      expect(component.displayXlsx).toBe(false);
+      expect(component.displayImage).toBe(false);
+      expect(component.displayPlainText).toBe(false);
+      expect(component.displayMarkdown).toBe(false);
+      expect(component.displayJson).toBe(false);
+      expect(component.displayMP4).toBe(false);
+      expect(component.displayMP3).toBe(false);
+      expect(component.isLoading).toBe(false);
+      expect(component.isFileLoadingError).toBe(false);
+      expect(component.isFileSizeUnloadable).toBe(false);
+      expect(component.isFileTypePreviewUnsupported).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `UserDatasetFileRendererComponent` spec (previously only the
two `isPreviewSupported` checks, ~37% coverage) to cover the untested handlers.

8 added tests cover:

- `reloadFileContent` — flags an unsupported file type (no backend call); flags an oversized file before loading; retrieves a supported file via `DatasetService.retrieveDatasetVersionSingleFile(filePath, isLogin)` and switches on the matching display.
- Error handlers — `onFileLoadingError` / `onFileSizeNotLoadable` / `onFileTypePreviewUnsupported` each set their respective error flag (and clear the displays).
- Display toggles — `toggleImageModal` flips `showImageModal`; `turnOffAllDisplay` resets every display and error flag.

No production code was changed.

### Any related issues, documentation, discussions?

Closes #6533

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by deliberately breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
# Test Files 1 passed (1) | Tests 10 passed (10)
prettier --write <spec>   # unchanged
eslint  <spec>            # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
