### PR TITLE
test(frontend): cover MenuComponent grid/worker toggles, report generation, and name sizing

### DIFF
--- a/frontend/src/app/workspace/component/menu/menu.component.spec.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.spec.ts
@@ -48,6 +48,7 @@ import type { ModalOptions } from "ng-zorro-antd/modal";
 import type { ComputingUnitSelectionComponent } from "../power-button/computing-unit-selection.component";
 import { WorkflowContent } from "../../../common/type/workflow";
 import { Router } from "@angular/router";
+import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { USER_WORKFLOW } from "../../../app-routing.constant";
 import type { Mocked } from "vitest";
 
@@ -783,6 +784,64 @@ describe("MenuComponent", () => {
 
       status$.next(ComputingUnitState.NoComputingUnit);
       expect(cuComponent.computingUnitStatus).toBe(ComputingUnitState.Running);
+    });
+  });
+
+  describe("grid / worker-count toggles, report, and name sizing", () => {
+    it("toggleGrid sets the joint paper grid size from the flag", () => {
+      const setGridSize = vi.fn();
+      vi.spyOn(workflowActionService, "getJointGraphWrapper").mockReturnValue({ mainPaper: { setGridSize } } as any);
+
+      component.showGrid = true;
+      component.toggleGrid();
+      expect(setGridSize).toHaveBeenCalledWith(2);
+
+      component.showGrid = false;
+      component.toggleGrid();
+      expect(setGridSize).toHaveBeenCalledWith(1);
+    });
+
+    it("toggleNumWorkers toggles the hide-worker-count class from the flag", () => {
+      const el = document.createElement("div");
+      vi.spyOn(workflowActionService, "getJointGraphWrapper").mockReturnValue({
+        mainPaper: { el, model: { getElements: () => [] } },
+      } as any);
+
+      component.showNumWorkers = false;
+      component.toggleNumWorkers();
+      expect(el.classList.contains("hide-worker-count")).toBe(true);
+
+      component.showNumWorkers = true;
+      component.toggleNumWorkers();
+      expect(el.classList.contains("hide-worker-count")).toBe(false);
+    });
+
+    it("onClickGenerateReport shows a blocking notification and builds the report html", () => {
+      const reportService = TestBed.inject(ReportGenerationService);
+      const blankSpy = vi.spyOn(notificationService, "blank");
+      vi.spyOn(reportService, "generateWorkflowSnapshot").mockReturnValue(of("snap-url"));
+      vi.spyOn(reportService, "getAllOperatorResults").mockReturnValue(of([]));
+      const htmlSpy = vi.spyOn(reportService, "generateReportAsHtml").mockImplementation(() => {});
+
+      component.onClickGenerateReport();
+
+      expect(blankSpy).toHaveBeenCalled();
+      expect(htmlSpy).toHaveBeenCalledWith("snap-url", [], expect.any(String));
+    });
+
+    it("adjustWorkflowNameWidth is a no-op when the name input is absent", () => {
+      component.workflowNameInput = undefined;
+      expect(() => component.adjustWorkflowNameWidth()).not.toThrow();
+    });
+
+    it("adjustWorkflowNameWidth sizes the input in px to fit its text", () => {
+      const input = document.createElement("input");
+      input.value = "my workflow";
+      component.workflowNameInput = { nativeElement: input } as typeof component.workflowNameInput;
+
+      component.adjustWorkflowNameWidth();
+
+      expect(input.style.width).toMatch(/^\d+px$/);
     });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `MenuComponent` spec to cover the toolbar methods it had
left untested
(`frontend/src/app/workspace/component/menu/menu.component.ts`).

> Note: the existing spec already covers most of the methods the issue lists
> (`getRunButtonBehavior`, `applyRunButtonBehavior`, `hasOperators`, the other
> toggles/handlers, name change). The remaining gaps were the four below.

5 tests cover:

- `toggleGrid` — sets the joint paper grid size from the `showGrid` flag.
- `toggleNumWorkers` — toggles the `hide-worker-count` class from the flag.
- `onClickGenerateReport` — shows the blocking notification and builds the report HTML from the snapshot + operator results.
- `adjustWorkflowNameWidth` — no-op without the name input; sizes the input in px otherwise.

The joint-graph wrapper, notification, and report services are stubbed. No
production code was changed.

### Any related issues, documentation, discussions?

Closes #6746

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/workspace/component/menu/menu.component.spec.ts
# Test Files 1 passed (1) | Tests 55 passed (55)
prettier --write <spec>   # clean
eslint  <spec>            # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
