### PR TITLE
chore(pyamber): silence pkg_resources deprecation warning from fs import

### DIFF
--- a/amber/pyproject.toml
+++ b/amber/pyproject.toml
@@ -43,3 +43,8 @@ addopts = "--import-mode=importlib"
 markers = [
     "integration: end-to-end test routed to the amber-integration CI job",
 ]
+# `fs` pulls in pkg_resources at import time (#4199); the same filter lives in
+# texera_run_python_worker.py for spawned workers.
+filterwarnings = [
+    "ignore:pkg_resources is deprecated as an API.*:UserWarning",
+]

--- a/amber/src/main/python/texera_run_python_worker.py
+++ b/amber/src/main/python/texera_run_python_worker.py
@@ -25,6 +25,11 @@ from loguru import logger
 # at import time (#4199), which emits this deprecation warning on stderr in
 # every spawned worker. It is not actionable on our side, so filter it before
 # the import chain runs. Mirrored for pytest in amber/pyproject.toml.
+#
+# Silencing this also hides the last recurring reminder that we depend on the
+# EOL PyFilesystem2 (`fs` 2.4.16) and must hold setuptools below the
+# pkg_resources removal. That debt is tracked in #6917 — remove this filter
+# once `fs` is gone.
 warnings.filterwarnings(
     "ignore",
     message="pkg_resources is deprecated as an API.*",

--- a/amber/src/main/python/texera_run_python_worker.py
+++ b/amber/src/main/python/texera_run_python_worker.py
@@ -18,7 +18,18 @@
 import base64
 import json
 import sys
+import warnings
 from loguru import logger
+
+# `fs` (imported transitively by the core import below) pulls in pkg_resources
+# at import time (#4199), which emits this deprecation warning on stderr in
+# every spawned worker. It is not actionable on our side, so filter it before
+# the import chain runs. Mirrored for pytest in amber/pyproject.toml.
+warnings.filterwarnings(
+    "ignore",
+    message="pkg_resources is deprecated as an API.*",
+    category=UserWarning,
+)
 
 try:
     from core.python_worker import PythonWorker


### PR DESCRIPTION
### What changes were proposed in this PR?

Every spawned Python UDF worker prints this on stderr at import time, dozens of times per amber-integration CI run:

```
site-packages/fs/__init__.py:4: UserWarning: pkg_resources is deprecated as an API. ...
```

Root cause: the worker entry point imports `core.python_worker`, which transitively imports `fs` (PyFilesystem2, used by `ExecutorManager` for the tmp filesystem that holds UDF source code); `fs/__init__.py` imports `pkg_resources`, which emits a `UserWarning`. It is a Python `warnings` warning, not a loguru log, so the existing log-level knobs (#6797) cannot suppress it. `fs` still needs `pkg_resources` — that is why setuptools is range-pinned (#6412) — so the warning is expected and not actionable on our side.

```
Before: worker spawn -> import core -> import fs -> UserWarning on stderr  (every worker)
After:  worker spawn -> install message-scoped filter -> import fs -> silent
```

| File | Change |
| --- | --- |
| `amber/src/main/python/texera_run_python_worker.py` | `warnings.filterwarnings` scoped to this one message + `category=UserWarning`, installed above the core import chain |
| `amber/pyproject.toml` | same filter mirrored via pytest `filterwarnings` so the suite's warnings summary is quiet too |

Only this exact message is filtered — unrelated warnings still print (verified with an injected control warning). The companion `declare_namespace` DeprecationWarnings from `fs` remain, but they only surface in pytest summaries; Python's default filters already hide them in spawned worker processes.

### Any related issues, documentation, discussions?

Listed as a follow-up item in #6796 (the log-verbosity reduction itself landed via #6797).

### How was this PR tested?

- Reproduced with the exact pinned deps (setuptools 80.10.2, fs 2.4.16): importing `texera_run_python_worker` printed the `UserWarning` before the change and is silent after; an injected unrelated `UserWarning` still prints, confirming the filter is not a blanket ignore.
- `pytest src/test/python -m "not integration"` from `amber/`: 749 passed and the `pkg_resources` `UserWarning` is gone from the warnings summary (the handful of Iceberg-catalog failures on this Windows machine are identical on a clean tree).
- `ruff check` and `ruff format --check` pass on the edited file.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Fable 5)
