### PR TITLE
test(frontend): cover getDefaultLinkCell

### DIFF
--- a/frontend/src/app/workspace/service/joint-ui/joint-ui.service.spec.ts
+++ b/frontend/src/app/workspace/service/joint-ui/joint-ui.service.spec.ts
@@ -290,6 +290,32 @@ describe("JointUIService", () => {
     });
   });
 
+  describe("getDefaultLinkCell (static)", () => {
+    it("builds a link routed with manhattan and connected with rounded corners", () => {
+      const link = JointUIService.getDefaultLinkCell();
+      expect(link).toBeInstanceOf(joint.dia.Link);
+      expect(link.get("router")).toEqual({ name: "manhattan" });
+      expect(link.get("connector")).toEqual({ name: "rounded" });
+    });
+
+    it("styles the connection stroke and hides the remove tool by default", () => {
+      const link = JointUIService.getDefaultLinkCell();
+      expect(link.attr(".connection/stroke")).toBe("#919191");
+      expect(link.attr(".connection/stroke-width")).toBe("2px");
+      // the delete affordance is present in the markup but hidden until hover.
+      expect(link.attr(".tool-remove/display")).toBe("none");
+      expect(link.attr(".tool-remove/fill")).toBe("#D8656A");
+    });
+
+    it("fills the source and target markers with the handle color", () => {
+      const link = JointUIService.getDefaultLinkCell();
+      expect(link.attr(".marker-source/fill")).toBe("#919191");
+      expect(link.attr(".marker-target/fill")).toBe("#919191");
+      expect(link.attr(".marker-source/stroke")).toBe("none");
+      expect(link.attr(".marker-target/stroke")).toBe("none");
+    });
+  });
+
   describe("getJointUserPointerName (static)", () => {
     it("prefixes the coeditor clientId with 'pointer_'", () => {
       expect(JointUIService.getJointUserPointerName({ clientId: "abc123" } as Coeditor)).toBe("pointer_abc123");


### PR DESCRIPTION
### What changes were proposed in this PR?
- Add coverage for JointUIService.getDefaultLinkCell (manhattan router, rounded connector).
- Assert the connection stroke, hidden remove tool, and source and target marker attributes.
### Any related issues, documentation, discussions?
Closes: #6694
### How was this PR tested?
- Run: `cd frontend && node --max-old-space-size=8192 ./node_modules/nx/dist/bin/nx.js test gui --watch=false --include=src/app/workspace/service/joint-ui/joint-ui.service.spec.ts`, expect the suite passing.
- Test-only change; no production code is modified.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF