### PR TITLE
chore(ci): disable Codecov carryforward for a one-time flag rebaseline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,12 @@
 #   1. Single-stack PRs leave non-uploaded flags as `?` in the comment and
 #      drop them from the rollup; carrying forward the base-branch report
 #      backfills them.
+#      TEMPORARILY DISABLED for one main rebaseline (see #6839): the
+#      reverted deferred-upload experiment (#6730/#6824) left the
+#      carryforward chain stuck, so every PR shows its own flag as
+#      `Carriedforward` instead of a fresh delta. Turning carryforward off
+#      for one full main build flushes the poisoned baseline; the follow-up
+#      PR restores it.
 #   2. Coverage of generated code (protobuf), build output, and the
 #      tests themselves dilutes the "real" coverage figure. Ignore
 #      those paths.
@@ -31,11 +37,9 @@
 #      even when behavior is preserved. Allow 1% slack on project and
 #      require 60% patch coverage.
 
-flag_management:
-  default_rules:
-    # If the current PR didn't run the job for a given flag, inherit
-    # the latest report on the base branch instead of showing `?`.
-    carryforward: true
+# flag_management.default_rules.carryforward is intentionally omitted here
+# for the one-time rebaseline described above (#6839). It is restored in the
+# follow-up PR once main has a full build under the current flag set.
 
 ignore:
   # Generated protobuf — line counts swamp real code.
@@ -82,8 +86,10 @@ coverage:
         threshold: 10%
 
 comment:
-  # CI is label-gated: a single-stack PR (e.g. a frontend-only change)
-  # uploads only its own flag. carryforward backfills the rest from main;
-  # this surfaces those carried rows (rendered `<ø>`) instead of hiding
-  # them, so every PR's table lists all flags.
+  # Once carryforward is restored (see #6839), it backfills missing flags
+  # from main, but Codecov's default still hides those rows from the PR
+  # comment. Show them so a frontend-only or pyamber-only PR's table lists
+  # every flag — fresh-data rows track the patch and carryforward'd rows
+  # render with `<ø>` to make their unchanged status obvious. (A harmless
+  # no-op while carryforward is temporarily off for the rebaseline.)
   show_carryforward_flags: true


### PR DESCRIPTION
### What changes were proposed in this PR?
Step 1 of a Codecov carryforward reset (see #6850). The deferred `workflow_run`
upload experiment (#6730, #6824) — since reverted (#6840, #6837) — left Codecov's
carryforward chain stuck: every PR renders its **own** flag as `Carriedforward`
instead of a fresh delta, so a PR's real coverage change never surfaces (full
diagnosis in #6839).

Reverting the upload path alone does not un-stick the chain; the poisoned base
report on `main` has to be flushed. This PR removes
`flag_management.default_rules.carryforward` so the next full `main` build
rebaselines Codecov against the current flag set, dropping the stale carried
sessions.

**This is intentionally temporary.** A follow-up PR restores `carryforward: true`
once `main` has a clean full-build baseline. During the window, single-stack PRs
may show non-run flags as `?` — expected, and the reason carryforward exists.

Ordered operational steps (per Codecov's [reset guidance](https://community.codecov.com/t/remove-old-carryforward-flag/3428)):
1. Merge this PR.
2. Let a full build run on `main` (all 11 flags upload fresh; nothing carried).
3. Merge the follow-up PR re-enabling carryforward.
4. Rebase open PRs onto the new `main`.

### Any related issues, documentation, discussions?
Closes #6850

### How was this PR tested?
Config-only change. Validated `codecov.yml` parses as valid YAML (`yaml.safe_load`)
and that the top-level keys are now `ignore`, `coverage`, `comment` — the
`flag_management` block is removed as intended. No behavior to unit-test; the
effect is verifiable on `main` post-merge by confirming PR comments show fresh
flag deltas again.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (claude-opus-4-8)
