### PR TITLE
fix(v1.2): Correct FilledAreaPlot x-value validation across groups 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -121,7 +121,7 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
        |                if x_values == None:
        |                    x_values = set(group[$x].unique())
        |                elif set(group[$x].unique()).intersection(x_values):
-       |                    X_values = x_values.union(set(group[$x].unique()))
+       |                    x_values = x_values.union(set(group[$x].unique()))
        |                elif not set(group[$x].unique()).intersection(x_values):
        |                    count += 1
        |                    if count > tolerance:


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6894 to `release/v1.2`, cherry-picked from bb7af8df3585a33ad1bd6485846313c1df1259d0. The cherry-pick applied cleanly.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) per a backport-coverage audit.

### Any related issues, documentation, discussions?

Backport of #6894. Originally linked #6728.

### How was this PR tested?

Release-branch CI runs on this PR. Cherry-pick applied cleanly onto `release/v1.2`; no manual conflict resolution was needed.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; the change itself is #6894 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)