### PR TITLE
fix(BarChart, v1.2): treat an empty categoryColumn as no category (px.bar color) 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -109,7 +109,9 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
       isPatternSelected = "True"
 
     var isCategoryColumn = "False"
-    if (categoryColumn != "No Selection")
+    // "" is the Scala default ("No Selection" is only JSON metadata); an empty
+    // column must also count as "no category", else px.bar(color="") fails.
+    if (categoryColumn.nonEmpty && categoryColumn != "No Selection")
       isCategoryColumn = "True"
 
     val finalCode =

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/barChart/BarChartOpDescSpec.scala
@@ -110,4 +110,14 @@ class BarChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
     ex.getMessage should (include("Value column") or include("Fields"))
   }
 
+  "BarChartOpDesc.generatePythonCode" should "treat an unset categoryColumn as no category (color guarded to None)" in {
+    // An empty categoryColumn (its Scala default) must guard color to None, not
+    // emit `... if True else None` with an empty column name for px.bar(color=).
+    opDesc.value = "score"
+    opDesc.fields = "name"
+    val code = opDesc.generatePythonCode()
+    code should include("color=self.decode_python_template('') if False else None")
+    code should not include "color=self.decode_python_template('') if True else None"
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6807 to `release/v1.2`, cherry-picked from c24755c98e0d17b07712ee677ee9ddd7d33ccb68. The cherry-pick applied cleanly.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) per a backport-coverage audit.

### Any related issues, documentation, discussions?

Backport of #6807. Originally linked #6792.

### How was this PR tested?

Release-branch CI runs on this PR. Cherry-pick applied cleanly onto `release/v1.2`; no manual conflict resolution was needed.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; the change itself is #6807 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)