### PR TITLE
test(frontend): cover WorkflowCompilingService getOperatorInputSchemaMap

### DIFF
--- a/frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.spec.ts
+++ b/frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.spec.ts
@@ -28,7 +28,12 @@ import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-
 import { JointUIService } from "../joint-ui/joint-ui.service";
 import { WorkflowUtilService } from "../workflow-graph/util/workflow-util.service";
 import { UndoRedoService } from "../undo-redo/undo-redo.service";
-import { mockPoint, mockScanPredicate } from "../workflow-graph/model/mock-workflow-data";
+import {
+  mockPoint,
+  mockScanPredicate,
+  mockResultPredicate,
+  mockScanResultLink,
+} from "../workflow-graph/model/mock-workflow-data";
 import { serializePortIdentity } from "../../../common/util/port-identity-serde";
 import { commonTestImports, commonTestProviders } from "../../../common/testing/test-utils";
 import { firstValueFrom } from "rxjs";
@@ -327,6 +332,40 @@ describe("WorkflowCompilingService public getters", () => {
     ]);
     expect(service.getOperatorInputAttributeType("op1", 0, "b")).toBe("integer");
     expect(service.getOperatorInputAttributeType("op1", 0, "missing")).toBeUndefined();
+  });
+
+  it("getOperatorInputSchemaMap returns undefined when uninitialized", () => {
+    setState({ state: CompilationState.Uninitialized });
+    expect(service.getOperatorInputSchemaMap("op1")).toBeUndefined();
+  });
+
+  it("getOperatorInputSchemaMap returns undefined when there is no output schema map", () => {
+    setState({ state: CompilationState.Succeeded, operatorOutputPortSchemaMap: undefined });
+    expect(service.getOperatorInputSchemaMap("op1")).toBeUndefined();
+  });
+
+  it("getOperatorInputSchemaMap returns undefined for an operator with no input links", () => {
+    const workflowActionService = TestBed.inject(WorkflowActionService);
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+    setState({ state: CompilationState.Succeeded, operatorOutputPortSchemaMap: {} });
+    expect(service.getOperatorInputSchemaMap(mockScanPredicate.operatorID)).toBeUndefined();
+  });
+
+  it("getOperatorInputSchemaMap resolves the input port schema from the upstream operator's output schema", () => {
+    const workflowActionService = TestBed.inject(WorkflowActionService);
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+    workflowActionService.addOperator(mockResultPredicate, mockPoint);
+    workflowActionService.addLink(mockScanResultLink);
+
+    const port0 = serializePortIdentity({ id: 0, internal: false });
+    const scanOutputSchema = [{ attributeName: "a", attributeType: "string" }];
+    setState({
+      state: CompilationState.Succeeded,
+      operatorOutputPortSchemaMap: { [mockScanPredicate.operatorID]: { [port0]: scanOutputSchema } },
+    });
+
+    const inputSchemaMap = service.getOperatorInputSchemaMap(mockResultPredicate.operatorID);
+    expect(inputSchemaMap?.[port0]).toEqual(scanOutputSchema);
   });
 });
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `WorkflowCompilingService` spec to cover
`getOperatorInputSchemaMap` — and, through it, the private
`extractOperatorInputPortSchemaMap`
(`frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.ts`).

> Note: the rest of the getters the issue lists
> (`getWorkflowCompilationState` / `getWorkflowCompilationErrors` /
> `getCompilationStateInfoChangedStream` / `getOperatorOutputSchemaMap` /
> `getPortInputSchema` / `getOperatorInputAttributeType`) are already covered on
> `main` (added in #6557), so this PR only fills the remaining gap.

4 tests cover `getOperatorInputSchemaMap`:

- returns `undefined` when the compilation state is uninitialized;
- returns `undefined` when there is no output-schema map;
- returns `undefined` for an operator with no input links (the
  `extractOperatorInputPortSchemaMap` early-out);
- resolves the input-port schema from an upstream operator's output schema over a
  real `scan → result` link.

No production code was changed.

### Any related issues, documentation, discussions?

Closes #6750

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/workspace/service/compile-workflow/workflow-compiling.service.spec.ts
# Test Files 1 passed (1) | Tests 33 passed (33)
prettier --write <spec>   # clean
eslint  <spec>            # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
