### PR TITLE
fix(BarChart): treat an empty categoryColumn as no category (px.bar color)

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -109,7 +109,9 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
       isPatternSelected = "True"
 
     var isCategoryColumn = "False"
-    if (categoryColumn != "No Selection")
+    // "" is the Scala default ("No Selection" is only JSON metadata); an empty
+    // column must also count as "no category", else px.bar(color="") fails.
+    if (categoryColumn.nonEmpty && categoryColumn != "No Selection")
       isCategoryColumn = "True"
 
     val finalCode =

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDescSpec.scala
@@ -116,8 +116,8 @@ class BarChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
     opDesc.value = "score"
     opDesc.fields = "name"
     val code = opDesc.generatePythonCode()
-    code should include("if False else None")
-    code should not include "if True else None"
+    code should include("color=self.decode_python_template('') if False else None")
+    code should not include "color=self.decode_python_template('') if True else None"
   }
 
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDescSpec.scala
@@ -110,4 +110,14 @@ class BarChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
     ex.getMessage should (include("Value column") or include("Fields"))
   }
 
+  "BarChartOpDesc.generatePythonCode" should "treat an unset categoryColumn as no category (color guarded to None)" in {
+    // An empty categoryColumn (its Scala default) must guard color to None, not
+    // emit `... if True else None` with an empty column name for px.bar(color=).
+    opDesc.value = "score"
+    opDesc.fields = "name"
+    val code = opDesc.generatePythonCode()
+    code should include("if False else None")
+    code should not include "if True else None"
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Fixes `BarChartOpDesc.generatePythonCode` treating an **unset** `categoryColumn` as a real column, which breaks `px.bar` at runtime.

`categoryColumn`'s Scala field default is the empty string, while its JSON `defaultValue = "No Selection"` is only schema metadata (not applied to the Scala var, and not present when the field is absent from the deserialized JSON). The category guard compared **only** against `"No Selection"`:

```scala
var isCategoryColumn = "False"
if (categoryColumn != "No Selection")   // "" != "No Selection" is true
  isCategoryColumn = "True"
```

So for an empty `categoryColumn`, `isCategoryColumn` became `"True"` and the empty column name flowed into the generated call:

```python
color=self.decode_python_template('') if True else None   # -> px.bar(color="")
```

`px.bar(color="")` raises at runtime, so a bar chart with **no category selected** fails.

The fix also guards against empty, so an unset category yields `color=None`:

```diff
-    if (categoryColumn != "No Selection")
+    if (categoryColumn.nonEmpty && categoryColumn != "No Selection")
```

### Any related issues, documentation, discussions?

Closes #6792

### How was this PR tested?

Added a regression test in `BarChartOpDescSpec` that constructs a `BarChartOpDesc` with `value`/`fields` set and `categoryColumn` left at its default, calls `generatePythonCode()`, and asserts the color site is guarded to `None` (`... if False else None`) with no `... if True else None`. Verified the test **fails** on the pre-fix code and **passes** with the fix; full `BarChartOpDescSpec` is green (9/9).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)