### PR TITLE
fix(workflow-operator, v1.2): fall back to day semantics for an unset interval type; extend aggregate and interval-join tests 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/intervalJoin/IntervalJoinOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/intervalJoin/IntervalJoinOpExec.scala
@@ -210,7 +210,11 @@ class IntervalJoinOpExec(descString: String) extends OperatorExecutor {
             Timestamp.valueOf(leftBoundValue.toLocalDateTime.plusMinutes(desc.constant))
           case Some(TimeIntervalType.SECOND) =>
             Timestamp.valueOf(leftBoundValue.toLocalDateTime.plusSeconds(desc.constant))
-          case None =>
+          case _ =>
+            // Unset interval type falls back to day semantics. This has to be a
+            // catch-all rather than `case None`: an absent JSON field
+            // deserializes to Some(null), not None, so matching only on None
+            // threw a MatchError instead of taking the fallback.
             Timestamp.valueOf(leftBoundValue.toLocalDateTime.plusDays(desc.constant))
         }
       result = processNumValue(


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6907 to `release/v1.2`, cherry-picked from 03a0e3a3b12424b99fa829d56fdb0a7512c6f173.

**Source fix only.** The test changes from #6907 were omitted: the touched test spec(s) do not exist on `release/v1.2` (or depend on main-only test infrastructure), so backporting them cleanly is not possible. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6907. Originally linked #6901.

### How was this PR tested?

Release-branch CI runs on this PR. The source change cherry-picked cleanly; test changes were intentionally dropped (see above).

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6907 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)