### PR TITLE
fix(deps, pyamber, v1.2): update dependency pillow to v12.3.0 [security]

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -372,7 +372,7 @@ Dependencies under the MIT-CMU License
 --------------------------------------------------------------------------------
 
 Python packages:
-  - pillow==12.2.0
+  - pillow==12.3.0
 
 Individual jars may contain their own META-INF/LICENSE and META-INF/NOTICE
 files that apply to their specific contents; those files continue to govern

--- a/amber/operator-requirements.txt
+++ b/amber/operator-requirements.txt
@@ -18,8 +18,12 @@
 wordcloud==1.9.3
 plotly==5.24.1
 praw==7.6.1
+<<<<<<< HEAD
 pillow==12.2.0
 pybase64==1.3.2
+=======
+pillow==12.3.0
+>>>>>>> 1b9a8c6ee (fix(deps, pyamber): update dependency pillow to v12.3.0 [security] (#6909))
 
 # Pin torch to the CPU wheel on Linux x86_64 to avoid the NVIDIA CUDA deps.
 --extra-index-url https://download.pytorch.org/whl/cpu

--- a/amber/operator-requirements.txt
+++ b/amber/operator-requirements.txt
@@ -18,12 +18,8 @@
 wordcloud==1.9.3
 plotly==5.24.1
 praw==7.6.1
-<<<<<<< HEAD
-pillow==12.2.0
-pybase64==1.3.2
-=======
 pillow==12.3.0
->>>>>>> 1b9a8c6ee (fix(deps, pyamber): update dependency pillow to v12.3.0 [security] (#6909))
+pybase64==1.3.2
 
 # Pin torch to the CPU wheel on Linux x86_64 to avoid the NVIDIA CUDA deps.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
### What changes were proposed in this PR?

Automated backport of #6909 to `release/v1.2`.

Source: 1b9a8c6ee84f96e9c70712171f99b2a209d8709b · [automation run](https://github.com/apache/texera/actions/runs/30315421786)

### Any related issues, documentation, discussions?

Backport of #6909, which fixes multiple Pillow security advisories: CVE-2026-54058, CVE-2026-54059, CVE-2026-54060, CVE-2026-55379, CVE-2026-55798, CVE-2026-59198, CVE-2026-59199, CVE-2026-59205 (see #6909 for full details).

### How was this PR tested?

Release-branch CI runs on this branch once the conflicts are resolved and this PR is marked ready for review.

### Was this PR authored or co-authored using generative AI tooling?

No.
