### PR TITLE
fix(amber, v1.2): log betterproto stderr as info to avoid false IDE build failures

### DIFF
--- a/amber/build.sbt
+++ b/amber/build.sbt
@@ -217,7 +217,7 @@ genPythonProto := {
         "Install protoc and `pip install betterproto[compiler]` before launching a Python worker or running pytest."
     )
   } else {
-    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.error(line))
+    val procLogger = scala.sys.process.ProcessLogger(line => log.info(line), line => log.info(line))
     val exit = scala.sys.process.Process(Seq("bash", script.getAbsolutePath), repoRoot).!(procLogger)
     if (exit != 0) sys.error(s"python-proto-gen.sh failed with exit code $exit")
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6245 to `release/v1.2`, cherry-picked from a6c85b3b193de317f73f9b567aa9ceb687bc022b.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) as part of a backport-coverage audit for fixes merged to `main` since early June that were never labeled for backport.

### Any related issues, documentation, discussions?

Backport of #6245. Originally linked #6243.

### How was this PR tested?

Release-branch CI runs on this PR. The cherry-pick applied cleanly onto `release/v1.2`; no manual conflict resolution was needed.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; the change itself is #6245 by its original author).
