### PR TITLE
ci: retry Codecov upload to survive flaky CLI signature verification

### DIFF
--- a/.github/workflows/codecov-upload.yml
+++ b/.github/workflows/codecov-upload.yml
@@ -140,11 +140,31 @@ jobs:
           echo "pr=$(cat cc/pr-number.txt 2>/dev/null | tr -cd '0-9')" >> "$GITHUB_OUTPUT"
           echo "sha=$(cat cc/commit-sha.txt 2>/dev/null | tr -cd '0-9a-fA-F')" >> "$GITHUB_OUTPUT"
           echo "branch=$(cat cc/branch.txt 2>/dev/null | tr -cd '[:alnum:]._/:-')" >> "$GITHUB_OUTPUT"
+      # codecov-action re-downloads and GPG-verifies the Codecov CLI on every run, and
+      # that runtime key import / signature check is intermittently flaky ("no valid
+      # OpenPGP data found" -> "Could not verify signature" -> exit 1), which would
+      # otherwise fail the leg and drop that flag's coverage. Each upload therefore
+      # runs as attempt + one retry: the first attempt is continue-on-error so a
+      # transient flake doesn't fail the leg, and the retry re-runs only when the first
+      # failed and does fail hard. A persistent failure still fails the leg (->
+      # notify-failure); a transient one self-heals on the retry.
       - name: Upload ${{ matrix.flag }} coverage to Codecov
+        id: cov
         # Every flag has coverage except the results-only amber-integration; hashFiles
-        # skips it there (its artifact has no coverage/ dir). fail_ci_if_error: true so
-        # a genuine upload failure fails the leg and trips notify-failure.
+        # skips it there (its artifact has no coverage/ dir).
         if: hashFiles('cc/coverage/**') != ''
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: cc/coverage
+          flags: ${{ matrix.flag }}
+          fail_ci_if_error: true
+          override_commit: ${{ steps.meta.outputs.sha }}
+          override_branch: ${{ steps.meta.outputs.branch }}
+          override_pr: ${{ steps.meta.outputs.pr }}
+      - name: Upload ${{ matrix.flag }} coverage to Codecov (retry)
+        if: steps.cov.outcome == 'failure'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -155,7 +175,21 @@ jobs:
           override_branch: ${{ steps.meta.outputs.branch }}
           override_pr: ${{ steps.meta.outputs.pr }}
       - name: Upload ${{ matrix.flag }} test results to Codecov
+        id: res
         if: hashFiles('cc/results/**') != ''
+        continue-on-error: true
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: cc/results
+          flags: ${{ matrix.flag }}
+          report_type: test_results
+          fail_ci_if_error: true
+          override_commit: ${{ steps.meta.outputs.sha }}
+          override_branch: ${{ steps.meta.outputs.branch }}
+          override_pr: ${{ steps.meta.outputs.pr }}
+      - name: Upload ${{ matrix.flag }} test results to Codecov (retry)
+        if: steps.res.outcome == 'failure'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### What changes were proposed in this PR?

Reported on #6800 ("codecov is not updating"). The deferred `Codecov Upload` workflow re-downloads and GPG-verifies the Codecov CLI on every leg, and that runtime key import / signature check is **intermittently flaky**:

```
gpg: no valid OpenPGP data found
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...        # exit code 1, before the upload even runs
```

With `fail_ci_if_error: true`, a flaked leg **fails** → that flag's coverage never uploads (Codecov shows stale) → and `notify-failure` fires spuriously. It's transient (sibling legs in the same run upload fine) and can hit any flag on any PR — observed failing the `notebook-migration-service` leg on an unrelated run.

**Fix:** run each upload as **attempt + one retry**. The first attempt is `continue-on-error`, so a transient flake doesn't fail the leg; the retry (same inputs, `fail_ci_if_error: true`, no `continue-on-error`) runs only when the first failed. A *persistent* failure still fails the leg → `notify-failure`; a transient CLI-download/GPG flake **self-heals** on the retry. CLI signature verification is kept intact (no `skip_validation`).

### Any related issues, documentation, discussions?

Reported on #6800. Follow-up to #6730 / #6824.

### How was this PR tested?

- `workflow_run` only activates from the copy on the default branch, so this can't run on its own PR. YAML validated; the retry logic is gated on `steps.<id>.outcome == 'failure'`, so it re-runs only after a failed first attempt and skips cleanly when the first attempt succeeded or was itself skipped (e.g. `amber-integration`, which has no coverage report).
- The `workflow_dispatch` (`run_id`) entry remains for manual post-merge validation.

### Was this PR authored or co-authored using generative AI tooling?

Yes.

Generated-by: Claude Code (Opus 4.8 [1M context])
