### PR TITLE
feat(k8s): CU node-pool isolation + PDBs for autoscaler safety

### DIFF
--- a/bin/k8s/templates/aws/computing-unit-nodepool/computing-unit-nodepool.yaml
+++ b/bin/k8s/templates/aws/computing-unit-nodepool/computing-unit-nodepool.yaml
@@ -1,0 +1,116 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.computingUnitNodePool.enabled }}
+# Dedicated Karpenter NodePool for the on-demand CU pods (AWS / EKS only).
+#
+# Rendered only when computingUnitNodePool.enabled is true, which values-aws.yaml
+# sets. It stays off for local / on-prem installs, which run no Karpenter and
+# have no karpenter.sh/v1 CRD.
+#
+# WHY THIS EXISTS
+# ---------------
+# CU pods (namespace texera-workflow-computing-unit-pool) are *bare* pods -- the
+# cu-manager creates them with no Deployment/StatefulSet behind them (see
+# KubernetesClient.createPod). So if Karpenter evicts one, nothing recreates it:
+# the CU is permanently gone (often leaving a "zombie" DB row that still shows
+# RUNNING). The EKS Auto Mode default `general-purpose` pool runs
+# consolidationPolicy: WhenEmptyOrUnderutilized, so ~30s after a node looks
+# underutilized Karpenter evicts its pods to repack -- which can mass-kill live
+# CUs during a burst of concurrent users. That pool cannot be fixed in place: it
+# is EKS-managed (app.kubernetes.io/managed-by=eks) and Auto Mode reconciles any
+# edit to it back within ~30 min.
+#
+# THE FIX
+# -------
+# Give CUs their own NON-EKS-managed NodePool, so its disruption policy actually
+# persists, and set consolidationPolicy: WhenEmpty. Karpenter then never evicts a
+# running CU to repack an underutilized node, while EMPTY CU nodes still scale
+# down normally (no orphaned EC2 instances).
+#
+# We deliberately do NOT put a karpenter.sh/do-not-disrupt annotation on CU pods
+# (see KubernetesClient.createPod): that annotation blocks empty-node scaledown
+# and expiry too, which is exactly what pinned nodes / leaked EC2 instances in a
+# past incident. WhenEmpty gives the protection without that side effect.
+#
+# The node label and the taint below are rendered from
+# workflowComputingUnitManager.computeUnitPlacement -- the same values the
+# cu-manager passes to each CU pod as a nodeSelector and toleration -- so the
+# pool and the pods it exists to attract cannot drift apart. Note that a CU pod
+# selects a node *label*; it never references this NodePool's name. The image
+# prepuller DaemonSet already tolerates every taint via operator: Exists.
+{{- $placement := .Values.workflowComputingUnitManager.computeUnitPlacement }}
+{{- if not (and $placement.nodeSelectorLabel $placement.nodeSelectorValue $placement.tolerationKey) }}
+{{- fail "computingUnitNodePool.enabled requires workflowComputingUnitManager.computeUnitPlacement.nodeSelectorLabel, .nodeSelectorValue and .tolerationKey to be set: they define the label and taint of this pool" }}
+{{- end }}
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: {{ .Values.computingUnitNodePool.name }}
+  labels:
+    app: {{ .Release.Name }}-{{ .Values.workflowComputingUnitPool.name }}
+spec:
+  disruption:
+    # Only reclaim a CU node once it is completely empty -- never evict a running
+    # CU to repack. This is the whole point of the pool.
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: {{ .Values.computingUnitNodePool.consolidateAfter }}
+    budgets:
+      - nodes: {{ .Values.computingUnitNodePool.disruptionBudgetNodes | quote }}
+  template:
+    metadata:
+      labels:
+        # CU pods select this via nodeSelector (KUBERNETES_COMPUTE_UNIT_NODE_SELECTOR_*).
+        {{ $placement.nodeSelectorLabel }}: {{ $placement.nodeSelectorValue | quote }}
+    spec:
+      # Bounded node rotation. With WhenEmpty and no do-not-disrupt, a node that
+      # always hosts >=1 CU never goes empty; expiry guarantees it still rotates
+      # (for patching), forcibly draining its CUs at that point.
+      expireAfter: {{ .Values.computingUnitNodePool.expireAfter }}
+      nodeClassRef:
+        {{- toYaml .Values.computingUnitNodePool.nodeClassRef | nindent 8 }}
+      taints:
+        # Keeps everything except CU pods (and the prepuller, which tolerates it
+        # via operator: Exists) off these nodes. The cu-manager's toleration also
+        # uses operator: Exists, so the taint needs no value.
+        - key: {{ $placement.tolerationKey }}
+          effect: NoSchedule
+      requirements:
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        {{- with .Values.computingUnitNodePool.capacityTypes }}
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values:{{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.computingUnitNodePool.architectures }}
+        - key: kubernetes.io/arch
+          operator: In
+          values:{{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.computingUnitNodePool.zones }}
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values:{{ toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.computingUnitNodePool.instanceTypes }}
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values:{{ toYaml . | nindent 12 }}
+        {{- end }}
+{{- end }}

--- a/bin/k8s/templates/aws/pod-disruption-budgets/app-service-pdbs.yaml
+++ b/bin/k8s/templates/aws/pod-disruption-budgets/app-service-pdbs.yaml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if .Values.podDisruptionBudgets.enabled }}
+# PodDisruptionBudgets for the Texera app services.
+#
+# A PDB constrains only *voluntary* evictions, so these exist for clusters where
+# something relocates pods on its own: a cluster autoscaler consolidating
+# underutilized nodes (e.g. Karpenter on EKS), or a routine node drain. Local and
+# on-prem installs do neither, which is why this lives under templates/aws/ and
+# is gated off by default (podDisruptionBudgets.enabled), enabled by
+# values-aws.yaml. Nothing here is AWS-specific, so any cluster that does
+# consolidate nodes can turn the same flag on.
+#
+# maxUnavailable: 1 lets that consolidation proceed while keeping each service
+# serving, at most one replica down at a time. On a single-replica service a PDB
+# is inert -- evicting the only pod still satisfies maxUnavailable: 1 -- so it
+# never blocks a drain; it simply starts protecting that service as soon as its
+# replica count is raised.
+#
+# The agent-service is included even though it is session-affine (pinned per
+# workflow via a consistent-hash BackendTrafficPolicy on X-Agent-Workflow-Id): a
+# PDB cannot save the individual sessions on a relocated replica, but rate-
+# limiting evictions to one replica at a time bounds the blast radius and keeps
+# the service reachable, which is the most a PDB can do for it. The same reasoning
+# covers shared-editing-server (y-websocket) and pylsp, which likewise hold
+# per-connection state in memory.
+{{- $svcs := list .Values.webserver.name .Values.accessControlService.name .Values.configService.name .Values.fileService.name .Values.workflowCompilingService.name .Values.workflowComputingUnitManager.name .Values.yWebsocketServer.name .Values.pythonLanguageServer.name }}
+{{- if .Values.litellm.enabled }}
+{{- $svcs = append $svcs .Values.litellm.name }}
+{{- end }}
+{{- if .Values.agentService.enabled }}
+{{- $svcs = append $svcs .Values.agentService.name }}
+{{- end }}
+{{- range $svc := $svcs }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ $.Release.Name }}-{{ $svc }}-pdb
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    app: {{ $.Release.Name }}-{{ $svc }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: {{ $.Release.Name }}-{{ $svc }}
+{{- end }}
+{{- end }}

--- a/bin/k8s/templates/base/workflow-computing-unit-manager/workflow-computing-unit-manager-deployment.yaml
+++ b/bin/k8s/templates/base/workflow-computing-unit-manager/workflow-computing-unit-manager-deployment.yaml
@@ -66,6 +66,17 @@ spec:
               value: {{ .Values.workflowComputingUnitPool.name }}-svc
             - name: KUBERNETES_IMAGE_NAME
               value: {{ .Values.texera.imageRegistry }}/{{ .Values.workflowComputingUnitPool.imageName }}:{{ .Values.texera.imageTag }}
+            {{- with .Values.workflowComputingUnitManager.computeUnitPlacement }}
+            {{- if .nodeSelectorLabel }}
+            # Pin CU pods to the dedicated CU node pool (templates/aws/computing-unit-nodepool/)
+            - name: KUBERNETES_COMPUTE_UNIT_NODE_SELECTOR_LABEL
+              value: {{ .nodeSelectorLabel | quote }}
+            - name: KUBERNETES_COMPUTE_UNIT_NODE_SELECTOR_VALUE
+              value: {{ .nodeSelectorValue | quote }}
+            - name: KUBERNETES_COMPUTE_UNIT_TOLERATION_KEY
+              value: {{ .tolerationKey | quote }}
+            {{- end }}
+            {{- end }}
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
               value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public

--- a/bin/k8s/values-aws.yaml
+++ b/bin/k8s/values-aws.yaml
@@ -25,6 +25,19 @@
 # own. The buckets must already exist (the init job does not create them).
 # ---------------------------------------------------------------------------
 
+# Karpenter consolidates underutilized nodes by evicting and rescheduling their
+# pods, so enable the PodDisruptionBudgets that cap each app service at one
+# replica down at a time (see templates/aws/pod-disruption-budgets/).
+podDisruptionBudgets:
+  enabled: true
+
+# The computing-unit manager is stateless, so run more than one replica in
+# production. Its PodDisruptionBudget (maxUnavailable: 1) then keeps at least one
+# replica serving while a cluster autoscaler (e.g. Karpenter) drains and
+# consolidates idle nodes one pod at a time.
+workflowComputingUnitManager:
+  numOfPods: 2
+
 # Turn off the bundled MinIO object store; the services talk to external S3.
 minio:
   enabled: false

--- a/bin/k8s/values-aws.yaml
+++ b/bin/k8s/values-aws.yaml
@@ -37,6 +37,40 @@ podDisruptionBudgets:
 # consolidates idle nodes one pod at a time.
 workflowComputingUnitManager:
   numOfPods: 2
+  # Pin the on-demand CU pods onto the dedicated Karpenter CU NodePool below.
+  # These three values are the single source for both sides: the cu-manager
+  # stamps them onto every CU pod as a nodeSelector + toleration, and
+  # templates/aws/computing-unit-nodepool/ renders the pool's node label and
+  # taint from them. Change them here and both sides move together; a CU pod
+  # matches this node label, not the pool's name (computingUnitNodePool.name).
+  computeUnitPlacement:
+    nodeSelectorLabel: texera.io/node-role
+    nodeSelectorValue: computing-unit
+    tolerationKey: texera.io/computing-unit
+
+# Dedicated Karpenter NodePool the CU pods above are pinned to, so consolidation
+# never evicts a running CU (see templates/aws/computing-unit-nodepool/ for
+# the full rationale). Requires Karpenter -- on EKS Auto Mode it is already
+# installed. Every requirement list below may be left empty, which drops that
+# constraint and lets Karpenter choose freely.
+computingUnitNodePool:
+  enabled: true
+  name: cu-pool
+  # on-demand only by default. Adding "spot" is cheaper but a spot reclamation
+  # kills the CU pods on that node for good -- they are bare pods, so nothing
+  # recreates them. Use ["on-demand", "spot"] only if that is acceptable to you.
+  capacityTypes: ["on-demand"]
+  # The stock CU master image is amd64-only. Empty (or adding "arm64") lets
+  # Karpenter launch Graviton nodes, which only works with a multi-arch image.
+  architectures: ["amd64"]
+  # Availability zones the CU nodes may launch in, e.g. ["us-west-2a",
+  # "us-west-2c"]. Empty = every zone the cluster's subnets cover.
+  zones: []
+  # Empty lets Karpenter pick any instance type that fits the pending CUs, which
+  # is usually what you want. Pin the list to control cost or packing, e.g.
+  # ["m6a.2xlarge", "m7a.2xlarge", "m6a.4xlarge"] -- an m-family 2xlarge-4xlarge
+  # packs several 4 vCPU / 16 Gi CUs per node.
+  instanceTypes: []
 
 # Turn off the bundled MinIO object store; the services talk to external S3.
 minio:

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -178,6 +178,16 @@ lakekeeperInit:
 texeraImages:
   pullPolicy: Always
 
+# PodDisruptionBudgets for the replicated app services (see
+# templates/aws/pod-disruption-budgets/). A PDB only constrains *voluntary*
+# evictions, so it is worth enabling on clusters where something evicts pods on
+# its own -- a cluster autoscaler consolidating underutilized nodes (e.g.
+# Karpenter on EKS), or routine node drains. Local / on-prem installs that never
+# consolidate nodes have nothing to constrain, so this is off by default and the
+# chart renders exactly as it did before. Enabled by values-aws.yaml.
+podDisruptionBudgets:
+  enabled: false
+
 # Example data loader configuration
 exampleDataLoader:
   enabled: true

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -188,6 +188,34 @@ texeraImages:
 podDisruptionBudgets:
   enabled: false
 
+# Dedicated Karpenter NodePool for the on-demand CU pods, so their disruption
+# policy is isolated from the shared nodes (see
+# templates/aws/computing-unit-nodepool/). AWS / EKS only: it needs the
+# karpenter.sh/v1 CRD, so it is off by default and enabled by values-aws.yaml,
+# which is also where the sizing knobs below belong.
+computingUnitNodePool:
+  enabled: false
+  name: cu-pool
+  # Karpenter requirements. An empty list drops that requirement entirely, i.e.
+  # leaves the choice unconstrained -- see values-aws.yaml for the trade-offs.
+  capacityTypes: []
+  architectures: []
+  zones: []
+  instanceTypes: []
+  # How long a CU node must sit completely empty before Karpenter removes it.
+  consolidateAfter: 2m
+  # Forced node rotation, so nodes still get patched even when they never go
+  # empty. Draining a node at expiry does kill the CUs on it.
+  expireAfter: 336h
+  # Cap on how many CU nodes Karpenter may disrupt at once.
+  disruptionBudgetNodes: "10%"
+  # The Karpenter NodeClass the pool provisions from. `default` is the one EKS
+  # Auto Mode ships; a self-managed Karpenter uses its own EC2NodeClass.
+  nodeClassRef:
+    group: eks.amazonaws.com
+    kind: NodeClass
+    name: default
+
 # Example data loader configuration
 exampleDataLoader:
   enabled: true
@@ -213,6 +241,16 @@ workflowComputingUnitManager:
   service:
     type: ClusterIP
     port: 8888
+  # Optional placement of the on-demand CU pods (which the cu-manager creates as
+  # bare pods) onto a dedicated, tainted node pool. The label is matched against
+  # a node label, not against a NodePool name; when computingUnitNodePool is
+  # enabled these same three values render that pool's label and taint, so the
+  # two sides cannot drift. Empty by default, so local / on-prem installs
+  # schedule CU pods on the cluster's default pool (no nodeSelector/toleration).
+  computeUnitPlacement:
+    nodeSelectorLabel: ""
+    nodeSelectorValue: ""
+    tolerationKey: ""
 
 workflowCompilingService:
   name: workflow-compiling-service

--- a/common/config/src/main/resources/kubernetes.conf
+++ b/common/config/src/main/resources/kubernetes.conf
@@ -54,4 +54,29 @@ kubernetes {
   # GPU resource key used in Kubernetes (vendor-specific)
   computing-unit-gpu-resource-key = "nvidia.com/gpu"
   computing-unit-gpu-resource-key = ${?KUBERNETES_COMPUTING_UNIT_GPU_RESOURCE_KEY}
+
+  # Optional: pin CU pods to a dedicated, tainted node pool so their disruption
+  # policy is isolated from the shared nodes. When the label key+value are set,
+  # the cu-manager adds a matching nodeSelector to each CU pod; when the
+  # toleration key is set, it adds a NoSchedule/Exists toleration for that taint.
+  #
+  # The label is matched against a *node label*, not against the name of a
+  # Karpenter NodePool. On a Helm install these come from
+  # workflowComputingUnitManager.computeUnitPlacement in values-aws.yaml, which
+  # is also what renders the pool's own label and taint
+  # (bin/k8s/templates/aws/computing-unit-nodepool/), so the two always
+  # agree. Set them by hand only if you manage the node pool yourself, and then
+  # make sure the label and taint you use here exist on those nodes -- otherwise
+  # the CU pods stay Pending.
+  #
+  # Leave all three EMPTY (default) to schedule CU pods on the cluster's default
+  # pool — required for local/dev clusters that have no dedicated CU node pool.
+  compute-unit-node-selector-label = ""
+  compute-unit-node-selector-label = ${?KUBERNETES_COMPUTE_UNIT_NODE_SELECTOR_LABEL}
+
+  compute-unit-node-selector-value = ""
+  compute-unit-node-selector-value = ${?KUBERNETES_COMPUTE_UNIT_NODE_SELECTOR_VALUE}
+
+  compute-unit-toleration-key = ""
+  compute-unit-toleration-key = ${?KUBERNETES_COMPUTE_UNIT_TOLERATION_KEY}
 }

--- a/common/config/src/main/scala/org/apache/texera/common/config/KubernetesConfig.scala
+++ b/common/config/src/main/scala/org/apache/texera/common/config/KubernetesConfig.scala
@@ -64,4 +64,14 @@ object KubernetesConfig {
 
   // GPU resource key used directly in Kubernetes resource specifications
   val gpuResourceKey: String = conf.getString("kubernetes.computing-unit-gpu-resource-key")
+
+  // Optional placement of CU pods onto a dedicated, tainted node pool (see
+  // kubernetes.conf). Empty => no nodeSelector/toleration, i.e. schedule on the
+  // default pool (local/dev).
+  val computeUnitNodeSelectorLabel: String =
+    conf.getString("kubernetes.compute-unit-node-selector-label")
+  val computeUnitNodeSelectorValue: String =
+    conf.getString("kubernetes.compute-unit-node-selector-value")
+  val computeUnitTolerationKey: String =
+    conf.getString("kubernetes.compute-unit-toleration-key")
 }

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/util/KubernetesClient.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/util/KubernetesClient.scala
@@ -133,6 +133,26 @@ object KubernetesClient {
       specBuilder.withRuntimeClassName("nvidia")
     }
 
+    // Pin CU pods to the dedicated CU node pool when configured (see
+    // KubernetesConfig); empty => schedule on the cluster's default pool.
+    if (
+      KubernetesConfig.computeUnitNodeSelectorLabel.nonEmpty &&
+      KubernetesConfig.computeUnitNodeSelectorValue.nonEmpty
+    ) {
+      specBuilder.addToNodeSelector(
+        KubernetesConfig.computeUnitNodeSelectorLabel,
+        KubernetesConfig.computeUnitNodeSelectorValue
+      )
+    }
+    if (KubernetesConfig.computeUnitTolerationKey.nonEmpty) {
+      specBuilder
+        .addNewToleration()
+        .withKey(KubernetesConfig.computeUnitTolerationKey)
+        .withOperator("Exists")
+        .withEffect("NoSchedule")
+        .endToleration()
+    }
+
     val containerBuilder = specBuilder
       .addNewContainer()
       .withName("computing-unit-master")


### PR DESCRIPTION
### What changes were proposed in this PR?

Roadmap item 3 from #5891 — autoscaler safety for the unified `base`/`aws`/`on-prem` chart. Two independent mechanisms, **both no-op by default**: with the default values the chart renders the exact same object set as before this PR, and the AWS behavior appears only under `values-aws.yaml`.

**1. Opt-in PodDisruptionBudgets** (`templates/aws/pod-disruption-budgets/app-service-pdbs.yaml`)

`maxUnavailable: 1` per app service, so a draining/consolidating node can take at most one replica down at a time instead of a whole service at once. A PDB only constrains *voluntary* evictions, so it matters only where something evicts pods on its own; on-prem does neither, so the set lives under `templates/aws/` and is gated behind **`podDisruptionBudgets.enabled` (default `false`)**, which `values-aws.yaml` turns on. Nothing in it is AWS-specific — any cluster that consolidates nodes can flip the same flag.

10 budgets when enabled: webserver, access-control, config, file, litellm, workflow-compiling, computing-unit manager, agent-service, shared-editing-server, pylsp. The session-affine ones (agent-service, and the single-replica shared-editing-server / pylsp) are included too — a PDB can't preserve per-connection state on a relocated replica, but it bounds how many go at once, and on a single-replica service it's simply inert until `replicaCount` is raised. The litellm/agent-service budgets follow their `enabled` flags so a disabled service leaves no dangling PDB.

**2. Computing-unit pods on a dedicated Karpenter NodePool** (`templates/aws/computing-unit-nodepool/`)

CU pods are **bare pods** (`KubernetesClient.createPod`) with no controller behind them, so if the autoscaler evicts one to repack a node, the CU is lost for good. EKS Auto Mode's default pool runs `WhenEmptyOrUnderutilized` and can mass-evict live CUs during a burst; it also can't be fixed in place (EKS-managed, reconciled back within ~30 min). The fix gives CUs their own NodePool with `consolidationPolicy: WhenEmpty` — never evicted to repack, while empty CU nodes still scale down normally. Gated behind **`computingUnitNodePool.enabled` (default `false`)** since it needs the `karpenter.sh/v1` CRD.

`workflowComputingUnitManager.computeUnitPlacement` is the single source for both sides: it renders the cu-manager's `KUBERNETES_COMPUTE_UNIT_NODE_SELECTOR_*` / `_TOLERATION_KEY` env **and** the pool's node label + taint, so the pod's selector and the pool it targets can't drift (a CU pod matches a node *label*, never the pool's name). Enabling the pool without it fails the render. Pool sizing is values-driven (`capacityTypes`, `architectures`, `zones`, `instanceTypes`, `consolidateAfter`, `expireAfter`, `disruptionBudgetNodes`, `nodeClassRef`); each requirement list may be left empty to leave that dimension unconstrained.

Deliberately **not** using `karpenter.sh/do-not-disrupt` — it also blocks empty-node scaledown/expiry and can pin nodes forever (orphaned EC2). `WhenEmpty` + PDBs give the protection without that.

### Any related issues, documentation, discussions?

Part of #5891 (item 3 of 6). Follows #5757 (template reorg) and #5932 / #6295 (pluggable object storage). Supersedes the review-only #6609 (closed). Ports a design validated on the downstream EKS deployment.

### How was this PR tested?

**Default render is provably unchanged** — same 102 objects at the base commit and this branch, name for name (0 PDBs, 0 NodePools, 0 placement env vars). `values-development.yaml`: 0 PDBs, 0 NodePools.

Under `values-aws.yaml`: all 10 PDBs render (each selector matching a real Deployment), the `cu-pool` NodePool renders with `WhenEmpty`, cu-manager runs 2 replicas, and CU pods carry the nodeSelector + toleration matching the pool's label/taint. Verified gating follows `enabled` flags (disabling agent-service/litellm drops exactly their PDBs), that empty requirement lists drop their constraint, and that enabling the pool without `computeUnitPlacement` fails the render. `helm lint` passes with default and AWS values; CI covers the Scala CU-placement change.

**End-to-end on minikube** (`values-development.yaml`, on-prem default): full stack came up healthy incl. the computing-unit manager, with **0** `KUBERNETES_COMPUTE_UNIT_*` env on it — confirming the placement wiring is a genuine no-op without the overlay — and GUI/login/editor/operator-metadata all worked, i.e. no regression to the default install.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)

