### PR TITLE
fix(docs): use a plain year range in NOTICE copyright

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/access-control-service/NOTICE-binary
+++ b/access-control-service/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/amber/NOTICE-binary
+++ b/amber/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/computing-unit-managing-service/NOTICE-binary
+++ b/computing-unit-managing-service/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/config-service/NOTICE-binary
+++ b/config-service/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/file-service/NOTICE-binary
+++ b/file-service/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/notebook-migration-service/NOTICE-binary
+++ b/notebook-migration-service/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/workflow-compiling-service/NOTICE-binary
+++ b/workflow-compiling-service/NOTICE-binary
@@ -1,5 +1,5 @@
 Apache Texera (Incubating)
-Copyright 2025 and onwards The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
### What changes were proposed in this PR?

Per ASF policy [1], the NOTICE copyright line should use a plain year
range, not "and onwards". Changed `Copyright 2025 and onwards The Apache
Software Foundation` to `Copyright 2025-2026 The Apache Software Foundation`
in the root `NOTICE` and all `*/NOTICE-binary` files.

[1] https://www.apache.org/legal/src-headers.html#notice

### Any related issues, documentation, discussions?

Closes #6981. To be backported to `release/v1.2` for RC4.

### How was this PR tested?

Text-only change; CI license/NOTICE checks pass with no generator drift.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)