### PR TITLE
fix(ci): rename backport auto-label output so its report step runs

### DIFF
--- a/.github/workflows/backport-auto-label.yml
+++ b/.github/workflows/backport-auto-label.yml
@@ -284,9 +284,13 @@ jobs:
 
             // Only hand work to the report step when there is something to say;
             // a "none" outcome leaves the output unset so that step is skipped.
+            // The output is named `decisions`, not `result`: actions/github-script
+            // always writes the script's return value to an output called `result`
+            // after the body runs, which would clobber an explicit setOutput of the
+            // same name (this script returns nothing, so that would blank it out).
             const result = await decide();
             if (result.mode !== "none") {
-              core.setOutput("result", JSON.stringify(result));
+              core.setOutput("decisions", JSON.stringify(result));
             }
 
       # Report step: runs under the default GITHUB_TOKEN so the review request
@@ -294,10 +298,10 @@ jobs:
       # retrigger comment-/review-driven workflows. It only touches the PR when
       # the label step handed it something to say.
       - name: Report backport decisions
-        if: ${{ steps.label.outputs.result }}
+        if: ${{ steps.label.outputs.decisions }}
         uses: actions/github-script@v9
         env:
-          RESULT: ${{ steps.label.outputs.result }}
+          RESULT: ${{ steps.label.outputs.decisions }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
### What changes were proposed in this PR?

The `Report backport decisions` step in `backport-auto-label.yml` is skipped on every run, so the report comment and release-manager review request added in #6962 never fire.

Root cause: the step's guard reads `steps.label.outputs.result`. `actions/github-script` always writes the script's return value to an output named `result` after the body runs. The `Label fix PRs` script has no `return`, so that post-run write blanks out the explicit `core.setOutput("result", …)` — the guard is therefore always false.

Fix: rename the output to `decisions` (github-script only reserves `result`), and update the guard and the `RESULT` env reference to match. No logic in either step changes.

### Any related issues, documentation, discussions?

Closes #7021.

### How was this PR tested?

- Confirmed the failure on run `30423275226` (PR #7013): the `Report backport decisions` step shows `skipped`.
- Verified 0 `<!-- backport-auto-label-report -->` comments across #7013, #6983, #6958, #6908 (including PRs that were auto-labeled), confirming the step is systemically skipped.
- Change is name-only; the report/review logic is untouched, so it runs unchanged once the guard sees the output.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
