### PR TITLE
fix(computing-unit, v1.2): return 404 instead of 500 when getOwner is called for a nonexistent unit 

### DIFF
--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitAccessResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitAccessResource.scala
@@ -205,7 +205,10 @@ class ComputingUnitAccessResource {
       val workflowComputingUnitDao = new WorkflowComputingUnitDao(ctx.configuration())
       val unit = workflowComputingUnitDao.fetchOneByCuid(cuid)
       if (unit == null) {
-        throw new IllegalArgumentException("Computing unit does not exist")
+        // JAX-RS exception so it maps to 404: the service registers no ExceptionMapper
+        // for IllegalArgumentException, which would otherwise surface as an HTTP 500.
+        // Message style matches ComputingUnitManagingResource's nonexistent-unit error.
+        throw new NotFoundException(s"Computing unit with cuid=$cuid does not exist.")
       }
 
       val uid = unit.getUid


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6612 to `release/v1.2`, cherry-picked from 3a671c31ffe7f5a48da5b2e98841b0d55e176acc.

**Source fix only.** The test changes from #6612 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6612. Originally linked #6475.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6612 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)