### PR TITLE
test(frontend): add unit tests for isDefined predicate

### DIFF
--- a/frontend/src/app/common/util/predicate.spec.ts
+++ b/frontend/src/app/common/util/predicate.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { isDefined } from "./predicate";
+
+describe("isDefined", () => {
+  it("returns false for undefined", () => {
+    expect(isDefined(undefined)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isDefined(null)).toBe(false);
+  });
+
+  it("returns true for defined primitive values", () => {
+    expect(isDefined(0)).toBe(true);
+    expect(isDefined("")).toBe(true);
+    expect(isDefined(false)).toBe(true);
+    expect(isDefined(NaN)).toBe(true);
+  });
+
+  it("returns true for defined object and array values", () => {
+    expect(isDefined({})).toBe(true);
+    expect(isDefined([])).toBe(true);
+    expect(isDefined(() => undefined)).toBe(true);
+  });
+
+  it("narrows the type so the value is usable without a nullable guard", () => {
+    const maybe: string | undefined = "hello";
+    if (isDefined(maybe)) {
+      // If narrowing failed this would not compile; assert runtime behavior too.
+      expect(maybe.toUpperCase()).toBe("HELLO");
+    } else {
+      throw new Error("expected value to be defined");
+    }
+  });
+
+  it("filters nullish entries out of a collection", () => {
+    const values: (number | null | undefined)[] = [1, null, 2, undefined, 3];
+    const defined: number[] = values.filter(isDefined);
+    expect(defined).toEqual([1, 2, 3]);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
- Add `frontend/src/app/common/util/predicate.spec.ts`, a new Vitest spec for the isDefined type guard, which previously had no dedicated unit tests.
- Cover the null and undefined branches returning false.
- Cover defined-but-falsy values (0, "", false, NaN) returning true.
- Cover type narrowing in a conditional and use as an array .filter(isDefined) callback.
### Any related issues, documentation, discussions?
Closes: #6627
### How was this PR tested?
- Run: `cd frontend && node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test gui --watch=false --include=src/app/common/util/predicate.spec.ts`, expect all 6 tests passing.
- Test-only change; no production code is modified.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF