### PR TITLE
ci: align renovate amber scopes (amber vs pyamber)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -70,9 +70,19 @@
       matchFileNames: ['bin/y-websocket-server/**'],
       semanticCommitScope: 'deps, y-websocket-server',
     },
+    // amber/ holds both the Scala engine and the Python (pyamber) worker,
+    // so the old blanket `pyamber` scope mislabeled Scala bumps. Split by
+    // manager: Python requirement bumps stay `pyamber`, Scala (sbt) bumps
+    // get `amber` (the directory's own name, not the Python-specific one).
     {
       matchFileNames: ['amber/**'],
+      matchManagers: ['pip_requirements'],
       semanticCommitScope: 'deps, pyamber',
+    },
+    {
+      matchFileNames: ['amber/**'],
+      matchManagers: ['sbt'],
+      semanticCommitScope: 'deps, amber',
     },
 
     // Patch bumps grouped into one weekly PR per area. Minor bumps are
@@ -101,6 +111,7 @@
     },
     {
       matchFileNames: ['amber/**'],
+      matchManagers: ['pip_requirements'],
       matchUpdateTypes: ['patch'],
       groupName: 'pyamber patch updates',
     },
@@ -131,6 +142,7 @@
     },
     {
       matchFileNames: ['amber/**'],
+      matchManagers: ['pip_requirements'],
       matchUpdateTypes: ['minor'],
       groupName: 'pyamber minor updates',
     },


### PR DESCRIPTION
### What changes were proposed in this PR?

`.github/renovate.json5` scoped and grouped **every** `amber/**` dependency bump as `pyamber`. But `amber/` holds both the Scala engine and the Python (pyamber) worker: `amber/build.sbt` alone declares ~80 versioned Scala deps. So an amber Scala dependency PR landed a `chore(deps, pyamber)` commit even though it is not a Python change, and amber sbt minors were grouped into "pyamber minor updates" instead of staying individual like every other sbt minor.

This splits the amber rules by Renovate manager:
- `pip_requirements` → `deps, pyamber` (unchanged intent)
- `sbt` → `deps, amber` (the directory's own name, not the Python-specific one)

As a side effect amber sbt patches now fall through to the shared `sbt patch updates` group and amber sbt minors stay individual, matching the config's own stated intent for sbt minors.

### Any related issues, documentation, discussions?

Closes #7067

### How was this PR tested?

- `renovate-config-validator` passes on the updated config.
- Manually traced each amber manager/update-type through the rules to confirm Scala bumps now scope `amber` and Python bumps stay `pyamber`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
