### PR TITLE
chore(ci): extend merge queue to release branches, restrict branch creation

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,6 +77,7 @@ github:
           exclude: []
           include:
             - "~DEFAULT_BRANCH"
+            - "refs/heads/release/*"
       rules:
         - type: deletion
         - type: non_fast_forward
@@ -113,17 +114,39 @@ github:
         includes:
           - "~DEFAULT_BRANCH"
           - "release/*"
-          - "rel/*"
-        excludes:
-          # TEMPORARY: exclude release/v1.1.0-incubating for manual
-          # release-branch maintenance; remove this entry to restore its
-          # deletion / force-push protection. All other release/* and
-          # rel/* branches stay protected.
-          - "release/v1.1.0-incubating"
+        excludes: []
       bypass_teams:
         - "root" # apache/root — ASF Infra team
       restrict_deletion: true
       restrict_force_push: true
+
+    # Restrict who can create branches: everything is blocked except the
+    # allowlisted prefixes below (main, release/*, backport/*, gh-pages).
+    # `creation` is not available in asfyaml convenience syntax, and that
+    # syntax forbids mixing bypass_teams into a raw payload, so this
+    # ruleset uses the raw form with a numeric actor_id for the Infra team.
+    - name: "Restrict Branch Creation"
+      target: branch
+      enforcement: active
+      conditions:
+        ref_name:
+          include:
+            - "~ALL"
+          exclude:
+            - "refs/heads/main"
+            - "refs/heads/release/*"
+            - "refs/heads/backport/*"
+            - "refs/heads/gh-pages"
+            # Temporary branches GitHub's merge queue creates to test
+            # queued groups; must stay creatable or the queue breaks.
+            - "refs/heads/gh-readonly-queue/*"
+      bypass_actors:
+        # apache/root — ASF Infra team.
+        - actor_id: 118420
+          actor_type: Team
+          bypass_mode: always
+      rules:
+        - type: creation
 notifications:
   commits: commits@texera.apache.org
   issues: notifications@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?

Harden the `.asf.yaml` branch-protection rulesets:

- **Merge queue on release branches.** Add `refs/heads/release/*` to the `Merge Queue` ruleset, so `release/*` gets the same merge-queue, PR-review, status-check, and linear-history rules as `main`.
- **Drop `rel/*`.** Remove `refs/heads/rel/*` from `Default Branch Protection` (deprecated, and not in the allowlist below).
- **Restore `release/v1.1.0-incubating`.** Remove its temporary exclude now that the #7085 maintenance is done.
- **Restrict branch creation.** A new `Restrict Branch Creation` ruleset blocks creating any branch except `main`, `release/*`, `backport/*`, `gh-pages`, and `gh-readonly-queue/*` (merge-queue temp branches). Direct pushes to `apache/texera` only; forks and Infra bypass unaffected.

`creation` is unsupported in asfyaml convenience syntax (which also bars `bypass_teams` in a raw payload), so that ruleset uses the raw form with `actor_id: 118420`. `Default Branch Protection` is kept for its explicit Infra bypass despite overlapping `Merge Queue`.

### Any related issues, documentation, discussions?

Closes #7093.

### How was this PR tested?

Ran the asfyaml normalizer (`asfyaml/feature/github/rulesets.py`, the code Infra applies) over the whole `.asf.yaml`: all three rulesets normalize to valid GitHub Rulesets payloads, and `bypass_teams: [root]` resolves to the same team id (118420) as the raw form. `.asf.yaml` has no unit tests; Infra applies it from the default branch.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
