### PR TITLE
fix(amber): treat a queued coordinator reply as processed work in EndWorker

### DIFF
--- a/amber/src/main/python/core/architecture/handlers/control/end_worker_handler.py
+++ b/amber/src/main/python/core/architecture/handlers/control/end_worker_handler.py
@@ -15,10 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from loguru import logger
-
 from core.architecture.handlers.control.control_handler_base import ControlHandler
-from core.util import IQueue
+from core.models.internal_queue import InternalQueue
 from proto.org.apache.texera.amber.engine.architecture.rpc import (
     EmptyReturn,
     EmptyRequest,
@@ -29,21 +27,32 @@ class EndWorkerHandler(ControlHandler):
     """
     The EndWorker control messages is needed to ensure all the other
     control messages in a worker are processed before worker termination.
+
+    EndWorker is the last *request* the coordinator sends to a worker, but not
+    the last message it receives: the coordinator sends EndWorker from inside
+    its port_completed handler, so the reply to that same port_completed trails
+    EndWorker on the control channel on every normal region teardown. A queued
+    ReturnInvocation therefore does not count as unprocessed work (see
+    InternalQueue.has_unprocessed_work).
     """
 
     async def end_worker(self, req: EmptyRequest) -> EmptyReturn:
         """
         The response of EndWorker to the coordinator indicates that this worker
         has finished not only the data processing logic, but also the processing
-        of all the control messages.
+        of all the queued control messages that represent work. On failure the
+        coordinator retries EndWorker after a delay instead of stopping a worker
+        that still has real queued work.
         """
-        # Ensure this is really the last message.
-        input_queue: IQueue = self.context.input_queue
-        if not input_queue.is_empty():
-            logger.warning(
-                f"Received EndHandler before all messages are "
-                f"processed. Unprocessed messages: {input_queue.get()}"
+        input_queue: InternalQueue = self.context.input_queue
+        if input_queue.has_unprocessed_work():
+            # peek(), never get(): a diagnostic must not consume the message it
+            # reports. The label is best-effort — peek() returns the highest-
+            # priority head, which is not necessarily the element that blocks.
+            pending = input_queue.peek()
+            raise RuntimeError(
+                "worker still has unprocessed messages: "
+                f"next = {type(pending).__name__}"
             )
-        assert input_queue.is_empty()
         # Now we can safely acknowledge that this worker can be terminated.
         return EmptyReturn()

--- a/amber/src/main/python/core/models/internal_queue.py
+++ b/amber/src/main/python/core/models/internal_queue.py
@@ -20,16 +20,21 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 from threading import RLock
-from typing import TypeVar, Set
+from typing import Optional, TypeVar, Set
 
 from core.models.internal_marker import InternalMarker
 from core.models.payload import DataPayload
+from core.util.atomic import AtomicInteger
 from core.util.customized_queue.linked_blocking_multi_queue import (
     LinkedBlockingMultiQueue,
 )
 from core.util.customized_queue.queue_base import IQueue, QueueElement
+from core.util.proto import get_one_of
 from proto.org.apache.texera.amber.core import ChannelIdentity
-from proto.org.apache.texera.amber.engine.architecture.rpc import EmbeddedControlMessage
+from proto.org.apache.texera.amber.engine.architecture.rpc import (
+    EmbeddedControlMessage,
+    ReturnInvocation,
+)
 from proto.org.apache.texera.amber.engine.common import DirectControlMessagePayloadV2
 
 
@@ -67,12 +72,23 @@ class InternalQueue(IQueue):
         self._queue_ids: Set[ChannelIdentity] = set()
         self._queue_state: Set[InternalQueue.DisableType] = set()
         self._lock = RLock()
+        # Number of queued elements that represent work (see _is_work). Counted at
+        # put/get time because the underlying multi-queue offers no iteration, and
+        # it must see elements in disabled (paused/backpressured) sub-queues too.
+        self._work_count = AtomicInteger()
 
     def is_empty(self, key=None) -> bool:
         return self._queue.is_empty(key)
 
     def get(self) -> T:
-        return self._queue.get()
+        item = self._queue.get()
+        if self._is_work(item):
+            self._work_count.dec()
+        return item
+
+    def peek(self) -> Optional[T]:
+        """Non-destructively return the next available item, or None when empty."""
+        return self._queue.peek()
 
     def put(self, item: T) -> None:
         if isinstance(item, InternalQueueElement):
@@ -87,6 +103,31 @@ class InternalQueue(IQueue):
                 raise ValueError(f"item {item} is not recognized by internal queue")
         else:
             self._queue.put("SYSTEM", item)
+        if self._is_work(item):
+            self._work_count.inc()
+
+    @staticmethod
+    def _is_work(item) -> bool:
+        """
+        A queued ReturnInvocation is not unprocessed work: processing it only
+        fulfills a promise for a request this worker already issued, and the
+        worker never chains work on those replies. The coordinator routinely
+        emits one behind EndWorker on the same control channel (the reply to
+        the port_completed whose handler triggered the termination), so counting
+        it as work would fail every first EndWorker attempt.
+        """
+        return not (
+            isinstance(item, DCMElement)
+            and isinstance(get_one_of(item.payload, sealed=False), ReturnInvocation)
+        )
+
+    def has_unprocessed_work(self) -> bool:
+        """
+        True when at least one queued element is real work, including elements
+        queued in disabled (paused/backpressured) sub-queues that size() and
+        get() do not see.
+        """
+        return self._work_count.value > 0
 
     def disable(self, channel_id: ChannelIdentity) -> None:
         self._queue.disable(channel_id)

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/scheduling/RegionExecutionManager.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/scheduling/RegionExecutionManager.scala
@@ -135,8 +135,11 @@ class RegionExecutionManager(
     *
     * Additionally, this method will also terminate all the workers of this region:
     *
-    * 1.  An `EndWorker` control message is first sent to all the workers. This will be the last message each worker
-    * receives. We wait for all workers have replied to indicate they have finished processing all control messages.
+    * 1.  An `EndWorker` control message is first sent to all the workers. `EndWorker` is the last *request* sent to
+    * each worker, but not the last message a worker receives: it is sent from inside the `portCompleted` handler
+    * (see `PortCompletedHandler`), whose own reply is emitted afterwards on the same control channel. We wait for all
+    * workers to reply that they have finished processing all queued control messages; a worker that is still draining
+    * fails the request and `terminateWorkersWithRetry` re-sends `EndWorker` after `killRetryDelay`.
     *
     * 2. Only after all workers have processed all control messages do we send a `gracefulStop` (pekko message) to each
     * worker. JVM workers will be terminated by `gracefulStop`. Python proxy workes will also be terminated by
@@ -219,7 +222,9 @@ class RegionExecutionManager(
         }
         Future.Unit // propagate success
       case Throw(err) =>
-        logger.warn(s"Error when terminating region ${region.id}.")
+        // `terminateWorkersWithRetry` logs this same failure with its attempt count (WARN) or
+        // gives up loudly (ERROR); logging it here too would only duplicate it without context.
+        logger.debug(s"Error when terminating region ${region.id}.", err)
         Future.exception(err) // propagate failure
     }
   }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/promisehandlers/EndHandler.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/promisehandlers/EndHandler.scala
@@ -24,33 +24,88 @@ import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
   AsyncRPCContext,
   EmptyRequest
 }
-import org.apache.texera.amber.engine.architecture.rpc.controlreturns.EmptyReturn
+import org.apache.texera.amber.engine.architecture.rpc.controlreturns.{
+  EmptyReturn,
+  ReturnInvocation
+}
 import org.apache.texera.amber.engine.architecture.worker.DataProcessorRPCHandlerInitializer
+import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.{
+  ActorCommandElement,
+  DPInputQueueElement,
+  FIFOMessageElement,
+  TimerBasedControlElement
+}
 
 /**
-  * The EndWorker control messages is needed to ensure all the other control messages in a worker
+  * The EndWorker control message is needed to ensure all the other control messages in a worker
   * are processed before worker termination.
+  *
+  * EndWorker is the last *request* the coordinator sends to a worker, but NOT the last message
+  * the worker receives: the coordinator sends EndWorker from inside the `portCompleted` handler
+  * (see `PortCompletedHandler`), so the reply to that same `portCompleted` is emitted afterwards
+  * on the same FIFO control channel and legitimately sits behind EndWorker in this worker's
+  * arrival queue on every normal region teardown.
   */
 trait EndHandler {
   this: DataProcessorRPCHandlerInitializer =>
 
   /**
     * The response of endWorker to the coordinator indicates that this worker has finished not only
-    * the data processing logic, but also the processing of all the control messages.
+    * the data processing logic, but also the processing of all the queued control messages that
+    * represent work. On failure the coordinator retries EndWorker after a delay instead of
+    * stopping a worker that still has real queued work.
     */
   override def endWorker(
       request: EmptyRequest,
       ctx: AsyncRPCContext
   ): Future[EmptyReturn] = {
-    // Ensure this is really the last message.
-    if (!dp.inputManager.inputMessageQueue.isEmpty) {
+    // `inputMessageQueue` is the DP thread's raw arrival queue, drained wholesale by the DP
+    // thread's main loop before this handler runs — anything visible here arrived while
+    // EndWorker was being processed.
+    val pendingWork = findPendingWork
+    if (pendingWork.isDefined) {
       logger.warn(
-        s"Received EndHandler before all messages are processed. Unprocessed messages: " +
-          s"${dp.inputManager.inputMessageQueue.peek()}"
+        s"Received endWorker while unprocessed work is still queued: " +
+          s"${describePending(pendingWork.get)}"
       )
       return Future.exception(new IllegalStateException("worker still has unprocessed messages"))
     }
     // Now we can safely acknowledge that this worker can be terminated.
     EmptyReturn()
   }
+
+  /**
+    * A queued `ReturnInvocation` is not unprocessed work: processing it only fulfills a promise
+    * for a request this worker already issued (see `AmberProcessor.processDCM`), and every
+    * worker-to-coordinator call discards its future, so no continuation is pending on it.
+    * Everything else — control invocations, data frames, timer-based controls, actor commands —
+    * still blocks termination.
+    */
+  private def findPendingWork: Option[DPInputQueueElement] = {
+    // LinkedBlockingQueue's iterator is weakly consistent; this decision is re-taken on every
+    // termination attempt, so a concurrent put is only deferred to the coordinator's retry.
+    val iterator = dp.inputManager.inputMessageQueue.iterator()
+    while (iterator.hasNext) {
+      val element = iterator.next()
+      val isWork = element match {
+        case FIFOMessageElement(msg) => !msg.payload.isInstanceOf[ReturnInvocation]
+        case _                       => true
+      }
+      if (isWork) {
+        return Some(element)
+      }
+    }
+    None
+  }
+
+  /** Bounded description of a pending element: payload type and channel only, never payload contents. */
+  private def describePending(element: DPInputQueueElement): String =
+    element match {
+      case FIFOMessageElement(msg) =>
+        s"${msg.payload.getClass.getSimpleName} from ${msg.channelId}"
+      case TimerBasedControlElement(control) =>
+        s"timer-based control ${control.methodName}"
+      case ActorCommandElement(cmd) =>
+        s"actor command ${cmd.getClass.getSimpleName}"
+    }
 }

--- a/amber/src/test/python/core/architecture/handlers/control/test_end_worker_handler.py
+++ b/amber/src/test/python/core/architecture/handlers/control/test_end_worker_handler.py
@@ -106,9 +106,7 @@ class TestEndWorkerHandler:
     def test_fails_when_a_control_invocation_is_queued(self, handler, queue):
         queue.put(_control_invocation_element())
 
-        with pytest.raises(
-            RuntimeError, match="worker still has unprocessed messages"
-        ):
+        with pytest.raises(RuntimeError, match="worker still has unprocessed messages"):
             asyncio.run(handler.end_worker(EmptyRequest()))
         assert queue.size() == 1
 
@@ -119,9 +117,7 @@ class TestEndWorkerHandler:
         queue.put(_coordinator_reply_element())
         queue.put(_control_invocation_element())
 
-        with pytest.raises(
-            RuntimeError, match="worker still has unprocessed messages"
-        ):
+        with pytest.raises(RuntimeError, match="worker still has unprocessed messages"):
             asyncio.run(handler.end_worker(EmptyRequest()))
         assert queue.size() == 2
 
@@ -129,9 +125,7 @@ class TestEndWorkerHandler:
     def test_fails_when_data_is_queued(self, handler, queue):
         queue.put(DataElement(tag=DATA_CHANNEL, payload=DataPayload()))
 
-        with pytest.raises(
-            RuntimeError, match="worker still has unprocessed messages"
-        ):
+        with pytest.raises(RuntimeError, match="worker still has unprocessed messages"):
             asyncio.run(handler.end_worker(EmptyRequest()))
         assert queue.size() == 1
 

--- a/amber/src/test/python/core/architecture/handlers/control/test_end_worker_handler.py
+++ b/amber/src/test/python/core/architecture/handlers/control/test_end_worker_handler.py
@@ -1,0 +1,147 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from core.architecture.handlers.control.end_worker_handler import EndWorkerHandler
+from core.models.internal_queue import DataElement, DCMElement, InternalQueue
+from core.models.payload import DataPayload
+from core.util.proto import set_one_of
+from proto.org.apache.texera.amber.core import ActorVirtualIdentity, ChannelIdentity
+from proto.org.apache.texera.amber.engine.architecture.rpc import (
+    ControlInvocation,
+    ControlReturn,
+    EmptyRequest,
+    EmptyReturn,
+    ReturnInvocation,
+)
+from proto.org.apache.texera.amber.engine.common import DirectControlMessagePayloadV2
+
+CONTROL_CHANNEL = ChannelIdentity(
+    ActorVirtualIdentity("CONTROLLER"),
+    ActorVirtualIdentity("dummy_worker_id"),
+    True,
+)
+DATA_CHANNEL = ChannelIdentity(
+    ActorVirtualIdentity("upstream_worker_id"),
+    ActorVirtualIdentity("dummy_worker_id"),
+    False,
+)
+
+
+def _build_handler(queue: InternalQueue) -> EndWorkerHandler:
+    instance = EndWorkerHandler.__new__(EndWorkerHandler)
+    instance.context = SimpleNamespace(input_queue=queue)
+    return instance
+
+
+def _coordinator_reply_element() -> DCMElement:
+    # The exact payload observed on every normal region teardown: the coordinator
+    # sends EndWorker from inside its port_completed handler, so the reply to that
+    # same port_completed trails EndWorker on the control channel.
+    return DCMElement(
+        tag=CONTROL_CHANNEL,
+        payload=set_one_of(
+            DirectControlMessagePayloadV2,
+            ReturnInvocation(
+                command_id=2,
+                return_value=set_one_of(ControlReturn, EmptyReturn()),
+            ),
+        ),
+    )
+
+
+def _control_invocation_element() -> DCMElement:
+    return DCMElement(
+        tag=CONTROL_CHANNEL,
+        payload=set_one_of(
+            DirectControlMessagePayloadV2,
+            ControlInvocation(method_name="QueryStatistics", command_id=1),
+        ),
+    )
+
+
+class TestEndWorkerHandler:
+    @pytest.fixture
+    def queue(self):
+        return InternalQueue()
+
+    @pytest.fixture
+    def handler(self, queue):
+        return _build_handler(queue)
+
+    def test_returns_empty_return_when_queue_is_empty(self, handler):
+        result = asyncio.run(handler.end_worker(EmptyRequest()))
+        assert isinstance(result, EmptyReturn)
+
+    @pytest.mark.timeout(2)
+    def test_succeeds_and_keeps_a_queued_coordinator_reply(self, handler, queue):
+        queue.put(_coordinator_reply_element())
+
+        result = asyncio.run(handler.end_worker(EmptyRequest()))
+
+        assert isinstance(result, EmptyReturn)
+        # The reply must still be queued afterwards: the previous implementation
+        # called input_queue.get() inside its log message and silently dropped it.
+        assert queue.size() == 1
+
+    @pytest.mark.timeout(2)
+    def test_fails_when_a_control_invocation_is_queued(self, handler, queue):
+        queue.put(_control_invocation_element())
+
+        with pytest.raises(
+            RuntimeError, match="worker still has unprocessed messages"
+        ):
+            asyncio.run(handler.end_worker(EmptyRequest()))
+        assert queue.size() == 1
+
+    @pytest.mark.timeout(2)
+    def test_fails_when_a_control_invocation_is_queued_behind_a_reply(
+        self, handler, queue
+    ):
+        queue.put(_coordinator_reply_element())
+        queue.put(_control_invocation_element())
+
+        with pytest.raises(
+            RuntimeError, match="worker still has unprocessed messages"
+        ):
+            asyncio.run(handler.end_worker(EmptyRequest()))
+        assert queue.size() == 2
+
+    @pytest.mark.timeout(2)
+    def test_fails_when_data_is_queued(self, handler, queue):
+        queue.put(DataElement(tag=DATA_CHANNEL, payload=DataPayload()))
+
+        with pytest.raises(
+            RuntimeError, match="worker still has unprocessed messages"
+        ):
+            asyncio.run(handler.end_worker(EmptyRequest()))
+        assert queue.size() == 1
+
+    @pytest.mark.timeout(2)
+    def test_is_idempotent_across_coordinator_retries(self, handler, queue):
+        # The coordinator re-sends EndWorker to every worker on every termination
+        # attempt, so repeated calls must neither consume nor change anything.
+        queue.put(_coordinator_reply_element())
+
+        for _ in range(2):
+            result = asyncio.run(handler.end_worker(EmptyRequest()))
+            assert isinstance(result, EmptyReturn)
+        assert queue.size() == 1

--- a/amber/src/test/python/core/models/test_internal_queue.py
+++ b/amber/src/test/python/core/models/test_internal_queue.py
@@ -27,9 +27,14 @@ from core.models.internal_queue import (
     InternalQueueElement,
 )
 from core.models.payload import DataPayload
+from core.util.proto import set_one_of
 from proto.org.apache.texera.amber.core import ActorVirtualIdentity, ChannelIdentity
 from proto.org.apache.texera.amber.engine.architecture.rpc import (
+    ControlInvocation,
+    ControlReturn,
     EmbeddedControlMessage,
+    EmptyReturn,
+    ReturnInvocation,
 )
 from proto.org.apache.texera.amber.engine.common import DirectControlMessagePayloadV2
 
@@ -87,6 +92,31 @@ class TestInternalQueue:
     @staticmethod
     def ecm_element(channel):
         return ECMElement(tag=channel, payload=EmbeddedControlMessage())
+
+    @staticmethod
+    def reply_dcm_element(channel):
+        # A coordinator ReturnInvocation: the one queued element that does not
+        # count as unprocessed work.
+        return DCMElement(
+            tag=channel,
+            payload=set_one_of(
+                DirectControlMessagePayloadV2,
+                ReturnInvocation(
+                    command_id=2,
+                    return_value=set_one_of(ControlReturn, EmptyReturn()),
+                ),
+            ),
+        )
+
+    @staticmethod
+    def invocation_dcm_element(channel):
+        return DCMElement(
+            tag=channel,
+            payload=set_one_of(
+                DirectControlMessagePayloadV2,
+                ControlInvocation(method_name="QueryStatistics", command_id=1),
+            ),
+        )
 
     def test_it_can_init(self, queue):
         assert queue.is_empty()
@@ -364,3 +394,77 @@ class TestInternalQueue:
         queue.enable(data_channel)
         assert queue.get() is blocked
         assert queue.is_empty()
+
+    @pytest.mark.timeout(2)
+    def test_peek_returns_none_on_an_empty_queue(self, queue):
+        assert queue.peek() is None
+
+    @pytest.mark.timeout(2)
+    def test_peek_is_non_destructive(self, queue, control_channel):
+        dcm = self.dcm_element(control_channel)
+        queue.put(dcm)
+        assert queue.peek() is dcm
+        assert queue.size() == 1
+        assert queue.get() is dcm
+
+    @pytest.mark.timeout(2)
+    def test_has_unprocessed_work_ignores_coordinator_replies(
+        self, queue, control_channel
+    ):
+        queue.put(self.reply_dcm_element(control_channel))
+        assert not queue.has_unprocessed_work()
+        assert not queue.is_empty()
+        queue.get()
+        assert not queue.has_unprocessed_work()
+
+    @pytest.mark.timeout(2)
+    def test_has_unprocessed_work_counts_control_invocations(
+        self, queue, control_channel
+    ):
+        queue.put(self.reply_dcm_element(control_channel))
+        queue.put(self.invocation_dcm_element(control_channel))
+        assert queue.has_unprocessed_work()
+        queue.get()  # the reply
+        assert queue.has_unprocessed_work()
+        queue.get()  # the invocation
+        assert not queue.has_unprocessed_work()
+
+    @pytest.mark.timeout(2)
+    def test_has_unprocessed_work_counts_data_and_ecm_elements(
+        self, queue, data_channel
+    ):
+        queue.put(self.data_element(data_channel))
+        queue.put(self.ecm_element(data_channel))
+        assert queue.has_unprocessed_work()
+        queue.get()
+        assert queue.has_unprocessed_work()
+        queue.get()
+        assert not queue.has_unprocessed_work()
+
+    @pytest.mark.timeout(2)
+    def test_has_unprocessed_work_counts_system_items(self, queue):
+        system_command = SystemCommand()
+        queue.put(system_command)
+        assert queue.has_unprocessed_work()
+        assert queue.get() is system_command
+        assert not queue.has_unprocessed_work()
+
+    @pytest.mark.timeout(2)
+    def test_has_unprocessed_work_sees_data_in_a_disabled_channel(
+        self, queue, data_channel
+    ):
+        # A disabled (paused/backpressured) channel hides its elements from
+        # get()/size(), but the data is still unprocessed work: acknowledging
+        # EndWorker over it would let the coordinator stop the worker and lose
+        # the queued tuples.
+        queue.put(self.data_element(data_channel))
+        queue.disable_data(InternalQueue.DisableType.DISABLE_BY_PAUSE)
+        assert queue.has_unprocessed_work()
+
+    @pytest.mark.timeout(2)
+    def test_has_unprocessed_work_is_not_counted_for_rejected_elements(
+        self, queue, data_channel
+    ):
+        with pytest.raises(ValueError, match="not recognized"):
+            queue.put(UnrecognizedElement(tag=data_channel))
+        assert not queue.has_unprocessed_work()

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/promisehandlers/EndHandlerSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/promisehandlers/EndHandlerSpec.scala
@@ -25,7 +25,10 @@ import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
   AsyncRPCContext,
   EmptyRequest
 }
-import org.apache.texera.amber.engine.architecture.rpc.controlreturns.EmptyReturn
+import org.apache.texera.amber.engine.architecture.rpc.controlreturns.{
+  EmptyReturn,
+  ReturnInvocation
+}
 import org.apache.texera.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc.METHOD_QUERY_STATISTICS
 import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.{
   ActorCommandElement,
@@ -48,8 +51,11 @@ import java.util.concurrent.LinkedBlockingQueue
 /**
   * `endWorker` is the coordinator's acknowledgement point before it sends actor-level `gracefulStop`.
   *
-  * A successful reply means the worker has drained every queued workflow message. If the queue still contains work,
-  * the handler must fail so the region execution manager can retry the kill instead of stopping the actor too early.
+  * A successful reply means the worker has drained every queued workflow message that represents work. If the queue
+  * still contains work, the handler must fail so the region execution manager can retry the kill instead of stopping
+  * the actor too early. A queued `ReturnInvocation` is not work: it only fulfills a promise for a request this worker
+  * already issued, and the coordinator routinely emits one behind `EndWorker` on the same control channel (the reply
+  * to the `portCompleted` whose handler triggered the termination).
   */
 class EndHandlerSpec extends AnyFlatSpec {
   private val workerId = ActorVirtualIdentity("Worker:WF1-test-op-main-0")
@@ -93,6 +99,15 @@ class EndHandlerSpec extends AnyFlatSpec {
     queue
   }
 
+  private def coordinatorReplyElement(seq: Long, commandId: Long): DPInputQueueElement =
+    FIFOMessageElement(
+      WorkflowFIFOMessage(
+        ChannelIdentity(COORDINATOR, workerId, isControl = true),
+        seq,
+        ReturnInvocation(commandId, EmptyReturn())
+      )
+    )
+
   "EndHandler" should "reply successfully when there are no unprocessed messages" in {
     val handler = createEndHandlerForQueue(new LinkedBlockingQueue[DPInputQueueElement]())
 
@@ -109,5 +124,57 @@ class EndHandlerSpec extends AnyFlatSpec {
     val handler = createEndHandlerForQueue(queueWithActorCommand())
 
     assertEndWorkerFails(handler)
+  }
+
+  it should "reply successfully when only a coordinator reply is queued" in {
+    // The exact payload observed on every normal region teardown: the coordinator sends
+    // `EndWorker` from inside the `portCompleted` handler, so the `ReturnInvocation` replying
+    // to that same `portCompleted` is emitted afterwards on the same FIFO control channel and
+    // legitimately sits behind `EndWorker` in this worker's arrival queue.
+    val queue = new LinkedBlockingQueue[DPInputQueueElement]()
+    queue.put(coordinatorReplyElement(seq = 0, commandId = 2))
+    val handler = createEndHandlerForQueue(queue)
+
+    assert(await(handler.endWorker(EmptyRequest(), rpcContext)) == EmptyReturn())
+    // The reply must only be inspected, never consumed.
+    assert(queue.size() == 1)
+  }
+
+  it should "reply successfully when multiple coordinator replies are queued" in {
+    val queue = new LinkedBlockingQueue[DPInputQueueElement]()
+    queue.put(coordinatorReplyElement(seq = 0, commandId = 2))
+    queue.put(coordinatorReplyElement(seq = 1, commandId = 3))
+    val handler = createEndHandlerForQueue(queue)
+
+    assert(await(handler.endWorker(EmptyRequest(), rpcContext)) == EmptyReturn())
+    assert(queue.size() == 2)
+  }
+
+  it should "fail when a control message is queued behind a coordinator reply" in {
+    // The pending-work scan must not stop at the queue's head: a reply followed by a real
+    // request is still unprocessed work.
+    val queue = new LinkedBlockingQueue[DPInputQueueElement]()
+    queue.put(coordinatorReplyElement(seq = 0, commandId = 2))
+    queue.put(
+      FIFOMessageElement(
+        WorkflowFIFOMessage(
+          ChannelIdentity(COORDINATOR, workerId, isControl = true),
+          1,
+          ControlInvocation(METHOD_QUERY_STATISTICS, EmptyRequest(), rpcContext, 1)
+        )
+      )
+    )
+    val handler = createEndHandlerForQueue(queue)
+
+    assertEndWorkerFails(handler)
+    assert(queue.size() == 2)
+  }
+
+  it should "not consume queued messages when it fails" in {
+    val queue = queueWithFifoControlMessage()
+    val handler = createEndHandlerForQueue(queue)
+
+    assertEndWorkerFails(handler)
+    assert(queue.size() == 1)
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

**Root cause.** On every normal region termination, the coordinator sends `EndWorker` from *inside* the `portCompleted` handler, so the `ReturnInvocation` replying to that same `portCompleted` is always emitted **after** `EndWorker` on the same FIFO control channel:

```
Coordinator — portCompleted(W) handler, one synchronous continuation:
  1. advanceRegionExecutions() ──> sends EndWorker to every worker   (seq N   on W's control channel)
  2. returns EmptyReturn()     ──> sends ReturnInvocation to W       (seq N+1, same channel)

Worker W — processes EndWorker while ReturnInvocation(N+1) may already sit in its arrival queue:
  old check: ANY queued element => IllegalStateException("worker still has unprocessed messages")
  => attempt 1 of 150 fails => 200 ms retry succeeds
```

Whether the trailing reply has landed when `EndHandler` runs is a thread-scheduling race, so healthy teardowns routinely fail the first termination attempt and log an alarming storm (2 ERRORs + 2 WARNs + 2 stack traces, then a wasted 200 ms retry). A queued `ReturnInvocation` is not work: processing it only fulfills a promise for a request the worker already issued, and every worker-to-coordinator call discards its future (`DataProcessor.scala:179,187,224,312`), so no continuation can be lost.

**Fix.** Both workers now exclude queued `ReturnInvocation`s from the unprocessed-messages check. Everything that *is* work — `ControlInvocation`s, data, ECMs, timer-based controls, actor commands — still blocks termination, and the 150 × 200 ms retry/give-up contract is untouched.

|  | Before | After |
|---|---|---|
| Normal teardown logs | 2 ERROR + 2 WARN + 2 stack traces | none |
| First `EndWorker` attempt | fails on a benign race | succeeds |
| Teardown latency | +200 ms retry | no retry |
| Real queued work | blocks termination | still blocks termination |
| Python: queued coordinator reply | fails `EndWorker` (since #6522; before that it was silently dropped by a destructive `get()`) | not counted as work; kept in the queue and the call succeeds |

Changes:
- **`EndHandler.scala`**: scan the arrival queue for pending *work* instead of testing bare emptiness; the warning names the payload type and channel instead of dumping the element; scaladoc no longer claims `EndWorker` is the last message a worker receives.
- **`end_worker_handler.py` / `internal_queue.py`**: reply-aware `has_unprocessed_work()` (an `AtomicInteger` work counter maintained in `put`/`get`, since the multi-queue offers no iteration; it also sees work in paused/backpressured sub-queues that `size()`/`get()` hide) plus a non-destructive `InternalQueue.peek()` used for the failure diagnostic. This builds on #6522, which stopped the handler from consuming stragglers; after this PR the Python worker also stops failing on the benign trailing reply, keeping it at parity with the Scala side (same `"worker still has unprocessed messages"` failure string).
- **`RegionExecutionManager.scala`**: fixed the false doc ("This will be the last message each worker receives") and demoted the detail-free duplicate `"Error when terminating region X."` WARN to debug — `terminateWorkersWithRetry` logs the same failure with attempt context (WARN) or gives up loudly (ERROR), unchanged.

### Any related issues, documentation, discussions?

Related: #6796 — this addresses the `EndWorker` retry-storm item behaviorally (the expected race no longer fails the first attempt) rather than by adjusting log levels. Follow-up to the CI log-verbosity work in #6797 and to #6522 (Python straggler-consumption fix). Adjacent teardown defects found during this investigation are filed separately: #6918, #6919, #6920, #6921, #6922, #6923, #6924, #6925.

### How was this PR tested?

- **`EndHandlerSpec`** (the three pre-existing tests are untouched — control invocations and actor commands still fail `endWorker`): new regression tests for the exact CI payload (`ReturnInvocation(2, EmptyReturn())` queued → success), multiple queued replies, a `ControlInvocation` queued *behind* a reply (the scan must not stop at the head), and queue-size preservation on both paths. Written test-first: the two new success tests fail without the `EndHandler` change.
- **`test_end_worker_handler.py`**: keeps the five tests introduced by #6522 verbatim (their straggler elements still count as work) and adds the reply-aware cases — a queued coordinator reply succeeds and stays queued (`size() == 1` afterwards), a `ControlInvocation` behind a reply still fails, queued data still fails, and repeated calls are idempotent across coordinator retries.
- **`test_internal_queue.py`**: `peek()` (None on empty, non-destructive) and `has_unprocessed_work()` (ignores replies; counts invocations, data, ECMs, SYSTEM items; sees data in a disabled sub-queue; not counted for rejected elements).
- Untouched and green as evidence the retry contract is unchanged: `RegionExecutionManagerSpec`, `WorkflowExecutionManagerSpec`, `DPThreadSpec`, `WorkerSpec`, `AsyncRPCClientSpec`.
- Lint: `scalafmtCheck`, `scalafixAll --check`, `ruff check` + `ruff format --check` all pass.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Fable 5)
