### PR TITLE
test(frontend): extend CardItem, ComputingUnitStatus, and FilesUploader spec coverage

### DIFF
--- a/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
+++ b/frontend/src/app/common/service/computing-unit/computing-unit-status/computing-unit-status.service.spec.ts
@@ -29,6 +29,7 @@ import { StubUserService } from "../../user/stub-user.service";
 import { AuthService } from "../../user/auth.service";
 import { StubAuthService } from "../../user/stub-auth.service";
 import { DashboardWorkflowComputingUnit } from "../../../type/workflow-computing-unit";
+import { ComputingUnitState } from "../../../type/computing-unit-connection.interface";
 import { commonTestProviders } from "../../../testing/test-utils";
 
 describe("ComputingUnitStatusService", () => {
@@ -142,5 +143,84 @@ describe("ComputingUnitStatusService", () => {
     // Switch units while disconnected: unit 7's stale state must still be cleared.
     service.selectComputingUnit(5, 8);
     expect(resetCount).toBe(1);
+  });
+
+  it("getAllComputingUnits() replays the current list and forwards later updates", () => {
+    const emissions: DashboardWorkflowComputingUnit[][] = [];
+    service.getAllComputingUnits().subscribe(units => emissions.push(units));
+
+    // allComputingUnitsSubject is a BehaviorSubject initialized with [], so it replays that value.
+    expect(emissions[0]).toEqual([]);
+
+    const units = [mockUnit(1), mockUnit(2)];
+    (service as any).allComputingUnitsSubject.next(units);
+    expect(emissions[emissions.length - 1]).toBe(units);
+  });
+
+  it("getSelectedComputingUnitValue() returns null before any unit is selected", () => {
+    expect(service.getSelectedComputingUnitValue()).toBeNull();
+  });
+
+  it("getSelectedComputingUnitValue() reflects the unit chosen via selectComputingUnit()", () => {
+    vi.spyOn(websocketService, "openWebsocket").mockImplementation(() => {});
+    const unit = mockUnit(7);
+    (service as any).allComputingUnitsSubject.next([unit]);
+
+    service.selectComputingUnit(5, 7);
+
+    expect(service.getSelectedComputingUnitValue()).toBe(unit);
+  });
+
+  it("getStatus() maps a null selection to NoComputingUnit", () => {
+    let status: ComputingUnitState | undefined;
+    service.getStatus().subscribe(s => (status = s));
+    expect(status).toBe(ComputingUnitState.NoComputingUnit);
+  });
+
+  it("getStatus() maps a Running unit to ComputingUnitState.Running", () => {
+    (service as any).selectedUnitSubject.next({
+      computingUnit: { cuid: 1 },
+      status: "Running",
+    } as unknown as DashboardWorkflowComputingUnit);
+
+    let status: ComputingUnitState | undefined;
+    service.getStatus().subscribe(s => (status = s));
+    expect(status).toBe(ComputingUnitState.Running);
+  });
+
+  it("getStatus() maps a Pending unit to ComputingUnitState.Pending", () => {
+    (service as any).selectedUnitSubject.next({
+      computingUnit: { cuid: 1 },
+      status: "Pending",
+    } as unknown as DashboardWorkflowComputingUnit);
+
+    let status: ComputingUnitState | undefined;
+    service.getStatus().subscribe(s => (status = s));
+    expect(status).toBe(ComputingUnitState.Pending);
+  });
+
+  it("getStatus() maps an unrecognized status to Pending (default branch)", () => {
+    (service as any).selectedUnitSubject.next({
+      computingUnit: { cuid: 1 },
+      status: "Terminating",
+    } as unknown as DashboardWorkflowComputingUnit);
+
+    let status: ComputingUnitState | undefined;
+    service.getStatus().subscribe(s => (status = s));
+    expect(status).toBe(ComputingUnitState.Pending);
+  });
+
+  it("refreshComputingUnitList() re-fetches the list and pushes it to subscribers", () => {
+    const managing = TestBed.inject(WorkflowComputingUnitManagingService);
+    const newUnits = [mockUnit(42)];
+    const listSpy = vi.spyOn(managing, "listComputingUnits").mockReturnValue(of(newUnits));
+
+    let latest: DashboardWorkflowComputingUnit[] = [];
+    service.getAllComputingUnits().subscribe(units => (latest = units));
+
+    service.refreshComputingUnitList();
+
+    expect(listSpy).toHaveBeenCalled();
+    expect(latest).toEqual(newUnits);
   });
 });

--- a/frontend/src/app/dashboard/component/user/files-uploader/files-uploader.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/files-uploader/files-uploader.component.spec.ts
@@ -186,4 +186,37 @@ describe("FilesUploaderComponent", () => {
     expect(modals).toHaveLength(1);
     expect(component.fileUploadBannerType).toBe("success");
   });
+
+  it("showFileUploadBanner marks uploading finished and stores the given type and message", () => {
+    // preconditions: fresh component starts hidden with the default "success" type and empty message
+    expect(component.fileUploadingFinished).toBe(false);
+    expect(component.fileUploadBannerType).toBe("success");
+    expect(component.fileUploadBannerMessage).toBe("");
+
+    component.showFileUploadBanner("error", "3 files failed to be selected.");
+
+    expect(component.fileUploadingFinished).toBe(true);
+    expect(component.fileUploadBannerType).toBe("error");
+    expect(component.fileUploadBannerMessage).toBe("3 files failed to be selected.");
+  });
+
+  it("showFileUploadBanner overwrites the previously shown banner on a second call", () => {
+    component.showFileUploadBanner("error", "first message");
+    component.showFileUploadBanner("info", "second message");
+
+    expect(component.fileUploadingFinished).toBe(true);
+    expect(component.fileUploadBannerType).toBe("info");
+    expect(component.fileUploadBannerMessage).toBe("second message");
+  });
+
+  it("hideBanner clears only the finished flag, leaving the last banner type and message intact", () => {
+    component.showFileUploadBanner("warning", "heads up");
+
+    component.hideBanner();
+
+    expect(component.fileUploadingFinished).toBe(false);
+    // hideBanner resets visibility only; it does not touch type or message
+    expect(component.fileUploadBannerType).toBe("warning");
+    expect(component.fileUploadBannerMessage).toBe("heads up");
+  });
 });

--- a/frontend/src/app/dashboard/component/user/list-item/card-item/card-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/card-item/card-item.component.spec.ts
@@ -17,8 +17,9 @@
  * under the License.
  */
 
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ComponentFixture, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { CardItemComponent } from "./card-item.component";
+import { ActionType, EntityType, HubService } from "src/app/hub/service/hub.service";
 import { WorkflowPersistService } from "src/app/common/service/workflow-persist/workflow-persist.service";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { NzModalService } from "ng-zorro-antd/modal";
@@ -30,7 +31,7 @@ import { UserService } from "../../../../../common/service/user/user.service";
 import { commonTestProviders } from "../../../../../common/testing/test-utils";
 import type { Mocked } from "vitest";
 import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
-import { HUB_WORKFLOW_RESULT_DETAIL, USER_WORKSPACE } from "../../../../../app-routing.constant";
+import { HUB_WORKFLOW_RESULT_DETAIL, USER_PROJECT, USER_WORKSPACE } from "../../../../../app-routing.constant";
 import { WorkflowCoverService } from "src/app/dashboard/service/user/workflow-cover/workflow-cover.service";
 import { NotificationService } from "../../../../../common/service/notification/notification.service";
 import { DatasetService } from "../../../../service/user/dataset/dataset.service";
@@ -402,5 +403,236 @@ describe("CardItemComponent", () => {
     component.ngOnChanges({ entry: { currentValue: component.entry } as any });
 
     expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("initializeEntry configures workflow metadata: disableDelete, workspace link, icon, counts", () => {
+    component.currentUid = 42;
+    component.entry = makeWorkflowEntry({
+      id: 7,
+      workflow: { isOwner: false },
+      accessibleUserIds: [42],
+      size: 123,
+      likeCount: 9,
+      viewCount: 4,
+      isLiked: true,
+    } as any);
+
+    component.initializeEntry();
+
+    expect(component.disableDelete).toBe(true); // !entry.workflow.isOwner
+    expect(component.entryLink).toEqual([USER_WORKSPACE, "7"]); // currentUid is an accessible owner
+    expect(component.size).toBe(123);
+    expect(component.iconType).toBe("project");
+    expect(component.likeCount).toBe(9);
+    expect(component.viewCount).toBe(4);
+    expect(component.isLiked).toBe(true);
+  });
+
+  it("initializeEntry sets the project link and container icon and resets the cover for a project entry", () => {
+    component.coverImageSrc = "stale-value";
+    component.entry = {
+      id: 3,
+      name: "proj",
+      type: "project",
+      likeCount: 2,
+      viewCount: 1,
+      isLiked: false,
+    } as unknown as DashboardEntry;
+
+    component.initializeEntry();
+
+    expect(component.entryLink).toEqual([USER_PROJECT, "3"]);
+    expect(component.iconType).toBe("container");
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE); // reset at method start
+    expect(component.likeCount).toBe(2);
+  });
+
+  it("initializeEntry uses the folder-open icon for a file entry", () => {
+    component.entry = {
+      id: 8,
+      name: "f",
+      type: "file",
+      likeCount: 0,
+      viewCount: 0,
+      isLiked: false,
+    } as unknown as DashboardEntry;
+
+    component.initializeEntry();
+
+    expect(component.iconType).toBe("folder-open");
+  });
+
+  it("initializeEntry throws for an unexpected entry type", () => {
+    component.entry = {
+      id: 1,
+      name: "x",
+      type: "bogus",
+      likeCount: 0,
+      viewCount: 0,
+      isLiked: false,
+    } as unknown as DashboardEntry;
+
+    expect(() => component.initializeEntry()).toThrow("Unexpected type in DashboardEntry.");
+  });
+
+  it("onEditName captures the original name, enters edit mode, and focuses the input at the caret end", fakeAsync(() => {
+    component.entry = makeWorkflowEntry({ name: "Current Name" }); // length 12
+    const focus = vi.fn();
+    const setSelectionRange = vi.fn();
+    component.nameInput = { nativeElement: { value: "Current Name", focus, setSelectionRange } } as any;
+
+    component.onEditName();
+
+    expect(component.originalName).toBe("Current Name");
+    expect(component.editingName).toBe(true);
+
+    tick(0); // flush the focus timer
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(setSelectionRange).toHaveBeenCalledWith(12, 12);
+  }));
+
+  it("onEditName enters edit mode without throwing when the input is not rendered", fakeAsync(() => {
+    component.entry = makeWorkflowEntry({ name: "n" });
+    component.nameInput = undefined as any;
+
+    component.onEditName();
+
+    expect(component.editingName).toBe(true);
+    expect(component.originalName).toBe("n");
+    expect(() => tick(0)).not.toThrow(); // timer guard skips the missing input
+  }));
+
+  it("onEditDescription captures the original description, enters edit mode, and focuses the textarea at the caret end", fakeAsync(() => {
+    component.entry = makeWorkflowEntry({ description: "Some desc" }); // length 9
+    const focus = vi.fn();
+    const setSelectionRange = vi.fn();
+    component.descriptionInput = { nativeElement: { value: "Some desc", focus, setSelectionRange } } as any;
+
+    component.onEditDescription();
+
+    expect(component.originalDescription).toBe("Some desc");
+    expect(component.editingDescription).toBe(true);
+
+    tick(0);
+
+    expect(focus).toHaveBeenCalledTimes(1);
+    expect(setSelectionRange).toHaveBeenCalledWith(9, 9);
+  }));
+
+  it("openDetailModal opens the workflow detail modal and bumps the view count", () => {
+    const modalService = TestBed.inject(NzModalService);
+    const hubService = TestBed.inject(HubService);
+    const createSpy = vi.spyOn(modalService, "create").mockReturnValue({ componentInstance: {} } as any);
+    const getCountsSpy = vi.spyOn(hubService, "getCounts").mockReturnValue(of([{ counts: { view: 5 } }] as any));
+
+    component.entry = makeWorkflowEntry({ id: 7 }); // type defaults to "workflow"
+    component.openDetailModal(7);
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const cfg = createSpy.mock.calls[0][0];
+    expect(cfg.nzData).toEqual({ wid: 7 });
+    expect(cfg.nzFooter).toBeNull();
+    expect(getCountsSpy).toHaveBeenCalledWith([EntityType.Workflow], [7], [ActionType.View]);
+    expect(component.viewCount).toBe(6); // (5 view count) + 1
+  });
+
+  it("openDetailModal defaults nzData wid to 0 and skips the count fetch when wid is undefined", () => {
+    const modalService = TestBed.inject(NzModalService);
+    const hubService = TestBed.inject(HubService);
+    const createSpy = vi.spyOn(modalService, "create").mockReturnValue({ componentInstance: {} } as any);
+    const getCountsSpy = vi.spyOn(hubService, "getCounts");
+
+    component.openDetailModal(undefined);
+
+    expect(createSpy.mock.calls[0][0].nzData).toEqual({ wid: 0 });
+    expect(getCountsSpy).not.toHaveBeenCalled();
+  });
+
+  it("openDetailModal skips the count fetch when the modal has no component instance", () => {
+    const modalService = TestBed.inject(NzModalService);
+    const hubService = TestBed.inject(HubService);
+    vi.spyOn(modalService, "create").mockReturnValue({ componentInstance: null } as any);
+    const getCountsSpy = vi.spyOn(hubService, "getCounts");
+
+    component.openDetailModal(7);
+
+    expect(getCountsSpy).not.toHaveBeenCalled();
+  });
+
+  it("toggleLike posts a like and refreshes the count when the entry is not yet liked", () => {
+    const hubService = TestBed.inject(HubService);
+    const postLikeSpy = vi.spyOn(hubService, "postLike").mockReturnValue(of(true));
+    const getCountsSpy = vi.spyOn(hubService, "getCounts").mockReturnValue(of([{ counts: { like: 10 } }] as any));
+
+    component.currentUid = 42;
+    component.entry = makeWorkflowEntry({ id: 7 });
+    component.isLiked = false;
+
+    component.toggleLike();
+
+    expect(postLikeSpy).toHaveBeenCalledWith(7, EntityType.Workflow);
+    expect(getCountsSpy).toHaveBeenCalledWith([EntityType.Workflow], [7], [ActionType.Like]);
+    expect(component.isLiked).toBe(true);
+    expect(component.likeCount).toBe(10);
+  });
+
+  it("toggleLike posts an unlike and refreshes the count when the entry is already liked", () => {
+    const hubService = TestBed.inject(HubService);
+    const postUnlikeSpy = vi.spyOn(hubService, "postUnlike").mockReturnValue(of(true));
+    const getCountsSpy = vi.spyOn(hubService, "getCounts").mockReturnValue(of([{ counts: { like: 3 } }] as any));
+
+    component.currentUid = 42;
+    component.entry = makeWorkflowEntry({ id: 7 });
+    component.isLiked = true;
+
+    component.toggleLike();
+
+    expect(postUnlikeSpy).toHaveBeenCalledWith(7, EntityType.Workflow);
+    expect(getCountsSpy).toHaveBeenCalledWith([EntityType.Workflow], [7], [ActionType.Like]);
+    expect(component.isLiked).toBe(false);
+    expect(component.likeCount).toBe(3);
+  });
+
+  it("toggleLike leaves state unchanged and skips the count fetch when the like request reports failure", () => {
+    const hubService = TestBed.inject(HubService);
+    vi.spyOn(hubService, "postLike").mockReturnValue(of(false));
+    const getCountsSpy = vi.spyOn(hubService, "getCounts");
+
+    component.currentUid = 42;
+    component.entry = makeWorkflowEntry({ id: 7 });
+    component.isLiked = false;
+
+    component.toggleLike();
+
+    expect(component.isLiked).toBe(false);
+    expect(getCountsSpy).not.toHaveBeenCalled();
+  });
+
+  it("toggleLike is a no-op when there is no current user", () => {
+    const hubService = TestBed.inject(HubService);
+    const postLikeSpy = vi.spyOn(hubService, "postLike");
+    const postUnlikeSpy = vi.spyOn(hubService, "postUnlike");
+
+    component.currentUid = undefined;
+    component.entry = makeWorkflowEntry({ id: 7 });
+
+    component.toggleLike();
+
+    expect(postLikeSpy).not.toHaveBeenCalled();
+    expect(postUnlikeSpy).not.toHaveBeenCalled();
+  });
+
+  it("toggleLike is a no-op when the entry has no id", () => {
+    const hubService = TestBed.inject(HubService);
+    const postLikeSpy = vi.spyOn(hubService, "postLike");
+
+    component.currentUid = 42;
+    component.entry = makeWorkflowEntry({ id: undefined });
+    component.isLiked = false;
+
+    component.toggleLike();
+
+    expect(postLikeSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends three existing Vitest specs to cover previously-untested methods
(each component/service already had a spec). No production code was changed.

**`CardItemComponent`** (+13 tests) —
- `initializeEntry`: workflow (owner→workspace link, counts, `disableDelete`),
  project (link + container icon + cover reset), file (folder-open icon), and
  the unexpected-type throw.
- `onEditName` / `onEditDescription`: snapshot the original + enter edit mode;
  the focus `setTimeout` is driven deterministically with `fakeAsync`/`tick`.
- `openDetailModal`: opens the modal and bumps the view count; defaults
  `wid` to 0 and skips the count fetch when `wid`/the modal instance is absent.
- `toggleLike`: like/unlike + count refresh; no-ops on failure, missing user,
  or missing entry id.

**`ComputingUnitStatusService`** (+8 tests) —
`getAllComputingUnits` (replay + forward), `getSelectedComputingUnitValue`
(null → selected), `getStatus` (null/Running/Pending/default → enum), and
`refreshComputingUnitList` (re-fetches and pushes to subscribers).

**`FilesUploaderComponent`** (+3 tests) —
`showFileUploadBanner` (sets flag/type/message, overwrites) and `hideBanner`
(clears only the finished flag).

All collaborators are stubbed (`vi.spyOn` on injected `HubService`/
`NzModalService`, the managing-service stub, synchronous `of(...)`); no backend,
no real modal, no wall-clock/timer dependence.

### Any related issues, documentation, discussions?

Closes #6553

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; failure paths
verified by breaking assertions to confirm the suites go red):

```
ng test --watch=false --include <each spec>
# files-uploader        8 passed  (5 existing + 3 new)
# computing-unit-status 13 passed (5 existing + 8 new)
# card-item             46 passed (33 existing + 13 new)
eslint <specs>       # clean
prettier --check     # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
