### PR TITLE
fix(engine, v1.2): Base64-encode Python worker startup config to survive Windows argv

### DIFF
--- a/amber/src/main/python/texera_run_python_worker.py
+++ b/amber/src/main/python/texera_run_python_worker.py
@@ -15,6 +15,11 @@
 # specific language governing permissions and limitations
 # under the License.
 
+<<<<<<< HEAD
+=======
+import base64
+import json
+>>>>>>> 6e5ab8922 (fix(engine): Base64-encode Python worker startup config to survive Windows argv (#5917))
 import sys
 from loguru import logger
 
@@ -49,6 +54,7 @@ def init_loguru_logger(stream_log_level) -> None:
     logger.add(sys.stderr, level=stream_log_level)
 
 
+<<<<<<< HEAD
 if __name__ == "__main__":
     (
         _,
@@ -73,6 +79,77 @@ if __name__ == "__main__":
         s3_large_binaries_base_uri,
     ) = sys.argv
     init_loguru_logger(logger_level)
+=======
+# Keys the JVM side (PythonWorkflowWorker) sends in the startup-config JSON.
+# Declared here so any drift between the two sides fails loudly instead of being
+# silently misassigned, as could happen with the previous positional unpacking.
+EXPECTED_CONFIG_KEYS = frozenset(
+    {
+        "workerId",
+        "outputPort",
+        "loggerLevel",
+        "rPath",
+        "icebergCatalogType",
+        "icebergPostgresCatalogUriWithoutScheme",
+        "icebergPostgresCatalogUsername",
+        "icebergPostgresCatalogPassword",
+        "icebergRestCatalogUri",
+        "icebergRestCatalogWarehouseName",
+        "icebergTableNamespace",
+        "icebergTableStateNamespace",
+        "icebergFileStorageDirectoryPath",
+        "icebergTableCommitBatchSize",
+        "s3Endpoint",
+        "s3Region",
+        "s3AuthUsername",
+        "s3AuthPassword",
+        "s3LargeBinariesBaseUri",
+    }
+)
+
+
+def parse_startup_config(raw_config: str) -> dict:
+    """Parse and validate the startup configuration.
+
+    The configuration is passed by name (see PythonWorkflowWorker on the JVM
+    side) as a Base64-encoded JSON object. Base64 is used so the argument carries
+    no quotes or spaces and survives command-line argv quoting on every platform
+    (a raw JSON string loses its quotes on Windows). The two sides must agree on
+    an exact key set; key order is irrelevant since it is a JSON object. Any drift
+    fails loudly:
+      - a missing or unexpected key raises ValueError;
+      - a non-string value raises TypeError.
+    """
+    config = json.loads(base64.b64decode(raw_config).decode("utf-8"))
+    if not isinstance(config, dict):
+        raise TypeError(
+            f"startup config must be a JSON object, got {type(config).__name__}"
+        )
+
+    actual_keys = set(config)
+    missing = EXPECTED_CONFIG_KEYS - actual_keys
+    unexpected = actual_keys - EXPECTED_CONFIG_KEYS
+    if missing or unexpected:
+        raise ValueError(
+            f"startup config key mismatch: missing={sorted(missing)}, "
+            f"unexpected={sorted(unexpected)}"
+        )
+
+    non_string_keys = sorted(k for k, v in config.items() if not isinstance(v, str))
+    if non_string_keys:
+        raise TypeError(
+            f"startup config values must be strings; non-string keys: {non_string_keys}"
+        )
+
+    return config
+
+
+def main(raw_config: str) -> None:
+    """Start a Python worker from its validated Base64-encoded JSON startup config."""
+    config = parse_startup_config(raw_config)
+
+    init_loguru_logger(config["loggerLevel"])
+>>>>>>> 6e5ab8922 (fix(engine): Base64-encode Python worker startup config to survive Windows argv (#5917))
     StorageConfig.initialize(
         iceberg_catalog_type,
         iceberg_postgres_catalog_uri_without_scheme,

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
@@ -40,13 +40,82 @@ import org.apache.texera.amber.engine.common.ambermessage.WorkflowMessage.getInM
 import org.apache.texera.amber.engine.common.ambermessage._
 import org.apache.texera.amber.engine.common.{CheckpointState, Utils}
 
+import java.nio.charset.StandardCharsets
 import java.nio.file.Path
 import org.apache.texera.web.resource.pythonvirtualenvironment.PveManager
+import java.util.Base64
 import java.util.concurrent.{ExecutorService, Executors}
 import scala.sys.process.{BasicIO, Process}
 
 object PythonWorkflowWorker {
   def props(workerConfig: WorkerConfig): Props = Props(new PythonWorkflowWorker(workerConfig))
+<<<<<<< HEAD
+=======
+
+  /**
+    * Serialize the Python worker startup configuration to a JSON object keyed by
+    * name, then Base64-encode it for safe passing as a command-line argument. Built
+    * from a sequence of (key, value) pairs so a duplicate key fails loudly here
+    * instead of being silently dropped by Map construction.
+    *
+    * The Base64 step matters on Windows: a raw JSON string passed as argv loses its
+    * quotes there (the JVM assembles argv into a single command line and the inner
+    * double quotes are stripped before Python receives it), so `json.loads` fails.
+    * Base64 uses only `[A-Za-z0-9+/=]`, which survives argv quoting on every
+    * platform. The Python side Base64-decodes before parsing the JSON.
+    */
+  def encodeStartupConfig(entries: Seq[(String, String)]): String = {
+    val duplicateKeys = entries.groupBy(_._1).collect { case (key, group) if group.size > 1 => key }
+    require(
+      duplicateKeys.isEmpty,
+      s"duplicate Python worker startup config keys: ${duplicateKeys.mkString(", ")}"
+    )
+    val json = objectMapper.writeValueAsString(entries.toMap)
+    Base64.getEncoder.encodeToString(json.getBytes(StandardCharsets.UTF_8))
+  }
+
+  /**
+    * Assemble the Python worker startup configuration as named (key, value) pairs.
+    * Worker-specific values are passed in; storage-related values are read from the
+    * shared StorageConfig (Postgres/REST catalog fields are blank unless that catalog
+    * type is active). Returned as a sequence (not a Map) so encodeStartupConfig can
+    * detect a duplicate key.
+    */
+  def buildStartupConfig(
+      workerId: String,
+      outputPort: String,
+      rPath: String,
+      largeBinaryBaseUri: String
+  ): Seq[(String, String)] = {
+    val isPostgres = StorageConfig.icebergCatalogType == "postgres"
+    val isRest = StorageConfig.icebergCatalogType == "rest"
+    Seq(
+      "workerId" -> workerId,
+      "outputPort" -> outputPort,
+      "loggerLevel" -> UdfConfig.pythonLogStreamHandlerLevel,
+      "rPath" -> rPath,
+      "icebergCatalogType" -> StorageConfig.icebergCatalogType,
+      "icebergPostgresCatalogUriWithoutScheme" ->
+        (if (isPostgres) StorageConfig.icebergPostgresCatalogUriWithoutScheme else ""),
+      "icebergPostgresCatalogUsername" ->
+        (if (isPostgres) StorageConfig.icebergPostgresCatalogUsername else ""),
+      "icebergPostgresCatalogPassword" ->
+        (if (isPostgres) StorageConfig.icebergPostgresCatalogPassword else ""),
+      "icebergRestCatalogUri" -> (if (isRest) StorageConfig.icebergRESTCatalogUri else ""),
+      "icebergRestCatalogWarehouseName" ->
+        (if (isRest) StorageConfig.icebergRESTCatalogWarehouseName else ""),
+      "icebergTableNamespace" -> StorageConfig.icebergTableResultNamespace,
+      "icebergTableStateNamespace" -> StorageConfig.icebergTableStateNamespace,
+      "icebergFileStorageDirectoryPath" -> StorageConfig.fileStorageDirectoryPath.toString,
+      "icebergTableCommitBatchSize" -> StorageConfig.icebergTableCommitBatchSize.toString,
+      "s3Endpoint" -> StorageConfig.s3Endpoint,
+      "s3Region" -> StorageConfig.s3Region,
+      "s3AuthUsername" -> StorageConfig.s3Username,
+      "s3AuthPassword" -> StorageConfig.s3Password,
+      "s3LargeBinariesBaseUri" -> largeBinaryBaseUri
+    )
+  }
+>>>>>>> 6e5ab8922 (fix(engine): Base64-encode Python worker startup config to survive Windows argv (#5917))
 }
 
 class PythonWorkflowWorker(

--- a/amber/src/test/python/test_run_python_worker.py
+++ b/amber/src/test/python/test_run_python_worker.py
@@ -1,0 +1,181 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import base64
+import json
+from unittest import mock
+
+import pytest
+
+import texera_run_python_worker as entry
+
+
+def _encode(config) -> str:
+    """Encode a config the way PythonWorkflowWorker does: Base64-encoded JSON.
+
+    The JVM side passes the startup config as Base64 so it survives command-line
+    argv quoting on every platform (a raw JSON string loses its quotes on Windows).
+    """
+    return base64.b64encode(json.dumps(config).encode("utf-8")).decode("ascii")
+
+
+def _full_config() -> dict:
+    """A complete startup config matching the keys PythonWorkflowWorker emits."""
+    return {
+        "workerId": "worker-1",
+        "outputPort": "5005",
+        "loggerLevel": "INFO",
+        "rPath": "",
+        "icebergCatalogType": "postgres",
+        "icebergPostgresCatalogUriWithoutScheme": "host:5432/db",
+        "icebergPostgresCatalogUsername": "pg-user",
+        "icebergPostgresCatalogPassword": "pg-pass",
+        "icebergRestCatalogUri": "",
+        "icebergRestCatalogWarehouseName": "",
+        "icebergTableNamespace": "result_ns",
+        "icebergTableStateNamespace": "state_ns",
+        "icebergFileStorageDirectoryPath": "/tmp/files",
+        "icebergTableCommitBatchSize": "100",
+        "s3Endpoint": "http://s3:9000",
+        "s3Region": "us-west-2",
+        "s3AuthUsername": "s3-user",
+        "s3AuthPassword": "s3-pass",
+        "s3LargeBinariesBaseUri": "s3://bucket/base",
+    }
+
+
+def _patched_collaborators():
+    """Patch the heavy collaborators so main() exercises only the config wiring."""
+    return (
+        mock.patch.object(entry, "StorageConfig"),
+        mock.patch.object(entry, "PythonWorker"),
+        mock.patch.object(entry, "init_loguru_logger"),
+    )
+
+
+def test_full_config_keys_match_the_expected_set():
+    # Guards against the sample config in this test drifting from the contract.
+    assert set(_full_config()) == set(entry.EXPECTED_CONFIG_KEYS)
+
+
+def test_main_maps_named_config_to_storage_and_worker():
+    """Each named field reaches the correct StorageConfig.initialize argument and
+    worker parameter — guarding against the silent misalignment that positional
+    argv passing allowed."""
+    config = _full_config()
+    storage_patch, worker_patch, _logger_patch = _patched_collaborators()
+    with storage_patch as storage_config, worker_patch as python_worker, _logger_patch:
+        entry.main(_encode(config))
+
+    storage_config.initialize.assert_called_once_with(
+        "postgres",
+        "host:5432/db",
+        "pg-user",
+        "pg-pass",
+        "",
+        "",
+        "result_ns",
+        "state_ns",
+        "/tmp/files",
+        "100",
+        "http://s3:9000",
+        "us-west-2",
+        "s3-user",
+        "s3-pass",
+        "s3://bucket/base",
+    )
+    python_worker.assert_called_once_with(
+        worker_id="worker-1", host="localhost", output_port=5005
+    )
+    python_worker.return_value.run.assert_called_once()
+
+
+def test_main_mapping_is_independent_of_key_order():
+    """Reordering the JSON keys must not change where values land (it is a dict)."""
+    reordered = dict(reversed(list(_full_config().items())))
+    storage_patch, worker_patch, _logger_patch = _patched_collaborators()
+    with storage_patch as storage_config, worker_patch as python_worker, _logger_patch:
+        entry.main(_encode(reordered))
+
+    storage_config.initialize.assert_called_once_with(
+        "postgres",
+        "host:5432/db",
+        "pg-user",
+        "pg-pass",
+        "",
+        "",
+        "result_ns",
+        "state_ns",
+        "/tmp/files",
+        "100",
+        "http://s3:9000",
+        "us-west-2",
+        "s3-user",
+        "s3-pass",
+        "s3://bucket/base",
+    )
+    python_worker.assert_called_once_with(
+        worker_id="worker-1", host="localhost", output_port=5005
+    )
+
+
+def test_main_sets_r_home_when_r_path_present(monkeypatch):
+    monkeypatch.delenv("R_HOME", raising=False)
+    config = _full_config()
+    config["rPath"] = "/opt/R"
+    storage_patch, worker_patch, _logger_patch = _patched_collaborators()
+    with storage_patch, worker_patch, _logger_patch:
+        import os
+
+        entry.main(_encode(config))
+        assert os.environ["R_HOME"] == "/opt/R"
+
+
+@pytest.mark.parametrize("missing_key", sorted(_full_config().keys()))
+def test_parse_rejects_a_missing_key(missing_key):
+    """A missing key fails loudly rather than being silently misassigned."""
+    config = _full_config()
+    del config[missing_key]
+    with pytest.raises(ValueError, match="key mismatch"):
+        entry.parse_startup_config(_encode(config))
+
+
+def test_parse_rejects_an_unexpected_key():
+    """An extra key (e.g. the JVM side added a field) fails instead of being ignored."""
+    config = _full_config()
+    config["someNewField"] = "value"
+    with pytest.raises(ValueError, match="key mismatch"):
+        entry.parse_startup_config(_encode(config))
+
+
+def test_parse_rejects_a_non_string_value():
+    """A wrongly-typed value (e.g. a number instead of a string) fails."""
+    config = _full_config()
+    config["outputPort"] = 5005  # number instead of the expected string
+    with pytest.raises(TypeError, match="must be strings"):
+        entry.parse_startup_config(_encode(config))
+
+
+def test_parse_rejects_a_non_object_payload():
+    with pytest.raises(TypeError, match="must be a JSON object"):
+        entry.parse_startup_config(_encode(["not", "an", "object"]))
+
+
+def test_parse_round_trips_a_base64_encoded_config():
+    """The config is passed as Base64-encoded JSON; parsing decodes it back."""
+    config = _full_config()
+    assert entry.parse_startup_config(_encode(config)) == config

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonWorkflowWorkerStartupConfigSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonWorkflowWorkerStartupConfigSpec.scala
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.architecture.pythonworker
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class PythonWorkflowWorkerStartupConfigSpec extends AnyFlatSpec {
+
+  private def decode(encoded: String): String =
+    new String(Base64.getDecoder.decode(encoded), StandardCharsets.UTF_8)
+
+  "encodeStartupConfig" should "serialize entries to a Base64-encoded JSON object keyed by name" in {
+    val encoded = PythonWorkflowWorker.encodeStartupConfig(
+      Seq("workerId" -> "w-1", "outputPort" -> "5005", "s3Region" -> "us-west-2")
+    )
+    val parsed = objectMapper.readValue(decode(encoded), classOf[java.util.Map[String, String]])
+    assert(parsed.get("workerId") == "w-1")
+    assert(parsed.get("outputPort") == "5005")
+    assert(parsed.get("s3Region") == "us-west-2")
+    assert(parsed.size() == 3)
+  }
+
+  it should "produce output free of quotes and whitespace so it survives argv quoting on Windows" in {
+    val encoded = PythonWorkflowWorker.encodeStartupConfig(
+      Seq("workerId" -> "w-1", "s3Region" -> "us-west-2")
+    )
+    assert(!encoded.exists(c => c == '"' || c.isWhitespace))
+  }
+
+  it should "fail loudly when the same key appears more than once" in {
+    val exception = intercept[IllegalArgumentException] {
+      PythonWorkflowWorker.encodeStartupConfig(
+        Seq("s3Region" -> "us-west-2", "s3Region" -> "us-east-1")
+      )
+    }
+    assert(exception.getMessage.contains("duplicate"))
+  }
+
+  private val expectedKeys = Set(
+    "workerId",
+    "outputPort",
+    "loggerLevel",
+    "rPath",
+    "icebergCatalogType",
+    "icebergPostgresCatalogUriWithoutScheme",
+    "icebergPostgresCatalogUsername",
+    "icebergPostgresCatalogPassword",
+    "icebergRestCatalogUri",
+    "icebergRestCatalogWarehouseName",
+    "icebergTableNamespace",
+    "icebergTableStateNamespace",
+    "icebergFileStorageDirectoryPath",
+    "icebergTableCommitBatchSize",
+    "s3Endpoint",
+    "s3Region",
+    "s3AuthUsername",
+    "s3AuthPassword",
+    "s3LargeBinariesBaseUri"
+  )
+
+  "buildStartupConfig" should "produce exactly the expected named keys with the worker values" in {
+    val config =
+      PythonWorkflowWorker.buildStartupConfig("worker-7", "6000", "/opt/R", "s3://bucket/uri")
+    val map = config.toMap
+
+    assert(config.size == expectedKeys.size, "no duplicate or missing keys")
+    assert(map.keySet == expectedKeys)
+    assert(map("workerId") == "worker-7")
+    assert(map("outputPort") == "6000")
+    assert(map("rPath") == "/opt/R")
+    assert(map("s3LargeBinariesBaseUri") == "s3://bucket/uri")
+  }
+
+  it should "produce a config that round-trips through encodeStartupConfig" in {
+    val encoded = PythonWorkflowWorker.encodeStartupConfig(
+      PythonWorkflowWorker.buildStartupConfig("w", "1", "", "uri")
+    )
+    val parsed = objectMapper.readValue(decode(encoded), classOf[java.util.Map[String, String]])
+    assert(parsed.get("workerId") == "w")
+    assert(parsed.get("s3LargeBinariesBaseUri") == "uri")
+    assert(parsed.size() == expectedKeys.size)
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #5917 to `release/v1.2`, cherry-picked from 6e5ab8922d3574acbb447883946dbf16550c952d.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) as part of a backport-coverage audit for fixes merged to `main` since early June that were never labeled for backport.

### Any related issues, documentation, discussions?

Backport of #5917. Originally linked #5916.

### How was this PR tested?

Release-branch CI runs once the conflicts are resolved and this PR is marked ready for review. The cherry-pick **conflicted** and was committed with conflict markers.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; conflicts left as markers for the original author to resolve; the change itself is #5917 by its original author).
