### PR TITLE
chore(ci): restore Codecov carryforward after flag rebaseline

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -23,12 +23,6 @@
 #   1. Single-stack PRs leave non-uploaded flags as `?` in the comment and
 #      drop them from the rollup; carrying forward the base-branch report
 #      backfills them.
-#      TEMPORARILY DISABLED for one main rebaseline (see #6839): the
-#      reverted deferred-upload experiment (#6730/#6824) left the
-#      carryforward chain stuck, so every PR shows its own flag as
-#      `Carriedforward` instead of a fresh delta. Turning carryforward off
-#      for one full main build flushes the poisoned baseline; the follow-up
-#      PR restores it.
 #   2. Coverage of generated code (protobuf), build output, and the
 #      tests themselves dilutes the "real" coverage figure. Ignore
 #      those paths.
@@ -37,9 +31,11 @@
 #      even when behavior is preserved. Allow 1% slack on project and
 #      require 60% patch coverage.
 
-# flag_management.default_rules.carryforward is intentionally omitted here
-# for the one-time rebaseline described above (#6839). It is restored in the
-# follow-up PR once main has a full build under the current flag set.
+flag_management:
+  default_rules:
+    # If the current PR didn't run the job for a given flag, inherit
+    # the latest report on the base branch instead of showing `?`.
+    carryforward: true
 
 ignore:
   # Generated protobuf — line counts swamp real code.
@@ -86,10 +82,8 @@ coverage:
         threshold: 10%
 
 comment:
-  # Once carryforward is restored (see #6839), it backfills missing flags
-  # from main, but Codecov's default still hides those rows from the PR
-  # comment. Show them so a frontend-only or pyamber-only PR's table lists
-  # every flag — fresh-data rows track the patch and carryforward'd rows
-  # render with `<ø>` to make their unchanged status obvious. (A harmless
-  # no-op while carryforward is temporarily off for the rebaseline.)
+  # CI is label-gated: a single-stack PR (e.g. a frontend-only change)
+  # uploads only its own flag. carryforward backfills the rest from main;
+  # this surfaces those carried rows (rendered `<ø>`) instead of hiding
+  # them, so every PR's table lists all flags.
   show_carryforward_flags: true


### PR DESCRIPTION
### What changes were proposed in this PR?
Step 2 (final) of the Codecov carryforward reset started in #6852.

#6852 removed `flag_management.default_rules.carryforward` and let `main` rebuild
once under the current flag set, flushing the stuck carryforward sessions left by
the reverted deferred-upload experiment (#6730/#6824). This PR re-enables
carryforward so single-stack PRs keep backfilling non-run flags from the base
report.

Net effect versus pre-#6852: **identical functional config** — the whole exercise
leaves no lasting config change; it only rebaselines Codecov's carryforward data
on `main`.

**⚠️ Verification gate.** This PR's own Codecov comment is the A/B test for the reset:
- #6852 (carryforward **off**) showed non-run flags as `?`.
- This PR (carryforward **on**) must show each PR's own flag as a **fresh** delta
  again, and must NOT resurrect any stale flag as a `0.00%` carried-forward row.

Do not merge until the Codecov comment here is confirmed clean.

### Any related issues, documentation, discussions?
Follows #6852. Closes #6851.

### How was this PR tested?
Config-only change. Validated `codecov.yml` parses as valid YAML and that the
functional blocks (`flag_management`, `coverage`, `comment`) match the pre-#6852
configuration, restoring `carryforward: true`. Behavioral verification is the
Codecov comment on this PR (see the verification gate above).

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (claude-opus-4-8)
