### PR TITLE
fix(workflow-operator, v1.2): qualify the AsterixDB FROM clause; add AsterixDBSourceOpExec unit tests 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/asterixdb/AsterixDBSourceOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/asterixdb/AsterixDBSourceOpExec.scala
@@ -308,7 +308,7 @@ class AsterixDBSourceOpExec private[asterixdb] (
       .map((entry: (String, Int)) => {
         s"if_missing(${entry._1},null) field_${entry._2}"
       })
-      .mkString(", ")} FROM $desc.database.$desc.table WHERE 1 = 1 "
+      .mkString(", ")} FROM ${desc.database}.${desc.table} WHERE 1 = 1 "
   }
 
   override def addLimit(queryBuilder: StringBuilder): Unit = {


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6878 to `release/v1.2`, cherry-picked from 52584a80cef1c9b9ee67b8083b617bf654be806e.

**Source fix only.** The test changes from #6878 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6878. Originally linked #6875.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6878 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)