### PR TITLE
test(workflow-execution-service): cover ResultExportService helpers

### DIFF
--- a/amber/src/test/scala/org/apache/texera/web/service/ResultExportServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/ResultExportServiceSpec.scala
@@ -19,6 +19,7 @@
 
 package org.apache.texera.web.service
 
+import com.fasterxml.jackson.core.JsonProcessingException
 import jakarta.ws.rs.core.Response
 import org.apache.texera.amber.core.virtualidentity.WorkflowIdentity
 import org.apache.texera.web.model.http.request.result.{OperatorExportInfo, ResultExportRequest}
@@ -63,7 +64,7 @@ class ResultExportServiceSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "throw when given a malformed JSON string" in {
-    an[Exception] should be thrownBy service.parseOperators("not json")
+    a[JsonProcessingException] should be thrownBy service.parseOperators("not json")
   }
 
   // -- validateExportRequest --------------------------------------------------
@@ -71,8 +72,7 @@ class ResultExportServiceSpec extends AnyFlatSpec with Matchers {
   "validateExportRequest" should "return a 400 response when no operators are selected" in {
     val result = service.validateExportRequest(requestWith(List.empty))
 
-    result should be(defined)
-    val response = result.get
+    val response = result.getOrElse(fail("expected a validation error response"))
     response.getStatus shouldBe Response.Status.BAD_REQUEST.getStatusCode
     response.getEntity match {
       case m: java.util.Map[_, _] => m.get("error") shouldBe "No operator selected"

--- a/amber/src/test/scala/org/apache/texera/web/service/ResultExportServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/ResultExportServiceSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.service
+
+import jakarta.ws.rs.core.Response
+import org.apache.texera.amber.core.virtualidentity.WorkflowIdentity
+import org.apache.texera.web.model.http.request.result.{OperatorExportInfo, ResultExportRequest}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+// Unit tests for the ResultExportService request helpers parseOperators and
+// validateExportRequest. Constructing the service is cheap (it only stores the
+// identity and computing-unit id), so no engine/DB dependency is needed here.
+class ResultExportServiceSpec extends AnyFlatSpec with Matchers {
+
+  private val service = new ResultExportService(WorkflowIdentity(1L), computingUnitId = 0)
+
+  private def requestWith(operators: List[OperatorExportInfo]): ResultExportRequest =
+    ResultExportRequest(
+      exportType = "csv",
+      workflowId = 1,
+      workflowName = "wf",
+      operators = operators,
+      datasetIds = List.empty,
+      rowIndex = 0,
+      columnIndex = 0,
+      filename = "",
+      computingUnitId = 0
+    )
+
+  // -- parseOperators ---------------------------------------------------------
+
+  "parseOperators" should "deserialize a JSON array into OperatorExportInfo objects" in {
+    val json =
+      """[{"id":"op-1","outputType":"csv"},{"id":"op-2","outputType":"arrow"}]"""
+    val parsed = service.parseOperators(json)
+
+    parsed shouldBe List(
+      OperatorExportInfo("op-1", "csv"),
+      OperatorExportInfo("op-2", "arrow")
+    )
+  }
+
+  it should "round-trip an empty JSON array to an empty list" in {
+    service.parseOperators("[]") shouldBe List.empty[OperatorExportInfo]
+  }
+
+  it should "throw when given a malformed JSON string" in {
+    an[Exception] should be thrownBy service.parseOperators("not json")
+  }
+
+  // -- validateExportRequest --------------------------------------------------
+
+  "validateExportRequest" should "return a 400 response when no operators are selected" in {
+    val result = service.validateExportRequest(requestWith(List.empty))
+
+    result should be(defined)
+    val response = result.get
+    response.getStatus shouldBe Response.Status.BAD_REQUEST.getStatusCode
+    response.getEntity match {
+      case m: java.util.Map[_, _] => m.get("error") shouldBe "No operator selected"
+      case other                  => fail(s"unexpected entity: $other")
+    }
+  }
+
+  it should "return None when at least one operator is selected" in {
+    val result =
+      service.validateExportRequest(requestWith(List(OperatorExportInfo("op-1", "csv"))))
+    result shouldBe None
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?
- Add ResultExportServiceSpec covering parseOperators deserialization, empty-array round-trip, and malformed-input failure.
- Cover validateExportRequest returning a 400 response when no operators are selected and None otherwise.
### Any related issues, documentation, discussions?
Closes: #6704
### How was this PR tested?
- Run: `sbt "WorkflowExecutionService/testOnly *ResultExportServiceSpec"`, expect all 5 tests passing.
- Test-only change; no production code is modified.
### Was this PR authored or co-authored using generative AI tooling?
Co-authored with Claude Opus 4.8 in compliance with ASF