### PR TITLE
ci: harden backport cherry-pick against package/directory renames

### DIFF
--- a/.github/scripts/create-backport-branch.sh
+++ b/.github/scripts/create-backport-branch.sh
@@ -91,7 +91,13 @@ git checkout -B "${branch}" "origin/${TARGET_BRANCH}"
 # everything turns the unmerged entries into a normal (dirty) commit.
 had_conflict=false
 conflict_files=""
-if ! git cherry-pick --no-commit "${MERGE_SHA}"; then
+# Rename-detection knobs kept identical to prepare-backport-checkout.sh so a
+# green preflight and this branch don't disagree over a package/directory
+# rename. See that script for the rationale behind each setting.
+if ! git -c merge.renameLimit=999999 \
+         -c diff.renameLimit=999999 \
+         -c merge.directoryRenames=true \
+         cherry-pick -Xrename-threshold=40% --no-commit "${MERGE_SHA}"; then
   had_conflict=true
   conflict_files="$(git diff --name-only --diff-filter=U | tr '\n' ' ')"
   log "cherry-pick conflicted in: ${conflict_files}"

--- a/.github/scripts/prepare-backport-checkout.sh
+++ b/.github/scripts/prepare-backport-checkout.sh
@@ -47,4 +47,15 @@ end_tree="$(git rev-parse "${end_sha}^{tree}")"
 squash_sha="$(git commit-tree -p "${start_sha}" -m "ci: squashed backport of ${commit_range}" "${end_tree}")"
 
 git checkout -B "${workspace_branch}" "origin/${target_branch}"
-git cherry-pick -x "${squash_sha}"
+# Rename-detection knobs (kept identical in create-backport-branch.sh so the
+# preflight and the branch it later builds agree): a package/directory rename
+# between main and the release branch would otherwise produce spurious
+# conflicts. Raise the rename limits so Git does not silently skip inexact
+# rename detection when many paths moved; enable directory-rename detection so
+# files this backport *adds* under an old package path follow the rename; and
+# lower the similarity threshold since a rename that also rewrites package/
+# import lines can drop a small file below the 50% default.
+git -c merge.renameLimit=999999 \
+    -c diff.renameLimit=999999 \
+    -c merge.directoryRenames=true \
+    cherry-pick -Xrename-threshold=40% -x "${squash_sha}"

--- a/.github/workflows/direct-backport-push.yml
+++ b/.github/workflows/direct-backport-push.yml
@@ -398,7 +398,14 @@ jobs:
           git checkout -B "${TARGET_BRANCH}" "origin/${TARGET_BRANCH}"
           base_sha=$(git rev-parse HEAD)
           log "base_sha=${base_sha}"
-          if ! git cherry-pick --no-commit "${MERGE_SHA}"; then
+          # Rename-detection knobs kept identical to prepare-backport-checkout.sh
+          # (the preflight) so a rename resolved cleanly there does not conflict
+          # here on the straight-to-release cherry-pick. See that script for the
+          # rationale behind each setting.
+          if ! git -c merge.renameLimit=999999 \
+                   -c diff.renameLimit=999999 \
+                   -c merge.directoryRenames=true \
+                   cherry-pick -Xrename-threshold=40% --no-commit "${MERGE_SHA}"; then
             endgroup
             group "Conflict diagnosis"
             conflicts=$(git diff --name-only --diff-filter=U)


### PR DESCRIPTION
### What changes were proposed in this PR?

The backport automation already uses `git cherry-pick` (a 3-way merge with rename detection), not `patch`/`git apply`, so a renamed file is normally followed to its new path automatically. But every `cherry-pick` call site invokes it **bare**, leaving three merge knobs at defaults that misbehave precisely when a **package/directory rename** lands between `main` and a `release/*` branch — producing spurious conflicts on backports that would otherwise apply cleanly.

This PR wraps all backport `cherry-pick` invocations with the same three settings:

```
git -c merge.renameLimit=999999 \
    -c diff.renameLimit=999999 \
    -c merge.directoryRenames=true \
    cherry-pick -Xrename-threshold=40% ...
```

- **`merge.renameLimit` / `diff.renameLimit`** — Git silently skips inexact rename detection once the number of unpaired added/deleted paths exceeds the limit (warning only). A package-wide rename can blow past the default, degrading renamed files to "deleted + added" so picked hunks land on paths that no longer exist. Raised so detection stays on.
- **`merge.directoryRenames=true`** — the default `conflict` will not auto-place a file the backport *adds* under an old package path into the renamed directory. Backports that add files are common here (see the feature-absent guard in `create-backport-branch.sh`).
- **`-Xrename-threshold=40%`** — a rename that also rewrites `package`/`import` lines can drop a small file's similarity below the 50% default and miss the rename.

Applied **identically** at all three cherry-pick call sites so no stage can disagree with another over a rename:

- `.github/scripts/prepare-backport-checkout.sh` — pre-merge preflight cherry-pick of the squashed range.
- `.github/scripts/create-backport-branch.sh` — post-merge fallback cherry-pick that opens the draft backport PR.
- `.github/workflows/direct-backport-push.yml` — post-merge green path that cherry-picks straight onto the release branch (thanks @xuang7 for catching this one).

Pure configuration passthrough to the merge machinery — no control-flow change, no new dependencies.

### Any related issues, documentation, discussions?

Closes #6963

### How was this PR tested?

This is a configuration-only change to two shell scripts and one workflow's shell step, with no control-flow change. Verified `bash -n` (syntax) on the edited scripts and YAML parse on the workflow. The added `-c` flags and `-Xrename-threshold` are standard, long-supported `git cherry-pick` / merge-machinery options, so behavior on the existing (no-rename) path is unchanged; the new settings only take effect when a rename is present, which is exactly the case that previously conflicted. No unit tests exist for these CI helper scripts, and the real end-to-end path (backport preflight + Direct Backport Push) exercises them on the next backport-labeled PR.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)
