### PR TITLE
fix(workflow-operator): make the AsterixDB version cache concurrency-safe

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/asterixdb/AsterixDBConnUtil.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/source/sql/asterixdb/AsterixDBConnUtil.scala
@@ -22,16 +22,18 @@ package org.apache.texera.amber.operator.source.sql.asterixdb
 import kong.unirest.json.JSONObject
 import kong.unirest.{HttpResponse, JsonNode, Unirest}
 
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
-import scala.collection.mutable.Map
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.{Failure, Success, Try}
 
 object AsterixDBConnUtil {
 
   // as asterixDB version update is unlikely to happen, this map
-  // is only updated when a new AsterixDBSourceOpExec is initialized
-  var asterixDBVersionMapping: Map[String, String] = Map()
+  // is only updated when a new AsterixDBSourceOpExec is initialized.
+  // Several of those can initialize concurrently in one JVM, so the map has to
+  // tolerate concurrent updates.
+  val asterixDBVersionMapping: mutable.Map[String, String] = TrieMap.empty
 
   def queryAsterixDB(
       host: String,
@@ -82,7 +84,7 @@ object AsterixDBConnUtil {
       parentName: String,
       host: String,
       port: String
-  ): Predef.Map[String, String] = {
+  ): Map[String, String] = {
     val result: mutable.Map[String, String] = mutable.Map()
     val response = queryAsterixDB(
       host,


### PR DESCRIPTION
### What changes were proposed in this PR?

**Root cause.** `AsterixDBConnUtil.asterixDBVersionMapping` is a process-global `host -> version` cache backed by an unsynchronized `scala.collection.mutable.Map` (a `HashMap`), but it is written from `updateAsterixDBVersionMapping`, reached from `queryAsterixDB` on the first query to each host. Several `AsterixDBSourceOpExec` workers can initialize concurrently in one JVM, so two threads can `+=` at the same time. Concurrent insertion into an unsynchronized `HashMap` can corrupt the table during a resize — surfacing as a lost entry, a spin, or a spurious `NoSuchElementException` from the read at `asterixDBVersionMapping(host)`.

**Fix.** Back it with `scala.collection.concurrent.TrieMap`, which is in the Scala standard library — no new dependency.

```diff
+import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
-import scala.collection.mutable.Map

-  var asterixDBVersionMapping: Map[String, String] = Map()
+  val asterixDBVersionMapping: mutable.Map[String, String] = TrieMap.empty
```

| | before | after |
| --- | --- | --- |
| concurrent `+=` | can corrupt the table | safe |
| `contains` then update | benign race — both threads fetch the same version for the same host and write the same value | unchanged, still benign |
| iteration | never iterated | unchanged (`TrieMap`'s snapshot iterators are not reachable here) |
| declaration | `var` | `val` — the map was only ever mutated in place, never reassigned |

Two incidental tidies that fall out of the same edit:

- Dropping `import scala.collection.mutable.Map` un-shadows `Predef.Map` for the whole file, so `fetchDataTypeFields`'s return type no longer needs to be written as `Predef.Map[String, String]` to mean the ordinary immutable `Map`.
- `var` → `val`: every write is an in-place `+=` / `-=`, in both the source and the specs, so nothing reassigned the reference.

`AsterixDBConnUtilSpec` and `AsterixDBSourceOpExecSpec` manipulate this map directly with `+=` and `-=`; both are in-place operations on `mutable.Map`, so both specs compile and pass unchanged.

### Any related issues, documentation, discussions?

Closes #7091

### How was this PR tested?

Existing tests only — this PR adds none. The defect is a data race whose deterministic reproduction would need thread-interleaving instrumentation the module has no harness for; the change is a type substitution whose safety property is provided by the standard library.

Locally, from the repo root with Java 17:

- `sbt "scalafixAll --check"` — clean.
- `sbt scalafmtCheckAll` — clean.
- `sbt "WorkflowOperator/testOnly *AsterixDB*"` — 84 tests, all pass, both specs unmodified.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
