### PR TITLE
test(frontend): extend WorkflowResultExportService unit test coverage

### DIFF
--- a/frontend/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
@@ -25,7 +25,7 @@ import { WorkflowActionService } from "../workflow-graph/model/workflow-action.s
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
 import { WorkflowResultService } from "../workflow-result/workflow-result.service";
-import { of } from "rxjs";
+import { of, throwError } from "rxjs";
 import { ExecutionState } from "../../types/execute-workflow.interface";
 import { DownloadService } from "src/app/dashboard/service/user/download/download.service";
 import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.service";
@@ -33,6 +33,10 @@ import { commonTestProviders } from "../../../common/testing/test-utils";
 import type { Mocked } from "vitest";
 import { JointGraphWrapper } from "../workflow-graph/model/joint-graph-wrapper";
 import { WorkflowGraph } from "../workflow-graph/model/workflow-graph";
+import { HttpResponse } from "@angular/common/http";
+import { GuiConfigService } from "../../../common/service/gui-config.service";
+import { MockGuiConfigService } from "../../../common/service/gui-config.service.mock";
+import { DashboardWorkflowComputingUnit } from "../../../common/type/workflow-computing-unit";
 describe("WorkflowResultExportService", () => {
   let service: WorkflowResultExportService;
   let workflowWebsocketServiceSpy: Mocked<WorkflowWebsocketService>;
@@ -135,6 +139,287 @@ describe("WorkflowResultExportService", () => {
 
     expect(service.hasResultToExportOnHighlightedOperators).toBe(false);
     expect(service.hasResultToExportOnAllOperators.value).toBe(false);
+  });
+
+  // ---- Test helpers ----------------------------------------------------------
+
+  function enableExport(): void {
+    const config = TestBed.inject(GuiConfigService) as unknown as MockGuiConfigService;
+    config.setConfig({ exportExecutionResultEnabled: true });
+  }
+
+  function makeUnit(): DashboardWorkflowComputingUnit {
+    return { computingUnit: { cuid: 1, type: "local" } } as unknown as DashboardWorkflowComputingUnit;
+  }
+
+  /** Stubs the export-flow methods the real DownloadService exposes but the base spy omits. */
+  function stubDownloadService(overrides?: {
+    downloadability?: Record<string, string[]>;
+    datasetResponse?: HttpResponse<unknown>;
+    datasetError?: unknown;
+  }): {
+    getWorkflowResultDownloadability: ReturnType<typeof vi.fn>;
+    exportWorkflowResultToDataset: ReturnType<typeof vi.fn>;
+    exportWorkflowResultToLocal: ReturnType<typeof vi.fn>;
+  } {
+    const getWorkflowResultDownloadability = vi.fn().mockReturnValue(of(overrides?.downloadability ?? {}));
+    const exportWorkflowResultToDataset = vi
+      .fn()
+      .mockReturnValue(
+        overrides?.datasetError !== undefined
+          ? throwError(() => overrides.datasetError)
+          : of(overrides?.datasetResponse ?? new HttpResponse({ body: { status: "success", message: "ok" } }))
+      );
+    const exportWorkflowResultToLocal = vi.fn();
+    (downloadServiceSpy as any).getWorkflowResultDownloadability = getWorkflowResultDownloadability;
+    (downloadServiceSpy as any).exportWorkflowResultToDataset = exportWorkflowResultToDataset;
+    (downloadServiceSpy as any).exportWorkflowResultToLocal = exportWorkflowResultToLocal;
+    (workflowResultServiceSpy as any).determineOutputExtension = vi.fn().mockReturnValue("csv");
+    return { getWorkflowResultDownloadability, exportWorkflowResultToDataset, exportWorkflowResultToLocal };
+  }
+
+  describe("computeRestrictionAnalysis", () => {
+    it("returns an empty restriction map without hitting the backend when the workflow has no id", () => {
+      workflowActionServiceSpy.getWorkflow.mockReturnValue({ wid: undefined } as any);
+      const download = stubDownloadService({ downloadability: { op1: ["ds1"] } });
+
+      let result: WorkflowResultDownloadability | undefined;
+      service.computeRestrictionAnalysis().subscribe(r => (result = r));
+
+      expect(result?.restrictedOperatorMap.size).toBe(0);
+      expect(download.getWorkflowResultDownloadability).not.toHaveBeenCalled();
+    });
+
+    it("maps the backend response into a Map of operatorId -> Set<datasetLabel>", () => {
+      const download = stubDownloadService({
+        downloadability: { op1: ["ds1 (a@x.com)"], op2: ["ds2 (b@y.com)", "ds3 (c@z.com)"] },
+      });
+
+      let result: WorkflowResultDownloadability | undefined;
+      service.computeRestrictionAnalysis().subscribe(r => (result = r));
+
+      expect(download.getWorkflowResultDownloadability).toHaveBeenCalledWith("workflow1");
+      expect(result?.restrictedOperatorMap.get("op1")).toEqual(new Set(["ds1 (a@x.com)"]));
+      expect(result?.restrictedOperatorMap.get("op2")).toEqual(new Set(["ds2 (b@y.com)", "ds3 (c@z.com)"]));
+    });
+
+    it("falls back to an empty restriction map when the backend call errors", () => {
+      const getWorkflowResultDownloadability = vi.fn().mockReturnValue(throwError(() => new Error("boom")));
+      (downloadServiceSpy as any).getWorkflowResultDownloadability = getWorkflowResultDownloadability;
+
+      let result: WorkflowResultDownloadability | undefined;
+      service.computeRestrictionAnalysis().subscribe(r => (result = r));
+
+      expect(result).toBeInstanceOf(WorkflowResultDownloadability);
+      expect(result?.restrictedOperatorMap.size).toBe(0);
+    });
+  });
+
+  describe("export flow (exportWorkflowExecutionResult / performExport)", () => {
+    it("does nothing when export is disabled in the gui config", () => {
+      const download = stubDownloadService();
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [1], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.loading).not.toHaveBeenCalled();
+      expect(notificationServiceSpy.error).not.toHaveBeenCalled();
+      expect(download.exportWorkflowResultToDataset).not.toHaveBeenCalled();
+    });
+
+    it("errors when the computing unit is null", () => {
+      enableExport();
+      const download = stubDownloadService();
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [1], 0, 0, "file", true, "dataset", null);
+
+      expect(notificationServiceSpy.error).toHaveBeenCalledWith(
+        "Cannot export result: computing unit is not available"
+      );
+      expect(notificationServiceSpy.loading).not.toHaveBeenCalled();
+      expect(download.exportWorkflowResultToDataset).not.toHaveBeenCalled();
+    });
+
+    it("errors when the workflow id is not available", () => {
+      enableExport();
+      workflowActionServiceSpy.getWorkflow.mockReturnValue({ wid: undefined } as any);
+      const download = stubDownloadService();
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [1], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.error).toHaveBeenCalledWith("Cannot export result: workflow ID is not available");
+      expect(download.exportWorkflowResultToDataset).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no operators are selected (highlighted export with empty selection)", () => {
+      enableExport();
+      const download = stubDownloadService();
+      jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.mockReturnValue([]);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [1], 0, 0, "file", false, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.loading).not.toHaveBeenCalled();
+      expect(notificationServiceSpy.error).not.toHaveBeenCalled();
+      expect(download.exportWorkflowResultToDataset).not.toHaveBeenCalled();
+    });
+
+    it("errors (no export) when every selected operator is blocked by a non-downloadable dataset", () => {
+      enableExport();
+      const download = stubDownloadService({ downloadability: { op1: ["ds1 (a@x.com)"] } });
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [1], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.error).toHaveBeenCalledWith(
+        "Cannot export result: selection depends on dataset(s) that are not downloadable: ds1 (a@x.com)"
+      );
+      expect(notificationServiceSpy.loading).not.toHaveBeenCalled();
+      expect(download.exportWorkflowResultToDataset).not.toHaveBeenCalled();
+    });
+
+    it("warns and still exports the unblocked operators when only some are blocked", () => {
+      enableExport();
+      (notificationServiceSpy as any).warning = vi.fn();
+      const download = stubDownloadService({ downloadability: { op2: ["ds2 (b@y.com)"] } });
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }, { operatorID: "op2" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [7], 1, 2, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.warning).toHaveBeenCalledWith(
+        "Some operators were skipped because their results depend on dataset(s) that are not downloadable" +
+          " (ds2 (b@y.com))"
+      );
+      expect(notificationServiceSpy.loading).toHaveBeenCalledWith("Exporting...");
+      expect(download.exportWorkflowResultToDataset).toHaveBeenCalledWith(
+        "csv",
+        "workflow1",
+        "wf",
+        [{ id: "op1", outputType: "csv" }],
+        [7],
+        1,
+        2,
+        "file",
+        expect.anything()
+      );
+      expect(notificationServiceSpy.success).toHaveBeenCalledWith("Result exported successfully");
+    });
+
+    it("exports to dataset and reports success on a success response", () => {
+      enableExport();
+      (notificationServiceSpy as any).warning = vi.fn();
+      const download = stubDownloadService();
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [5], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.warning).not.toHaveBeenCalled();
+      expect(notificationServiceSpy.loading).toHaveBeenCalledWith("Exporting...");
+      expect(download.exportWorkflowResultToDataset).toHaveBeenCalledTimes(1);
+      expect(notificationServiceSpy.success).toHaveBeenCalledWith("Result exported successfully");
+    });
+
+    it("reports the server message when the dataset export response is not successful", () => {
+      enableExport();
+      stubDownloadService({
+        datasetResponse: new HttpResponse({ body: { status: "failure", message: "quota exceeded" } }),
+      });
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [5], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.error).toHaveBeenCalledWith("quota exceeded");
+      expect(notificationServiceSpy.success).not.toHaveBeenCalled();
+    });
+
+    it("reports a default error message when the dataset export response has no body", () => {
+      enableExport();
+      stubDownloadService({ datasetResponse: new HttpResponse({}) });
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [5], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.error).toHaveBeenCalledWith("An error occurred during export");
+    });
+
+    it("reports the extracted error message when the dataset export call fails", () => {
+      enableExport();
+      stubDownloadService({ datasetError: { error: { message: "server exploded" } } });
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("csv", "wf", [5], 0, 0, "file", true, "dataset", makeUnit());
+
+      expect(notificationServiceSpy.error).toHaveBeenCalledWith(
+        "An error happened in exporting operator results: server exploded"
+      );
+    });
+
+    it("routes to the local-filesystem export when destination is 'local'", () => {
+      enableExport();
+      const download = stubDownloadService();
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "op1" }] as any);
+
+      service.exportWorkflowExecutionResult("json", "wf", [], 3, 4, "local-file", true, "local", makeUnit());
+
+      expect(notificationServiceSpy.loading).toHaveBeenCalledWith("Exporting...");
+      expect(download.exportWorkflowResultToLocal).toHaveBeenCalledWith(
+        "json",
+        "workflow1",
+        "wf",
+        [{ id: "op1", outputType: "csv" }],
+        3,
+        4,
+        "local-file",
+        expect.anything()
+      );
+      expect(download.exportWorkflowResultToDataset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("updateExportAvailabilityFlags", () => {
+    it("marks results exportable when execution is idle and operators have a result snapshot", () => {
+      executeWorkflowServiceSpy.getExecutionState.mockReturnValue({ state: ExecutionState.Completed } as any);
+      jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.mockReturnValue(["opH"]);
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "opA" }] as any);
+      // hasAnyResult is false, so the snapshot side of the OR must decide exportability.
+      workflowResultServiceSpy.hasAnyResult.mockReturnValue(false);
+      workflowResultServiceSpy.getResultService.mockReturnValue({
+        getCurrentResultSnapshot: () => ({}),
+      } as any);
+
+      (service as any).updateExportAvailabilityFlags();
+
+      expect(service.hasResultToExportOnHighlightedOperators).toBe(true);
+      expect(service.hasResultToExportOnAllOperators.value).toBe(true);
+    });
+
+    it("keeps results non-exportable while a workflow is still executing", () => {
+      executeWorkflowServiceSpy.getExecutionState.mockReturnValue({ state: ExecutionState.Running } as any);
+      jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.mockReturnValue(["opH"]);
+      texeraGraphSpy.getAllOperators.mockReturnValue([{ operatorID: "opA" }] as any);
+      workflowResultServiceSpy.hasAnyResult.mockReturnValue(true);
+      workflowResultServiceSpy.getResultService.mockReturnValue({
+        getCurrentResultSnapshot: () => ({}),
+      } as any);
+
+      (service as any).updateExportAvailabilityFlags();
+
+      expect(service.hasResultToExportOnHighlightedOperators).toBe(false);
+      expect(service.hasResultToExportOnAllOperators.value).toBe(false);
+    });
+  });
+
+  it("getExportOnAllOperatorsStatusStream emits the current all-operators availability value", () => {
+    service.hasResultToExportOnAllOperators.next(true);
+
+    const emitted: boolean[] = [];
+    service
+      .getExportOnAllOperatorsStatusStream()
+      .subscribe(v => emitted.push(v))
+      .unsubscribe();
+
+    expect(emitted).toEqual([true]);
   });
 });
 

--- a/frontend/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
@@ -25,9 +25,9 @@ import { WorkflowActionService } from "../workflow-graph/model/workflow-action.s
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
 import { WorkflowResultService } from "../workflow-result/workflow-result.service";
-import { of, throwError } from "rxjs";
+import { Observable, of, throwError } from "rxjs";
 import { ExecutionState } from "../../types/execute-workflow.interface";
-import { DownloadService } from "src/app/dashboard/service/user/download/download.service";
+import { DownloadService, ExportWorkflowJsonResponse } from "src/app/dashboard/service/user/download/download.service";
 import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.service";
 import { commonTestProviders } from "../../../common/testing/test-utils";
 import type { Mocked } from "vitest";
@@ -93,7 +93,12 @@ describe("WorkflowResultExportService", () => {
     ewSpy.getExecutionState.mockReturnValue({ state: ExecutionState.Completed });
 
     const wrSpy = { hasAnyResult: vi.fn(), getResultService: vi.fn(), getPaginatedResultService: vi.fn() };
-    const downloadSpy = { downloadOperatorsResult: vi.fn() };
+    const downloadSpy = {
+      downloadOperatorsResult: vi.fn(),
+      getWorkflowResultDownloadability: vi.fn(),
+      exportWorkflowResultToDataset: vi.fn(),
+      exportWorkflowResultToLocal: vi.fn(),
+    };
     downloadSpy.downloadOperatorsResult.mockReturnValue(of(new Blob()));
 
     const datasetSpy = { retrieveAccessibleDatasets: vi.fn() };
@@ -125,6 +130,12 @@ describe("WorkflowResultExportService", () => {
     workflowResultServiceSpy = TestBed.inject(WorkflowResultService) as unknown as Mocked<WorkflowResultService>;
     downloadServiceSpy = TestBed.inject(DownloadService) as unknown as Mocked<DownloadService>;
     datasetServiceSpy = TestBed.inject(DatasetService) as unknown as Mocked<DatasetService>;
+
+    // Reset the GuiConfig to a known baseline (export disabled) so tests that
+    // enable it via enableExport() do not leak state and become order-dependent.
+    (TestBed.inject(GuiConfigService) as unknown as MockGuiConfigService).setConfig({
+      exportExecutionResultEnabled: false,
+    });
   });
 
   it("should be created", () => {
@@ -157,25 +168,28 @@ describe("WorkflowResultExportService", () => {
     downloadability?: Record<string, string[]>;
     datasetResponse?: HttpResponse<unknown>;
     datasetError?: unknown;
-  }): {
-    getWorkflowResultDownloadability: ReturnType<typeof vi.fn>;
-    exportWorkflowResultToDataset: ReturnType<typeof vi.fn>;
-    exportWorkflowResultToLocal: ReturnType<typeof vi.fn>;
-  } {
-    const getWorkflowResultDownloadability = vi.fn().mockReturnValue(of(overrides?.downloadability ?? {}));
-    const exportWorkflowResultToDataset = vi
+  }): Pick<
+    Mocked<DownloadService>,
+    "getWorkflowResultDownloadability" | "exportWorkflowResultToDataset" | "exportWorkflowResultToLocal"
+  > {
+    downloadServiceSpy.getWorkflowResultDownloadability.mockReturnValue(of(overrides?.downloadability ?? {}));
+    downloadServiceSpy.exportWorkflowResultToDataset.mockReturnValue(
+      (overrides?.datasetError !== undefined
+        ? throwError(() => overrides.datasetError)
+        : of(
+            overrides?.datasetResponse ?? new HttpResponse({ body: { status: "success", message: "ok" } })
+          )) as Observable<HttpResponse<ExportWorkflowJsonResponse>>
+    );
+    // determineOutputExtension echoes the requested export type so the stubbed
+    // outputType stays coherent with the format passed to each export call.
+    (workflowResultServiceSpy as any).determineOutputExtension = vi
       .fn()
-      .mockReturnValue(
-        overrides?.datasetError !== undefined
-          ? throwError(() => overrides.datasetError)
-          : of(overrides?.datasetResponse ?? new HttpResponse({ body: { status: "success", message: "ok" } }))
-      );
-    const exportWorkflowResultToLocal = vi.fn();
-    (downloadServiceSpy as any).getWorkflowResultDownloadability = getWorkflowResultDownloadability;
-    (downloadServiceSpy as any).exportWorkflowResultToDataset = exportWorkflowResultToDataset;
-    (downloadServiceSpy as any).exportWorkflowResultToLocal = exportWorkflowResultToLocal;
-    (workflowResultServiceSpy as any).determineOutputExtension = vi.fn().mockReturnValue("csv");
-    return { getWorkflowResultDownloadability, exportWorkflowResultToDataset, exportWorkflowResultToLocal };
+      .mockImplementation((_operatorId: string, exportType: string) => exportType);
+    return {
+      getWorkflowResultDownloadability: downloadServiceSpy.getWorkflowResultDownloadability,
+      exportWorkflowResultToDataset: downloadServiceSpy.exportWorkflowResultToDataset,
+      exportWorkflowResultToLocal: downloadServiceSpy.exportWorkflowResultToLocal,
+    };
   }
 
   describe("computeRestrictionAnalysis", () => {
@@ -367,7 +381,7 @@ describe("WorkflowResultExportService", () => {
         "json",
         "workflow1",
         "wf",
-        [{ id: "op1", outputType: "csv" }],
+        [{ id: "op1", outputType: "json" }],
         3,
         4,
         "local-file",


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `workflow-result-export.service.spec.ts` with 17 new tests (7 -> 24) for `WorkflowResultExportService`, targeting previously-uncovered behavior:
- `computeRestrictionAnalysis` (no-wid guard, backend map, `catchError`);
- the `performExport` flow (config-disabled no-op, null computing unit, missing workflow id, empty selection, all-blocked error vs partial-block warning+export, dataset export success / non-success body / null body / error callback, and `local` routing);
- `updateExportAvailabilityFlags` (idle+snapshot vs running); and
- the export-status stream.

Reuses the existing subject-backed service doubles; no module-level `vi.mock`. Statement coverage: ~48% -> 100% (51 -> 0 uncovered lines). No existing tests modified.

### Any related issues, documentation, discussions?

Closes #6595.

### How was this PR tested?

`npx ng test --watch=false --include='**/workflow-result-export.service.spec.ts'` -> 24/24 passing. `yarn format:ci` passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])