### PR TITLE
test(frontend): extend unit test coverage for UserProjectListItemComponent

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-project/user-project-list-item/user-project-list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-project/user-project-list-item/user-project-list-item.component.spec.ts
@@ -25,11 +25,13 @@ import { UserProjectService } from "../../../../service/user/project/user-projec
 import { DashboardProject } from "../../../../type/dashboard-project.interface";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { NzListComponent } from "ng-zorro-antd/list";
-import { NzModalService } from "ng-zorro-antd/modal";
+import { NzModalService, NzModalRef } from "ng-zorro-antd/modal";
 import { provideRouter } from "@angular/router";
 import { StubUserService } from "../../../../../common/service/user/stub-user.service";
 import { UserService } from "../../../../../common/service/user/user.service";
 import { commonTestProviders } from "../../../../../common/testing/test-utils";
+import { ShareAccessComponent } from "../../share-access/share-access.component";
+import { of } from "rxjs";
 
 // UserProjectListItemComponent is rooted at <nz-list-item>; instantiating it
 // outside an <nz-list> host throws "No provider found for NzListComponent".
@@ -53,6 +55,9 @@ class TestHostComponent {
 describe("UserProjectListItemComponent", () => {
   let component: UserProjectListItemComponent;
   let hostFixture: ComponentFixture<TestHostComponent>;
+  let userProjectService: UserProjectService;
+  let modalService: NzModalService;
+  let notificationService: NotificationService;
   const januaryFirst1970 = 28800000; // 1970-01-01 in PST
   const testProject: DashboardProject = {
     color: null,
@@ -80,13 +85,137 @@ describe("UserProjectListItemComponent", () => {
 
   beforeEach(() => {
     hostFixture = TestBed.createComponent(TestHostComponent);
-    hostFixture.componentInstance.entry = testProject;
+    // Clone so per-test mutations (saveProjectName/Description mutate entry in place)
+    // don't leak into other tests through the shared testProject fixture.
+    hostFixture.componentInstance.entry = { ...testProject };
     hostFixture.componentInstance.editable = true;
     hostFixture.detectChanges();
     component = hostFixture.componentInstance.inner;
+    userProjectService = TestBed.inject(UserProjectService);
+    modalService = TestBed.inject(NzModalService);
+    notificationService = TestBed.inject(NotificationService);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("updateProjectColor", () => {
+    it("persists a valid color and updates local state", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectColor").mockReturnValue(of({} as Response));
+      component.color = "#123456";
+
+      component.updateProjectColor();
+
+      expect(spy).toHaveBeenCalledWith(1, "123456");
+      expect(component.color).toBe("123456");
+      expect(component.entry.color).toBe("123456");
+      expect(component.editingColor).toBe(false);
+    });
+
+    it("rejects an invalid HEX color and does not call the service", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectColor");
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+      component.color = "#zzz";
+
+      component.updateProjectColor();
+
+      expect(errorSpy).toHaveBeenCalled();
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it("is a no-op when the item is not editable", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectColor");
+      component.editable = false;
+      component.color = "#123456";
+
+      component.updateProjectColor();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeProjectColor", () => {
+    it("deletes the color and resets local state", () => {
+      const spy = vi.spyOn(userProjectService, "deleteProjectColor").mockReturnValue(of({} as Response));
+      // Start from a non-default state so the reset is actually observable.
+      component.color = "#123456";
+      component.entry = { ...component.entry, color: "123456" };
+      component.editingColor = true;
+
+      component.removeProjectColor();
+
+      expect(spy).toHaveBeenCalledWith(1);
+      expect(component.color).toBe("#ffffff");
+      expect(component.entry.color).toBeNull();
+      expect(component.editingColor).toBe(false);
+    });
+  });
+
+  describe("saveProjectName", () => {
+    it("persists a changed name", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectName").mockReturnValue(of({} as Response));
+
+      component.saveProjectName("renamed");
+
+      expect(spy).toHaveBeenCalledWith(1, "renamed");
+      expect(component.entry.name).toBe("renamed");
+      expect(component.editingName).toBe(false);
+    });
+
+    it("does not call the service when the name is unchanged", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectName");
+
+      component.saveProjectName("project1");
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(component.editingName).toBe(false);
+    });
+  });
+
+  describe("saveProjectDescription", () => {
+    it("persists a changed description and notifies success", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectDescription").mockReturnValue(of({} as Response));
+      const successSpy = vi.spyOn(notificationService, "success").mockImplementation(() => {});
+
+      component.saveProjectDescription("a new description");
+
+      expect(spy).toHaveBeenCalledWith(1, "a new description");
+      expect(component.entry.description).toBe("a new description");
+      expect(successSpy).toHaveBeenCalled();
+      expect(component.editingDescription).toBe(false);
+    });
+
+    it("does not call the service when the description is unchanged", () => {
+      const spy = vi.spyOn(userProjectService, "updateProjectDescription");
+
+      component.saveProjectDescription("description");
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(component.editingDescription).toBe(false);
+    });
+  });
+
+  describe("onClickOpenShareAccess", () => {
+    it("opens the share-access modal and refreshes when it closes", () => {
+      const createSpy = vi
+        .spyOn(modalService, "create")
+        .mockReturnValue({ afterClose: of(undefined) } as unknown as NzModalRef);
+      const refreshSpy = vi.spyOn(component.refresh, "emit");
+
+      component.onClickOpenShareAccess();
+
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          nzContent: ShareAccessComponent,
+          nzData: { writeAccess: true, type: "project", id: 1 },
+        })
+      );
+      expect(refreshSpy).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `UserProjectListItemComponent` spec (which only had a
`should create` test; codecov ~43%) to cover the previously-untested action
methods, adding 9 tests. `UserProjectService` (already provided real via the
`HttpClientTestingModule` setup) is `vi.spyOn`-stubbed per test:

- **`updateProjectColor`** — persists a valid HEX color and updates local state;
  rejects an invalid HEX (notifies error, no service call); no-ops when the item
  is not editable.
- **`removeProjectColor`** — deletes the color and resets `color` / `entry.color`.
- **`saveProjectName`** — persists a changed name; no service call when unchanged.
- **`saveProjectDescription`** — persists a changed description and notifies
  success; no service call when unchanged.
- **`onClickOpenShareAccess`** — opens the share-access modal with the expected
  `nzContent` / `nzData`, and emits `refresh` when the modal closes.

Also clones the shared `testProject` fixture into the host per test
(`entry = { ...testProject }`), since `saveProjectName` / `saveProjectDescription`
mutate `entry` in place and would otherwise leak state across tests.
No production code was changed.

### Any related issues, documentation, discussions?

Closes #6534

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/dashboard/component/user/user-project/user-project-list-item/user-project-list-item.component.spec.ts
# Tests  10 passed (10)
eslint <spec>       # clean
prettier --check    # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
