### PR TITLE
fix(workflow-operator, v1.2): set alreadyClosed before onClose 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/AutoClosingIterator.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/scan/AutoClosingIterator.scala
@@ -35,8 +35,8 @@ class AutoClosingIterator[T](iter: Iterator[T], onClose: () => Unit) extends Ite
   override def hasNext: Boolean = {
     val hn = iter.hasNext
     if (!hn && !alreadyClosed) {
-      onClose()
       alreadyClosed = true
+      onClose()
     }
     hn
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #5678 to `release/v1.2`, cherry-picked from 1a65a3168c5ffbd171e8ed0d64dec495e45c1b24.

**Source fix only.** The test changes from #5678 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #5678. Originally linked #5660.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #5678 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)