### PR TITLE
test(frontend): extend unit test coverage for ResultPanelComponent

### DIFF
--- a/frontend/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/frontend/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -18,11 +18,19 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ElementRef } from "@angular/core";
+import { CdkDragEnd } from "@angular/cdk/drag-drop";
+import { NzResizeEvent } from "ng-zorro-antd/resizable";
 
-import { ResultPanelComponent } from "./result-panel.component";
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, ResultPanelComponent } from "./result-panel.component";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
 import { WorkflowResultService } from "../../service/workflow-result/workflow-result.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { PanelResizeService } from "../../service/workflow-result/panel-resize/panel-resize.service";
+import { ResultTableFrameComponent } from "./result-table-frame/result-table-frame.component";
+import { VisualizationFrameContentComponent } from "../visualization-panel-content/visualization-frame-content.component";
+import { ErrorFrameComponent } from "./error-frame/error-frame.component";
+import { ConsoleFrameComponent } from "./console-frame/console-frame.component";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
 import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
 import { By } from "@angular/platform-browser";
@@ -40,6 +48,7 @@ describe("ResultPanelComponent", () => {
   let executeWorkflowService: ExecuteWorkflowService;
   let workflowActionService: WorkflowActionService;
   let workflowResultService: WorkflowResultService;
+  let resizeService: PanelResizeService;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -63,6 +72,7 @@ describe("ResultPanelComponent", () => {
     executeWorkflowService = TestBed.inject(ExecuteWorkflowService);
     workflowActionService = TestBed.inject(WorkflowActionService);
     workflowResultService = TestBed.inject(WorkflowResultService);
+    resizeService = TestBed.inject(PanelResizeService);
     fixture.detectChanges();
   });
 
@@ -102,5 +112,175 @@ describe("ResultPanelComponent", () => {
     expect(component.frameComponentConfigs.size).toBe(0);
     expect(component.currentOperatorId).toBeUndefined();
     expect(component.operatorTitle).toBe("");
+  });
+
+  describe("visibility", () => {
+    it("openPanel sets default dimensions and notifies the resize service", () => {
+      const resizeSpy = vi.spyOn(resizeService, "changePanelSize");
+
+      component.openPanel();
+
+      expect(component.height).toBe(DEFAULT_HEIGHT);
+      expect(component.width).toBe(DEFAULT_WIDTH);
+      expect(resizeSpy).toHaveBeenCalledWith(DEFAULT_WIDTH, DEFAULT_HEIGHT);
+    });
+
+    it("closePanel collapses the panel", () => {
+      component.openPanel();
+
+      component.closePanel();
+
+      expect(component.height).toBe(32.5);
+      expect(component.width).toBe(0);
+    });
+
+    it("isPanelDocked is true only when the drag position matches the return position", () => {
+      component.returnPosition = { x: 5, y: 7 };
+      component.dragPosition = { x: 5, y: 7 };
+      expect(component.isPanelDocked()).toBe(true);
+
+      component.dragPosition = { x: 5, y: 8 };
+      expect(component.isPanelDocked()).toBe(false);
+    });
+
+    it("clearResultPanel empties the frame configs", () => {
+      component.frameComponentConfigs.set("Result", { component: ResultTableFrameComponent, componentInputs: {} });
+
+      component.clearResultPanel();
+
+      expect(component.frameComponentConfigs.size).toBe(0);
+    });
+  });
+
+  describe("content frames", () => {
+    it("displayConsole registers a console frame", () => {
+      component.displayConsole("op1", true);
+
+      const config = component.frameComponentConfigs.get("Console");
+      expect(config?.component).toBe(ConsoleFrameComponent);
+      expect(config?.componentInputs).toEqual({ operatorId: "op1", consoleInputEnabled: true });
+    });
+
+    it("displayError registers a static error frame", () => {
+      component.displayError("op1");
+
+      const config = component.frameComponentConfigs.get("Static Error");
+      expect(config?.component).toBe(ErrorFrameComponent);
+      expect(config?.componentInputs).toEqual({ operatorId: "op1" });
+    });
+
+    it("displayResult uses the table frame when a paginated result exists", () => {
+      vi.spyOn(workflowResultService, "getPaginatedResultService").mockReturnValue(
+        {} as unknown as ReturnType<typeof workflowResultService.getPaginatedResultService>
+      );
+
+      component.displayResult("op1");
+
+      expect(component.frameComponentConfigs.get("Result")?.component).toBe(ResultTableFrameComponent);
+    });
+
+    it("displayResult uses the visualization frame when only a non-paginated result exists", () => {
+      vi.spyOn(workflowResultService, "getPaginatedResultService").mockReturnValue(undefined);
+      vi.spyOn(workflowResultService, "getResultService").mockReturnValue(
+        {} as unknown as ReturnType<typeof workflowResultService.getResultService>
+      );
+
+      component.displayResult("op1");
+
+      expect(component.frameComponentConfigs.get("Result")?.component).toBe(VisualizationFrameContentComponent);
+    });
+
+    it("displayResult registers nothing when the operator has no result", () => {
+      vi.spyOn(workflowResultService, "getPaginatedResultService").mockReturnValue(undefined);
+      vi.spyOn(workflowResultService, "getResultService").mockReturnValue(undefined);
+
+      component.displayResult("op1");
+
+      expect(component.frameComponentConfigs.has("Result")).toBe(false);
+    });
+  });
+
+  describe("position & resize", () => {
+    it("resetPanelPosition moves the drag position back to the return position", () => {
+      component.returnPosition = { x: 3, y: 9 };
+      component.dragPosition = { x: 100, y: 200 };
+
+      component.resetPanelPosition();
+
+      expect(component.dragPosition).toEqual({ x: 3, y: 9 });
+    });
+
+    it("updateReturnPosition shifts y by the height delta", () => {
+      component.returnPosition = { x: 4, y: 10 };
+
+      component.updateReturnPosition(500, 300); // y + (500 - 300)
+
+      expect(component.returnPosition).toEqual({ x: 4, y: 210 });
+    });
+
+    it("updateReturnPosition is a no-op when the new height is undefined", () => {
+      component.returnPosition = { x: 4, y: 10 };
+
+      component.updateReturnPosition(500, undefined);
+
+      expect(component.returnPosition).toEqual({ x: 4, y: 10 });
+    });
+
+    it("onResize applies the new size and notifies the resize service", () => {
+      // Run the requestAnimationFrame callback synchronously so the assertion is deterministic.
+      // These spies patch the global `window`, so restore them locally to avoid leaking across tests.
+      const cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+      const rafSpy = vi.spyOn(window, "requestAnimationFrame").mockImplementation(cb => {
+        cb(0);
+        return 1;
+      });
+      const resizeSpy = vi.spyOn(resizeService, "changePanelSize");
+
+      try {
+        component.onResize({ width: 900, height: 600 } as NzResizeEvent);
+
+        expect(component.width).toBe(900);
+        expect(component.height).toBe(600);
+        expect(resizeSpy).toHaveBeenCalledWith(900, 600);
+      } finally {
+        rafSpy.mockRestore();
+        cancelSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("drag", () => {
+    it("handleStartDrag hides the visualization overlay when it is present", () => {
+      const vizEl = { style: { zIndex: 0 } };
+      component.componentOutlets = {
+        nativeElement: { querySelector: () => vizEl },
+      } as unknown as ElementRef;
+
+      component.handleStartDrag();
+
+      expect(vizEl.style.zIndex).toBe(-1);
+    });
+
+    it("handleEndDrag records the final free-drag position", () => {
+      component.componentOutlets = {
+        nativeElement: { querySelector: () => null },
+      } as unknown as ElementRef;
+      const source = { getFreeDragPosition: () => ({ x: 12, y: 34 }) };
+
+      component.handleEndDrag({ source } as unknown as CdkDragEnd);
+
+      expect(component.dragPosition).toEqual({ x: 12, y: 34 });
+    });
+  });
+
+  describe("rerenderResultPanel", () => {
+    it("does nothing while previewing a workflow version", () => {
+      component.previewWorkflowVersion = true;
+      const clearSpy = vi.spyOn(component, "clearResultPanel");
+
+      component.rerenderResultPanel();
+
+      expect(clearSpy).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `ResultPanelComponent` spec (codecov ~57.5%) with 16 tests
covering the previously-untested public methods. Existing services are the
real ones from the spec's `TestBed`; specific methods are `vi.spyOn`-stubbed:

- **visibility** — `openPanel` (default dims + notifies resize service),
  `closePanel` (collapses), `isPanelDocked` (docked vs. undocked),
  `clearResultPanel`.
- **content frames** — `displayConsole`, `displayError`, and `displayResult`
  across all three branches (paginated → table frame, non-paginated result →
  visualization frame, no result → nothing).
- **position & resize** — `resetPanelPosition`, `updateReturnPosition` (delta +
  undefined no-op), and `onResize` (the `requestAnimationFrame` callback is run
  synchronously via a locally-restored spy so the assertion is deterministic).
- **drag** — `handleStartDrag` (hides the viz overlay) and `handleEndDrag`
  (records the free-drag position).
- **rerenderResultPanel** — no-ops while previewing a workflow version.

All tests are deterministic (no real timers/network/random; the one rAF is
mocked synchronously and restored locally). No production code was changed.

### Any related issues, documentation, discussions?

Closes #6549

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/workspace/component/result-panel/result-panel.component.spec.ts
# Tests  20 passed (20)   (4 existing + 16 new)
eslint <spec>       # clean
prettier --check    # clean
```

(The component reads `localStorage` on init; on Node 26 that needs
`NODE_OPTIONS=--localstorage-file=...` locally — CI on Node 24.10.0 provides it.)

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
