### PR TITLE
fix(pyamber): measure elapsed time for the TimedBuffer flush interval

### DIFF
--- a/amber/src/main/python/core/util/buffer/timed_buffer.py
+++ b/amber/src/main/python/core/util/buffer/timed_buffer.py
@@ -36,7 +36,7 @@ class TimedBuffer(IBuffer):
         if (
             flush
             or len(self._buffer) >= self._max_message_num
-            or (datetime.now() - self._last_output_time).seconds
+            or (datetime.now() - self._last_output_time).total_seconds()
             >= self._max_flush_interval_in_ms / 1000
         ):
             self._last_output_time = datetime.now()

--- a/amber/src/test/python/core/util/buffer/test_timed_buffer.py
+++ b/amber/src/test/python/core/util/buffer/test_timed_buffer.py
@@ -130,8 +130,8 @@ class TestFlushOnSize:
 
 class TestFlushOnTime:
     def test_elapsed_interval_triggers_flush(self, clock):
-        # Interval of 2000ms -> 2.0s threshold. timedelta.seconds is an
-        # integer, so 3 whole seconds (>= 2.0) triggers the time-based flush.
+        # Interval of 2000ms -> 2.0s threshold, so 3 seconds triggers the
+        # time-based flush.
         buffer = TimedBuffer(max_message_num=100, max_flush_interval_in_ms=2000)
         buffer.put(_make_message())
         _advance(clock, 3)
@@ -165,6 +165,31 @@ class TestFlushOnTime:
         # Clock not advanced at all.
         assert list(buffer.get()) == []
         assert len(buffer._buffer) == 1
+
+    def test_sub_second_interval_triggers_flush(self, clock):
+        # The default interval is 500ms, so sub-second thresholds are the
+        # common case. 0.6s is past a 0.5s threshold.
+        buffer = TimedBuffer(max_message_num=100, max_flush_interval_in_ms=500)
+        buffer.put(_make_message())
+        _advance(clock, 0.6)
+        assert len(list(buffer.get())) == 1
+        assert len(buffer._buffer) == 0
+
+    def test_sub_second_interval_withholds_before_the_threshold(self, clock):
+        buffer = TimedBuffer(max_message_num=100, max_flush_interval_in_ms=500)
+        buffer.put(_make_message())
+        _advance(clock, 0.4)
+        assert list(buffer.get()) == []
+        assert len(buffer._buffer) == 1
+
+    def test_whole_day_elapsed_triggers_flush(self, clock):
+        # timedelta carries whole days separately from the seconds field, so
+        # an exact multiple of 24h must still count as elapsed time.
+        buffer = TimedBuffer(max_message_num=100, max_flush_interval_in_ms=2000)
+        buffer.put(_make_message())
+        _advance(clock, 86400)
+        assert len(list(buffer.get())) == 1
+        assert len(buffer._buffer) == 0
 
 
 class TestDefaults:


### PR DESCRIPTION
### What changes were proposed in this PR?

**Root cause.** `TimedBuffer`'s elapsed-time check reads `timedelta.seconds`, which is the *seconds component* (an integer in `[0, 86399)`, with whole days carried separately in `.days`), not the elapsed time. The elapsed time is `.total_seconds()`.

```diff
- or (datetime.now() - self._last_output_time).seconds
+ or (datetime.now() - self._last_output_time).total_seconds()
      >= self._max_flush_interval_in_ms / 1000
```

**Before → after.**

| elapsed | `.seconds` (before) | `.total_seconds()` (after) | 500 ms threshold |
| --- | ---: | ---: | --- |
| 400 ms | `0` | `0.4` | withhold → withhold |
| 999 ms | `0` | `0.999` | withhold → **flush** |
| 24 h exactly | `0` | `86400.0` | withhold → **flush** |

The user-visible effect is that every flush interval below 1000 ms was silently rounded up to a full second. The default is `max_flush_interval_in_ms=500`, so console output from a Python UDF reached the UI in roughly twice the configured interval. Separately, at exact multiples of 24h the component wraps back to `0`, so an idle buffer withheld instead of flushing.

Nothing was lost — messages just arrived late — which is why this went unnoticed.

**Why the existing tests missed it.** Every case in `TestFlushOnTime` advanced the fake clock by whole seconds (1s, 3s), where `.seconds` and `.total_seconds()` agree. Three tests are added to close that gap, pinning both directions and the day-boundary edge case:

| new test | before | after |
| --- | --- | --- |
| `test_sub_second_interval_triggers_flush` (0.6s past a 0.5s threshold) | ❌ fails | ✅ passes |
| `test_sub_second_interval_withholds_before_the_threshold` (0.4s) | ✅ passes | ✅ passes |
| `test_whole_day_elapsed_triggers_flush` (86400s) | ❌ fails | ✅ passes |

I also dropped a stale comment in `test_elapsed_interval_triggers_flush` that documented the buggy behaviour as if it were intended.

### Any related issues, documentation, discussions?

Closes #7089

### How was this PR tested?

Written test-first: the two new failing tests were added and confirmed red against unmodified source, then the one-word fix turned them green.

From `amber/`:

- Before the fix — `python -m pytest src/test/python/core/util/buffer/test_timed_buffer.py` → **2 failed, 14 passed** (`test_sub_second_interval_triggers_flush`, `test_whole_day_elapsed_triggers_flush`).
- After the fix — `python -m pytest src/test/python/core/util/buffer/` → **16 passed**.
- `python -m ruff check` and `python -m ruff format --check` on both the source and test directories — clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
