### PR TITLE
fix(deps, ci, v1.2): bump sbt/setup-sbt to v1.5.2 for ASF actions allowlist

### DIFF
--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -126,7 +126,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
 
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:
@@ -328,7 +328,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
 
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:
@@ -408,7 +408,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
 
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
         env:
           PGPASSWORD: postgres
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
@@ -391,7 +391,7 @@ jobs:
         env:
           PGPASSWORD: postgres
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
@@ -585,7 +585,7 @@ jobs:
           distribution: "temurin"
           java-version: 17
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
       - uses: coursier/cache-action@90c37294538be80a558fd665531fcdc2b467b475 # v8.1.0
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'


### PR DESCRIPTION
### What changes were proposed in this PR?

`release/v1.2` pins `sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41` (v1.1.22), which is **not on the ASF GitHub Enterprise actions allowlist**. GitHub rejects the workflow while building the graph, so the **Required Checks** workflow ends in `startup_failure` and no CI runs on `release/v1.2` — the `precheck` job never executes, which is why CI appears to "not trigger by label".

This bumps all 6 pins to the allowlisted version already used on `main` (green there):

```
- sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
+ sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
```

- `.github/workflows/build.yml` (×3)
- `.github/workflows/build-and-push-images.yml` (×3)

Minimal targeted change rather than backporting the large github-actions group bump (#6187), which touches 15 actions across 17 files and conflicts heavily against v1.2.

### Any related issues, documentation, discussions?

Fixes #6989. `main` reached v1.5.2 via #6710 (`d28b761ae`). Unblocks backport PRs #6982 and #6984.

### How was this PR tested?

This PR's own Required Checks run is the test: because the head branch already uses the allowlisted `sbt/setup-sbt@6444f4c8` (v1.5.2), the workflow should now start successfully instead of `startup_failure`. Diff is limited to the 6 action pins (verified no other `508b753e` references remain in `.github/workflows/`).

### Was this PR authored or co-authored using generative AI tooling?

Yes — authored with Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
