### PR TITLE
ci: enable Renovate config migration PRs

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -27,6 +27,10 @@
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['config:recommended'],
 
+  // When a config option we use is renamed or deprecated upstream,
+  // Renovate opens a PR migrating this file instead of logging a warning.
+  configMigration: true,
+
   // Only the ecosystems dependabot.yml covered; enable more (docker,
   // gradle, etc.) deliberately in follow-ups rather than by default.
   enabledManagers: ['npm', 'bun', 'sbt', 'pip_requirements', 'github-actions'],


### PR DESCRIPTION
### What changes were proposed in this PR?

Set `configMigration: true` in `.github/renovate.json5`, so that when a config option we use is renamed or deprecated upstream, Renovate opens a PR migrating this file instead of silently logging a warning.

The branch is deliberately named `renovate/reconfigure`: per the [Renovate reconfigure docs](https://docs.renovatebot.com/config-overview/#reconfigure-via-pr), the bot validates the edited config and posts the expected changes as a comment on this PR. This also serves as a liveness probe — Renovate has not processed the repo since `.github/renovate.json5` landed in #6848 (the onboarding PR #6855 was closed unmerged shortly before that merge, which flagged the repo as disabled on Mend's side).

### Any related issues, documentation, discussions?

Follow-up to #6848; related to onboarding PR #6855.

### How was this PR tested?

- `renovate.json5` change validated against the Renovate config schema.
- Renovate's config validation comment on this PR (once the bot processes it) is the end-to-end check.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Fable 5)