### PR TITLE
ci: skip contributor template check for renovate-bot's User account

### DIFF
--- a/.github/workflows/contributor-checks.yml
+++ b/.github/workflows/contributor-checks.yml
@@ -51,7 +51,13 @@ permissions:
 
 jobs:
   contributor-checks:
-    if: github.event.sender.type != 'Bot'
+    # Skip automated PR/issue openers. GitHub App bots (e.g. dependabot)
+    # have sender.type == 'Bot', but Renovate runs under a regular User
+    # account (`renovate-bot`, type: User) and would otherwise be nagged
+    # for not following the template, so exclude it explicitly by login.
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      github.event.sender.login != 'renovate-bot'
     runs-on: ubuntu-latest
     steps:
       # pull_request_target and issues both resolve to the trusted base


### PR DESCRIPTION
### What changes were proposed in this PR?

The `contributor-checks` job in `.github/workflows/contributor-checks.yml` gates on `github.event.sender.type != 'Bot'` so it won't nag automated PR/issue openers about not following the contribution template.

That gate catches GitHub App bots (e.g. `dependabot[bot]`, whose account `type` is `Bot`) but **not** Renovate, which on this repo runs under a regular User account: `renovate-bot` has `type: User`, so it slips through and gets the "the description doesn't follow our template" warning on every dependency-update PR (example: #7060).

This PR excludes `renovate-bot` explicitly by login:

```yaml
if: >-
  github.event.sender.type != 'Bot' &&
  github.event.sender.login != 'renovate-bot'
```

### Any related issues, documentation, discussions?

Closes #7063.

Example of the false warning: #7060.

### How was this PR tested?

- Confirmed via the GitHub API that `renovate-bot` has `type: User` (not `Bot`), which is why the existing `sender.type != 'Bot'` gate did not exclude it.
- Validated the workflow YAML parses and the folded `if:` expression resolves to the intended single-line condition.
- The change is confined to the job-level `if:` gate; no `run:` step or untrusted-input interpolation is touched.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8)