### PR TITLE
fix(MachineLearningScorer, v1.2): splice metric_list verbatim instead of double-encoding 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
@@ -122,8 +122,10 @@ class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
       case _                           => throw new IllegalArgumentException("Unknown metric type")
     }
 
-  private def getSelectedMetrics(): EncodableString = {
-    // Return a string of metrics using the getEachScorerName() method
+  // Must be a plain String, not EncodableString: this is a raw Python fragment
+  // spliced verbatim into `metric_list = [...]`. An EncodableString would be
+  // re-encoded as one quoted value, collapsing the list into a single element.
+  private def getSelectedMetrics(): String = {
     val metric = if (isRegression) regressionMetrics else classificationMetrics
     metric.map(metric => getMetricName(metric)).mkString("'", "','", "'")
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6805 to `release/v1.2`, cherry-picked from 3a51bfb8761e96d10460f097b0e1803e27c2c5d0.

**Source fix only.** The test changes from #6805 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6805. Originally linked #6790.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6805 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)