### PR TITLE
fix(QuiverPlot, RangeSlider, v1.2): retarget numeric attributeTypeRules to real fields 

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
@@ -33,7 +33,16 @@ import org.apache.texera.amber.pybuilder.PythonTemplateBuilder
 @JsonSchemaInject(json = """
 {
   "attributeTypeRules": {
-    "value": {
+    "x": {
+      "enum": ["integer", "long", "double"]
+    },
+    "y": {
+      "enum": ["integer", "long", "double"]
+    },
+    "u": {
+      "enum": ["integer", "long", "double"]
+    },
+    "v": {
       "enum": ["integer", "long", "double"]
     }
   }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/rangeSlider/RangeSliderOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/rangeSlider/RangeSliderOpDesc.scala
@@ -32,11 +32,12 @@ import org.apache.texera.amber.pybuilder.PythonTemplateBuilder
 
 import javax.validation.constraints.NotNull
 
-// type constraint: value can only be numeric
+// type constraint: Y-axis is aggregated (mean/sum), so it must be numeric;
+// X-axis is only a grouping key and may be any type.
 @JsonSchemaInject(json = """
 {
   "attributeTypeRules": {
-    "value": {
+    "Y-axis": {
       "enum": ["integer", "long", "double"]
     }
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6810 to `release/v1.2`, cherry-picked from 1c411dedaad2bb8bd8fd4f5301843ae1f2f1c781.

**Source fix only.** Test changes from #6810 were omitted (the touched specs do not exist on `release/v1.2` or depend on main-only test infrastructure); only the source fix is carried over, per maintainer guidance.

### Any related issues, documentation, discussions?

Backport of #6810. Originally linked #6795.

### How was this PR tested?

Release-branch CI runs on this PR. Source change cherry-picked cleanly; test changes intentionally dropped.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick + conflict resolution; the change itself is #6810 by its original author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)