### PR TITLE
test(frontend): add unit tests for dataset-file parsing

### DIFF
--- a/frontend/src/app/common/type/dataset-file.spec.ts
+++ b/frontend/src/app/common/type/dataset-file.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { DatasetFile, parseDatasetFileToFilePath, parseFilePathToDatasetFile } from "./dataset-file";
+
+describe("parseFilePathToDatasetFile", () => {
+  it("parses owner, dataset, version, and single-segment relative path", () => {
+    const result = parseFilePathToDatasetFile("/bob@texera.com/twitterDataset/v1/tw1.csv");
+    expect(result).toEqual({
+      ownerEmail: "bob@texera.com",
+      datasetName: "twitterDataset",
+      versionName: "v1",
+      fileRelativePath: "tw1.csv",
+    });
+  });
+
+  it("joins remaining segments into a nested relative path", () => {
+    const result = parseFilePathToDatasetFile("/bob@texera.com/twitterDataset/v1/california/irvine/tw1.csv");
+    expect(result.ownerEmail).toBe("bob@texera.com");
+    expect(result.datasetName).toBe("twitterDataset");
+    expect(result.versionName).toBe("v1");
+    expect(result.fileRelativePath).toBe("california/irvine/tw1.csv");
+  });
+
+  it("ignores empty segments from leading, trailing, and duplicate slashes", () => {
+    const result = parseFilePathToDatasetFile("//bob@texera.com//twitterDataset/v1/dir//file.csv/");
+    expect(result).toEqual({
+      ownerEmail: "bob@texera.com",
+      datasetName: "twitterDataset",
+      versionName: "v1",
+      fileRelativePath: "dir/file.csv",
+    });
+  });
+
+  it("throws when there are fewer than four path segments", () => {
+    expect(() => parseFilePathToDatasetFile("/bob@texera.com/twitterDataset/v1")).toThrow("Invalid file path format");
+    expect(() => parseFilePathToDatasetFile("")).toThrow("Invalid file path format");
+    expect(() => parseFilePathToDatasetFile("/just/three/parts")).toThrow("Invalid file path format");
+  });
+});
+
+describe("parseDatasetFileToFilePath", () => {
+  it("assembles a slash-delimited path with a leading slash", () => {
+    const datasetFile: DatasetFile = {
+      ownerEmail: "bob@texera.com",
+      datasetName: "twitterDataset",
+      versionName: "v1",
+      fileRelativePath: "california/irvine/tw1.csv",
+    };
+    expect(parseDatasetFileToFilePath(datasetFile)).toBe("/bob@texera.com/twitterDataset/v1/california/irvine/tw1.csv");
+  });
+});
+
+describe("dataset-file round trips", () => {
+  it("path -> DatasetFile -> path is stable for a canonical path", () => {
+    const path = "/bob@texera.com/twitterDataset/v1/california/irvine/tw1.csv";
+    expect(parseDatasetFileToFilePath(parseFilePathToDatasetFile(path))).toBe(path);
+  });
+
+  it("DatasetFile -> path -> DatasetFile is stable for a canonical object", () => {
+    const datasetFile: DatasetFile = {
+      ownerEmail: "alice@texera.com",
+      datasetName: "sensorData",
+      versionName: "v42",
+      fileRelativePath: "2026/reading.json",
+    };
+    expect(parseFilePathToDatasetFile(parseDatasetFileToFilePath(datasetFile))).toEqual(datasetFile);
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?
- Add `frontend/src/app/common/type/dataset-file.spec.ts`, a new Vitest spec for the dataset-file path helpers, which previously had no dedicated unit tests.
- Cover parseFilePathToDatasetFile for single and nested relative paths, with empty-segment filtering for leading, trailing, and double slashes.
- Cover the fewer-than-four-segment throw path.
- Cover parseDatasetFileToFilePath and both round-trip directions.
### Any related issues, documentation, discussions?
Closes: #6644
### How was this PR tested?
- Run: `cd frontend && node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test gui --watch=false --include=src/app/common/type/dataset-file.spec.ts`, expect all 7 tests passing.
- Test-only change; no production code is modified.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF