### PR TITLE
fix(TablesPlot, v1.2): join selected columns with a comma to emit valid Python 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
@@ -36,7 +36,10 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
   var includedColumns: List[TablesConfig] = List()
 
   private def getAttributes: String =
-    includedColumns.map(c => pyb"""${c.attributeName}""").mkString("','")
+    // Join with a plain comma: each column renders to a decode_python_template(...)
+    // call, so joining with the literal ',' would put a string right after a call
+    // and produce invalid Python.
+    includedColumns.map(c => pyb"""${c.attributeName}""").mkString(",")
 
   def manipulateTable(): PythonTemplateBuilder = {
     assert(includedColumns.nonEmpty)


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6806 to `release/v1.2`, cherry-picked from 991608a3ad41a21fbd4a32cc981ac95be26b958a.

**Source fix only.** The test changes from #6806 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6806. Originally linked #6791.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6806 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)