### PR TITLE
test(frontend): cover DatasetDetailComponent upload-status, version-node selection, and trackByTask

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
@@ -1008,4 +1008,32 @@ describe("DatasetDetailComponent behavior", () => {
       expect(notificationServiceStub.error).toHaveBeenCalledWith("Failed to copy file path");
     });
   });
+
+  describe("upload status, version-node selection, and trackBy", () => {
+    it("getUploadStatus maps the upload status to a progress state", () => {
+      expect(component.getUploadStatus("uploading")).toBe("active");
+      expect(component.getUploadStatus("initializing")).toBe("active");
+      expect(component.getUploadStatus("aborted")).toBe("exception");
+      expect(component.getUploadStatus("failed")).toBe("exception");
+      expect(component.getUploadStatus("finished")).toBe("success");
+    });
+
+    it("onVersionFileTreeNodeSelected loads the selected node's content", () => {
+      const node = { name: "file.csv", type: "file" } as unknown as Parameters<
+        typeof component.onVersionFileTreeNodeSelected
+      >[0];
+      const loadSpy = vi
+        .spyOn(component as unknown as { loadFileContent: (n: unknown) => void }, "loadFileContent")
+        .mockImplementation(() => {});
+
+      component.onVersionFileTreeNodeSelected(node);
+
+      expect(loadSpy).toHaveBeenCalledWith(node);
+    });
+
+    it("trackByTask returns the task's file path", () => {
+      const task = { filePath: "owner/data/file.csv" } as unknown as Parameters<typeof component.trackByTask>[1];
+      expect(component.trackByTask(0, task)).toBe("owner/data/file.csv");
+    });
+  });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `DatasetDetailComponent` spec to cover a few untested
methods
(`frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts`).

> Note: most of the methods the issue lists are already covered by the existing
> spec. `removeFromPendingQueue` / `refreshPendingChanges` are `private` and are
> exercised indirectly through the upload/handler flows, so this PR focuses on
> the remaining public gaps.

3 tests cover:

- `getUploadStatus` — maps the multipart upload status to a progress state (`active` / `exception` / `success`).
- `onVersionFileTreeNodeSelected` — loads the selected node's content.
- `trackByTask` — returns the task's file path.

No production code was changed.

### Any related issues, documentation, discussions?

Closes #6747

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
# Test Files 1 passed (1) | Tests 63 passed (63)
prettier --write <spec>   # clean
eslint  <spec>            # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
