### PR TITLE
fix(LogicalOp, v1.2): register SklearnLogisticRegression(CV) subtypes exactly once 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/LogicalOp.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/LogicalOp.scala
@@ -351,11 +351,6 @@ trait StateTransferFunc
       value = classOf[SklearnTrainingLogisticRegressionCVOpDesc],
       name = "SklearnTrainingLogisticRegressionCV"
     ),
-    new Type(value = classOf[SklearnLogisticRegressionOpDesc], name = "SklearnLogisticRegression"),
-    new Type(
-      value = classOf[SklearnLogisticRegressionCVOpDesc],
-      name = "SklearnLogisticRegressionCV"
-    ),
     new Type(value = classOf[SklearnRidgeOpDesc], name = "SklearnRidge"),
     new Type(value = classOf[SklearnRidgeCVOpDesc], name = "SklearnRidgeCV"),
     new Type(value = classOf[SklearnSDGOpDesc], name = "SklearnSDG"),


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6808 to `release/v1.2`, cherry-picked from e81ba0ea478b131a88335dbbeadfb0229ff008ed.

**Source fix only.** The test changes from #6808 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6808. Originally linked #6793.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6808 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)