### PR TITLE
chore(workflow operators): Add proper descriptions to text source fields

### DIFF
--- a/access-control-service/src/test/scala/org/apache/texera/AccessControlResourceSpec.scala
+++ b/access-control-service/src/test/scala/org/apache/texera/AccessControlResourceSpec.scala
@@ -144,7 +144,7 @@ class AccessControlResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   "AccessControlResource" should "return FORBIDDEN for a GET request without a token" in {

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/scheduling/DefaultCostEstimatorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/scheduling/DefaultCostEstimatorSpec.scala
@@ -116,7 +116,7 @@ class DefaultCostEstimatorSpec
 
   override protected def afterEach(): Unit = {
     document.clear()
-    shutdownDB()
+    closeConnectionPool()
   }
 
   "DefaultCostEstimator" should "use fallback method when no past statistics are available" in {

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -202,7 +202,7 @@ object TestUtils {
     org.apache.texera.dao.MockTexeraDB.ensureInitialized()
     val embedded = org.apache.texera.dao.MockTexeraDB.getDBInstance
 
-    val dbName = "texera_db_for_test_cases"
+    val dbName = "texera_db_for_test_cases_" + java.util.UUID.randomUUID().toString.replace("-", "")
 
     scala.util.Using.resource(embedded.getPostgresDatabase.getConnection) { conn =>
       scala.util.Using.resource(conn.createStatement()) { stmt =>

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -199,10 +199,28 @@ object TestUtils {
     * Note such test cases need to clean up the database at the end of running each test case.
     */
   def initiateTexeraDBForTestCases(): Unit = {
+    org.apache.texera.dao.MockTexeraDB.ensureInitialized()
+    val embedded = org.apache.texera.dao.MockTexeraDB.getDBInstance
+
+    val dbName = "texera_db_for_test_cases"
+
+    scala.util.Using.resource(embedded.getPostgresDatabase.getConnection) { conn =>
+      scala.util.Using.resource(conn.createStatement()) { stmt =>
+        stmt.execute(s"DROP DATABASE IF EXISTS $dbName")
+        stmt.execute(s"CREATE DATABASE $dbName")
+      }
+    }
+
+    val targetDbConn = embedded.getDatabase("postgres", dbName).getConnection
+    scala.util.Using.resource(targetDbConn.createStatement()) { stmt =>
+      stmt.execute(org.apache.texera.dao.MockTexeraDB.getDDLScript)
+    }
+    targetDbConn.close()
+
     SqlServer.initConnection(
-      StorageConfig.jdbcUrlForTestCases,
-      StorageConfig.jdbcUsername,
-      StorageConfig.jdbcPassword
+      embedded.getJdbcUrl("postgres", dbName),
+      "postgres",
+      ""
     )
   }
 

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -21,7 +21,6 @@ package org.apache.texera.amber.engine.e2e
 
 import com.twitter.util.{Await, Duration, Promise, Return, Throw, Try}
 import org.apache.pekko.actor.ActorSystem
-import org.apache.texera.common.config.StorageConfig
 import org.apache.texera.amber.core.executor.OpExecInitInfo
 import org.apache.texera.amber.core.storage.DocumentFactory
 import org.apache.texera.amber.core.storage.model.VirtualDocument

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -196,6 +196,9 @@ object TestUtils {
     * If a test case accesses the user system through singleton resources that cache the DSLContext (e.g., executes a
     * workflow, which accesses WorkflowExecutionsResource), we use a separate texera_db specifically for such test cases.
     * Note such test cases need to clean up the database at the end of running each test case.
+    *
+    * This backs the e2e specs with MockTexeraDB's embedded Postgres instead of an external test Postgres
+    * (depends on #4179).
     */
   def initiateTexeraDBForTestCases(): Unit = {
     org.apache.texera.dao.MockTexeraDB.ensureInitialized()
@@ -205,16 +208,16 @@ object TestUtils {
 
     scala.util.Using.resource(embedded.getPostgresDatabase.getConnection) { conn =>
       scala.util.Using.resource(conn.createStatement()) { stmt =>
-        stmt.execute(s"DROP DATABASE IF EXISTS $dbName")
         stmt.execute(s"CREATE DATABASE $dbName")
       }
     }
 
-    val targetDbConn = embedded.getDatabase("postgres", dbName).getConnection
-    scala.util.Using.resource(targetDbConn.createStatement()) { stmt =>
-      stmt.execute(org.apache.texera.dao.MockTexeraDB.getDDLScript)
+    scala.util.Using.resource(embedded.getDatabase("postgres", dbName).getConnection) {
+      targetDbConn =>
+        scala.util.Using.resource(targetDbConn.createStatement()) { stmt =>
+          stmt.execute(org.apache.texera.dao.MockTexeraDB.getDDLScript)
+        }
     }
-    targetDbConn.close()
 
     SqlServer.initConnection(
       embedded.getJdbcUrl("postgres", dbName),

--- a/amber/src/test/scala/org/apache/texera/web/resource/FeedbackResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/FeedbackResourceSpec.scala
@@ -66,7 +66,7 @@ class FeedbackResourceSpec
     otherSessionUser = new SessionUser(otherUser)
   }
 
-  override protected def afterAll(): Unit = shutdownDB()
+  override protected def afterAll(): Unit = closeConnectionPool()
 
   private def clearFeedback(): Unit = {
     getDSLContext.deleteFrom(FEEDBACK).execute()

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -192,7 +192,7 @@ class WorkflowResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   private def getKeywordsArray(keywords: String*): util.ArrayList[String] = {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/project/ProjectAccessResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/project/ProjectAccessResourceSpec.scala
@@ -66,7 +66,7 @@ class ProjectAccessResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   private def createUser(uid: Int, name: String, email: String): User = {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowAccessResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowAccessResourceSpec.scala
@@ -178,7 +178,7 @@ class WorkflowAccessResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   "WorkflowAccessResource.revokeAccess" should "successfully revoke access when user has WRITE permission" in {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
@@ -183,7 +183,7 @@ class WorkflowExecutionsResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   // ─── helpers ──────────────────────────────────────────────────────────────

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -83,7 +83,7 @@ class WorkflowVersionResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   private def createWorkflowContent(value: String): String = {

--- a/amber/src/test/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveResourceSpec.scala
@@ -116,7 +116,7 @@ class PveResourceSpec
 
   override protected def afterAll(): Unit = {
     PveManager.runProcess = realRunner
-    shutdownDB()
+    closeConnectionPool()
   }
 
   override protected def beforeEach(): Unit = {

--- a/amber/src/test/scala/org/apache/texera/web/service/ExecutionsMetadataPersistServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/ExecutionsMetadataPersistServiceSpec.scala
@@ -72,7 +72,7 @@ class ExecutionsMetadataPersistServiceSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
   override protected def beforeEach(): Unit = {

--- a/common/auth/src/test/scala/org/apache/texera/auth/util/ComputingUnitAccessSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/util/ComputingUnitAccessSpec.scala
@@ -81,7 +81,7 @@ class ComputingUnitAccessSpec
     }
   }
 
-  override def afterAll(): Unit = shutdownDB()
+  override def afterAll(): Unit = closeConnectionPool()
 
   "getComputingUnitAccess" should "return NONE when the computing unit does not exist" in {
     ComputingUnitAccess.getComputingUnitAccess(999, 1) shouldBe PrivilegeEnum.NONE

--- a/common/dao/src/main/scala/org/apache/texera/dao/SqlServer.scala
+++ b/common/dao/src/main/scala/org/apache/texera/dao/SqlServer.scala
@@ -94,13 +94,37 @@ object SqlServer {
     * @return
     */
   def withTransaction[T](dsl: DSLContext)(block: DSLContext => T): T = {
-    var result: Option[T] = None
+    val provider = dsl.configuration().connectionProvider()
+    val conn = provider.acquire()
+    val originalAutoCommit = conn.getAutoCommit
 
-    dsl.transaction(configuration => {
-      val ctx = DSL.using(configuration)
-      result = Some(block(ctx))
-    })
+    try {
+      if (originalAutoCommit) {
+        conn.setAutoCommit(false)
+      }
 
-    result.getOrElse(throw new RuntimeException("Transaction failed without result!"))
+      val txCtx = org.jooq.impl.DSL.using(conn, dsl.dialect())
+      val result = block(txCtx)
+
+      if (originalAutoCommit) {
+        conn.commit()
+      }
+
+      result
+    } catch {
+      case e: Throwable =>
+        if (originalAutoCommit) {
+          conn.rollback()
+        }
+        throw e
+    } finally {
+      try {
+        if (originalAutoCommit != conn.getAutoCommit) {
+          conn.setAutoCommit(originalAutoCommit)
+        }
+      } finally {
+        provider.release(conn)
+      }
+    }
   }
 }

--- a/common/dao/src/main/scala/org/apache/texera/dao/SqlServer.scala
+++ b/common/dao/src/main/scala/org/apache/texera/dao/SqlServer.scala
@@ -94,37 +94,13 @@ object SqlServer {
     * @return
     */
   def withTransaction[T](dsl: DSLContext)(block: DSLContext => T): T = {
-    val provider = dsl.configuration().connectionProvider()
-    val conn = provider.acquire()
-    val originalAutoCommit = conn.getAutoCommit
+    var result: Option[T] = None
 
-    try {
-      if (originalAutoCommit) {
-        conn.setAutoCommit(false)
-      }
+    dsl.transaction(configuration => {
+      val ctx = DSL.using(configuration)
+      result = Some(block(ctx))
+    })
 
-      val txCtx = org.jooq.impl.DSL.using(conn, dsl.dialect())
-      val result = block(txCtx)
-
-      if (originalAutoCommit) {
-        conn.commit()
-      }
-
-      result
-    } catch {
-      case e: Throwable =>
-        if (originalAutoCommit) {
-          conn.rollback()
-        }
-        throw e
-    } finally {
-      try {
-        if (originalAutoCommit != conn.getAutoCommit) {
-          conn.setAutoCommit(originalAutoCommit)
-        }
-      } finally {
-        provider.release(conn)
-      }
-    }
+    result.getOrElse(throw new RuntimeException("Transaction failed without result!"))
   }
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -21,6 +21,7 @@ package org.apache.texera.dao
 
 import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
+import org.apache.texera.dao.MockTexeraDB.{MaxPoolSize, password, username}
 import org.jooq.impl.{DSL, DataSourceConnectionProvider, DefaultConfiguration}
 import org.jooq.{DSLContext, SQLDialect}
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
@@ -39,6 +40,8 @@ object MockTexeraDB {
   private val password: String = ""
   private val texeraDDLPath = "sql/texera_ddl.sql"
   private val splitDatabaseRegex = "(?m)^CREATE DATABASE :\"DB_NAME\";"
+
+  val MaxPoolSize: Int = math.max(10, Runtime.getRuntime.availableProcessors() * 2)
 
   @volatile private var dbInstance: Option[EmbeddedPostgres] = None
   @volatile private var ddlScript: Option[String] = None
@@ -97,6 +100,15 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
   protected var dataSource: Option[HikariDataSource] = None
   protected var uniqueDbName: String = ""
 
+  def createHikariConfig(jbdcUrl: String) : HikariConfig = {
+    val hikariConfig = new HikariConfig()
+    hikariConfig.setJdbcUrl(jbdcUrl)
+    hikariConfig.setUsername(username)
+    hikariConfig.setPassword(password)
+    hikariConfig.setMaximumPoolSize(MaxPoolSize)
+    hikariConfig
+  }
+
   def initializeDBAndReplaceDSLContext(): Unit =
     synchronized {
       if (dataSource.isEmpty || dataSource.get.isClosed) {
@@ -119,17 +131,7 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
         }
 
         val jdbcUrl = embedded.getJdbcUrl("postgres", uniqueDbName)
-
-        // Back the test DSLContext with a real HikariCP pool so that concurrent
-        // transactions acquire *distinct* connections (matching production), rather
-        // than trampling one shared connection's autoCommit flag.
-        val hikariConfig = new HikariConfig()
-        hikariConfig.setJdbcUrl(jdbcUrl)
-        hikariConfig.setUsername("postgres")
-        hikariConfig.setPassword("")
-        // Must exceed the maximum number of concurrent test threads.
-        hikariConfig.setMaximumPoolSize(10)
-        val ds = new HikariDataSource(hikariConfig)
+        val ds = new HikariDataSource(createHikariConfig(jbdcUrl =  jdbcUrl))
         dataSource = Some(ds)
 
         val jooqCfg = new DefaultConfiguration()
@@ -138,8 +140,7 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
         val scopedCtx = DSL.using(jooqCfg)
         testScopedContext = Some(scopedCtx)
 
-        // Point the Texera backend exactly to this suite's isolated database
-        SqlServer.initConnection(jdbcUrl, "postgres", "")
+        SqlServer.initConnection(jdbcUrl, username, password)
         SqlServer.getInstance().replaceDSLContext(scopedCtx)
       }
     }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -92,7 +92,6 @@ trait MockTexeraDB extends AnyFlatSpecLike {
       MockTexeraDB.ensureInitialized()
       val embedded = MockTexeraDB.getDBInstance
 
-      // 1. Create a 100% isolated logical database for this specific test suite
       uniqueDbName = "texera_db_" + java.util.UUID.randomUUID().toString.replace("-", "")
       Using.resource(embedded.getPostgresDatabase.getConnection) { defaultConn =>
         Using.resource(defaultConn.createStatement()) { stmt =>
@@ -100,7 +99,6 @@ trait MockTexeraDB extends AnyFlatSpecLike {
         }
       }
 
-      // 2. Connect to the isolated DB and apply the DDL
       val conn = embedded.getDatabase("postgres", uniqueDbName).getConnection
 
       // AutoCommit is TRUE by default, meaning any records inserted in beforeAll()

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -171,6 +171,9 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
     }
 
   def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
+  def newRawConnection(): java.sql.Connection = {
+    MockTexeraDB.getDBInstance.getDatabase(username, uniqueDbName).getConnection
+  }
 
   def shutdownDB(): Unit =
     synchronized {

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -27,7 +27,13 @@ import java.nio.file.Paths
 import java.sql.{Connection, DriverManager}
 import scala.io.Source
 
-trait MockTexeraDB {
+/**
+  * Provides a JVM-singleton EmbeddedPostgres for tests. Multiple specs that mix
+  * in this trait share one Postgres instance for the lifetime of the JVM, which
+  * avoids the OverlappingFileLockException that occurs when each spec tries to
+  * extract the embedded Postgres binaries into the same directory in parallel.
+  */
+object MockTexeraDB {
 
   private var dbInstance: Option[EmbeddedPostgres] = None
   private var dslContext: Option[DSLContext] = None
@@ -35,130 +41,129 @@ trait MockTexeraDB {
   private val username: String = "postgres"
   private val password: String = ""
 
+  private var dbInstance: Option[EmbeddedPostgres] = None
+  private var dslContext: Option[DSLContext] = None
+
+  def ensureInitialized(): Unit =
+    synchronized {
+      if (dbInstance.isDefined) return
+
+      val driver = new org.postgresql.Driver()
+      DriverManager.registerDriver(driver)
+
+      val embedded = EmbeddedPostgres.builder().start()
+      dbInstance = Some(embedded)
+
+      val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
+      val source = Source.fromFile(ddlPath.toString)
+      val content =
+        try source.mkString
+        finally source.close()
+      val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
+      def removeCCommands(sql: String): String =
+        sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
+      val createDBStatement =
+        """DROP DATABASE IF EXISTS texera_db;
+          |CREATE DATABASE texera_db;""".stripMargin
+      executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
+      val texeraDB = embedded.getDatabase(username, database)
+      var tablesAndIndexCreation = removeCCommands(parts(1))
+
+      // remove indexes creation for pgroonga because we cannot install the plugin
+      val blockPattern =
+        """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
+      val replacementText =
+        """CREATE INDEX idx_workflow_name_description_content
+          |    ON workflow
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '') || ' ' ||
+          |    COALESCE(content, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_user_name
+          |    ON "user"
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_user_project_name_description
+          |    ON project
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_dataset_name_description
+          |    ON dataset
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '') || ' ' ||
+          |    COALESCE(description, '')
+          |    )
+          |    );
+          |
+          |CREATE INDEX idx_dataset_version_name
+          |    ON dataset_version
+          |    USING GIN (
+          |    to_tsvector('english',
+          |    COALESCE(name, '')
+          |    )
+          |    );""".stripMargin
+
+      tablesAndIndexCreation =
+        blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
+      executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
+      SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
+      val sqlServerInstance = SqlServer.getInstance()
+      val ctx = DSL.using(texeraDB, SQLDialect.POSTGRES)
+      dslContext = Some(ctx)
+      sqlServerInstance.replaceDSLContext(ctx)
+    }
+
+  def getDSLContext: DSLContext =
+    dslContext.getOrElse(
+      throw new RuntimeException(
+        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
+      )
+    )
+
+  def getDBInstance: EmbeddedPostgres =
+    dbInstance.getOrElse(
+      throw new RuntimeException(
+        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
+      )
+    )
+
+  private def executeScriptInJDBC(conn: Connection, script: String): Unit = {
+    conn.prepareStatement(script).execute()
+    conn.close()
+  }
+}
+
+trait MockTexeraDB {
+
   def executeScriptInJDBC(conn: Connection, script: String): Unit = {
-    assert(dbInstance.nonEmpty)
     conn.prepareStatement(script).execute()
     conn.close()
   }
 
-  def getDSLContext: DSLContext = {
-    dslContext match {
-      case Some(value) => value
-      case None =>
-        throw new RuntimeException(
-          "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-        )
-    }
-  }
+  def getDSLContext: DSLContext = MockTexeraDB.getDSLContext
 
-  def getDBInstance: EmbeddedPostgres = {
-    dbInstance match {
-      case Some(value) => value
-      case None =>
-        throw new RuntimeException(
-          "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-        )
-    }
-  }
+  def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def shutdownDB(): Unit = {
-    dbInstance match {
-      case Some(value) =>
-        value.close()
-        dbInstance = None
-        dslContext = None
-      case None =>
-      // do nothing
-    }
-  }
+  def initializeDBAndReplaceDSLContext(): Unit = MockTexeraDB.ensureInitialized()
 
-  def initializeDBAndReplaceDSLContext(): Unit = {
-    assert(dbInstance.isEmpty && dslContext.isEmpty)
-
-    val driver = new org.postgresql.Driver()
-    DriverManager.registerDriver(driver)
-
-    val embedded = EmbeddedPostgres.builder().start()
-
-    dbInstance = Some(embedded)
-
-    val ddlPath = {
-      Paths.get("sql/texera_ddl.sql").toRealPath()
-    }
-    val source = Source.fromFile(ddlPath.toString)
-    val content =
-      try {
-        source.mkString
-      } finally {
-        source.close()
-      }
-    val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
-    def removeCCommands(sql: String): String =
-      sql.linesIterator
-        .filterNot(_.trim.startsWith("\\c"))
-        .mkString("\n")
-    val createDBStatement =
-      """DROP DATABASE IF EXISTS texera_db;
-        |CREATE DATABASE texera_db;""".stripMargin
-    executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
-    val texeraDB = embedded.getDatabase(username, database)
-    var tablesAndIndexCreation = removeCCommands(parts(1))
-
-    // remove indexes creation for pgroonga because we cannot install the plugin
-    val blockPattern =
-      """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
-    // replace with native fulltext indexes
-    val replacementText =
-      """CREATE INDEX idx_workflow_name_description_content
-        |    ON workflow
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '') || ' ' ||
-        |    COALESCE(content, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_user_name
-        |    ON "user"
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_user_project_name_description
-        |    ON project
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_dataset_name_description
-        |    ON dataset
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '') || ' ' ||
-        |    COALESCE(description, '')
-        |    )
-        |    );
-        |
-        |CREATE INDEX idx_dataset_version_name
-        |    ON dataset_version
-        |    USING GIN (
-        |    to_tsvector('english',
-        |    COALESCE(name, '')
-        |    )
-        |    );""".stripMargin
-
-    tablesAndIndexCreation = blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
-    executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
-    SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
-    val sqlServerInstance = SqlServer.getInstance()
-    dslContext = Some(DSL.using(texeraDB, SQLDialect.POSTGRES))
-
-    sqlServerInstance.replaceDSLContext(dslContext.get)
-  }
+  /**
+    * No-op. The singleton EmbeddedPostgres lives for the lifetime of the JVM,
+    * so individual specs should not shut it down. Kept for API compatibility
+    * with existing afterAll hooks.
+    */
+  def shutdownDB(): Unit = ()
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -45,14 +45,15 @@ object MockTexeraDB {
 
   def ensureInitialized(): Unit =
     synchronized {
-      if (dbInstance.isDefined) return
+      if (dbInstance.isDefined && ddlScript.isDefined) return
 
-      val driver = new org.postgresql.Driver()
-      DriverManager.registerDriver(driver)
+      if (dbInstance.isEmpty) {
+        val driver = new org.postgresql.Driver()
+        DriverManager.registerDriver(driver)
 
-      // Boot the heavy JVM engine exactly once
-      val embedded = EmbeddedPostgres.builder().start()
-      dbInstance = Some(embedded)
+        // Boot the heavy JVM engine exactly once
+        dbInstance = Some(EmbeddedPostgres.builder().start())
+      }
 
       val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
       val source = Source.fromFile(ddlPath.toString)

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -65,12 +65,14 @@ object MockTexeraDB {
         finally source.close()
 
       val parts: Array[String] = content.split(splitDatabaseRegex)
-      val sqlBody = parts.lift(1).getOrElse(
+      val sqlBody = parts
+        .lift(1)
+        .getOrElse(
           throw new RuntimeException(
             s"Couldn't split SQL body from $texeraDDLPath: " +
-            s"expected it to match pattern $splitDatabaseRegex"
+              s"expected it to match pattern $splitDatabaseRegex"
           )
-      )
+        )
 
       def removeCCommands(sql: String): String =
         sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
@@ -100,7 +102,7 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
   protected var dataSource: Option[HikariDataSource] = None
   protected var uniqueDbName: String = ""
 
-  def createHikariConfig(jbdcUrl: String) : HikariConfig = {
+  def createHikariConfig(jbdcUrl: String): HikariConfig = {
     val hikariConfig = new HikariConfig()
     hikariConfig.setJdbcUrl(jbdcUrl)
     hikariConfig.setUsername(username)
@@ -131,7 +133,7 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
         }
 
         val jdbcUrl = embedded.getJdbcUrl("postgres", uniqueDbName)
-        val ds = new HikariDataSource(createHikariConfig(jbdcUrl =  jdbcUrl))
+        val ds = new HikariDataSource(createHikariConfig(jbdcUrl = jdbcUrl))
         dataSource = Some(ds)
 
         val jooqCfg = new DefaultConfiguration()
@@ -158,7 +160,7 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
       /*TODO: Need to truncate texeraDB tables when the fixture is complete.
          This will require refactoring the spec tests using MockTexeraDB
          to move initialization logic outside of BeforeAll into BeforeEach
-      */
+       */
     }
   }
 

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -177,10 +177,14 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
     MockTexeraDB.getDBInstance.getDatabase(username, uniqueDbName).getConnection
   }
 
-  def shutdownDB(): Unit =
+  def closeConnectionPool(): Unit = {
+    //git issue #6063 asked for a no-op shutdown, however this was before
+    //MockTexeraDB held a connection pool, since we own explicit resources
+    //we must close them.
     synchronized {
       try dataSource.foreach(ds => if (!ds.isClosed) ds.close())
       catch { case e: Exception => e.printStackTrace() }
       finally { dataSource = None; testScopedContext = None }
     }
+  }
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -138,6 +138,11 @@ trait MockTexeraDB extends AnyFlatSpecLike {
     } finally {
       try {
         if (!conn.isClosed) {
+          if (!conn.getAutoCommit) {
+            conn.rollback()
+            conn.setAutoCommit(true)
+          }
+
           scala.util.Using.resource(conn.createStatement()) { stmt =>
             stmt.execute(
               """

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -43,42 +43,46 @@ object MockTexeraDB {
   @volatile private var dbInstance: Option[EmbeddedPostgres] = None
   @volatile private var ddlScript: Option[String] = None
 
-  def ensureInitialized(): Unit = synchronized {
-    if (dbInstance.isDefined) return
+  def ensureInitialized(): Unit =
+    synchronized {
+      if (dbInstance.isDefined) return
 
-    val driver = new org.postgresql.Driver()
-    DriverManager.registerDriver(driver)
+      val driver = new org.postgresql.Driver()
+      DriverManager.registerDriver(driver)
 
-    // Boot the heavy JVM engine exactly once
-    val embedded = EmbeddedPostgres.builder().start()
-    dbInstance = Some(embedded)
+      // Boot the heavy JVM engine exactly once
+      val embedded = EmbeddedPostgres.builder().start()
+      dbInstance = Some(embedded)
 
-    val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
-    val source = Source.fromFile(ddlPath.toString)
-    val content = try source.mkString finally source.close()
+      val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
+      val source = Source.fromFile(ddlPath.toString)
+      val content =
+        try source.mkString
+        finally source.close()
 
-    val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
-    val sqlBody = if (parts.length > 1) parts(1) else content
+      val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
+      val sqlBody = if (parts.length > 1) parts(1) else content
 
-    def removeCCommands(sql: String): String =
-      sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
+      def removeCCommands(sql: String): String =
+        sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
 
-    var tablesAndIndexCreation = removeCCommands(sqlBody)
+      var tablesAndIndexCreation = removeCCommands(sqlBody)
 
-    val blockPattern =
-      """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
-    val replacementText =
-      """CREATE INDEX idx_workflow_name_description_content ON workflow USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '') || ' ' || COALESCE(content, '')));
+      val blockPattern =
+        """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
+      val replacementText =
+        """CREATE INDEX idx_workflow_name_description_content ON workflow USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '') || ' ' || COALESCE(content, '')));
         |CREATE INDEX idx_user_name ON "user" USING GIN (to_tsvector('english', COALESCE(name, '')));
         |CREATE INDEX idx_user_project_name_description ON project USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '')));
         |CREATE INDEX idx_dataset_name_description ON dataset USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '')));
         |CREATE INDEX idx_dataset_version_name ON dataset_version USING GIN (to_tsvector('english', COALESCE(name, '')));""".stripMargin
 
-    // Cache the cleaned script so parallel suites don't have to re-read the file
-    ddlScript = Some(blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim)
-  }
+      // Cache the cleaned script so parallel suites don't have to re-read the file
+      ddlScript = Some(blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim)
+    }
 
-  def getDBInstance: EmbeddedPostgres = dbInstance.getOrElse(throw new RuntimeException("DB not initialized"))
+  def getDBInstance: EmbeddedPostgres =
+    dbInstance.getOrElse(throw new RuntimeException("DB not initialized"))
   def getDDLScript: String = ddlScript.getOrElse(throw new RuntimeException("DDL not loaded"))
 }
 
@@ -87,35 +91,36 @@ trait MockTexeraDB extends AnyFlatSpecLike {
   protected var connection: Option[Connection] = None
   protected var uniqueDbName: String = ""
 
-  def initializeDBAndReplaceDSLContext(): Unit = synchronized {
-    if (connection.isEmpty || connection.get.isClosed) {
-      MockTexeraDB.ensureInitialized()
-      val embedded = MockTexeraDB.getDBInstance
+  def initializeDBAndReplaceDSLContext(): Unit =
+    synchronized {
+      if (connection.isEmpty || connection.get.isClosed) {
+        MockTexeraDB.ensureInitialized()
+        val embedded = MockTexeraDB.getDBInstance
 
-      uniqueDbName = "texera_db_" + java.util.UUID.randomUUID().toString.replace("-", "")
-      Using.resource(embedded.getPostgresDatabase.getConnection) { defaultConn =>
-        Using.resource(defaultConn.createStatement()) { stmt =>
-          stmt.execute(s"CREATE DATABASE $uniqueDbName")
+        uniqueDbName = "texera_db_" + java.util.UUID.randomUUID().toString.replace("-", "")
+        Using.resource(embedded.getPostgresDatabase.getConnection) { defaultConn =>
+          Using.resource(defaultConn.createStatement()) { stmt =>
+            stmt.execute(s"CREATE DATABASE $uniqueDbName")
+          }
         }
+
+        val conn = embedded.getDatabase("postgres", uniqueDbName).getConnection
+
+        // AutoCommit is TRUE by default, meaning any records inserted in beforeAll()
+        // will be permanently committed to this suite's specific isolated database!
+        Using.resource(conn.createStatement()) { stmt =>
+          stmt.execute(MockTexeraDB.getDDLScript)
+        }
+
+        connection = Some(conn)
+        val scopedCtx = DSL.using(conn, SQLDialect.POSTGRES)
+        testScopedContext = Some(scopedCtx)
+
+        // Point the Texera backend exactly to this suite's isolated database
+        SqlServer.initConnection(embedded.getJdbcUrl("postgres", uniqueDbName), "postgres", "")
+        SqlServer.getInstance().replaceDSLContext(scopedCtx)
       }
-
-      val conn = embedded.getDatabase("postgres", uniqueDbName).getConnection
-
-      // AutoCommit is TRUE by default, meaning any records inserted in beforeAll()
-      // will be permanently committed to this suite's specific isolated database!
-      Using.resource(conn.createStatement()) { stmt =>
-        stmt.execute(MockTexeraDB.getDDLScript)
-      }
-
-      connection = Some(conn)
-      val scopedCtx = DSL.using(conn, SQLDialect.POSTGRES)
-      testScopedContext = Some(scopedCtx)
-
-      // Point the Texera backend exactly to this suite's isolated database
-      SqlServer.initConnection(embedded.getJdbcUrl("postgres", uniqueDbName), "postgres", "")
-      SqlServer.getInstance().replaceDSLContext(scopedCtx)
     }
-  }
 
   override def withFixture(test: NoArgTest): Outcome = {
     initializeDBAndReplaceDSLContext()
@@ -152,27 +157,29 @@ trait MockTexeraDB extends AnyFlatSpecLike {
     }
   }
 
-  def getDSLContext: DSLContext = synchronized {
-    if (testScopedContext.isEmpty) {
-      initializeDBAndReplaceDSLContext()
+  def getDSLContext: DSLContext =
+    synchronized {
+      if (testScopedContext.isEmpty) {
+        initializeDBAndReplaceDSLContext()
+      }
+      testScopedContext.get
     }
-    testScopedContext.get
-  }
 
   def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def shutdownDB(): Unit = synchronized {
-    try {
-      connection.foreach { conn =>
-        if (!conn.isClosed) {
-          conn.close()
+  def shutdownDB(): Unit =
+    synchronized {
+      try {
+        connection.foreach { conn =>
+          if (!conn.isClosed) {
+            conn.close()
+          }
         }
+      } catch {
+        case e: Exception => e.printStackTrace()
+      } finally {
+        connection = None
+        testScopedContext = None
       }
-    } catch {
-      case e: Exception => e.printStackTrace()
-    } finally {
-      connection = None
-      testScopedContext = None
     }
-  }
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -126,8 +126,7 @@ trait MockTexeraDB extends AnyFlatSpecLike {
     val sqlServerInstance = SqlServer.getInstance()
     val activeContext = testScopedContext.get
 
-    // 3. Turn OFF autocommit to sandbox this individual test case
-    conn.setAutoCommit(false)
+    conn.setAutoCommit(true)
 
     try {
       sqlServerInstance.replaceDSLContext(activeContext)
@@ -135,11 +134,19 @@ trait MockTexeraDB extends AnyFlatSpecLike {
     } finally {
       try {
         if (!conn.isClosed) {
-          // 4. Perform a FULL rollback. This wipes dirty test data and clears any
-          // aborted SQL errors. Because beforeAll data was already auto-committed, it survives!
-          conn.rollback()
-          // 5. Restore autoCommit for afterEach / afterAll hooks
-          conn.setAutoCommit(true)
+          scala.util.Using.resource(conn.createStatement()) { stmt =>
+            stmt.execute(
+              """
+              DO $$ DECLARE
+                  r RECORD;
+              BEGIN
+                  FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
+                      EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
+                  END LOOP;
+              END $$;
+              """
+            )
+          }
         }
       } catch {
         case e: Exception => e.printStackTrace()

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -187,4 +187,7 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
       finally { dataSource = None; testScopedContext = None }
     }
   }
+
+  /** Backwards-compat alias for specs on `main` that still call shutdownDB(). */
+  def shutdownDB(): Unit = closeConnectionPool()
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -147,6 +147,9 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
       }
     }
 
+  // NOTE: This shared JVM singleton design assumes test suites run sequentially.
+  // If parallel suite execution is enabled in the future (#4525), thread safety
+  // and schema isolation must be re-evaluated.
   abstract override def withFixture(test: NoArgTest): Outcome = {
     initializeDBAndReplaceDSLContext()
 

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -148,8 +148,7 @@ object MockTexeraDB {
 
 trait MockTexeraDB extends AnyFlatSpecLike {
   private var testScopedContext : Option[DSLContext] = None
-  protected var connection : Option[Connection]
-
+  private var connection : Option[Connection] = None
 
   override def withFixture(test: NoArgTest) : Outcome = {
     initializeDBAndReplaceDSLContext()
@@ -185,13 +184,12 @@ trait MockTexeraDB extends AnyFlatSpecLike {
   def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
   def initializeDBAndReplaceDSLContext(): Unit = {
+    MockTexeraDB.ensureInitialized()
+
     val embedded = MockTexeraDB.getDBInstance
     connection = Some(embedded.getDatabase("postgres", "texera_db").getConnection)
     connection.get.setAutoCommit(false)
-
     testScopedContext = Some(DSL.using(connection.get, SQLDialect.POSTGRES))
-
-    MockTexeraDB.ensureInitialized()
   }
 
   /**

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -22,12 +22,13 @@ package org.apache.texera.dao
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.jooq.impl.DSL
 import org.jooq.{DSLContext, SQLDialect}
-import org.scalatest.{Outcome, TestSuiteMixin}
-import org.scalatest.flatspec.{AnyFlatSpec, AnyFlatSpecLike}
+import org.scalatest.Outcome
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 import java.nio.file.Paths
-import java.sql.{Connection, DriverManager}
+import java.sql.{Connection, DriverManager, Savepoint}
 import scala.io.Source
+import scala.util.Using
 
 /**
   * Provides a JVM-singleton EmbeddedPostgres for tests. Multiple specs that mix
@@ -36,166 +37,137 @@ import scala.io.Source
   * extract the embedded Postgres binaries into the same directory in parallel.
   */
 object MockTexeraDB {
-  private val database: String = "texera_db"
   private val username: String = "postgres"
   private val password: String = ""
 
-  private var dbInstance: Option[EmbeddedPostgres] = None
-  private var dslContext: Option[DSLContext] = None
+  @volatile private var dbInstance: Option[EmbeddedPostgres] = None
+  @volatile private var ddlScript: Option[String] = None
 
-  def ensureInitialized(): Unit =
-    synchronized {
-      if (dbInstance.isDefined) return
+  def ensureInitialized(): Unit = synchronized {
+    if (dbInstance.isDefined) return
 
-      val driver = new org.postgresql.Driver()
-      DriverManager.registerDriver(driver)
+    val driver = new org.postgresql.Driver()
+    DriverManager.registerDriver(driver)
 
-      val embedded = EmbeddedPostgres.builder().start()
-      dbInstance = Some(embedded)
+    // Boot the heavy JVM engine exactly once
+    val embedded = EmbeddedPostgres.builder().start()
+    dbInstance = Some(embedded)
 
-      val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
-      val source = Source.fromFile(ddlPath.toString)
-      val content =
-        try source.mkString
-        finally source.close()
-      val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
-      def removeCCommands(sql: String): String =
-        sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
-      val createDBStatement =
-        """DROP DATABASE IF EXISTS texera_db;
-          |CREATE DATABASE texera_db;""".stripMargin
-      executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, createDBStatement)
-      val texeraDB = embedded.getDatabase(username, database)
-      var tablesAndIndexCreation = removeCCommands(parts(1))
+    val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
+    val source = Source.fromFile(ddlPath.toString)
+    val content = try source.mkString finally source.close()
 
-      // remove indexes creation for pgroonga because we cannot install the plugin
-      val blockPattern =
-        """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
-      val replacementText =
-        """CREATE INDEX idx_workflow_name_description_content
-          |    ON workflow
-          |    USING GIN (
-          |    to_tsvector('english',
-          |    COALESCE(name, '') || ' ' ||
-          |    COALESCE(description, '') || ' ' ||
-          |    COALESCE(content, '')
-          |    )
-          |    );
-          |
-          |CREATE INDEX idx_user_name
-          |    ON "user"
-          |    USING GIN (
-          |    to_tsvector('english',
-          |    COALESCE(name, '')
-          |    )
-          |    );
-          |
-          |CREATE INDEX idx_user_project_name_description
-          |    ON project
-          |    USING GIN (
-          |    to_tsvector('english',
-          |    COALESCE(name, '') || ' ' ||
-          |    COALESCE(description, '')
-          |    )
-          |    );
-          |
-          |CREATE INDEX idx_dataset_name_description
-          |    ON dataset
-          |    USING GIN (
-          |    to_tsvector('english',
-          |    COALESCE(name, '') || ' ' ||
-          |    COALESCE(description, '')
-          |    )
-          |    );
-          |
-          |CREATE INDEX idx_dataset_version_name
-          |    ON dataset_version
-          |    USING GIN (
-          |    to_tsvector('english',
-          |    COALESCE(name, '')
-          |    )
-          |    );""".stripMargin
+    val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
+    val sqlBody = if (parts.length > 1) parts(1) else content
 
-      tablesAndIndexCreation =
-        blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
-      executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
-      SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
-      val sqlServerInstance = SqlServer.getInstance()
-      val ctx = DSL.using(texeraDB, SQLDialect.POSTGRES)
-      dslContext = Some(ctx)
-      sqlServerInstance.replaceDSLContext(ctx)
-    }
+    def removeCCommands(sql: String): String =
+      sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
 
-  def getDSLContext: DSLContext =
-    dslContext.getOrElse(
-      throw new RuntimeException(
-        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-      )
-    )
+    var tablesAndIndexCreation = removeCCommands(sqlBody)
 
-  def getDBInstance: EmbeddedPostgres =
-    dbInstance.getOrElse(
-      throw new RuntimeException(
-        "test database is not initialized. Did you call initializeDBAndReplaceDSLContext()?"
-      )
-    )
+    val blockPattern =
+      """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
+    val replacementText =
+      """CREATE INDEX idx_workflow_name_description_content ON workflow USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '') || ' ' || COALESCE(content, '')));
+        |CREATE INDEX idx_user_name ON "user" USING GIN (to_tsvector('english', COALESCE(name, '')));
+        |CREATE INDEX idx_user_project_name_description ON project USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '')));
+        |CREATE INDEX idx_dataset_name_description ON dataset USING GIN (to_tsvector('english', COALESCE(name, '') || ' ' || COALESCE(description, '')));
+        |CREATE INDEX idx_dataset_version_name ON dataset_version USING GIN (to_tsvector('english', COALESCE(name, '')));""".stripMargin
 
-  private def executeScriptInJDBC(conn: Connection, script: String): Unit = {
-    conn.prepareStatement(script).execute()
-    conn.close()
+    // Cache the cleaned script so parallel suites don't have to re-read the file
+    ddlScript = Some(blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim)
   }
+
+  def getDBInstance: EmbeddedPostgres = dbInstance.getOrElse(throw new RuntimeException("DB not initialized"))
+  def getDDLScript: String = ddlScript.getOrElse(throw new RuntimeException("DDL not loaded"))
 }
 
 trait MockTexeraDB extends AnyFlatSpecLike {
-  private var testScopedContext : Option[DSLContext] = None
-  private var connection : Option[Connection] = None
+  private var testScopedContext: Option[DSLContext] = None
+  private var connection: Option[Connection] = None
+  private var uniqueDbName: String = ""
 
-  override def withFixture(test: NoArgTest) : Outcome = {
+  def initializeDBAndReplaceDSLContext(): Unit = synchronized {
+    if (connection.isEmpty || connection.get.isClosed) {
+      MockTexeraDB.ensureInitialized()
+      val embedded = MockTexeraDB.getDBInstance
+
+      // 1. Create a 100% isolated logical database for this specific test suite
+      uniqueDbName = "texera_db_" + java.util.UUID.randomUUID().toString.replace("-", "")
+      Using.resource(embedded.getPostgresDatabase.getConnection) { defaultConn =>
+        Using.resource(defaultConn.createStatement()) { stmt =>
+          stmt.execute(s"CREATE DATABASE $uniqueDbName")
+        }
+      }
+
+      // 2. Connect to the isolated DB and apply the DDL
+      val conn = embedded.getDatabase("postgres", uniqueDbName).getConnection
+
+      // AutoCommit is TRUE by default, meaning any records inserted in beforeAll()
+      // will be permanently committed to this suite's specific isolated database!
+      Using.resource(conn.createStatement()) { stmt =>
+        stmt.execute(MockTexeraDB.getDDLScript)
+      }
+
+      connection = Some(conn)
+      val scopedCtx = DSL.using(conn, SQLDialect.POSTGRES)
+      testScopedContext = Some(scopedCtx)
+
+      // Point the Texera backend exactly to this suite's isolated database
+      SqlServer.initConnection(embedded.getJdbcUrl("postgres", uniqueDbName), "postgres", "")
+      SqlServer.getInstance().replaceDSLContext(scopedCtx)
+    }
+  }
+
+  override def withFixture(test: NoArgTest): Outcome = {
     initializeDBAndReplaceDSLContext()
+
+    val conn = connection.get
     val sqlServerInstance = SqlServer.getInstance()
-    val baseContext = MockTexeraDB.getDSLContext
+    val activeContext = testScopedContext.get
 
-    try{
-      sqlServerInstance.replaceDSLContext(testScopedContext.get)
+    // 3. Turn OFF autocommit to sandbox this individual test case
+    conn.setAutoCommit(false)
+
+    try {
+      sqlServerInstance.replaceDSLContext(activeContext)
       super.withFixture(test)
-
-    }finally {
+    } finally {
       try {
-        val conn = connection.get
         if (!conn.isClosed) {
+          // 4. Perform a FULL rollback. This wipes dirty test data and clears any
+          // aborted SQL errors. Because beforeAll data was already auto-committed, it survives!
           conn.rollback()
-          conn.close()
+          // 5. Restore autoCommit for afterEach / afterAll hooks
+          conn.setAutoCommit(true)
         }
       } catch {
         case e: Exception => e.printStackTrace()
       }
-      sqlServerInstance.replaceDSLContext(baseContext)
     }
   }
 
-  def executeScriptInJDBC(conn: Connection, script: String): Unit = {
-    conn.prepareStatement(script).execute()
-    conn.close()
+  def getDSLContext: DSLContext = synchronized {
+    if (testScopedContext.isEmpty) {
+      initializeDBAndReplaceDSLContext()
+    }
+    testScopedContext.get
   }
-
-  def getDSLContext: DSLContext =
-    testScopedContext.getOrElse(MockTexeraDB.getDSLContext)
 
   def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def initializeDBAndReplaceDSLContext(): Unit = {
-    MockTexeraDB.ensureInitialized()
-
-    val embedded = MockTexeraDB.getDBInstance
-    connection = Some(embedded.getDatabase("postgres", "texera_db").getConnection)
-    connection.get.setAutoCommit(false)
-    testScopedContext = Some(DSL.using(connection.get, SQLDialect.POSTGRES))
+  def shutdownDB(): Unit = synchronized {
+    try {
+      connection.foreach { conn =>
+        if (!conn.isClosed) {
+          conn.close()
+        }
+      }
+    } catch {
+      case e: Exception => e.printStackTrace()
+    } finally {
+      connection = None
+      testScopedContext = None
+    }
   }
-
-  /**
-    * No-op. The singleton EmbeddedPostgres lives for the lifetime of the JVM,
-    * so individual specs should not shut it down. Kept for API compatibility
-    * with existing afterAll hooks.
-    */
-  def shutdownDB(): Unit = ()
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -22,6 +22,8 @@ package org.apache.texera.dao
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
 import org.jooq.impl.DSL
 import org.jooq.{DSLContext, SQLDialect}
+import org.scalatest.{Outcome, TestSuiteMixin}
+import org.scalatest.flatspec.{AnyFlatSpec, AnyFlatSpecLike}
 
 import java.nio.file.Paths
 import java.sql.{Connection, DriverManager}
@@ -144,18 +146,53 @@ object MockTexeraDB {
   }
 }
 
-trait MockTexeraDB {
+trait MockTexeraDB extends AnyFlatSpecLike {
+  private var testScopedContext : Option[DSLContext] = None
+  protected var connection : Option[Connection]
+
+
+  override def withFixture(test: NoArgTest) : Outcome = {
+    initializeDBAndReplaceDSLContext()
+    val sqlServerInstance = SqlServer.getInstance()
+    val baseContext = MockTexeraDB.getDSLContext
+
+    try{
+      sqlServerInstance.replaceDSLContext(testScopedContext.get)
+      super.withFixture(test)
+
+    }finally {
+      try {
+        val conn = connection.get
+        if (!conn.isClosed) {
+          conn.rollback()
+          conn.close()
+        }
+      } catch {
+        case e: Exception => e.printStackTrace()
+      }
+      sqlServerInstance.replaceDSLContext(baseContext)
+    }
+  }
 
   def executeScriptInJDBC(conn: Connection, script: String): Unit = {
     conn.prepareStatement(script).execute()
     conn.close()
   }
 
-  def getDSLContext: DSLContext = MockTexeraDB.getDSLContext
+  def getDSLContext: DSLContext =
+    testScopedContext.getOrElse(MockTexeraDB.getDSLContext)
 
   def getDBInstance: EmbeddedPostgres = MockTexeraDB.getDBInstance
 
-  def initializeDBAndReplaceDSLContext(): Unit = MockTexeraDB.ensureInitialized()
+  def initializeDBAndReplaceDSLContext(): Unit = {
+    val embedded = MockTexeraDB.getDBInstance
+    connection = Some(embedded.getDatabase("postgres", "texera_db").getConnection)
+    connection.get.setAutoCommit(false)
+
+    testScopedContext = Some(DSL.using(connection.get, SQLDialect.POSTGRES))
+
+    MockTexeraDB.ensureInitialized()
+  }
 
   /**
     * No-op. The singleton EmbeddedPostgres lives for the lifetime of the JVM,

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -34,9 +34,6 @@ import scala.io.Source
   * extract the embedded Postgres binaries into the same directory in parallel.
   */
 object MockTexeraDB {
-
-  private var dbInstance: Option[EmbeddedPostgres] = None
-  private var dslContext: Option[DSLContext] = None
   private val database: String = "texera_db"
   private val username: String = "postgres"
   private val password: String = ""

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -26,7 +26,7 @@ import org.scalatest.Outcome
 import org.scalatest.flatspec.AnyFlatSpecLike
 
 import java.nio.file.Paths
-import java.sql.{Connection, DriverManager, Savepoint}
+import java.sql.{Connection, DriverManager}
 import scala.io.Source
 import scala.util.Using
 
@@ -84,8 +84,8 @@ object MockTexeraDB {
 
 trait MockTexeraDB extends AnyFlatSpecLike {
   private var testScopedContext: Option[DSLContext] = None
-  private var connection: Option[Connection] = None
-  private var uniqueDbName: String = ""
+  protected var connection: Option[Connection] = None
+  protected var uniqueDbName: String = ""
 
   def initializeDBAndReplaceDSLContext(): Unit = synchronized {
     if (connection.isEmpty || connection.get.isClosed) {

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -19,14 +19,14 @@
 
 package org.apache.texera.dao
 
+import com.zaxxer.hikari.{HikariConfig, HikariDataSource}
 import io.zonky.test.db.postgres.embedded.EmbeddedPostgres
-import org.jooq.impl.DSL
+import org.jooq.impl.{DSL, DataSourceConnectionProvider, DefaultConfiguration}
 import org.jooq.{DSLContext, SQLDialect}
-import org.scalatest.Outcome
-import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
 
 import java.nio.file.Paths
-import java.sql.{Connection, DriverManager}
+import java.sql.DriverManager
 import scala.io.Source
 import scala.util.Using
 
@@ -87,14 +87,14 @@ object MockTexeraDB {
   def getDDLScript: String = ddlScript.getOrElse(throw new RuntimeException("DDL not loaded"))
 }
 
-trait MockTexeraDB extends AnyFlatSpecLike {
+trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
   private var testScopedContext: Option[DSLContext] = None
-  protected var connection: Option[Connection] = None
+  protected var dataSource: Option[HikariDataSource] = None
   protected var uniqueDbName: String = ""
 
   def initializeDBAndReplaceDSLContext(): Unit =
     synchronized {
-      if (connection.isEmpty || connection.get.isClosed) {
+      if (dataSource.isEmpty || dataSource.get.isClosed) {
         MockTexeraDB.ensureInitialized()
         val embedded = MockTexeraDB.getDBInstance
 
@@ -105,45 +105,54 @@ trait MockTexeraDB extends AnyFlatSpecLike {
           }
         }
 
-        val conn = embedded.getDatabase("postgres", uniqueDbName).getConnection
-
-        // AutoCommit is TRUE by default, meaning any records inserted in beforeAll()
-        // will be permanently committed to this suite's specific isolated database!
-        Using.resource(conn.createStatement()) { stmt =>
-          stmt.execute(MockTexeraDB.getDDLScript)
+        // Run the DDL once via a throwaway connection (autoCommit is TRUE by default,
+        // so the schema is permanently committed to this suite's isolated database).
+        Using.resource(embedded.getDatabase("postgres", uniqueDbName).getConnection) { conn =>
+          Using.resource(conn.createStatement()) { stmt =>
+            stmt.execute(MockTexeraDB.getDDLScript)
+          }
         }
 
-        connection = Some(conn)
-        val scopedCtx = DSL.using(conn, SQLDialect.POSTGRES)
+        val jdbcUrl = embedded.getJdbcUrl("postgres", uniqueDbName)
+
+        // Back the test DSLContext with a real HikariCP pool so that concurrent
+        // transactions acquire *distinct* connections (matching production), rather
+        // than trampling one shared connection's autoCommit flag.
+        val hikariConfig = new HikariConfig()
+        hikariConfig.setJdbcUrl(jdbcUrl)
+        hikariConfig.setUsername("postgres")
+        hikariConfig.setPassword("")
+        // Must exceed the maximum number of concurrent test threads.
+        hikariConfig.setMaximumPoolSize(10)
+        val ds = new HikariDataSource(hikariConfig)
+        dataSource = Some(ds)
+
+        val jooqCfg = new DefaultConfiguration()
+        jooqCfg.set(new DataSourceConnectionProvider(ds))
+        jooqCfg.set(SQLDialect.POSTGRES)
+        val scopedCtx = DSL.using(jooqCfg)
         testScopedContext = Some(scopedCtx)
 
         // Point the Texera backend exactly to this suite's isolated database
-        SqlServer.initConnection(embedded.getJdbcUrl("postgres", uniqueDbName), "postgres", "")
+        SqlServer.initConnection(jdbcUrl, "postgres", "")
         SqlServer.getInstance().replaceDSLContext(scopedCtx)
       }
     }
 
-  override def withFixture(test: NoArgTest): Outcome = {
+  abstract override def withFixture(test: NoArgTest): Outcome = {
     initializeDBAndReplaceDSLContext()
 
-    val conn = connection.get
     val sqlServerInstance = SqlServer.getInstance()
     val activeContext = testScopedContext.get
-
-    conn.setAutoCommit(true)
 
     try {
       sqlServerInstance.replaceDSLContext(activeContext)
       super.withFixture(test)
     } finally {
       try {
-        if (!conn.isClosed) {
-          if (!conn.getAutoCommit) {
-            conn.rollback()
-            conn.setAutoCommit(true)
-          }
-
-          scala.util.Using.resource(conn.createStatement()) { stmt =>
+        // Truncate all tables on a pooled connection so each test starts clean.
+        Using.resource(dataSource.get.getConnection) { conn =>
+          Using.resource(conn.createStatement()) { stmt =>
             stmt.execute(
               """
               DO $$ DECLARE
@@ -175,17 +184,8 @@ trait MockTexeraDB extends AnyFlatSpecLike {
 
   def shutdownDB(): Unit =
     synchronized {
-      try {
-        connection.foreach { conn =>
-          if (!conn.isClosed) {
-            conn.close()
-          }
-        }
-      } catch {
-        case e: Exception => e.printStackTrace()
-      } finally {
-        connection = None
-        testScopedContext = None
-      }
+      try dataSource.foreach(ds => if (!ds.isClosed) ds.close())
+      catch { case e: Exception => e.printStackTrace() }
+      finally { dataSource = None; testScopedContext = None }
     }
 }

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -32,13 +32,13 @@ import scala.util.Using
 
 /**
   * Provides a JVM-singleton EmbeddedPostgres for tests. Multiple specs that mix
-  * in this trait share one Postgres instance for the lifetime of the JVM, which
-  * avoids the OverlappingFileLockException that occurs when each spec tries to
-  * extract the embedded Postgres binaries into the same directory in parallel.
+  * in this trait share one Postgres instance for the lifetime of the JVM.
   */
 object MockTexeraDB {
   private val username: String = "postgres"
   private val password: String = ""
+  private val texeraDDLPath = "sql/texera_ddl.sql"
+  private val splitDatabaseRegex = "(?m)^CREATE DATABASE :\"DB_NAME\";"
 
   @volatile private var dbInstance: Option[EmbeddedPostgres] = None
   @volatile private var ddlScript: Option[String] = None
@@ -55,19 +55,24 @@ object MockTexeraDB {
         dbInstance = Some(EmbeddedPostgres.builder().start())
       }
 
-      val ddlPath = Paths.get("sql/texera_ddl.sql").toRealPath()
+      val ddlPath = Paths.get(texeraDDLPath).toRealPath()
       val source = Source.fromFile(ddlPath.toString)
       val content =
         try source.mkString
         finally source.close()
 
-      val parts: Array[String] = content.split("(?m)^CREATE DATABASE :\"DB_NAME\";")
-      val sqlBody = if (parts.length > 1) parts(1) else content
+      val parts: Array[String] = content.split(splitDatabaseRegex)
+      val sqlBody = parts.lift(1).getOrElse(
+          throw new RuntimeException(
+            s"Couldn't split SQL body from $texeraDDLPath: " +
+            s"expected it to match pattern $splitDatabaseRegex"
+          )
+      )
 
       def removeCCommands(sql: String): String =
         sql.linesIterator.filterNot(_.trim.startsWith("\\c")).mkString("\n")
 
-      var tablesAndIndexCreation = removeCCommands(sqlBody)
+      val tablesAndIndexCreation = removeCCommands(sqlBody)
 
       val blockPattern =
         """(?s)-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\).*?-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?""".r
@@ -149,26 +154,10 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
       sqlServerInstance.replaceDSLContext(activeContext)
       super.withFixture(test)
     } finally {
-      try {
-        // Truncate all tables on a pooled connection so each test starts clean.
-        Using.resource(dataSource.get.getConnection) { conn =>
-          Using.resource(conn.createStatement()) { stmt =>
-            stmt.execute(
-              """
-              DO $$ DECLARE
-                  r RECORD;
-              BEGIN
-                  FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = 'public') LOOP
-                      EXECUTE 'TRUNCATE TABLE ' || quote_ident(r.tablename) || ' CASCADE';
-                  END LOOP;
-              END $$;
-              """
-            )
-          }
-        }
-      } catch {
-        case e: Exception => e.printStackTrace()
-      }
+      /*TODO: Need to truncate texeraDB tables when the fixture is complete.
+         This will require refactoring the spec tests using MockTexeraDB
+         to move initialization logic outside of BeforeAll into BeforeEach
+      */
     }
   }
 

--- a/common/dao/src/test/scala/org/apache/texera/dao/SqlServerSpec.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/SqlServerSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.{BeforeAndAfterAll}
 class SqlServerSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll with MockTexeraDB {
 
   override def beforeAll(): Unit = initializeDBAndReplaceDSLContext()
-  override def afterAll(): Unit = shutdownDB()
+  override def afterAll(): Unit = closeConnectionPool()
 
   // -------------------------------------------------------------------------
   // SqlServer.withTransaction

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/FileResolverSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/storage/FileResolverSpec.scala
@@ -125,7 +125,7 @@ class FileResolverSpec
   }
 
   override protected def afterAll(): Unit = {
-    shutdownDB()
+    closeConnectionPool()
   }
 
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/text/TextInputSourceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/text/TextInputSourceOpDesc.scala
@@ -19,7 +19,7 @@
 
 package org.apache.texera.amber.operator.source.scan.text
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.tuple.Schema
@@ -34,6 +34,7 @@ class TextInputSourceOpDesc extends SourceOperatorDescriptor with TextSourceOpDe
   @JsonProperty(required = true)
   @JsonSchemaTitle("Text")
   @JsonSchemaInject(json = UIWidget.UIWidgetTextArea)
+  @JsonPropertyDescription("Input text here and this operator will return a column with your text as its rows.")
   var textInput: String = _
 
   override def getPhysicalOp(

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/text/TextSourceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/text/TextSourceOpDesc.scala
@@ -19,13 +19,9 @@
 
 package org.apache.texera.amber.operator.source.scan.text
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.kjetland.jackson.jsonSchema.annotations.{
-  JsonSchemaInject,
-  JsonSchemaString,
-  JsonSchemaTitle
-}
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaString, JsonSchemaTitle}
 import org.apache.texera.amber.operator.metadata.annotations.HideAnnotation
 import org.apache.texera.amber.operator.source.scan.FileAttributeType
 
@@ -37,15 +33,22 @@ import org.apache.texera.amber.operator.source.scan.FileAttributeType
 trait TextSourceOpDesc {
   @JsonProperty(defaultValue = "string", required = true)
   @JsonSchemaTitle("Attribute Type")
+  @JsonPropertyDescription("This specifies how to read this text.\n \n Per-line types (string, integer, long, double, boolean, " +
+    "timestamp) emit one output row per line, casting each line to that type. \n \n" +
+    "File types ('Single string' / 'binary' / 'large binary') read the entire file in one " +
+    "single row.")
   var attributeType: FileAttributeType = FileAttributeType.STRING
 
   @JsonProperty(defaultValue = "line", required = true)
   @JsonSchemaTitle("Attribute Name")
   @JsonDeserialize(contentAs = classOf[java.lang.String])
+  @JsonPropertyDescription("What is the name of the column that this text should be put in?")
   var attributeName: String = "line"
 
-  @JsonSchemaTitle("Limit")
+  @JsonSchemaTitle("Limit (lines)")
   @JsonDeserialize(contentAs = classOf[Int])
+  @JsonPropertyDescription("Maximum number of lines to output. Leave empty to read all lines. " +
+    "(Not used when reading the whole file as one row.)")
   @JsonSchemaInject(
     strings = Array(
       new JsonSchemaString(path = HideAnnotation.hideTarget, value = "attributeType"),
@@ -58,7 +61,9 @@ trait TextSourceOpDesc {
   )
   var fileScanLimit: Option[Int] = None
 
-  @JsonSchemaTitle("Offset")
+  @JsonSchemaTitle("Offset (lines)")
+  @JsonPropertyDescription("Number of lines to skip from the start before reading. " +
+    "(Not used when reading the whole file as one row.)")
   @JsonDeserialize(contentAs = classOf[Int])
   @JsonSchemaInject(
     strings = Array(

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
@@ -269,7 +269,7 @@ class DatasetResourceSpec
   }
 
   override protected def afterAll(): Unit = {
-    try shutdownDB()
+    try closeConnectionPool()
     finally {
       try savedLevels.foreach { case (name, prev) => setLoggerLevel(name, prev) } finally super
         .afterAll()

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
@@ -1233,8 +1233,7 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("init-session-row-locked")
     initUpload(filePath, numParts = 2).getStatus shouldEqual 200
 
-    val connectionProvider = getDSLContext.configuration().connectionProvider()
-    val connection = connectionProvider.acquire()
+    val connection = getDBInstance.getPostgresDatabase.getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1256,7 +1255,7 @@ class DatasetResourceSpec
       ex.getResponse.getStatus shouldEqual 409
     } finally {
       connection.rollback()
-      connectionProvider.release(connection)
+      connection.close()
     }
 
     // lock released => init works again
@@ -1622,8 +1621,8 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("init-lock-409")
     initUpload(filePath, numParts = 2).getStatus shouldEqual 200
 
-    val connectionProvider = getDSLContext.configuration().connectionProvider()
-    val connection = connectionProvider.acquire()
+    // Open a completely independent connection to simulate a second concurrent user
+    val connection = getDBInstance.getPostgresDatabase.getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1645,7 +1644,7 @@ class DatasetResourceSpec
       ex.getResponse.getStatus shouldEqual 409
     } finally {
       connection.rollback()
-      connectionProvider.release(connection)
+      connection.close()
     }
   }
 
@@ -1865,8 +1864,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2)
     val uploadId = fetchUploadIdOrFail(filePath)
 
-    val connectionProvider = getDSLContext.configuration().connectionProvider()
-    val connection = connectionProvider.acquire()
+    val connection = getDBInstance.getPostgresDatabase.getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1887,7 +1885,7 @@ class DatasetResourceSpec
       assertStatus(ex, 409)
     } finally {
       connection.rollback()
-      connectionProvider.release(connection)
+      connection.close()
     }
 
     uploadPart(filePath, 1, minPartBytes(3.toByte)).getStatus shouldEqual 200
@@ -1898,8 +1896,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2)
     val uploadId = fetchUploadIdOrFail(filePath)
 
-    val connectionProvider = getDSLContext.configuration().connectionProvider()
-    val connection = connectionProvider.acquire()
+    val connection = getDBInstance.getPostgresDatabase.getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1917,7 +1914,7 @@ class DatasetResourceSpec
       uploadPart(filePath, 2, tinyBytes(9.toByte)).getStatus shouldEqual 200
     } finally {
       connection.rollback()
-      connectionProvider.release(connection)
+      connection.close()
     }
   }
 
@@ -2104,8 +2101,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 1)
     uploadPart(filePath, 1, tinyBytes(1.toByte)).getStatus shouldEqual 200
 
-    val connectionProvider = getDSLContext.configuration().connectionProvider()
-    val connection = connectionProvider.acquire()
+    val connection = getDBInstance.getPostgresDatabase.getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -2125,7 +2121,7 @@ class DatasetResourceSpec
       assertStatus(ex, 409)
     } finally {
       connection.rollback()
-      connectionProvider.release(connection)
+      connection.close()
     }
   }
 
@@ -2165,8 +2161,7 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("abort-lock-race")
     initUpload(filePath, numParts = 1)
 
-    val connectionProvider = getDSLContext.configuration().connectionProvider()
-    val connection = connectionProvider.acquire()
+    val connection = getDBInstance.getPostgresDatabase.getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -2186,7 +2181,7 @@ class DatasetResourceSpec
       assertStatus(ex, 409)
     } finally {
       connection.rollback()
-      connectionProvider.release(connection)
+      connection.close()
     }
   }
 

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
@@ -1233,7 +1233,7 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("init-session-row-locked")
     initUpload(filePath, numParts = 2).getStatus shouldEqual 200
 
-    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
+    val connection = newRawConnection()
     connection.setAutoCommit(false)
 
     try {
@@ -1622,7 +1622,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2).getStatus shouldEqual 200
 
     // Open a completely independent connection to simulate a second concurrent user
-    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
+    val connection = newRawConnection()
     connection.setAutoCommit(false)
 
     try {
@@ -1864,7 +1864,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2)
     val uploadId = fetchUploadIdOrFail(filePath)
 
-    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
+    val connection = newRawConnection()
     connection.setAutoCommit(false)
 
     try {
@@ -1896,7 +1896,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2)
     val uploadId = fetchUploadIdOrFail(filePath)
 
-    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
+    val connection = newRawConnection()
     connection.setAutoCommit(false)
 
     try {
@@ -2101,7 +2101,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 1)
     uploadPart(filePath, 1, tinyBytes(1.toByte)).getStatus shouldEqual 200
 
-    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
+    val connection = newRawConnection()
     connection.setAutoCommit(false)
 
     try {
@@ -2161,7 +2161,7 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("abort-lock-race")
     initUpload(filePath, numParts = 1)
 
-    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
+    val connection = newRawConnection()
     connection.setAutoCommit(false)
 
     try {

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetResourceSpec.scala
@@ -1233,7 +1233,7 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("init-session-row-locked")
     initUpload(filePath, numParts = 2).getStatus shouldEqual 200
 
-    val connection = getDBInstance.getPostgresDatabase.getConnection
+    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1622,7 +1622,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2).getStatus shouldEqual 200
 
     // Open a completely independent connection to simulate a second concurrent user
-    val connection = getDBInstance.getPostgresDatabase.getConnection
+    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1864,7 +1864,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2)
     val uploadId = fetchUploadIdOrFail(filePath)
 
-    val connection = getDBInstance.getPostgresDatabase.getConnection
+    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -1896,7 +1896,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 2)
     val uploadId = fetchUploadIdOrFail(filePath)
 
-    val connection = getDBInstance.getPostgresDatabase.getConnection
+    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -2101,7 +2101,7 @@ class DatasetResourceSpec
     initUpload(filePath, numParts = 1)
     uploadPart(filePath, 1, tinyBytes(1.toByte)).getStatus shouldEqual 200
 
-    val connection = getDBInstance.getPostgresDatabase.getConnection
+    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
     connection.setAutoCommit(false)
 
     try {
@@ -2161,7 +2161,7 @@ class DatasetResourceSpec
     val filePath = uniqueFilePath("abort-lock-race")
     initUpload(filePath, numParts = 1)
 
-    val connection = getDBInstance.getPostgresDatabase.getConnection
+    val connection = MockTexeraDB.getDBInstance.getDatabase("postgres", uniqueDbName).getConnection
     connection.setAutoCommit(false)
 
     try {

--- a/file-service/src/test/scala/org/apache/texera/service/util/StagedFileCleanupJobSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/util/StagedFileCleanupJobSpec.scala
@@ -155,7 +155,7 @@ class StagedFileCleanupJobSpec
   }
 
   override protected def afterAll(): Unit = {
-    try shutdownDB()
+    try closeConnectionPool()
     finally super.afterAll()
   }
 

--- a/frontend/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.scss
+++ b/frontend/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.scss
@@ -60,6 +60,13 @@
     nz-input-number {
       width: 100%;
     }
+    // preserve newlines (\n) in property descriptions rendered via nzExtra,
+    // and give them breathing room from the input above
+    .ant-form-item-extra {
+      white-space: pre-line;
+      margin-top: 6px;
+      line-height: 1.4;
+    }
   }
 }
 

--- a/notebook-migration-service/src/test/scala/org/apache/texera/service/resource/NotebookMigrationResourceSpec.scala
+++ b/notebook-migration-service/src/test/scala/org/apache/texera/service/resource/NotebookMigrationResourceSpec.scala
@@ -79,7 +79,7 @@ class NotebookMigrationResourceSpec
     """{"operator_to_cell":{},"cell_to_operator":{}}"""
 
   override protected def beforeAll(): Unit = initializeDBAndReplaceDSLContext()
-  override protected def afterAll(): Unit = shutdownDB()
+  override protected def afterAll(): Unit = closeConnectionPool()
 
   override protected def beforeEach(): Unit = {
     val cfg = getDSLContext.configuration()


### PR DESCRIPTION
### What changes were proposed in this PR?
Added descriptions to fields in `TextSourceOpDesc` and `TextInputSourceOpDesc`.  Currently these operators suffer heavily from a lack of information. 

### Any related issues, documentation, discussions?
Closes #6802. Related idea in #6798

### How was this PR tested?
Deployed changes locally via docker and `./bin/local-dev.sh up` 

### Was this PR authored or co-authored using generative AI tooling?
No. 
