### PR TITLE
test(frontend): extend TimeTravelComponent unit test coverage

### DIFF
--- a/frontend/src/app/workspace/component/left-panel/time-travel/time-travel.component.spec.ts
+++ b/frontend/src/app/workspace/component/left-panel/time-travel/time-travel.component.spec.ts
@@ -23,16 +23,30 @@ import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { FormlyModule } from "@ngx-formly/core";
 import { TEXERA_FORMLY_CONFIG } from "../../../../common/formly/formly-config";
-import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { of } from "rxjs";
 import { TimeTravelComponent } from "./time-travel.component";
 import { ComputingUnitStatusService } from "../../../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
 import { MockComputingUnitStatusService } from "../../../../common/service/computing-unit/computing-unit-status/mock-computing-unit-status.service";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
+import {
+  WORKFLOW_EXECUTIONS_API_BASE_URL,
+  WorkflowExecutionsService,
+} from "../../../../dashboard/service/user/workflow-executions/workflow-executions.service";
+import { WorkflowVersionService } from "../../../../dashboard/service/user/workflow-version/workflow-version.service";
+import { ExecuteWorkflowService } from "../../../service/execute-workflow/execute-workflow.service";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WorkflowExecutionsEntry } from "../../../../dashboard/type/workflow-executions-entry";
+
+function makeExecution(eId: number, logLocation: string | undefined): WorkflowExecutionsEntry {
+  return { eId, logLocation } as unknown as WorkflowExecutionsEntry;
+}
 
 describe("TimeTravelComponent", () => {
   let component: TimeTravelComponent;
   let fixture: ComponentFixture<TimeTravelComponent>;
   let workflowActionService: WorkflowActionService;
+  let metadataSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -54,10 +68,159 @@ describe("TimeTravelComponent", () => {
     fixture = TestBed.createComponent(TimeTravelComponent);
     component = fixture.componentInstance;
     workflowActionService = TestBed.inject(WorkflowActionService);
+    // Stub before detectChanges so the ngOnInit timer(0, 5000) poller sees no wid
+    // (WorkflowActionService otherwise reports wid 0) and never schedules an
+    // executions request in any test. Tests that need a wid override this spy.
+    metadataSpy = vi.spyOn(workflowActionService, "getWorkflowMetadata").mockReturnValue(undefined as any);
     fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    // Destroy the component so @UntilDestroy unsubscribes the ngOnInit timer(0, 5000)
+    // poller; otherwise it keeps ticking in real time and could fire a stray request
+    // in a later test once the metadata stub is restored.
+    fixture.destroy();
+    vi.restoreAllMocks();
   });
 
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("extended method coverage", () => {
+    let executionsService: WorkflowExecutionsService;
+    let versionService: WorkflowVersionService;
+    let executeService: ExecuteWorkflowService;
+    let notificationService: NotificationService;
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+      executionsService = TestBed.inject(WorkflowExecutionsService);
+      versionService = TestBed.inject(WorkflowVersionService);
+      executeService = TestBed.inject(ExecuteWorkflowService);
+      notificationService = TestBed.inject(NotificationService);
+      httpMock = TestBed.inject(HttpTestingController);
+      // metadataSpy (installed in the outer beforeEach) already stubs getWorkflowMetadata
+      // to no wid; tests that need one override it below.
+    });
+
+    describe("getWid", () => {
+      it("returns the current workflow id from the metadata", () => {
+        metadataSpy.mockReturnValue({ wid: 42 } as any);
+        expect(component.getWid()).toBe(42);
+      });
+
+      it("returns undefined when there is no workflow metadata", () => {
+        metadataSpy.mockReturnValue(undefined as any);
+        expect(component.getWid()).toBeUndefined();
+      });
+    });
+
+    describe("retrieveLoggedExecutions", () => {
+      it("keeps only executions that have a non-empty log location", () => {
+        vi.spyOn(executionsService, "retrieveWorkflowExecutions").mockReturnValue(
+          of([makeExecution(1, "s3://log"), makeExecution(2, ""), makeExecution(3, undefined)])
+        );
+
+        let result: WorkflowExecutionsEntry[] = [];
+        component.retrieveLoggedExecutions(1).subscribe(r => (result = r));
+
+        expect(executionsService.retrieveWorkflowExecutions).toHaveBeenCalledWith(1);
+        expect(result.map(e => e.eId)).toEqual([1]);
+      });
+    });
+
+    describe("retrieveInteractionHistory", () => {
+      it("GETs the interactions endpoint for the given wid/eid", () => {
+        let result: string[] = [];
+        component.retrieveInteractionHistory(11, 22).subscribe(r => (result = r));
+
+        const req = httpMock.expectOne(`${WORKFLOW_EXECUTIONS_API_BASE_URL}/11/interactions/22`);
+        expect(req.request.method).toBe("GET");
+        req.flush(["h1", "h2"]);
+
+        expect(result).toEqual(["h1", "h2"]);
+      });
+    });
+
+    describe("getInteractionHistory", () => {
+      it("does nothing when there is no wid", () => {
+        const spy = vi.spyOn(component, "retrieveInteractionHistory");
+        component.getInteractionHistory(5);
+        expect(spy).not.toHaveBeenCalled();
+        expect(component.interactionHistories[5]).toBeUndefined();
+      });
+
+      it("stores the fetched interaction history under the eid", () => {
+        metadataSpy.mockReturnValue({ wid: 1 } as any);
+        vi.spyOn(component, "retrieveInteractionHistory").mockReturnValue(of(["click-a", "click-b"]));
+
+        component.getInteractionHistory(5);
+
+        expect(component.retrieveInteractionHistory).toHaveBeenCalledWith(1, 5);
+        expect(component.interactionHistories[5]).toEqual(["click-a", "click-b"]);
+      });
+    });
+
+    describe("displayExecutionWithLogs", () => {
+      it("stores the executions and refreshes the interaction history of expanded rows", () => {
+        const executions = [makeExecution(1, "s3://log")];
+        vi.spyOn(component, "retrieveLoggedExecutions").mockReturnValue(of(executions));
+        const interactionSpy = vi.spyOn(component, "getInteractionHistory").mockImplementation(() => {});
+        component.expandedRows = new Set([7]);
+
+        component.displayExecutionWithLogs(3);
+
+        expect(component.executionList).toBe(executions);
+        expect(interactionSpy).toHaveBeenCalledWith(7);
+      });
+    });
+
+    describe("onInteractionClick", () => {
+      it("does nothing when there is no wid", () => {
+        const spy = vi.spyOn(versionService, "retrieveWorkflowByVersion");
+        component.onInteractionClick(2, 3, "x");
+        expect(spy).not.toHaveBeenCalled();
+        expect(component.revertedToInteraction).toBeUndefined();
+      });
+
+      it("loads the versioned workflow, records the reverted interaction, and starts the replay", () => {
+        const versionedWorkflow = { wid: 1, name: "v1" } as any;
+        metadataSpy.mockReturnValue({ wid: 1 } as any);
+        vi.spyOn(versionService, "retrieveWorkflowByVersion").mockReturnValue(of(versionedWorkflow));
+        const displaySpy = vi.spyOn(versionService, "displayReadonlyWorkflow").mockImplementation(() => {});
+        const infoSpy = vi.spyOn(notificationService, "info").mockImplementation(() => undefined as any);
+        const replaySpy = vi.spyOn(executeService, "executeWorkflowWithReplay").mockImplementation(() => {});
+        // This test sets revertedToInteraction, so ngOnDestroy (via fixture.destroy in
+        // afterEach) would run the real replay-cleanup; keep those calls inert.
+        vi.spyOn(versionService, "closeReadonlyWorkflowDisplay").mockImplementation(() => {});
+        vi.spyOn(executeService, "killWorkflow").mockImplementation(() => {});
+
+        component.onInteractionClick(2, 3, "click-x");
+
+        expect(versionService.retrieveWorkflowByVersion).toHaveBeenCalledWith(1, 2);
+        expect(displaySpy).toHaveBeenCalledWith(versionedWorkflow);
+        expect(component.revertedToInteraction).toEqual({ eid: 3, interaction: "click-x" });
+        expect(infoSpy).toHaveBeenCalledWith("start replay to interaction click-x at execution 3");
+        expect(replaySpy).toHaveBeenCalledWith({ eid: 3, interaction: "click-x" });
+      });
+    });
+
+    describe("toggleRow", () => {
+      it("expands a collapsed row and loads its interaction history", () => {
+        const spy = vi.spyOn(component, "getInteractionHistory").mockImplementation(() => {});
+        component.toggleRow(9);
+        expect(component.expandedRows.has(9)).toBe(true);
+        expect(spy).toHaveBeenCalledWith(9);
+      });
+
+      it("collapses an expanded row without reloading", () => {
+        const spy = vi.spyOn(component, "getInteractionHistory").mockImplementation(() => {});
+        component.toggleRow(9); // expand (loads once)
+        component.toggleRow(9); // collapse
+        expect(component.expandedRows.has(9)).toBe(false);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `TimeTravelComponent` spec
(`frontend/src/app/workspace/component/left-panel/time-travel/`), which only had
`should create` (codecov ~34%), to cover its previously-untested methods. Follows
`frontend/TESTING.md`.

Adds 11 tests under a nested `extended method coverage` block:

- **`getWid`** — returns the workflow id from the metadata; undefined when absent.
- **`retrieveLoggedExecutions`** — keeps only executions with a non-empty log location.
- **`retrieveInteractionHistory`** — GETs `.../{wid}/interactions/{eid}` (verified via `HttpTestingController`).
- **`getInteractionHistory`** — no-ops without a wid; otherwise stores the fetched history under the eid.
- **`displayExecutionWithLogs`** — stores the executions and refreshes the interaction history of expanded rows.
- **`onInteractionClick`** — no-ops without a wid; otherwise loads the versioned
  workflow, displays it read-only, records the reverted interaction, notifies, and
  starts the replay.
- **`toggleRow`** — expands a collapsed row and loads its history; collapses an
  expanded row without reloading.

The `ngOnInit` 5s poller is neutralized by stubbing `getWorkflowMetadata` to return
no wid, so its callback early-returns and no stray request lands in the mock. No
production code was changed.

### Any related issues, documentation, discussions?

Closes #6532

### How was this PR tested?

Extended Vitest spec, run locally in `frontend/` (all green; failure path verified
by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/workspace/component/left-panel/time-travel/time-travel.component.spec.ts
# Test Files 1 passed (1) / Tests 12 passed (12)
eslint <spec>      # clean
prettier --check   # clean
```

Services are stubbed via `vi.spyOn` and `HttpTestingController`, so the spec makes
no real network calls.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
