### PR TITLE
chore(ci): remove ci-enable/** push trigger from CI workflows

### DIFF
--- a/.github/workflows/check-header.yml
+++ b/.github/workflows/check-header.yml
@@ -19,7 +19,6 @@ name: Release Auditing
 on:
   push:
     branches:
-      - 'ci-enable/**'
       - 'main'
   pull_request:
   merge_group:

--- a/.github/workflows/required-checks.yml
+++ b/.github/workflows/required-checks.yml
@@ -20,7 +20,6 @@ name: Required Checks
 on:
   push:
     branches:
-      - 'ci-enable/**'
       - 'main'
       - 'release/**'
   pull_request:


### PR DESCRIPTION
### What changes were proposed in this PR?

Removes the `ci-enable/**` entry from the `push.branches` list in two CI workflows:

- `.github/workflows/required-checks.yml` (Required Checks)
- `.github/workflows/check-header.yml` (Release Auditing)

The `ci-enable/*` branch namespace was a manual escape hatch for triggering CI on a scratch branch without opening a PR. It is no longer used — CI runs through PRs and the merge queue — so the trigger is dropped. Both workflows still run on `main`, PRs, and the merge group (Required Checks additionally on `release/**`).

### Any related issues, documentation, discussions?

Closes #7081

### How was this PR tested?

- Diff is trigger-only; no job logic changed.
- Confirmed the remaining `push`/`pull_request`/`merge_group` triggers still cover main, PRs, and the merge queue.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
