### PR TITLE
fix(ci): type routine Renovate bumps as chore, drop [security] suffix

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -46,6 +46,9 @@
   osvVulnerabilityAlerts: true,
   vulnerabilityAlerts: {
     semanticCommitType: 'fix',
+    // Drop Renovate's default `[SECURITY]` title suffix; the `security`
+    // label below already identifies these PRs.
+    commitMessageSuffix: '',
     // release/v1.2 flags the fix for backporting to the current release
     // line; bump it when a new release branch is cut.
     labels: ['dependencies', 'security', 'release/v1.2'],
@@ -160,6 +163,17 @@
       matchPackageNames: ['/^@angular/', '@schematics/angular'],
       matchUpdateTypes: ['major'],
       enabled: false,
+    },
+
+    // config:recommended pulls in :semanticPrefixFixDepsChoreOthers,
+    // which types runtime-dependency bumps as fix(...). We want the
+    // opposite: every routine bump is chore(...), and only
+    // vulnerabilityAlerts (above) uses fix(...). This catch-all runs
+    // last, so it overrides that preset; vulnerabilityAlerts is applied
+    // as a higher-priority layer for security branches and is unaffected.
+    {
+      matchPackageNames: ['*'],
+      semanticCommitType: 'chore',
     },
   ],
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Two corrections to `.github/renovate.json5`:

1. **Routine bumps are now `chore(...)`.** `extends: ['config:recommended']` pulls in the [`:semanticPrefixFixDepsChoreOthers`](https://docs.renovatebot.com/presets-default/) preset, whose `packageRules` type runtime dependencies as `fix` and override our top-level `semanticCommitType: 'chore'`. So routine, non-security majors came through as `fix(...)` — e.g. #7060 (ng-zorro-antd v22), #7059 (fuse.js v7) — while devDependency bumps correctly stayed `chore(...)`. A catch-all rule (`matchPackageNames: ['*'] → chore`) now runs last and overrides the preset.
2. **Drop the `[security]` title suffix.** `commitMessageSuffix: ''` inside `vulnerabilityAlerts` removes Renovate's default `[SECURITY]` suffix; the `security` label already identifies those PRs.

Resulting behavior:

- Routine bump → `chore(deps, ...): ...`
- Vulnerability fix → `fix(deps, ...): ...` + `security` label (no `[security]` suffix)

`vulnerabilityAlerts` is applied as a higher-priority layer for security branches, so it keeps its `fix` type regardless of the catch-all.

### Any related issues, documentation, discussions?

Fixes #7071. The mis-typed routine PRs that surfaced this: #7060, #7059.

### How was this PR tested?

Validated with the official `renovate-config-validator` (`npx --package renovate -- renovate-config-validator .github/renovate.json5`), which reported `Config validated successfully`. No unit tests apply to a Renovate configuration change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
