### PR TITLE
test(frontend): extend computing-unit util unit test coverage

### DIFF
--- a/frontend/src/app/common/util/computing-unit.util.spec.ts
+++ b/frontend/src/app/common/util/computing-unit.util.spec.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 
+import { TestBed, ComponentFixture } from "@angular/core/testing";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
 import type { DashboardWorkflowComputingUnit } from "../type/workflow-computing-unit";
 import {
+  ComputingUnitMetadataComponent,
   parseResourceUnit,
   parseResourceNumber,
   cpuResourceConversion,
@@ -35,6 +38,36 @@ import {
   getJvmMemorySliderConfig,
   buildLocalComputingUnitUri,
 } from "./computing-unit.util";
+
+function makeUnit(overrides: Partial<DashboardWorkflowComputingUnit> = {}): DashboardWorkflowComputingUnit {
+  return {
+    computingUnit: {
+      cuid: 1,
+      uid: 1,
+      name: "unit-a",
+      creationTime: 1700000000000,
+      terminateTime: undefined,
+      type: "kubernetes",
+      uri: "http://localhost/wsapi",
+      resource: {
+        cpuLimit: "1000m",
+        memoryLimit: "2Gi",
+        gpuLimit: "1",
+        jvmMemorySize: "2G",
+        shmSize: "64Mi",
+        nodeAddresses: [],
+      },
+      ...(overrides.computingUnit ?? {}),
+    },
+    status: "Running",
+    metrics: { cpuUsage: "N/A", memoryUsage: "N/A" },
+    isOwner: true,
+    accessPrivilege: "READ",
+    ownerGoogleAvatar: "",
+    ownerName: "owner",
+    ...overrides,
+  };
+}
 
 describe("parseResourceUnit", () => {
   it("should extract the unit from a resource string", () => {
@@ -237,5 +270,129 @@ describe("buildLocalComputingUnitUri", () => {
     expect(buildLocalComputingUnitUri({ protocol: "https:", hostname: "example.com", port: "" })).toBe(
       "https://example.com/wsapi"
     );
+  });
+});
+
+describe("cpuResourceConversion (fallback units)", () => {
+  it("should fall back to the millicore scale for an unknown source unit", () => {
+    // "k" is not a known CPU unit, so cpuScales[from] is undefined and the "m" scale is used
+    expect(cpuResourceConversion("5k", "m")).toBe("5.00");
+  });
+
+  it("should fall back to the core scale for an unknown target unit", () => {
+    // "x" is not a known CPU unit, so cpuScales[to] is undefined and the "" (cores) scale is used
+    expect(cpuResourceConversion("2", "x")).toBe("2");
+  });
+});
+
+describe("memoryResourceConversion (edge branches)", () => {
+  it("should treat a unitless source value as bytes", () => {
+    expect(memoryResourceConversion("1073741824", "Gi")).toBe("1.0000");
+  });
+
+  it("should treat a unitless target unit as bytes", () => {
+    expect(memoryResourceConversion("1Gi", "")).toBe("1073741824.0000");
+  });
+
+  it("should fall back to a byte scale for an unknown source unit", () => {
+    // "Ti" is not a known memory unit, so memoryScales[from] is undefined and 1 (bytes) is used
+    expect(memoryResourceConversion("5Ti", "")).toBe("5.0000");
+  });
+
+  it("should fall back to a byte scale for an unknown target unit", () => {
+    // "Ti" is not a known memory unit, so memoryScales[to] is undefined and 1 (bytes) is used
+    expect(memoryResourceConversion("1Gi", "Ti")).toBe("1073741824.0000");
+  });
+});
+
+describe("memoryPercentage (limit guard)", () => {
+  it("should return 0 when the limit is not positive", () => {
+    expect(memoryPercentage("512Mi", "0")).toBe(0);
+  });
+});
+
+describe("isComputingUnitShmTooLarge (non-Gi selected memory)", () => {
+  it("should treat a Mi selected memory as-is when comparing", () => {
+    expect(isComputingUnitShmTooLarge("2048Mi", 3, "Gi")).toBe(true);
+    expect(isComputingUnitShmTooLarge("2048Mi", 1024, "Mi")).toBe(false);
+  });
+});
+
+describe("getJvmMemorySliderConfig (memory unit handling)", () => {
+  it("should convert a Mi memory value to whole GiB", () => {
+    // 2048Mi -> 2Gi -> small path (<=3), defaultValue 2 (not 1)
+    const config = getJvmMemorySliderConfig("2048Mi");
+    expect(config.showJvmMemorySlider).toBe(false);
+    expect(config.jvmMemorySteps).toEqual([1, 2]);
+    expect(config.selectedJvmMemorySize).toBe("2G");
+    expect(config.jvmMemorySliderValue).toBe(1);
+  });
+
+  it("should floor sub-GiB Mi values up to a minimum of 1 GiB", () => {
+    // 512Mi -> floor(512/1024)=0 -> Math.max(1, 0) = 1
+    const config = getJvmMemorySliderConfig("512Mi");
+    expect(config.jvmMemorySteps).toEqual([1]);
+    expect(config.selectedJvmMemorySize).toBe("1G");
+  });
+
+  it("should build slider steps from a larger Mi value", () => {
+    // 8192Mi -> 8Gi -> slider path
+    const config = getJvmMemorySliderConfig("8192Mi");
+    expect(config.showJvmMemorySlider).toBe(true);
+    expect(config.jvmMemorySteps).toEqual([2, 4, 8]);
+    expect(config.selectedJvmMemorySize).toBe("2G");
+  });
+
+  it("should default to 1 GiB for a value with an unrecognized memory unit", () => {
+    // "Ki" is neither Gi nor Mi, so memoryToGb falls back to 1
+    const config = getJvmMemorySliderConfig("500Ki");
+    expect(config.jvmMemorySteps).toEqual([1]);
+    expect(config.selectedJvmMemorySize).toBe("1G");
+  });
+});
+
+describe("ComputingUnitMetadataComponent", () => {
+  let fixture: ComponentFixture<ComputingUnitMetadataComponent> | undefined;
+
+  function render(unit: DashboardWorkflowComputingUnit): ComputingUnitMetadataComponent {
+    TestBed.configureTestingModule({
+      declarations: [ComputingUnitMetadataComponent],
+      providers: [{ provide: NZ_MODAL_DATA, useValue: unit }],
+    });
+    fixture = TestBed.createComponent(ComputingUnitMetadataComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+    fixture = undefined;
+    TestBed.resetTestingModule();
+  });
+
+  it("should expose the injected unit and a formatted creation time", () => {
+    const unit = makeUnit();
+    const instance = render(unit);
+    expect(instance.unit).toBe(unit);
+    expect(instance.createdAt).toBe(new Date(unit.computingUnit.creationTime).toLocaleString());
+  });
+
+  it("should render owner access and the gpu limit when present", () => {
+    const unit = makeUnit({ isOwner: true });
+    unit.computingUnit.resource.gpuLimit = "2";
+    render(unit);
+    const text = (fixture as ComponentFixture<ComputingUnitMetadataComponent>).nativeElement.textContent as string;
+    expect(text).toContain("Owner");
+    expect(text).toContain("2");
+    expect(text).not.toContain("None");
+  });
+
+  it('should render the access privilege and "None" when there is no gpu limit', () => {
+    const unit = makeUnit({ isOwner: false, accessPrivilege: "WRITE" });
+    unit.computingUnit.resource.gpuLimit = "";
+    render(unit);
+    const text = (fixture as ComponentFixture<ComputingUnitMetadataComponent>).nativeElement.textContent as string;
+    expect(text).toContain("WRITE");
+    expect(text).toContain("None");
   });
 });

--- a/frontend/src/app/common/util/computing-unit.util.spec.ts
+++ b/frontend/src/app/common/util/computing-unit.util.spec.ts
@@ -41,6 +41,15 @@ import {
 
 function makeUnit(overrides: Partial<DashboardWorkflowComputingUnit> = {}): DashboardWorkflowComputingUnit {
   return {
+    status: "Running",
+    metrics: { cpuUsage: "N/A", memoryUsage: "N/A" },
+    isOwner: true,
+    accessPrivilege: "READ",
+    ownerGoogleAvatar: "",
+    ownerName: "owner",
+    ...overrides,
+    // Set computingUnit last so a `computingUnit` override merges into (rather than replaces)
+    // the nested default object, keeping fixtures valid even for partial overrides.
     computingUnit: {
       cuid: 1,
       uid: 1,
@@ -59,13 +68,6 @@ function makeUnit(overrides: Partial<DashboardWorkflowComputingUnit> = {}): Dash
       },
       ...(overrides.computingUnit ?? {}),
     },
-    status: "Running",
-    metrics: { cpuUsage: "N/A", memoryUsage: "N/A" },
-    isOwner: true,
-    accessPrivilege: "READ",
-    ownerGoogleAvatar: "",
-    ownerName: "owner",
-    ...overrides,
   };
 }
 
@@ -364,6 +366,14 @@ describe("ComputingUnitMetadataComponent", () => {
     return fixture.componentInstance;
   }
 
+  // Return the trimmed text of the <td> value cell whose <th> header matches `label`.
+  function cellText(label: string): string {
+    const nativeElement = (fixture as ComponentFixture<ComputingUnitMetadataComponent>).nativeElement as HTMLElement;
+    const rows = Array.from(nativeElement.querySelectorAll("tr"));
+    const row = rows.find(r => r.querySelector("th")?.textContent?.trim() === label);
+    return row?.querySelector("td")?.textContent?.trim() ?? "";
+  }
+
   afterEach(() => {
     fixture?.destroy();
     fixture = undefined;
@@ -381,18 +391,15 @@ describe("ComputingUnitMetadataComponent", () => {
     const unit = makeUnit({ isOwner: true });
     unit.computingUnit.resource.gpuLimit = "2";
     render(unit);
-    const text = (fixture as ComponentFixture<ComputingUnitMetadataComponent>).nativeElement.textContent as string;
-    expect(text).toContain("Owner");
-    expect(text).toContain("2");
-    expect(text).not.toContain("None");
+    expect(cellText("Access")).toBe("Owner");
+    expect(cellText("GPU Limit")).toBe("2");
   });
 
   it('should render the access privilege and "None" when there is no gpu limit', () => {
     const unit = makeUnit({ isOwner: false, accessPrivilege: "WRITE" });
     unit.computingUnit.resource.gpuLimit = "";
     render(unit);
-    const text = (fixture as ComponentFixture<ComputingUnitMetadataComponent>).nativeElement.textContent as string;
-    expect(text).toContain("WRITE");
-    expect(text).toContain("None");
+    expect(cellText("Access")).toBe("WRITE");
+    expect(cellText("GPU Limit")).toBe("None");
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends `computing-unit.util.spec.ts` with 15 tests (34 -> 49) covering the ComputingUnitMetadataComponent render branches (owner vs access-privilege, present/empty gpuLimit), the cpu/memory resource-conversion unknown-unit and unitless fallbacks, the `memoryPercentage` non-positive-limit guard, and the JVM memory-slider / `memoryToGb` Mi/floor/fallback paths. Coverage -> ~100%. No existing tests modified.

### Any related issues, documentation, discussions?

Closes #6731.

### How was this PR tested?

`ng test --include='**/computing-unit.util.spec.ts'` -> 49/49 passing. `yarn format:ci` passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])