### PR TITLE
test(frontend): add unit tests for exhaustiveGuard

### DIFF
--- a/frontend/src/app/common/util/switch.spec.ts
+++ b/frontend/src/app/common/util/switch.spec.ts
@@ -28,7 +28,7 @@ describe("exhaustiveGuard", () => {
 
   it("includes the offending value in the error message", () => {
     expect(() => exhaustiveGuard("oops" as never)).toThrow(
-      "ERROR! Reached forbidden guard function with unexpected value: \"oops\""
+      'ERROR! Reached forbidden guard function with unexpected value: "oops"'
     );
   });
 

--- a/frontend/src/app/common/util/switch.spec.ts
+++ b/frontend/src/app/common/util/switch.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { exhaustiveGuard } from "./switch";
+
+describe("exhaustiveGuard", () => {
+  it("always throws when reached at runtime", () => {
+    // Cast is required because the signature only accepts `never`; a real
+    // caller reaches this line when an unexpected value slips past a switch.
+    expect(() => exhaustiveGuard("unexpected" as never)).toThrow();
+  });
+
+  it("includes the offending value in the error message", () => {
+    expect(() => exhaustiveGuard("oops" as never)).toThrow(
+      "ERROR! Reached forbidden guard function with unexpected value: \"oops\""
+    );
+  });
+
+  it("serializes object values with JSON.stringify in the message", () => {
+    expect(() => exhaustiveGuard({ kind: "bad" } as never)).toThrow(
+      'ERROR! Reached forbidden guard function with unexpected value: {"kind":"bad"}'
+    );
+  });
+
+  it("acts as the default branch of an exhaustive switch", () => {
+    type Shape = "circle" | "square";
+    const area = (shape: Shape): number => {
+      switch (shape) {
+        case "circle":
+          return 1;
+        case "square":
+          return 2;
+        default:
+          return exhaustiveGuard(shape);
+      }
+    };
+    expect(area("circle")).toBe(1);
+    expect(area("square")).toBe(2);
+    // A value outside the union must trigger the guard's throw.
+    expect(() => area("triangle" as Shape)).toThrow(/unexpected value/);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
- Add `frontend/src/app/common/util/switch.spec.ts`, a new Vitest spec for the exhaustiveGuard helper, which previously had no dedicated unit tests.
- Confirm it always throws and that the thrown message includes the offending value.
- Cover JSON.stringify serialization of object values in the message.
- Cover its intended use as the default branch of an exhaustive switch.
### Any related issues, documentation, discussions?
Closes: #6629
### How was this PR tested?
- Run: `cd frontend && node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test gui --watch=false --include=src/app/common/util/switch.spec.ts`, expect all 4 tests passing.
- Test-only change; no production code is modified.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF