### PR TITLE
fix(amber, v1.2): persist operator port result URIs through a ClientEvent

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/ClientEvent.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/controller/ClientEvent.scala
@@ -21,13 +21,21 @@ package org.apache.texera.amber.engine.architecture.controller
 
 import org.apache.texera.amber.core.tuple.Tuple
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
+import org.apache.texera.amber.core.workflow.GlobalPortIdentity
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import org.apache.texera.amber.engine.common.ambermessage.WorkflowFIFOMessagePayload
 import org.apache.texera.amber.engine.common.executionruntimestate.OperatorMetrics
 
+import java.net.URI
+
 trait ClientEvent extends WorkflowFIFOMessagePayload
 
 case class ExecutionStateUpdate(state: WorkflowAggregatedState) extends ClientEvent
+
+case class OperatorPortResultUriAvailable(
+    globalPortId: GlobalPortIdentity,
+    uri: URI
+) extends ClientEvent
 
 case class ExecutionStatsUpdate(operatorMetrics: Map[String, OperatorMetrics]) extends ClientEvent
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/scheduling/RegionExecutionCoordinator.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/scheduling/RegionExecutionCoordinator.scala
@@ -23,7 +23,6 @@ import org.apache.pekko.pattern.gracefulStop
 import com.twitter.util.{Duration => TwitterDuration, Future, JavaTimer, Return, Throw, Timer}
 import org.apache.texera.amber.core.state.State
 import org.apache.texera.amber.core.storage.{DocumentFactory, VFSURIFactory}
-import org.apache.texera.amber.core.storage.VFSURIFactory.decodeURI
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
 import org.apache.texera.amber.core.workflow.{GlobalPortIdentity, PhysicalLink, PhysicalOp}
 import org.apache.texera.amber.engine.architecture.common.{
@@ -39,6 +38,7 @@ import org.apache.texera.amber.engine.architecture.controller.execution.{
 import org.apache.texera.amber.engine.architecture.controller.{
   ControllerConfig,
   ExecutionStatsUpdate,
+  OperatorPortResultUriAvailable,
   RuntimeStatisticsPersist,
   WorkerAssignmentUpdate
 }
@@ -58,7 +58,6 @@ import org.apache.texera.amber.engine.common.rpc.AsyncRPCClient
 import org.apache.texera.amber.engine.common.virtualidentity.util.CONTROLLER
 import org.apache.texera.web.SessionState
 import org.apache.texera.web.model.websocket.event.RegionStateEvent
-import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
@@ -607,11 +606,8 @@ class RegionExecutionCoordinator(
         DocumentFactory.createDocument(resultURI, schema)
         DocumentFactory.createDocument(stateURI, State.schema)
         if (!isRestart) {
-          val (_, eid, _, _) = decodeURI(resultURI)
-          WorkflowExecutionsResource.insertOperatorPortResultUri(
-            eid = eid,
-            globalPortId = outputPortId,
-            uri = resultURI
+          asyncRPCClient.sendToClient(
+            OperatorPortResultUriAvailable(outputPortId, resultURI)
           )
         }
     }

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
@@ -234,22 +234,6 @@ object WorkflowExecutionsResource {
     restrictionMap.toMap
   }
 
-  def insertOperatorPortResultUri(
-      eid: ExecutionIdentity,
-      globalPortId: GlobalPortIdentity,
-      uri: URI
-  ): Unit = {
-    context
-      .insertInto(OPERATOR_PORT_EXECUTIONS)
-      .columns(
-        OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID,
-        OPERATOR_PORT_EXECUTIONS.GLOBAL_PORT_ID,
-        OPERATOR_PORT_EXECUTIONS.RESULT_URI
-      )
-      .values(eid.id.toInt, globalPortId.serializeAsString, uri.toString)
-      .execute()
-  }
-
   def insertOperatorExecutions(
       eid: Long,
       opId: String,

--- a/amber/src/main/scala/org/apache/texera/web/service/ExecutionResultService.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/ExecutionResultService.scala
@@ -28,6 +28,10 @@ import org.apache.texera.amber.core.storage.model.VirtualDocument
 import org.apache.texera.amber.core.storage.result._
 import org.apache.texera.amber.core.storage.{DocumentFactory, VFSURIFactory}
 import org.apache.texera.amber.core.tuple.{AttributeType, Tuple, TupleUtils}
+import org.apache.texera.amber.util.serde.GlobalPortIdentitySerde.SerdeOps
+import org.apache.texera.dao.SqlServer
+import org.apache.texera.dao.jooq.generated.tables.daos.OperatorPortExecutionsDao
+import org.apache.texera.dao.jooq.generated.tables.pojos.OperatorPortExecutions
 import org.apache.texera.amber.core.virtualidentity.{
   ExecutionIdentity,
   OperatorIdentity,
@@ -35,7 +39,15 @@ import org.apache.texera.amber.core.virtualidentity.{
 }
 import org.apache.texera.amber.core.workflow.OutputPort.OutputMode
 import org.apache.texera.amber.core.workflow.{PhysicalOp, PhysicalPlan, PortIdentity}
+<<<<<<< HEAD
 import org.apache.texera.amber.engine.architecture.controller.{ExecutionStateUpdate, FatalError}
+=======
+import org.apache.texera.amber.engine.architecture.coordinator.{
+  ExecutionStateUpdate,
+  FatalError,
+  OperatorPortResultUriAvailable
+}
+>>>>>>> e42f6b365 (fix(amber): persist operator port result URIs through a ClientEvent (#5434))
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
   COMPLETED,
   FAILED,
@@ -65,6 +77,29 @@ import scala.concurrent.duration.DurationInt
 import scala.language.existentials
 
 object ExecutionResultService {
+
+  /**
+    * Callback body for `OperatorPortResultUriAvailable`: persist the URI to
+    * `operator_port_executions`. Lives on the companion (not the class) so
+    * tests and fixture-row writers can drive the same insert as the
+    * production callback without re-implementing the schema mapping.
+    *
+    * `executionId` comes from the caller rather than the event payload —
+    * the engine→web event is execution-scoped, so re-encoding the eid into
+    * the wire and decoding it on receipt would be redundant.
+    */
+  def persistOperatorPortResultUri(
+      executionId: ExecutionIdentity,
+      evt: OperatorPortResultUriAvailable
+  ): Unit = {
+    val pojo = new OperatorPortExecutions()
+    pojo.setWorkflowExecutionId(executionId.id.toInt)
+    pojo.setGlobalPortId(evt.globalPortId.serializeAsString)
+    pojo.setResultUri(evt.uri.toString)
+    new OperatorPortExecutionsDao(
+      SqlServer.getInstance().createDSLContext().configuration()
+    ).insert(pojo)
+  }
 
   private val defaultPageSize: Int = 5
   private val binaryPreviewLeadingBits: Int = 10
@@ -350,6 +385,19 @@ class ExecutionResultService(
         if (resultUpdateCancellable != null) {
           resultUpdateCancellable.cancel()
         }
+      )
+    )
+
+    // Must be registered before the workflow starts. The engine fires
+    // OperatorPortResultUriAvailable as soon as each port's storage doc
+    // is materialized; if no subscriber is attached at that point the
+    // URI is silently never persisted to operator_port_executions, which
+    // means the dashboard can later compute results just fine but can
+    // never look them up. Today the WS and sync REST entry points both
+    // call attachToExecution before startWorkflow — keep that ordering.
+    addSubscription(
+      client.registerCallback[OperatorPortResultUriAvailable](evt =>
+        ExecutionResultService.persistOperatorPortResultUri(executionId, evt)
       )
     )
 

--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -35,6 +35,11 @@ import org.apache.texera.amber.core.workflow.{PortIdentity, WorkflowContext, Wor
 import org.apache.texera.amber.engine.architecture.controller.{
   ControllerConfig,
   ExecutionStateUpdate,
+<<<<<<< HEAD
+=======
+  FatalError,
+  OperatorPortResultUriAvailable,
+>>>>>>> e42f6b365 (fix(amber): persist operator port result URIs through a ClientEvent (#5434))
   Workflow
 }
 import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
@@ -65,6 +70,7 @@ import org.apache.texera.dao.jooq.generated.tables.pojos.{
 }
 import org.apache.texera.web.model.websocket.request.LogicalPlanPojo
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource.getResultUriByLogicalPortId
+import org.apache.texera.web.service.ExecutionResultService
 import org.apache.texera.workflow.{LogicalLink, WorkflowCompiler}
 
 object TestUtils {
@@ -99,6 +105,123 @@ object TestUtils {
   }
 
   /**
+<<<<<<< HEAD
+=======
+    * Resolve and read each operator's external RESULT document at `executionId`,
+    * applying `extract` to the opened document. Operators with no external
+    * RESULT uri (e.g. one whose output wasn't materialized) are omitted. Shared
+    * by the e2e specs so the lookup-open-extract block doesn't drift between
+    * copies.
+    */
+  def readMaterializedResults[T](
+      executionId: ExecutionIdentity,
+      operatorIds: Iterable[OperatorIdentity],
+      extract: VirtualDocument[Tuple] => T
+  ): Map[OperatorIdentity, T] =
+    operatorIds.flatMap { opId =>
+      getResultUriByLogicalPortId(executionId, opId, PortIdentity()).map { uri =>
+        opId -> extract(
+          DocumentFactory.openDocument(uri)._1.asInstanceOf[VirtualDocument[Tuple]]
+        )
+      }
+    }.toMap
+
+  /**
+    * Convenience over `readMaterializedResults` for the common case: read each
+    * terminal operator's result of `workflow` as a `List[Tuple]`.
+    */
+  def readMaterializedResults(workflow: Workflow): Map[OperatorIdentity, List[Tuple]] =
+    readMaterializedResults(
+      workflow.context.executionId,
+      workflow.logicalPlan.getTerminalOperatorIds,
+      _.get().toList
+    )
+
+  /**
+    * Run `workflow` to COMPLETED, then read the requested operators' materialized
+    * results via `readMaterializedResults`. A FatalError aborts the run and is
+    * surfaced as the exception from the completion await. Specs that drive the
+    * run differently (e.g. a pause/resume flow) read results directly inside
+    * their own completion callback instead.
+    */
+  def runWorkflowAndReadResults[T](
+      system: ActorSystem,
+      workflow: Workflow,
+      operatorIds: Iterable[OperatorIdentity],
+      extract: VirtualDocument[Tuple] => T,
+      completionTimeout: Duration = Duration.fromMinutes(1)
+  ): Map[OperatorIdentity, T] = {
+    // The Promise carries the result so completing the run and handing back the
+    // value are atomic. Every terminal path uses `updateIfEmpty`, so a second
+    // event (a late FatalError after COMPLETED, or a repeated state update)
+    // can't throw inside a callback and get swallowed -- which would otherwise
+    // mask the real failure as a timeout. A read failure inside the COMPLETED
+    // callback fails the Promise (via `Try`) instead of hanging, and
+    // `shutdown()` runs in a `finally` so a timeout or error can't leak the
+    // client's actors.
+    val completion = Promise[Map[OperatorIdentity, T]]()
+    val client = new AmberClient(
+      system,
+      workflow.context,
+      workflow.physicalPlan,
+      CoordinatorConfig.default,
+      e => completion.updateIfEmpty(Throw(e))
+    )
+    try {
+      client.registerCallback[FatalError](evt => completion.updateIfEmpty(Throw(evt.e)))
+      // The engine emits `OperatorPortResultUriAvailable` for each
+      // materialized output port; production wires this to a DB insert in
+      // `ExecutionResultService.persistOperatorPortResultUri`. The e2e
+      // harness doesn't construct an `ExecutionResultService` (it builds an
+      // `AmberClient` directly), so register the same callback here so the
+      // post-completion `readMaterializedResults` lookup via
+      // `getResultUriByLogicalPortId` finds the rows.
+      registerResultUriPersistence(client, workflow.context.executionId)
+      client.registerCallback[ExecutionStateUpdate](evt => {
+        if (evt.state == COMPLETED) {
+          completion.updateIfEmpty(
+            Try(readMaterializedResults(workflow.context.executionId, operatorIds, extract))
+          )
+        }
+      })
+      Await.result(client.coordinatorInterface.startWorkflow(EmptyRequest(), ()))
+      Await.result(completion, completionTimeout)
+    } finally {
+      client.shutdown()
+    }
+  }
+
+  /**
+    * Mirror the production `OperatorPortResultUriAvailable` → DB write that
+    * `ExecutionResultService.persistOperatorPortResultUri` does, but driven
+    * from a test-owned `AmberClient`. Specs that build their own client
+    * (the harness above, or `shouldReconfigure` for the pause/resume flow)
+    * call this so subsequent `getResultUriByLogicalPortId` lookups succeed.
+    */
+  def registerResultUriPersistence(client: AmberClient, executionId: ExecutionIdentity): Unit =
+    client.registerCallback[OperatorPortResultUriAvailable](evt =>
+      ExecutionResultService.persistOperatorPortResultUri(executionId, evt)
+    )
+
+  /**
+    * Convenience over `runWorkflowAndReadResults` for the common case: run
+    * `workflow` and read each terminal operator's result as a `List[Tuple]`.
+    */
+  def runWorkflowAndReadTerminalResults(
+      system: ActorSystem,
+      workflow: Workflow,
+      completionTimeout: Duration = Duration.fromMinutes(1)
+  ): Map[OperatorIdentity, List[Tuple]] =
+    runWorkflowAndReadResults(
+      system,
+      workflow,
+      workflow.logicalPlan.getTerminalOperatorIds,
+      _.get().toList,
+      completionTimeout
+    )
+
+  /**
+>>>>>>> e42f6b365 (fix(amber): persist operator port result URIs through a ClientEvent (#5434))
     * If a test case accesses the user system through singleton resources that cache the DSLContext (e.g., executes a
     * workflow, which accesses WorkflowExecutionsResource), we use a separate texera_db specifically for such test cases.
     * Note such test cases need to clean up the database at the end of running each test case.
@@ -206,6 +329,12 @@ object TestUtils {
       ControllerConfig.default,
       error => {}
     )
+<<<<<<< HEAD
+=======
+    // Timeout for control-command acks (start/pause/reconfigure/resume).
+    val commandTimeout = Duration.fromSeconds(30)
+    registerResultUriPersistence(client, workflow.context.executionId)
+>>>>>>> e42f6b365 (fix(amber): persist operator port result URIs through a ClientEvent (#5434))
     val completion = Promise[Unit]()
     var result: Map[OperatorIdentity, List[Tuple]] = null
     client.registerCallback[ExecutionStateUpdate](evt => {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
@@ -47,6 +47,8 @@ import org.apache.texera.dao.jooq.generated.tables.pojos.{
   WorkflowExecutions,
   WorkflowVersion
 }
+import org.apache.texera.amber.engine.architecture.coordinator.OperatorPortResultUriAvailable
+import org.apache.texera.web.service.ExecutionResultService
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, PrivateMethodTester}
 
@@ -228,6 +230,19 @@ class WorkflowExecutionsResourceSpec
     execution
   }
 
+  // Local convenience over the production callback: fixture rows the
+  // lookup specs below need go through the same insert prod uses, so a
+  // regression in the column list shows up here too.
+  private def insertOperatorPortResult(
+      eid: ExecutionIdentity,
+      globalPortId: GlobalPortIdentity,
+      uri: URI
+  ): Unit =
+    ExecutionResultService.persistOperatorPortResultUri(
+      eid,
+      OperatorPortResultUriAvailable(globalPortId, uri)
+    )
+
   // ─── existing tests (preserved) ───────────────────────────────────────────
 
   "WorkflowExecutionsResource.getWorkflowExecutions" should "return executions with EIDs in descending order" in {
@@ -264,28 +279,8 @@ class WorkflowExecutionsResourceSpec
     )
   }
 
-  "WorkflowExecutionsResource.insertOperatorPortResultUri" should "insert a result URI row" in {
-    val execution = insertExecution(name = "Execution with duplicate result URI insert")
-
-    val executionId = ExecutionIdentity(execution.getEid.longValue())
-    val globalPortId = GlobalPortIdentity(
-      PhysicalOpIdentity(OperatorIdentity("operator-1"), "main"),
-      PortIdentity(),
-      input = false
-    )
-    val uri = URI.create("vfs:///test-result")
-
-    WorkflowExecutionsResource.insertOperatorPortResultUri(executionId, globalPortId, uri)
-
-    val rows = getDSLContext
-      .selectFrom(OPERATOR_PORT_EXECUTIONS)
-      .where(OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID.eq(execution.getEid))
-      .and(OPERATOR_PORT_EXECUTIONS.GLOBAL_PORT_ID.eq(globalPortId.serializeAsString))
-      .fetch()
-
-    assert(rows.size() == 1)
-    assert(rows.get(0).getResultUri == uri.toString)
-  }
+  // (The production callback body that writes operator_port_executions is
+  // covered by `ExecutionResultServiceSpec.persistOperatorPortResultUri`.)
 
   // ─── new: status-filtered execution listing ───────────────────────────────
 
@@ -441,8 +436,8 @@ class WorkflowExecutionsResourceSpec
       input = false
     )
 
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, opA, URI.create("vfs:///A"))
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, opB, URI.create("vfs:///B"))
+    insertOperatorPortResult(eid, opA, URI.create("vfs:///A"))
+    insertOperatorPortResult(eid, opB, URI.create("vfs:///B"))
     // Empty-string URI row — the helper should drop it from the returned list.
     getDSLContext
       .insertInto(OPERATOR_PORT_EXECUTIONS)
@@ -522,7 +517,7 @@ class WorkflowExecutionsResourceSpec
       PortIdentity(),
       input = false
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(
+    insertOperatorPortResult(
       eid,
       globalPortId,
       URI.create("vfs:///r")
@@ -576,7 +571,7 @@ class WorkflowExecutionsResourceSpec
       PortIdentity(),
       input = false
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(
+    insertOperatorPortResult(
       eid,
       globalPortId,
       URI.create("vfs:///r")
@@ -610,7 +605,7 @@ class WorkflowExecutionsResourceSpec
     val targetUri = VFSURIFactory.resultURI(
       VFSURIFactory.createPortBaseURI(wfId, eid, targetGlobalPort)
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, targetGlobalPort, targetUri)
+    insertOperatorPortResult(eid, targetGlobalPort, targetUri)
 
     // Distractor: same workflow, different op id.
     val otherGlobalPort = GlobalPortIdentity(
@@ -621,7 +616,7 @@ class WorkflowExecutionsResourceSpec
     val otherUri = VFSURIFactory.resultURI(
       VFSURIFactory.createPortBaseURI(wfId, eid, otherGlobalPort)
     )
-    WorkflowExecutionsResource.insertOperatorPortResultUri(eid, otherGlobalPort, otherUri)
+    insertOperatorPortResult(eid, otherGlobalPort, otherUri)
 
     val found =
       WorkflowExecutionsResource.getResultUriByLogicalPortId(eid, targetOpId, targetPortId)

--- a/amber/src/test/scala/org/apache/texera/web/service/ExecutionResultServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/ExecutionResultServiceSpec.scala
@@ -20,10 +20,160 @@
 package org.apache.texera.web.service
 
 import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema, Tuple}
+<<<<<<< HEAD
+=======
+import org.apache.texera.amber.core.virtualidentity.{
+  ExecutionIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
+import org.apache.texera.amber.core.workflow.{GlobalPortIdentity, PortIdentity}
+import org.apache.texera.amber.engine.architecture.coordinator.OperatorPortResultUriAvailable
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.apache.texera.amber.util.serde.GlobalPortIdentitySerde.SerdeOps
+import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.jooq.generated.Tables.{
+  OPERATOR_PORT_EXECUTIONS,
+  USER,
+  WORKFLOW,
+  WORKFLOW_EXECUTIONS,
+  WORKFLOW_VERSION
+}
+import org.apache.texera.dao.jooq.generated.tables.daos.{
+  UserDao,
+  WorkflowDao,
+  WorkflowExecutionsDao,
+  WorkflowVersionDao
+}
+import org.apache.texera.dao.jooq.generated.tables.pojos.{
+  User,
+  Workflow,
+  WorkflowExecutions,
+  WorkflowVersion
+}
+import org.apache.texera.web.service.ExecutionResultService.{
+  PaginationMode,
+  SetDeltaMode,
+  SetSnapshotMode,
+  WebDataUpdate,
+  WebPaginationUpdate
+}
+>>>>>>> e42f6b365 (fix(amber): persist operator port result URIs through a ClientEvent (#5434))
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
-class ExecutionResultServiceSpec extends AnyFlatSpec with Matchers {
+import java.net.URI
+import java.sql.Timestamp
+import scala.jdk.CollectionConverters._
+
+class ExecutionResultServiceSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with MockTexeraDB {
+
+  // Fixed (not random) so a failure replays identically across runs. The
+  // spec owns its embedded DB so collision with other specs isn't a concern.
+  private val testWid: Integer = 9001
+  private val testUid: Integer = 9001
+  private var executionsDao: WorkflowExecutionsDao = _
+  private var testVid: Integer = _
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdownDB()
+  }
+
+  override protected def beforeEach(): Unit = {
+    val user = new User
+    user.setUid(testUid)
+    user.setName("execution-result-test-user")
+    user.setEmail(s"u$testUid@example.com")
+    user.setPassword("password")
+    new UserDao(getDSLContext.configuration()).insert(user)
+
+    val workflow = new Workflow
+    workflow.setWid(testWid)
+    workflow.setName(s"execution-result-test-$testWid")
+    workflow.setContent("{}")
+    workflow.setDescription("")
+    workflow.setCreationTime(new Timestamp(System.currentTimeMillis()))
+    workflow.setLastModifiedTime(new Timestamp(System.currentTimeMillis()))
+    new WorkflowDao(getDSLContext.configuration()).insert(workflow)
+
+    val version = new WorkflowVersion
+    version.setWid(testWid)
+    version.setContent("{}")
+    version.setCreationTime(new Timestamp(System.currentTimeMillis()))
+    new WorkflowVersionDao(getDSLContext.configuration()).insert(version)
+    // The vid sequence isn't reset between tests, so capture the
+    // generated key here instead of assuming it's `1` later.
+    testVid = version.getVid
+
+    executionsDao = new WorkflowExecutionsDao(getDSLContext.configuration())
+  }
+
+  override protected def afterEach(): Unit = {
+    val ctx = getDSLContext
+    // Scope every delete to the test's own ids so this spec stays safe
+    // if it ever shares a DB with another spec.
+    ctx
+      .deleteFrom(OPERATOR_PORT_EXECUTIONS)
+      .where(
+        OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID.in(
+          ctx
+            .select(WORKFLOW_EXECUTIONS.EID)
+            .from(WORKFLOW_EXECUTIONS)
+            .where(WORKFLOW_EXECUTIONS.UID.eq(testUid))
+        )
+      )
+      .execute()
+    ctx
+      .deleteFrom(WORKFLOW_EXECUTIONS)
+      .where(WORKFLOW_EXECUTIONS.UID.eq(testUid))
+      .execute()
+    ctx.deleteFrom(WORKFLOW_VERSION).where(WORKFLOW_VERSION.WID.eq(testWid)).execute()
+    ctx.deleteFrom(WORKFLOW).where(WORKFLOW.WID.eq(testWid)).execute()
+    ctx.deleteFrom(USER).where(USER.UID.eq(testUid)).execute()
+  }
+
+  "persistOperatorPortResultUri" should
+    "insert the URI carried by an OperatorPortResultUriAvailable event" in {
+    val execution = new WorkflowExecutions
+    execution.setVid(testVid)
+    execution.setUid(testUid)
+    execution.setStatus(0.toByte)
+    execution.setStartingTime(new Timestamp(System.currentTimeMillis()))
+    execution.setBookmarked(false)
+    execution.setName("execution-result-callback-test")
+    execution.setEnvironmentVersion("test-env")
+    executionsDao.insert(execution)
+    val eid = ExecutionIdentity(execution.getEid.longValue())
+    val globalPortId = GlobalPortIdentity(
+      PhysicalOpIdentity(OperatorIdentity("op-X"), "main"),
+      PortIdentity(),
+      input = false
+    )
+    val uri = URI.create("vfs:///exec-result-callback")
+
+    ExecutionResultService.persistOperatorPortResultUri(
+      eid,
+      OperatorPortResultUriAvailable(globalPortId, uri)
+    )
+
+    val rows = getDSLContext
+      .selectFrom(OPERATOR_PORT_EXECUTIONS)
+      .where(OPERATOR_PORT_EXECUTIONS.WORKFLOW_EXECUTION_ID.eq(execution.getEid))
+      .and(OPERATOR_PORT_EXECUTIONS.GLOBAL_PORT_ID.eq(globalPortId.serializeAsString))
+      .fetch()
+    rows.size() shouldBe 1
+    rows.get(0).getResultUri shouldBe uri.toString
+  }
 
   "convertTuplesToJson" should "convert tuples with various field types correctly" in {
     // Create a schema with different attribute types


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #5434 to `release/v1.2`, cherry-picked from e42f6b3651208e6d93d1069e02bf870ee707b0d7.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) as part of a backport-coverage audit for fixes merged to `main` since early June that were never labeled for backport.

### Any related issues, documentation, discussions?

Backport of #5434. Originally linked #5430.

### How was this PR tested?

Release-branch CI runs once the conflicts are resolved and this PR is marked ready for review. The cherry-pick **conflicted** and was committed with conflict markers.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; conflicts left as markers for the original author to resolve; the change itself is #5434 by its original author).
