### PR TITLE
feat(k8s): core-services node placement + PDBs for autoscaler safety

### DIFF
--- a/bin/k8s/templates/base/pod-disruption-budgets/app-service-pdbs.yaml
+++ b/bin/k8s/templates/base/pod-disruption-budgets/app-service-pdbs.yaml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# PodDisruptionBudgets for the replicated, stateless app services.
+#
+# These services run multiple interchangeable replicas with no anti-affinity, so
+# a cluster autoscaler (e.g. Karpenter) is free to consolidate idle nodes by
+# relocating their pods. A PDB with maxUnavailable: 1 keeps each service
+# continuously available (at most one replica down at a time) while still
+# permitting that consolidation — the right trade-off for stateless,
+# horizontally-replicated services.
+#
+# Deliberately excluded: singletons that cannot tolerate eviction (the
+# computing-unit manager is pinned to a dedicated node pool via coreServices
+# instead) and stateful/session-affine services (shared-editing-server, pylsp),
+# whose pods hold per-connection state that eviction would drop.
+{{- range $svc := list .Values.webserver.name .Values.accessControlService.name .Values.agentService.name .Values.configService.name .Values.fileService.name .Values.litellm.name .Values.workflowCompilingService.name }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $.Release.Name }}-{{ $svc }}-pdb
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}-{{ $svc }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-{{ $svc }}
+{{- end }}

--- a/bin/k8s/templates/base/workflow-computing-unit-manager/workflow-computing-unit-manager-deployment.yaml
+++ b/bin/k8s/templates/base/workflow-computing-unit-manager/workflow-computing-unit-manager-deployment.yaml
@@ -33,6 +33,14 @@ spec:
         app: {{ .Release.Name }}-{{ .Values.workflowComputingUnitManager.name }}
     spec:
       serviceAccountName: {{ .Values.workflowComputingUnitManager.serviceAccountName }}
+      {{- with .Values.coreServices.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.coreServices.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: wait-lakekeeper
           image: curlimages/curl:latest

--- a/bin/k8s/values-aws.yaml
+++ b/bin/k8s/values-aws.yaml
@@ -25,6 +25,19 @@
 # own. The buckets must already exist (the init job does not create them).
 # ---------------------------------------------------------------------------
 
+# Pin the always-on singleton services onto a dedicated, long-lived node pool so a
+# cluster autoscaler (e.g. Karpenter) never evicts them to consolidate a transient
+# or computing-unit node. Replace the label/taint below with whatever your core
+# node pool actually uses. Leave this section out for a default (unpinned) install.
+coreServices:
+  nodeSelector:
+    texera.io/node-pool: core-services
+  tolerations:
+    - key: texera.io/node-pool
+      operator: Equal
+      value: core-services
+      effect: NoSchedule
+
 # Turn off the bundled MinIO object store; the services talk to external S3.
 minio:
   enabled: false

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -26,6 +26,16 @@ global:
   security:
     allowInsecureImages: true
 
+# Node placement for always-on singleton services (currently the computing-unit
+# manager). Empty by default, so local / on-prem installs are unaffected and pods
+# schedule anywhere. On a cluster autoscaler such as Karpenter, set a nodeSelector
+# and tolerations here (via an AWS overlay like values-aws.yaml) to pin these
+# singletons onto a dedicated, long-lived "core services" node pool, so they never
+# land on — and thereby block the scale-down of — a transient / computing-unit node.
+coreServices:
+  nodeSelector: {}
+  tolerations: []
+
 # Persistence Configuration
 # This controls how Persistent Volumes (PVs) and Persistent Volume Claims (PVCs) are managed
 # 


### PR DESCRIPTION
> ⚠️ **Review-only PR — opened so the diff is easy to review on GitHub, then closed immediately. Not intended for merge as-is.**

### What changes were proposed in this PR?

Roadmap item 3 from #5891 — **core-services node placement + autoscaler safety** — ported to the `base`/`aws`/`on-prem` layout. Two complementary, opt-in-by-default mechanisms so a cluster autoscaler (e.g. Karpenter) can reclaim idle nodes while core services stay available:

1. **`coreServices` placement** (`values.yaml`): a `nodeSelector` + `tolerations`, **empty by default** (no-op for local / on-prem), wired into the always-on singleton **computing-unit manager**. An AWS overlay pins it onto a dedicated core-services node pool so it never blocks consolidation of a transient node.
2. **PodDisruptionBudgets** (`maxUnavailable: 1`) for the replicated, stateless app services (webserver, access-control, agent, config, file, litellm, workflow-compiling) — new `templates/base/pod-disruption-budgets/app-service-pdbs.yaml`. They stay continuously available while remaining relocatable.

Deliberately **not** using `karpenter.sh/do-not-disrupt`: on replicated services it blocks consolidation, and on singletons it can pin a node indefinitely (orphaned capacity). PDBs + node placement give the protection without that side effect. Stateful/session-affine services (`shared-editing-server`, `pylsp`) are excluded from PDBs since eviction would drop per-connection state.

`values-aws.yaml` gains an example `coreServices` pin (node-pool label + toleration).

### Any related issues, documentation, discussions?

Part of #5891 (item 3 of 6). Follows the object-storage work (#5932, #6295) and the template reorg (#5757). Ports a design validated downstream.

### How was this PR tested?

`helm lint` passes. Rendered default vs AWS overlay:

```bash
cd bin/k8s && helm dependency build
# default: placement is a no-op (0 nodeSelector/tolerations on cu-manager)
helm template test . | grep -c 'nodeSelector'   # cu-manager: 0
# AWS overlay: cu-manager pinned, PDBs present
helm template test . -f values-aws.yaml | grep 'texera.io/node-pool'
```

- **Default render:** cu-manager pod spec unchanged (empty `coreServices` renders nothing); the 7 app-service PDBs render (inert on a static cluster — a PDB only gates *voluntary* evictions).
- **AWS overlay render:** cu-manager carries the `nodeSelector` + `toleration`; all 7 PDBs present.

**Open question for reviewers:** the 7 PDBs render unconditionally (they change the default render by adding 7 inert objects). Happy to gate them behind a flag if the "default render strictly unchanged" guarantee should cover them too.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
