### PR TITLE
chore(ci): exclude release/v1.1.0-incubating from branch protection, drop stale xuang7 bypass

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -108,27 +108,22 @@ github:
               - context: Validate PR title
 
     - name: "Default Branch Protection"
-      target: branch
-      enforcement: active
-      conditions:
-        ref_name:
-          include:
-            - "~DEFAULT_BRANCH"
-            - "refs/heads/release/*"
-            - "refs/heads/rel/*"
-          exclude: []
-      bypass_actors:
-        # apache/root — ASF Infra team.
-        - actor_id: 118420
-          actor_type: Team
-          bypass_mode: always
-        # xuang7 — granted bypass as the v1.2 release manager.
-        - actor_id: 162244362
-          actor_type: User
-          bypass_mode: always
-      rules:
-        - type: deletion
-        - type: non_fast_forward
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes:
+          # TEMPORARY: exclude release/v1.1.0-incubating for manual
+          # release-branch maintenance; remove this entry to restore its
+          # deletion / force-push protection. All other release/* and
+          # rel/* branches stay protected.
+          - "release/v1.1.0-incubating"
+      bypass_teams:
+        - "root" # apache/root — ASF Infra team
+      restrict_deletion: true
+      restrict_force_push: true
 notifications:
   commits: commits@texera.apache.org
   issues: notifications@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?

Rework the `Default Branch Protection` ruleset in `.asf.yaml`:

1. **Exclude one release branch for maintenance.** Add `release/v1.1.0-incubating` to the ruleset's `branches.excludes`, so `deletion` / `non_fast_forward` are no longer enforced on that branch — enabling manual release-branch maintenance. All other `release/*` and `rel/*` branches and the default branch stay protected (exclude wins over include only for the listed ref). Remove the exclude entry to restore protection.
2. **Drop the stale `xuang7` bypass.** Remove the `xuang7` bypass actor, granted as the v1.2 release manager and no longer used.
3. **Use the default notation for the Infra bypass.** Express the retained ASF Infra bypass via the asfyaml convenience syntax (`bypass_teams: [root]`) instead of a raw numeric `actor_id`. asfyaml rejects mixing convenience keys into a raw payload, so the whole ruleset moves to convenience form; the resulting GitHub ruleset is unchanged apart from the exclude.

> **Temporary:** item 1 is meant to be reverted once the release-branch work is done.

### Any related issues, documentation, discussions?

Fixes #7085.

### How was this PR tested?

Parsed `.asf.yaml` with a YAML loader to confirm valid syntax and the resulting ruleset: `branches.includes` is `[~DEFAULT_BRANCH, release/*, rel/*]` and `branches.excludes` is `[release/v1.1.0-incubating]`, `bypass_teams` is `[root]`. Cross-checked the raw-vs-convenience handling against the asfyaml source (`asfyaml/feature/github/rulesets.py`): the convenience form normalizes to the same GitHub Rulesets API payload as the existing raw `Merge Queue` ruleset. `.asf.yaml` is not covered by unit tests; ASF Infra applies it from the default branch.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
