### PR TITLE
fix(computing-unit, v1.2): fix 500s in share/revoke (unknown email + privilege change) 

### DIFF
--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitAccessResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitAccessResource.scala
@@ -113,6 +113,19 @@ class ComputingUnitAccessResource {
   }
   final private val userDao = new UserDao(context.configuration())
 
+  /**
+    * Resolves an email to its user id, throwing a JAX-RS BadRequestException (400) when no
+    * account matches — the service registers no ExceptionMapper for IllegalArgumentException,
+    * so that would otherwise surface as an opaque HTTP 500. Shared by grant/revoke.
+    */
+  private def resolveUidByEmail(email: String): Integer = {
+    val user = userDao.fetchOneByEmail(email)
+    if (user == null) {
+      throw new BadRequestException("User with the given email does not exist")
+    }
+    user.getUid
+  }
+
   @GET
   @Produces(Array(MediaType.APPLICATION_JSON))
   @Path("/computing-unit/list/{cuid}")
@@ -148,14 +161,10 @@ class ComputingUnitAccessResource {
   ): Unit = {
     ensureSharingIsEnabled()
     if (!hasWriteAccess(cuid, user.getUid)) {
-      throw new IllegalArgumentException("User does not have permission to grant access")
+      throw new ForbiddenException("User does not have permission to grant access")
     }
 
-    // TODO: add try except and check how to display error message in the frontend
-    val granteeId = userDao.fetchOneByEmail(email).getUid
-    if (granteeId == null) {
-      throw new IllegalArgumentException("User with the given email does not exist")
-    }
+    val granteeId = resolveUidByEmail(email)
 
     withTransaction(context) { ctx =>
       val computingUnitUserAccessDao = new ComputingUnitUserAccessDao(ctx.configuration())
@@ -163,7 +172,10 @@ class ComputingUnitAccessResource {
       access.setCuid(cuid)
       access.setUid(granteeId)
       access.setPrivilege(privilege)
-      computingUnitUserAccessDao.insert(access)
+      // merge (upsert) rather than insert: re-granting an existing grantee updates
+      // their privilege in place instead of hitting a duplicate-primary-key error
+      // (the (cuid, uid) PK). Mirrors DatasetAccessResource/WorkflowAccessResource.
+      computingUnitUserAccessDao.merge(access)
     }
   }
 
@@ -176,13 +188,10 @@ class ComputingUnitAccessResource {
   ): Unit = {
     ensureSharingIsEnabled()
     if (!hasWriteAccess(cuid, user.getUid)) {
-      throw new IllegalArgumentException("User does not have permission to revoke access")
+      throw new ForbiddenException("User does not have permission to revoke access")
     }
 
-    val granteeId = userDao.fetchOneByEmail(email).getUid
-    if (granteeId == null) {
-      throw new IllegalArgumentException("User with the given email does not exist")
-    }
+    val granteeId = resolveUidByEmail(email)
 
     withTransaction(context) { ctx =>
       ctx


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6446 to `release/v1.2`, cherry-picked from 8df38afe777b1240c5c9263fb16862ccb199f441.

**Source fix only.** #'s test and its test-only build dependency (`configs(Test).dependsOn(DAO % "test->test")`) are omitted — the test spec does not exist on `release/v1.2`. Only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6446. Originally linked #6445.

### How was this PR tested?

Release-branch CI runs on this PR.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (cherry-pick + manual conflict resolution; the change itself is #6446 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)