### PR TITLE
fix(k8s, v1.2): add missing AUTH_JWT_SECRET to values-development.yaml 

### DIFF
--- a/bin/k8s/values-development.yaml
+++ b/bin/k8s/values-development.yaml
@@ -352,6 +352,12 @@ texeraEnvVars:
     value: ""
   - name: USER_SYS_DOMAIN
     value: ""
+  - name: AUTH_JWT_SECRET
+    # Obvious non-secret placeholder for LOCAL DEVELOPMENT ONLY (64 chars = 512-bit
+    # HMAC key, well above the 256-bit HS256 minimum). All services must share the
+    # same value, so this is a fixed shared string rather than a per-pod random one.
+    # Production environments MUST override this with a securely generated secret.
+    value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 yWebsocketServer:
   name: y-websocket-server


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6610 to `release/v1.2`, cherry-picked from f14cd3975e7446b77241990b7d573d182d61f88f. The cherry-pick applied cleanly.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) per a backport-coverage audit.

### Any related issues, documentation, discussions?

Backport of #6610.

### How was this PR tested?

Release-branch CI runs on this PR. Cherry-pick applied cleanly onto `release/v1.2`; no manual conflict resolution was needed.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; the change itself is #6610 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)