### PR TITLE
fix(ci): skip boot smoke steps on backport targets that predate smoke-boot.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -656,10 +656,18 @@ jobs:
         # `amber` and runs in parallel (as platform-integration does vs
         # platform); the sbt compile is already warm from the integration-test
         # run above. ubuntu-only: the boot is pure-JVM and OS-independent.
-        if: matrix.os == 'ubuntu-latest'
+        #
+        # hashFiles keys this step (and the unzip + smoke steps below, which
+        # form one unit with it) on smoke-boot.sh being present in the
+        # checked-out tree: backport legs rebuild the workspace as the
+        # release/* target (Prepare backport workspace above), and targets
+        # that predate the harness (#6319) would otherwise fail the smoke
+        # steps with exit 127. The guard self-retires once the script is
+        # backported to the target branch.
+        if: matrix.os == 'ubuntu-latest' && hashFiles('.github/scripts/smoke-boot.sh') != ''
         run: sbt "WorkflowExecutionService/dist"
       - name: Unzip amber dist
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && hashFiles('.github/scripts/smoke-boot.sh') != ''
         run: |
           mkdir -p /tmp/dists
           unzip -q amber/target/universal/amber-*.zip -d /tmp/dists/
@@ -670,7 +678,7 @@ jobs:
         # working directory for a directory named `amber`; run from the checkout
         # root (the default) that resolves to ./amber and reads
         # amber/src/main/resources/web-config.yml (port 8080).
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && hashFiles('.github/scripts/smoke-boot.sh') != ''
         env:
           # Quiet boot logs, same wiring as the test steps above. Safe here:
           # smoke-boot's verdict is LISTEN-based, never log-scraping (#6332).
@@ -687,7 +695,7 @@ jobs:
         # so no iceberg / S3 access. Config resolves via Utils.amberHomePath to
         # amber/src/main/resources/computing-unit-master-config.yml (port 8085).
         # Reuses the amber dist built + unzipped above for the texera-web boot.
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && hashFiles('.github/scripts/smoke-boot.sh') != ''
         env:
           # Quiet boot logs, same wiring as the test steps above. Safe here:
           # smoke-boot's verdict is LISTEN-based, never log-scraping (#6332).
@@ -929,15 +937,25 @@ jobs:
         # compiling its own tests) rather than downloading an artifact from the
         # `platform` job, so the two stay independent and run in parallel. No
         # jacoco here — unit tests + coverage live in `platform`.
+        #
+        # hashFiles keys this step (and every step below — the whole job is
+        # the boot smoke test) on smoke-boot.sh being present in the
+        # checked-out tree: backport legs rebuild the workspace as the
+        # release/* target (Prepare backport workspace above), and targets
+        # that predate the harness (#6319) would otherwise fail the smoke
+        # step with exit 127. The guard self-retires once the script is
+        # backported to the target branch.
+        if: hashFiles('.github/scripts/smoke-boot.sh') != ''
         run: sbt "${{ matrix.sbt_project }}/dist"
       - name: Unzip ${{ matrix.service }} dist
+        if: hashFiles('.github/scripts/smoke-boot.sh') != ''
         run: |
           mkdir -p /tmp/dists
           unzip -q ${{ matrix.service }}/target/universal/${{ matrix.service }}-*.zip -d /tmp/dists/
       - name: Start MinIO
         # file-service's boot creates its S3 bucket via S3StorageClient; only
         # that service needs an object store, so the rest of the matrix skips this.
-        if: ${{ matrix.object_store }}
+        if: ${{ matrix.object_store && hashFiles('.github/scripts/smoke-boot.sh') != '' }}
         run: |
           docker run -d --name minio --network host \
             -e MINIO_ROOT_USER=texera_minio \
@@ -954,7 +972,7 @@ jobs:
         # LakeFSStorageClient.healthCheck(), so this must be up for it to reach a
         # listening state. Config mirrors bin/single-node (compose + .env),
         # adapted to CI creds (postgres/postgres @ localhost).
-        if: ${{ matrix.object_store }}
+        if: ${{ matrix.object_store && hashFiles('.github/scripts/smoke-boot.sh') != '' }}
         run: |
           docker run -d --name lakefs --network host \
             -e LAKEFS_DATABASE_TYPE=postgres \
@@ -976,6 +994,7 @@ jobs:
       - name: Smoke-test ${{ matrix.service }} boots
         # Launch the packaged service and assert it reaches LISTEN on its port
         # without a runtime classpath/linkage crash (#6220).
+        if: hashFiles('.github/scripts/smoke-boot.sh') != ''
         env:
           TEXERA_HOME: ${{ github.workspace }}
           # Quiet boot logs, same wiring as the amber jobs. Safe here:


### PR DESCRIPTION
### What changes were proposed in this PR?

The `backport (release/*)` CI legs rebuild the workspace as the release target tree (`prepare-backport-checkout.sh`) while executing **main's** `build.yml`. Steps that invoke `.github/scripts/smoke-boot.sh` therefore fail with exit 127 when the target branch predates the harness (added in #6319): the script is simply not in the checked-out tree. `release/v1.2` is in that state today, and the backport leg of #6910 — the first `release/*`-labeled PR to fire `amber-integration` since the harness landed — is blocked by it:

```
.github/scripts/smoke-boot.sh: No such file or directory
##[error]Process completed with exit code 127.
```
(https://github.com/apache/texera/actions/runs/30297805997/job/90102731299)

This PR keys every boot-smoke step on the script's presence in the checked-out tree, following the workflow's existing tree-adaptive pattern (`if [ -f amber/requirements.txt ]`):

- `amber-integration`: the dist/unzip/smoke-test unit (4 steps) gains `hashFiles('.github/scripts/smoke-boot.sh') != ''` alongside the existing ubuntu-only condition.
- `platform-integration`: the whole job is the boot smoke test, so its dist/unzip/MinIO/LakeFS/smoke steps (5 steps) gain the same guard.

`hashFiles` is evaluated on the runner against the workspace *after* the backport tree swap, so main/PR runs are unaffected (script present → everything runs exactly as before), while backport legs against pre-harness targets skip the steps visibly instead of failing. The guard self-retires the moment `smoke-boot.sh` is backported to the target branch — doing that for `release/v1.2` to restore boot-smoke coverage on its backport legs is a sensible follow-up, but shouldn't hold the currently blocked security backport hostage.

### Any related issues, documentation, discussions?

- Unblocks the `release/v1.2` backport leg of #6910 (torch CVE bump).
- Harness introduced in #6319 / #6274; never backported to `release/v1.2`.

### How was this PR tested?

- `build.yml` parses (`yaml.safe_load`); expression semantics reviewed: `matrix.object_store && hashFiles(...) != ''` preserves the skip for non-object-store services (`null && …` stays falsy).
- The script-present path is exercised by this PR's own CI: touching `.github/**` applies the `ci` label, so all stacks including both smoke jobs run here with the guard evaluating true.
- The skip path can't run pre-merge (it needs a backport leg against `release/v1.2`); after merge it can be observed by re-triggering #6910's Required Checks (e.g. remove and re-add its `release/v1.2` label).

### Was this PR authored or co-authored using generative AI tooling?

Co-authored with Claude Fable 5 in compliance with ASF.