### PR TITLE
test(frontend): cover parseIntOrDefault

### DIFF
--- a/frontend/src/app/common/util/format.util.spec.ts
+++ b/frontend/src/app/common/util/format.util.spec.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { formatCount, formatRelativeTime, formatSpeed, formatTime } from "./format.util";
+import { formatCount, formatRelativeTime, formatSpeed, formatTime, parseIntOrDefault } from "./format.util";
 
 describe("formatSpeed", () => {
   it('returns "0.0 MB/s" for zero, negative, or undefined input', () => {
@@ -136,5 +136,36 @@ describe("formatCount", () => {
     expect(formatCount(1500)).toBe("1.5k");
     expect(formatCount(12345)).toBe("12.3k");
     expect(formatCount(999999)).toBe("1000.0k");
+  });
+});
+
+describe("parseIntOrDefault", () => {
+  it("parses a well-formed integer string", () => {
+    expect(parseIntOrDefault("42", 7)).toBe(42);
+    expect(parseIntOrDefault("-5", 7)).toBe(-5);
+  });
+
+  it("parses a leading integer and ignores the trailing non-numeric part", () => {
+    // parseInt semantics: reads as many leading digits as possible.
+    expect(parseIntOrDefault("128px", 7)).toBe(128);
+  });
+
+  it("preserves a legitimately stored 0 instead of falling back", () => {
+    // This is the whole point of the helper over `parseInt(raw) || fallback`.
+    expect(parseIntOrDefault("0", 7)).toBe(0);
+  });
+
+  it("returns the fallback for null or undefined", () => {
+    expect(parseIntOrDefault(null, 7)).toBe(7);
+    expect(parseIntOrDefault(undefined, 7)).toBe(7);
+  });
+
+  it("returns the fallback for an empty or whitespace-only string", () => {
+    expect(parseIntOrDefault("", 7)).toBe(7);
+    expect(parseIntOrDefault("   ", 7)).toBe(7);
+  });
+
+  it("returns the fallback for an unparsable, non-numeric string", () => {
+    expect(parseIntOrDefault("abc", 7)).toBe(7);
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?
- Append a describe block to format.util.spec.ts covering parseIntOrDefault.
- Assert integer parsing, preservation of a stored 0, and fallback on null, undefined, empty, and unparsable input.
### Any related issues, documentation, discussions?
Closes: #6678
### How was this PR tested?
- Run: `cd frontend && node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test gui --watch=false --include=src/app/common/util/format.util.spec.ts`, expect the suite passing.
- Test-only change; no production code is modified.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF