### PR TITLE
fix(workflow, v1.2): include coverImage in search and list API responses

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/UnifiedResourceSchema.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/UnifiedResourceSchema.scala
@@ -73,7 +73,8 @@ object UnifiedResourceSchema {
       isDatasetPublic: Field[java.lang.Boolean] = DSL.cast(null, classOf[java.lang.Boolean]),
       isDatasetDownloadable: Field[java.lang.Boolean] = DSL.cast(null, classOf[java.lang.Boolean]),
       datasetUserAccess: Field[PrivilegeEnum] = DSL.castNull(classOf[PrivilegeEnum]),
-      datasetCoverImage: Field[String] = DSL.cast(null, classOf[String])
+      datasetCoverImage: Field[String] = DSL.cast(null, classOf[String]),
+      workflowCoverImage: Field[String] = DSL.cast(null, classOf[String])
   ): UnifiedResourceSchema = {
     new UnifiedResourceSchema(
       Seq(
@@ -98,7 +99,8 @@ object UnifiedResourceSchema {
         isDatasetPublic -> isDatasetPublic.as("is_dataset_public"),
         isDatasetDownloadable -> isDatasetDownloadable.as("is_dataset_downloadable"),
         datasetUserAccess -> datasetUserAccess.as("user_dataset_access"),
-        datasetCoverImage -> datasetCoverImage.as("cover_image")
+        datasetCoverImage -> datasetCoverImage.as("cover_image"),
+        workflowCoverImage -> workflowCoverImage.as("workflow_cover_image")
       )
     )
   }

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/WorkflowSearchQueryBuilder.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/WorkflowSearchQueryBuilder.scala
@@ -44,7 +44,8 @@ object WorkflowSearchQueryBuilder extends SearchQueryBuilder {
       uid = WORKFLOW_OF_USER.UID,
       ownerId = WORKFLOW_OF_USER.UID,
       userName = USER.NAME,
-      projectsOfWorkflow = groupConcatDistinct(WORKFLOW_OF_PROJECT.PID)
+      projectsOfWorkflow = groupConcatDistinct(WORKFLOW_OF_PROJECT.PID),
+      workflowCoverImage = DSL.max(WORKFLOW_COVER_IMAGE.IMAGE).as("workflow_cover_image")
     )
   }
 
@@ -64,6 +65,8 @@ object WorkflowSearchQueryBuilder extends SearchQueryBuilder {
       .on(WORKFLOW_OF_PROJECT.WID.eq(WORKFLOW.WID))
       .leftJoin(PROJECT_USER_ACCESS)
       .on(PROJECT_USER_ACCESS.PID.eq(WORKFLOW_OF_PROJECT.PID))
+      .leftJoin(WORKFLOW_COVER_IMAGE)
+      .on(WORKFLOW_COVER_IMAGE.WID.eq(WORKFLOW.WID))
 
     var condition: Condition = DSL.trueCondition()
     if (uid == null) {
@@ -154,7 +157,8 @@ object WorkflowSearchQueryBuilder extends SearchQueryBuilder {
           .map(number => Integer.valueOf(number))
           .toList
       },
-      record.into(USER).getUid
+      record.into(USER).getUid,
+      Option(record.get("workflow_cover_image", classOf[String]))
     )
     DashboardClickableFileEntry(SearchQueryBuilder.WORKFLOW_RESOURCE_TYPE, workflow = Some(dw))
   }

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -41,8 +41,8 @@ import org.apache.texera.web.resource.dashboard.hub.EntityType
 import org.apache.texera.web.resource.dashboard.hub.HubResource.recordCloneAction
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowAccessResource.hasReadAccess
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowResource._
-import org.jooq.impl.DSL.{groupConcatDistinct, noCondition}
-import org.jooq.{Condition, DSLContext, Record9, Result, SelectOnConditionStep}
+import org.jooq.impl.DSL.{groupConcatDistinct, noCondition, max}
+import org.jooq.{Condition, DSLContext, Record10, Result, SelectOnConditionStep}
 
 import java.sql.Timestamp
 import java.util
@@ -119,7 +119,8 @@ object WorkflowResource {
       ownerName: String,
       workflow: Workflow,
       projectIDs: List[Integer],
-      ownerId: Integer
+      ownerId: Integer,
+      coverImage: Option[String]
   )
 
   case class WorkflowWithPrivilege(
@@ -185,7 +186,7 @@ object WorkflowResource {
     }
   }
 
-  def baseWorkflowSelect(): SelectOnConditionStep[Record9[
+  def baseWorkflowSelect(): SelectOnConditionStep[Record10[
     Integer,
     String,
     String,
@@ -193,6 +194,7 @@ object WorkflowResource {
     Timestamp,
     PrivilegeEnum,
     Integer,
+    String,
     String,
     String
   ]] = {
@@ -206,7 +208,8 @@ object WorkflowResource {
         WORKFLOW_USER_ACCESS.PRIVILEGE,
         WORKFLOW_OF_USER.UID,
         USER.NAME,
-        groupConcatDistinct(WORKFLOW_OF_PROJECT.PID).as("projects")
+        groupConcatDistinct(WORKFLOW_OF_PROJECT.PID).as("projects"),
+        max(WORKFLOW_COVER_IMAGE.IMAGE).as("cover_image")
       )
       .from(WORKFLOW)
       .leftJoin(WORKFLOW_USER_ACCESS)
@@ -217,10 +220,12 @@ object WorkflowResource {
       .on(USER.UID.eq(WORKFLOW_OF_USER.UID))
       .leftJoin(WORKFLOW_OF_PROJECT)
       .on(WORKFLOW.WID.eq(WORKFLOW_OF_PROJECT.WID))
+      .leftJoin(WORKFLOW_COVER_IMAGE)
+      .on(WORKFLOW.WID.eq(WORKFLOW_COVER_IMAGE.WID))
   }
 
   def mapWorkflowEntries(
-      workflowEntries: Result[Record9[
+      workflowEntries: Result[Record10[
         Integer,
         String,
         String,
@@ -228,6 +233,7 @@ object WorkflowResource {
         Timestamp,
         PrivilegeEnum,
         Integer,
+        String,
         String,
         String
       ]],
@@ -249,7 +255,8 @@ object WorkflowResource {
           if (workflowRecord.component9() == null) List[Integer]()
           else
             workflowRecord.component9().split(',').map(str => Integer.valueOf(str)).toList,
-          workflowRecord.into(WORKFLOW_OF_USER).getUid
+          workflowRecord.into(WORKFLOW_OF_USER).getUid,
+          Option(workflowRecord.get("cover_image", classOf[String]))
         )
       )
       .asScala
@@ -578,7 +585,8 @@ class WorkflowResource extends LazyLogging {
         user.getName,
         workflowDao.fetchOneByWid(workflow.getWid),
         List[Integer](),
-        user.getUid
+        user.getUid,
+        None
       )
     }
 

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -26,6 +26,7 @@ import org.apache.texera.dao.jooq.generated.enums.UserRoleEnum
 import org.apache.texera.dao.jooq.generated.tables.daos.UserDao
 import org.apache.texera.dao.jooq.generated.tables.pojos.{Project, User, Workflow}
 import org.apache.texera.web.resource.dashboard.DashboardResource.SearchQueryParams
+import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowResource.CoverImageRequest
 import org.apache.texera.web.resource.dashboard.user.project.ProjectResource
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowResource
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowResource.{
@@ -780,4 +781,73 @@ class WorkflowResourceSpec
     assert(resources.results(2).workflow.get.workflow.getName == "test_workflow1")
   }
 
+<<<<<<< HEAD
+=======
+  it should "order workflow by execution time correctly" in {
+    // Create several resources with different names (no execution times are set, but the SQL query should parse correctly)
+    workflowResource.persistWorkflow(testWorkflow1, sessionUser1)
+    workflowResource.persistWorkflow(testWorkflow3, sessionUser1)
+    workflowResource.persistWorkflow(testWorkflow2, sessionUser1)
+
+    // Retrieve resources ordered by execution time ascending
+    var resources =
+      dashboardResource.searchAllResourcesCall(
+        sessionUser1,
+        SearchQueryParams(resourceType = "workflow", orderBy = "ExecutionTimeAsc")
+      )
+
+    // Execution times are null so order is not guaranteed, but we verify it returns 3 results
+    assert(resources.results.length == 3)
+
+    // Retrieve resources ordered by execution time descending
+    resources = dashboardResource.searchAllResourcesCall(
+      sessionUser1,
+      SearchQueryParams(resourceType = "workflow", orderBy = "ExecutionTimeDesc")
+    )
+
+    // Verify it returns 3 results
+    assert(resources.results.length == 3)
+  }
+
+  it should "include workflow cover image in search results" in {
+    // Create workflow
+    workflowResource.persistWorkflow(testWorkflow1, sessionUser1)
+
+    // Set cover image
+    val workflowId =
+      workflowResource.retrieveWorkflowsBySessionUser(sessionUser1).head.workflow.getWid
+
+    val coverImage = "data:image/jpeg;base64,/9j/4AAQSkZJRg=="
+    workflowResource.setCoverImage(
+      workflowId,
+      CoverImageRequest(coverImage),
+      sessionUser1
+    )
+
+    // Search workflows
+    val results =
+      dashboardResource.searchAllResourcesCall(
+        sessionUser1,
+        SearchQueryParams(resourceType = "workflow")
+      )
+
+    // Verify cover image is included in response
+    assert(results.results.length == 1)
+
+    val workflowEntry = results.results.head.workflow.get
+    assert(workflowEntry.coverImage.contains(coverImage))
+  }
+
+  it should "create a workflow with coverImage set to None" in {
+    val workflow = new Workflow()
+    workflow.setName("test_create_workflow")
+    workflow.setContent(exampleContent)
+
+    val result = workflowResource.createWorkflow(workflow, sessionUser1)
+
+    assert(result.workflow.getName == "test_create_workflow")
+    assert(result.coverImage.isEmpty)
+  }
+
+>>>>>>> ff82fd82f (fix(workflow): include coverImage in search and list API responses (#6280))
 }

--- a/frontend/src/app/dashboard/component/user-dashboard-test-fixtures.ts
+++ b/frontend/src/app/dashboard/component/user-dashboard-test-fixtures.ts
@@ -138,6 +138,7 @@ export const testWorkflowFileNameConflictEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [1],
     ownerId: 1,
+    coverImage: null,
   }),
   new DashboardEntry({
     workflow: testDownloadWorkflow2,
@@ -146,6 +147,7 @@ export const testWorkflowFileNameConflictEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [1, 2],
     ownerId: 1,
+    coverImage: null,
   }),
   new DashboardEntry({
     workflow: testDownloadWorkflow3,
@@ -154,6 +156,7 @@ export const testWorkflowFileNameConflictEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [1],
     ownerId: 2,
+    coverImage: null,
   }),
 ];
 
@@ -165,6 +168,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [1],
     ownerId: 1,
+    coverImage: null,
   }),
   new DashboardEntry({
     workflow: testWorkflow2,
@@ -173,6 +177,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [1, 2],
     ownerId: 1,
+    coverImage: null,
   }),
   new DashboardEntry({
     workflow: testWorkflow3,
@@ -181,6 +186,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [1],
     ownerId: 2,
+    coverImage: null,
   }),
   new DashboardEntry({
     workflow: testWorkflow4,
@@ -189,6 +195,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [3],
     ownerId: 2,
+    coverImage: null,
   }),
   new DashboardEntry({
     workflow: testWorkflow5,
@@ -197,6 +204,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
     accessLevel: "Write",
     projectIDs: [3],
     ownerId: 3,
+    coverImage: null,
   }),
 ];
 

--- a/frontend/src/app/dashboard/component/user/list-item/card-item/card-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/card-item/card-item.component.spec.ts
@@ -1,0 +1,366 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { CardItemComponent } from "./card-item.component";
+import { WorkflowPersistService } from "src/app/common/service/workflow-persist/workflow-persist.service";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { of, throwError } from "rxjs";
+import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { RouterTestingModule } from "@angular/router/testing";
+import { StubUserService } from "../../../../../common/service/user/stub-user.service";
+import { UserService } from "../../../../../common/service/user/user.service";
+import { commonTestProviders } from "../../../../../common/testing/test-utils";
+import type { Mocked } from "vitest";
+import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
+import { HUB_WORKFLOW_RESULT_DETAIL, USER_WORKSPACE } from "../../../../../app-routing.constant";
+import { WorkflowCoverService } from "src/app/dashboard/service/user/workflow-cover/workflow-cover.service";
+import { NotificationService } from "../../../../../common/service/notification/notification.service";
+import { DatasetService } from "../../../../service/user/dataset/dataset.service";
+
+function makeWorkflowEntry(overrides: Partial<DashboardEntry> = {}): DashboardEntry {
+  return {
+    id: 1,
+    name: "wf",
+    description: "",
+    type: "workflow",
+    workflow: { isOwner: true },
+    accessibleUserIds: [],
+    likeCount: 0,
+    viewCount: 0,
+    isLiked: false,
+    size: 0,
+    ...overrides,
+  } as unknown as DashboardEntry;
+}
+
+function makeDatasetEntry(overrides: Partial<DashboardEntry> = {}): DashboardEntry {
+  return {
+    id: 5,
+    name: "ds",
+    description: "",
+    type: "dataset",
+    dataset: { isOwner: true },
+    accessibleUserIds: [],
+    likeCount: 0,
+    viewCount: 0,
+    isLiked: false,
+    size: 0,
+    ...overrides,
+  } as unknown as DashboardEntry;
+}
+
+describe("CardItemComponent", () => {
+  let component: CardItemComponent;
+  let fixture: ComponentFixture<CardItemComponent>;
+  let workflowPersistService: Mocked<WorkflowPersistService>;
+  let workflowCoverService: Mocked<WorkflowCoverService>;
+  let datasetService: Mocked<DatasetService>;
+
+  beforeEach(async () => {
+    const workflowPersistServiceSpy = { updateWorkflowName: vi.fn(), updateWorkflowDescription: vi.fn() };
+    const workflowCoverServiceSpy = {
+      getCover: vi.fn().mockReturnValue(of(undefined)),
+      setCoverFromFile: vi.fn(),
+      clearCover: vi.fn().mockReturnValue(of(undefined)),
+    };
+    const datasetServiceSpy = { getDatasetCoverUrl: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [CardItemComponent, HttpClientTestingModule, BrowserAnimationsModule, RouterTestingModule],
+      providers: [
+        { provide: WorkflowPersistService, useValue: workflowPersistServiceSpy },
+        { provide: WorkflowCoverService, useValue: workflowCoverServiceSpy },
+        { provide: DatasetService, useValue: datasetServiceSpy },
+        { provide: UserService, useClass: StubUserService },
+        NzModalService,
+        ...commonTestProviders,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CardItemComponent);
+    component = fixture.componentInstance;
+    workflowPersistService = TestBed.inject(WorkflowPersistService) as unknown as Mocked<WorkflowPersistService>;
+    workflowCoverService = TestBed.inject(WorkflowCoverService) as unknown as Mocked<WorkflowCoverService>;
+    datasetService = TestBed.inject(DatasetService) as unknown as Mocked<DatasetService>;
+    component.entry = makeWorkflowEntry();
+    fixture.detectChanges();
+  });
+
+  it("should update workflow name successfully", () => {
+    const newName = "New Workflow Name";
+    component.entry = makeWorkflowEntry({ id: 1, name: "Old Name" });
+    workflowPersistService.updateWorkflowName.mockReturnValue(of({} as Response));
+
+    component.confirmUpdateCustomName(newName);
+
+    expect(workflowPersistService.updateWorkflowName).toHaveBeenCalledWith(1, newName);
+    expect(component.entry.name).toBe(newName);
+    expect(component.editingName).toBe(false);
+  });
+
+  it("should revert the name and exit edit mode when the update fails", () => {
+    component.entry = makeWorkflowEntry({ id: 1, name: "Old Name" });
+    component.originalName = "Old Name";
+    workflowPersistService.updateWorkflowName.mockReturnValue(throwError(() => new Error("Error")));
+
+    component.confirmUpdateCustomName("New Workflow Name");
+
+    expect(component.entry.name).toBe("Old Name");
+    expect(component.editingName).toBe(false);
+  });
+
+  it("should update workflow description successfully", () => {
+    component.entry = makeWorkflowEntry({ id: 1, description: "Old Description" });
+    workflowPersistService.updateWorkflowDescription.mockReturnValue(of({} as Response));
+
+    component.confirmUpdateCustomDescription("New Description");
+
+    expect(workflowPersistService.updateWorkflowDescription).toHaveBeenCalledWith(1, "New Description");
+    expect(component.entry.description).toBe("New Description");
+    expect(component.editingDescription).toBe(false);
+  });
+
+  it("should revert the description and exit edit mode when the update fails", () => {
+    component.entry = makeWorkflowEntry({ id: 1, description: "Old Description" });
+    component.originalDescription = "Old Description";
+    workflowPersistService.updateWorkflowDescription.mockReturnValue(throwError(() => new Error("Error")));
+
+    component.confirmUpdateCustomDescription("New Description");
+
+    expect(component.entry.description).toBe("Old Description");
+    expect(component.editingDescription).toBe(false);
+  });
+
+  it("should route owners to the workspace and non-owners to the hub detail view", () => {
+    component.currentUid = 42;
+    component.entry = makeWorkflowEntry({ id: 7, accessibleUserIds: [42] });
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+    expect(component.entryLink).toEqual([USER_WORKSPACE, "7"]);
+
+    component.entry = makeWorkflowEntry({ id: 7, accessibleUserIds: [99] });
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+    expect(component.entryLink).toEqual([HUB_WORKFLOW_RESULT_DETAIL, "7"]);
+  });
+
+  it("should format counts as kilo for values >= 1000", () => {
+    expect(component.formatCount(999)).toBe("999");
+    expect(component.formatCount(1500)).toBe("1.5k");
+    expect(component.formatCount(0)).toBe("0");
+  });
+
+  it("should return 'Unknown' for undefined timestamps", () => {
+    expect(component.formatTime(undefined)).toBe("Unknown");
+  });
+
+  it("should emit deleted when the parent triggers the delete confirmation", () => {
+    const spy = vi.fn();
+    component.deleted.subscribe(spy);
+    component.deleted.emit();
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should toggle the entry checked flag and emit checkboxChanged", () => {
+    const entry = makeWorkflowEntry({ checked: false } as any);
+    component.entry = entry;
+    const spy = vi.fn();
+    component.checkboxChanged.subscribe(spy);
+
+    component.onCheckboxChange(entry);
+
+    expect((entry as any).checked).toBe(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("should show cover controls only for an owned workflow in private search", () => {
+    component.isPrivateSearch = true;
+    component.entry = makeWorkflowEntry({ workflow: { isOwner: true } } as any);
+    expect(component.canEditCover).toBe(true);
+
+    component.entry = makeWorkflowEntry({ workflow: { isOwner: false } } as any);
+    expect(component.canEditCover).toBe(false);
+
+    component.entry = makeWorkflowEntry({ workflow: { isOwner: true } } as any);
+    component.isPrivateSearch = false;
+    expect(component.canEditCover).toBe(false);
+  });
+
+  it("should use the stored cover image on initialization", () => {
+    const cover = "data:image/jpeg;base64,abc";
+    const entry = makeWorkflowEntry({ id: 7 });
+    entry.coverImageUrl = cover;
+
+    component.entry = entry;
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+
+    expect(workflowCoverService.getCover).not.toHaveBeenCalled();
+    expect(component.hasCustomImage).toBe(true);
+    expect(component.coverImageSrc).toBe(cover);
+  });
+
+  it("should fall back to the default preview image when no cover is set", () => {
+    const entry = makeWorkflowEntry({ id: 7 });
+    entry.coverImageUrl = undefined;
+
+    component.entry = entry;
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+
+    expect(workflowCoverService.getCover).not.toHaveBeenCalled();
+    expect(component.hasCustomImage).toBe(false);
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should upload a selected image and use the returned data URL as the cover", async () => {
+    const dataUrl = "data:image/jpeg;base64,xyz";
+    workflowCoverService.setCoverFromFile.mockResolvedValue(dataUrl);
+    component.entry = makeWorkflowEntry({ id: 7 });
+    const file = new File(["x"], "pic.png", { type: "image/png" });
+
+    await component.onImageSelected({ target: { files: [file], value: "pic.png" } } as any);
+
+    expect(workflowCoverService.setCoverFromFile).toHaveBeenCalledWith(7, file);
+    expect(component.coverImageSrc).toBe(dataUrl);
+    expect(component.hasCustomImage).toBe(true);
+  });
+
+  it("should reject a non-image file and not upload it", async () => {
+    const notificationService = TestBed.inject(NotificationService);
+    const errorSpy = vi.spyOn(notificationService, "error");
+    const file = new File(["x"], "notes.txt", { type: "text/plain" });
+
+    await component.onImageSelected({ target: { files: [file], value: "notes.txt" } } as any);
+
+    expect(workflowCoverService.setCoverFromFile).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("should notify on upload failure and keep the previous preview image", async () => {
+    const notificationService = TestBed.inject(NotificationService);
+    const errorSpy = vi.spyOn(notificationService, "error");
+    workflowCoverService.setCoverFromFile.mockRejectedValue(new Error("boom"));
+    component.entry = makeWorkflowEntry({ id: 7 });
+    const file = new File(["x"], "pic.png", { type: "image/png" });
+
+    await component.onImageSelected({ target: { files: [file], value: "pic.png" } } as any);
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should clear the cover and revert to the default image on reset", () => {
+    workflowCoverService.clearCover.mockReturnValue(of(undefined));
+    component.entry = makeWorkflowEntry({ id: 7 });
+    (component as any).customImage = "data:image/jpeg;base64,abc";
+
+    component.resetImage();
+
+    expect(workflowCoverService.clearCover).toHaveBeenCalledWith(7);
+    expect(component.hasCustomImage).toBe(false);
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should notify and keep the cover when reset fails", () => {
+    const notificationService = TestBed.inject(NotificationService);
+    const errorSpy = vi.spyOn(notificationService, "error");
+    workflowCoverService.clearCover.mockReturnValue(throwError(() => new Error("boom")));
+    component.entry = makeWorkflowEntry({ id: 7 });
+    (component as any).customImage = "data:image/jpeg;base64,abc";
+
+    component.resetImage();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(component.hasCustomImage).toBe(true);
+  });
+
+  it("openImagePicker clicks the hidden file input", () => {
+    const clickSpy = vi.fn();
+    (component as any).backgroundInput = { nativeElement: { click: clickSpy } };
+    component.openImagePicker();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("openImagePicker is a no-op when the file input is absent", () => {
+    (component as any).backgroundInput = undefined;
+    expect(() => component.openImagePicker()).not.toThrow();
+  });
+
+  it("should do nothing when no file is selected", async () => {
+    await component.onImageSelected({ target: { files: [], value: "" } } as any);
+    expect(workflowCoverService.setCoverFromFile).not.toHaveBeenCalled();
+  });
+
+  it("should not upload when the entry id is not numeric", async () => {
+    component.entry = makeWorkflowEntry({ id: "not-a-number" as any });
+    const file = new File(["x"], "pic.png", { type: "image/png" });
+    await component.onImageSelected({ target: { files: [file], value: "pic.png" } } as any);
+    expect(workflowCoverService.setCoverFromFile).not.toHaveBeenCalled();
+  });
+
+  it("resetImage does nothing when the entry id is not numeric", () => {
+    component.entry = makeWorkflowEntry({ id: "not-a-number" as any });
+    component.resetImage();
+    expect(workflowCoverService.clearCover).not.toHaveBeenCalled();
+  });
+
+  it("should load the dataset cover into the preview when the entry has a cover", () => {
+    datasetService.getDatasetCoverUrl.mockReturnValue(of({ url: "https://cover.example/img.png" }));
+    component.entry = makeDatasetEntry({ id: 5, coverImageUrl: "cover/path.png" });
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+
+    expect(datasetService.getDatasetCoverUrl).toHaveBeenCalledWith(5);
+    expect(component.coverImageSrc).toBe("https://cover.example/img.png");
+  });
+
+  it("should fall back to the default preview when the cover fetch fails", () => {
+    datasetService.getDatasetCoverUrl.mockReturnValue(throwError(() => new Error("cover fetch failed")));
+    component.entry = makeDatasetEntry({ coverImageUrl: "cover/path.png" });
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should reset the preview to the default image on cover load error", () => {
+    component.coverImageSrc = "https://cover.example/img.png";
+    component.onCoverError();
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should keep the default preview for non-dataset entries", () => {
+    component.entry = makeWorkflowEntry();
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should not fetch a cover when the dataset has no cover image", () => {
+    component.entry = makeDatasetEntry({ coverImageUrl: undefined });
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+
+    expect(datasetService.getDatasetCoverUrl).not.toHaveBeenCalled();
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+
+  it("should use the default preview when the cover url resolves to null", () => {
+    datasetService.getDatasetCoverUrl.mockReturnValue(of({ url: null }));
+    component.entry = makeDatasetEntry({ coverImageUrl: "cover/path.png" });
+    component.ngOnChanges({ entry: { currentValue: component.entry } as any });
+
+    expect(component.coverImageSrc).toBe(CardItemComponent.DEFAULT_PREVIEW_IMAGE);
+  });
+});

--- a/frontend/src/app/dashboard/component/user/list-item/card-item/card-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/list-item/card-item/card-item.component.ts
@@ -1,0 +1,511 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from "@angular/core";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { NgIf } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+import { RouterLink } from "@angular/router";
+import { NzCardComponent } from "ng-zorro-antd/card";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzCheckboxComponent } from "ng-zorro-antd/checkbox";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzPopconfirmDirective } from "ng-zorro-antd/popconfirm";
+import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
+import { NzModalRef, NzModalService } from "ng-zorro-antd/modal";
+import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
+import { ShareAccessComponent } from "../../share-access/share-access.component";
+import { UserAvatarComponent } from "../../user-avatar/user-avatar.component";
+import {
+  DEFAULT_WORKFLOW_NAME,
+  WorkflowPersistService,
+} from "src/app/common/service/workflow-persist/workflow-persist.service";
+import { firstValueFrom } from "rxjs";
+import { HubWorkflowDetailComponent } from "../../../../../hub/component/workflow/detail/hub-workflow-detail.component";
+import { ActionType, HubService } from "../../../../../hub/service/hub.service";
+import { DownloadService } from "src/app/dashboard/service/user/download/download.service";
+import { formatSize } from "src/app/common/util/size-formatter.util";
+import { formatRelativeTime, formatCount } from "src/app/common/util/format.util";
+import { DatasetService, DEFAULT_DATASET_NAME } from "../../../../service/user/dataset/dataset.service";
+import { NotificationService } from "../../../../../common/service/notification/notification.service";
+import { WorkflowCoverService } from "../../../../service/user/workflow-cover/workflow-cover.service";
+import {
+  HUB_DATASET_RESULT_DETAIL,
+  HUB_WORKFLOW_RESULT_DETAIL,
+  USER_DATASET,
+  USER_PROJECT,
+  USER_WORKSPACE,
+} from "../../../../../app-routing.constant";
+import { isDefined } from "../../../../../common/util/predicate";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-card-item",
+  templateUrl: "./card-item.component.html",
+  styleUrls: ["./card-item.component.scss"],
+  imports: [
+    NzCardComponent,
+    RouterLink,
+    NgIf,
+    FormsModule,
+    NzCheckboxComponent,
+    UserAvatarComponent,
+    NzIconDirective,
+    NzButtonComponent,
+    NzPopconfirmDirective,
+    ɵNzTransitionPatchDirective,
+  ],
+})
+export class CardItemComponent implements OnChanges {
+  private owners: number[] = [];
+  public originalName: string = "";
+  public originalDescription: string | undefined = undefined;
+  public disableDelete: boolean = false;
+  @Input() currentUid: number | undefined;
+  @ViewChild("nameInput") nameInput!: ElementRef;
+  @ViewChild("descriptionInput") descriptionInput!: ElementRef;
+  editingName = false;
+  editingDescription = false;
+  likeCount: number = 0;
+  viewCount = 0;
+  entryLink: string[] = [];
+  size: number | undefined = 0;
+  public iconType: string = "";
+  isLiked: boolean = false;
+  @Input() isPrivateSearch = false;
+  @Input() editable = false;
+  private _entry?: DashboardEntry;
+  hovering: boolean = false;
+  /** The default top image, used when the user has not uploaded a custom one. */
+  static readonly DEFAULT_PREVIEW_IMAGE = "assets/card_background.jpg";
+  /** Resolved preview/cover image; stays the placeholder until a dataset cover loads. */
+  coverImageSrc: string = CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+
+  /** The workflow's custom cover image data URL, if one has been set. */
+  private customImage?: string;
+  @ViewChild("backgroundInput") backgroundInput!: ElementRef<HTMLInputElement>;
+
+  @Input()
+  get entry(): DashboardEntry {
+    if (!this._entry) {
+      throw new Error("entry property must be provided.");
+    }
+    return this._entry;
+  }
+
+  set entry(value: DashboardEntry) {
+    this._entry = value;
+  }
+
+  @Output() checkboxChanged = new EventEmitter<void>();
+  @Output() deleted = new EventEmitter<void>();
+  @Output() duplicated = new EventEmitter<void>();
+  @Output() refresh = new EventEmitter<void>();
+
+  constructor(
+    private modalService: NzModalService,
+    private workflowPersistService: WorkflowPersistService,
+    private datasetService: DatasetService,
+    private modal: NzModalService,
+    private hubService: HubService,
+    private downloadService: DownloadService,
+    private cdr: ChangeDetectorRef,
+    private notificationService: NotificationService,
+    private workflowCoverService: WorkflowCoverService
+  ) {}
+
+  get hasCustomImage(): boolean {
+    return this.customImage !== undefined;
+  }
+
+  /** Whether the cover-image controls are shown: an editable workflow in private search. */
+  get canEditCover(): boolean {
+    return this.isPrivateSearch && this.entry.type === "workflow" && this.entry.workflow.isOwner;
+  }
+
+  openImagePicker(): void {
+    this.backgroundInput?.nativeElement.click();
+  }
+
+  async onImageSelected(event: Event): Promise<void> {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    input.value = ""; // allow re-selecting the same file
+    if (!file) {
+      return;
+    }
+    if (!file.type.startsWith("image/")) {
+      this.notificationService.error("Please choose an image file.");
+      return;
+    }
+    if (typeof this.entry.id !== "number") {
+      return;
+    }
+    try {
+      this.customImage = await this.workflowCoverService.setCoverFromFile(this.entry.id, file);
+      this.coverImageSrc = this.customImage;
+      this.cdr.markForCheck();
+    } catch (e) {
+      this.notificationService.error("Failed to set the cover image.");
+    }
+  }
+
+  resetImage(): void {
+    if (typeof this.entry.id !== "number") {
+      return;
+    }
+    this.workflowCoverService
+      .clearCover(this.entry.id)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          this.customImage = undefined;
+          this.coverImageSrc = CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+          this.cdr.markForCheck();
+        },
+        error: () => this.notificationService.error("Failed to reset the cover image."),
+      });
+  }
+
+  initializeEntry() {
+    this.coverImageSrc = CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+    this.customImage = undefined;
+    if (this.entry.type === "workflow") {
+      if (typeof this.entry.id === "number") {
+        this.disableDelete = !this.entry.workflow.isOwner;
+        this.owners = this.entry.accessibleUserIds;
+        if (this.currentUid !== undefined && this.owners.includes(this.currentUid)) {
+          this.entryLink = [USER_WORKSPACE, String(this.entry.id)];
+        } else {
+          this.entryLink = [HUB_WORKFLOW_RESULT_DETAIL, String(this.entry.id)];
+        }
+        this.size = this.entry.size;
+        this.coverImageSrc = this.entry.coverImageUrl ?? CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+        this.customImage = this.entry.coverImageUrl ?? undefined;
+      }
+      this.iconType = "project";
+    } else if (this.entry.type === "project") {
+      this.entryLink = [USER_PROJECT, String(this.entry.id)];
+      this.iconType = "container";
+    } else if (this.entry.type === "dataset") {
+      if (typeof this.entry.id === "number") {
+        this.disableDelete = !this.entry.dataset.isOwner;
+        this.owners = this.entry.accessibleUserIds;
+        if (this.currentUid !== undefined && this.owners.includes(this.currentUid)) {
+          this.entryLink = [USER_DATASET, String(this.entry.id)];
+        } else {
+          this.entryLink = [HUB_DATASET_RESULT_DETAIL, String(this.entry.id)];
+        }
+        this.iconType = "database";
+        this.size = this.entry.size;
+        this.loadDatasetCover(this.entry.id);
+      }
+    } else if (this.entry.type === "file") {
+      // not sure where to redirect
+      this.iconType = "folder-open";
+    } else {
+      throw new Error("Unexpected type in DashboardEntry.");
+    }
+    this.likeCount = this.entry.likeCount;
+    this.viewCount = this.entry.viewCount;
+    this.isLiked = this.entry.isLiked;
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["entry"]) {
+      this.initializeEntry();
+    }
+  }
+
+  /** Loads the dataset cover into the preview slot, falling back to the placeholder. */
+  private loadDatasetCover(did: number): void {
+    if (!this.entry.coverImageUrl) {
+      return;
+    }
+    this.datasetService
+      .getDatasetCoverUrl(did)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: ({ url }) => {
+          this.coverImageSrc = url ?? CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.coverImageSrc = CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /** Falls the preview back to the placeholder if the cover image fails to load. */
+  onCoverError(): void {
+    this.coverImageSrc = CardItemComponent.DEFAULT_PREVIEW_IMAGE;
+  }
+
+  onCheckboxChange(entry: DashboardEntry): void {
+    entry.checked = !entry.checked;
+    this.cdr.markForCheck();
+    this.checkboxChanged.emit();
+  }
+
+  public async onClickOpenShareAccess(): Promise<void> {
+    let modal: NzModalRef<ShareAccessComponent> | undefined;
+
+    if (this.entry.type === "workflow") {
+      modal = this.modalService.create({
+        nzContent: ShareAccessComponent,
+        nzData: {
+          writeAccess: this.entry.workflow.accessLevel === "WRITE",
+          type: this.entry.type,
+          id: this.entry.id,
+          allOwners: await firstValueFrom(this.workflowPersistService.retrieveOwners()),
+          inWorkspace: false,
+        },
+        nzFooter: null,
+        nzTitle: "Share this workflow with others",
+        nzCentered: true,
+        nzWidth: "700px",
+      });
+    } else if (this.entry.type === "dataset") {
+      modal = this.modalService.create({
+        nzContent: ShareAccessComponent,
+        nzData: {
+          writeAccess: this.entry.accessLevel === "WRITE",
+          type: "dataset",
+          id: this.entry.id,
+          allOwners: await firstValueFrom(this.datasetService.retrieveOwners()),
+        },
+        nzFooter: null,
+        nzTitle: "Share this dataset with others",
+        nzCentered: true,
+        nzWidth: "700px",
+      });
+    }
+    if (modal) {
+      modal.componentInstance?.refresh.pipe(untilDestroyed(this)).subscribe(() => {
+        this.refresh.emit();
+      });
+    }
+  }
+
+  public onClickDownload = (): void => {
+    if (!this.entry.id) return;
+
+    if (this.entry.type === "workflow") {
+      this.downloadService
+        .downloadWorkflow(this.entry.id, this.entry.workflow.workflow.name)
+        .pipe(untilDestroyed(this))
+        .subscribe();
+    } else if (this.entry.type === "dataset") {
+      this.downloadService.downloadDataset(this.entry.id, this.entry.name).pipe(untilDestroyed(this)).subscribe();
+    }
+  };
+
+  onEditName(): void {
+    this.originalName = this.entry.name;
+    this.editingName = true;
+    setTimeout(() => {
+      if (this.nameInput) {
+        const inputElement = this.nameInput.nativeElement;
+        const valueLength = inputElement.value.length;
+        inputElement.focus();
+        inputElement.setSelectionRange(valueLength, valueLength);
+      }
+    }, 0);
+  }
+
+  onEditDescription(): void {
+    this.originalDescription = this.entry.description;
+    this.editingDescription = true;
+    setTimeout(() => {
+      if (this.descriptionInput) {
+        const textareaElement = this.descriptionInput.nativeElement;
+        const valueLength = textareaElement.value.length;
+        textareaElement.focus();
+        textareaElement.setSelectionRange(valueLength, valueLength);
+      }
+    }, 0);
+  }
+
+  private updateProperty(
+    updateMethod: (id: number, value: string) => any,
+    propertyName: "name" | "description",
+    newValue: string,
+    originalValue: string | undefined
+  ): void {
+    if (!this.entry.id) {
+      this.notificationService.error("Id is missing");
+      return;
+    }
+
+    updateMethod(this.entry.id, newValue)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          this.entry[propertyName] = newValue; // Dynamic property assignment
+        },
+        error: () => {
+          this.notificationService.error("Update failed");
+          (this.entry as any)[propertyName] = originalValue ?? ""; // Fallback to original value
+          this.setEditingState(propertyName, false);
+        },
+        complete: () => {
+          this.setEditingState(propertyName, false);
+        },
+      });
+  }
+
+  private setEditingState(propertyName: "name" | "description", state: boolean): void {
+    if (propertyName === "name") {
+      this.editingName = state;
+    } else if (propertyName === "description") {
+      this.editingDescription = state;
+    }
+  }
+
+  public confirmUpdateCustomName(name: string): void {
+    if (this.entry.name === this.originalName) {
+      this.editingName = false;
+      return;
+    }
+    const newName = this.entry.type === "workflow" ? name || DEFAULT_WORKFLOW_NAME : name || DEFAULT_DATASET_NAME;
+
+    if (this.entry.type === "workflow") {
+      this.updateProperty(
+        this.workflowPersistService.updateWorkflowName.bind(this.workflowPersistService),
+        "name",
+        newName,
+        this.originalName
+      );
+    } else if (this.entry.type === "dataset") {
+      this.updateProperty(
+        this.datasetService.updateDatasetName.bind(this.datasetService),
+        "name",
+        newName,
+        this.originalName
+      );
+    }
+  }
+
+  public confirmUpdateCustomDescription(description: string | undefined): void {
+    if (this.entry.description === this.originalDescription) {
+      this.editingDescription = false;
+      return;
+    }
+    const updatedDescription = description ?? "";
+
+    if (this.entry.type === "workflow") {
+      this.updateProperty(
+        this.workflowPersistService.updateWorkflowDescription.bind(this.workflowPersistService),
+        "description",
+        updatedDescription,
+        this.originalDescription
+      );
+    } else if (this.entry.type === "dataset") {
+      this.updateProperty(
+        this.datasetService.updateDatasetDescription.bind(this.datasetService),
+        "description",
+        updatedDescription,
+        this.originalDescription
+      );
+    }
+  }
+
+  openDetailModal(wid: number | undefined): void {
+    const modalRef = this.modal.create({
+      nzTitle: "Workflow Detail",
+      nzContent: HubWorkflowDetailComponent,
+      nzData: {
+        wid: wid ?? 0,
+      },
+      nzFooter: null,
+      nzStyle: { width: "60%" },
+      nzBodyStyle: { maxHeight: "70vh", overflow: "auto" },
+    });
+
+    const instance = modalRef.componentInstance;
+    if (instance) {
+      if (wid !== undefined) {
+        this.hubService
+          .getCounts([this.entry.type], [wid], [ActionType.View])
+          .pipe(untilDestroyed(this))
+          .subscribe(counts => {
+            const count = counts[0];
+            this.viewCount = (count?.counts.view ?? 0) + 1; // hacky fix to display view correctly
+          });
+      }
+    }
+  }
+
+  toggleLike(): void {
+    const userId = this.currentUid;
+    if (!isDefined(userId) || !isDefined(this.entry.id)) {
+      return;
+    }
+
+    const entryId = this.entry.id!;
+
+    if (this.isLiked) {
+      this.hubService
+        .postUnlike(entryId, this.entry.type)
+        .pipe(untilDestroyed(this))
+        .subscribe((success: boolean) => {
+          if (success) {
+            this.isLiked = false;
+            this.hubService
+              .getCounts([this.entry.type], [entryId], [ActionType.Like])
+              .pipe(untilDestroyed(this))
+              .subscribe(counts => {
+                this.likeCount = counts[0].counts.like ?? 0;
+              });
+          }
+        });
+    } else {
+      this.hubService
+        .postLike(entryId, this.entry.type)
+        .pipe(untilDestroyed(this))
+        .subscribe((success: boolean) => {
+          if (success) {
+            this.isLiked = true;
+            this.hubService
+              .getCounts([this.entry.type], [entryId], [ActionType.Like])
+              .pipe(untilDestroyed(this))
+              .subscribe(counts => {
+                this.likeCount = counts[0].counts.like ?? 0;
+              });
+          }
+        });
+    }
+  }
+
+  // aliases for the shared formatting utilities so the template can call them directly
+  formatTime = formatRelativeTime;
+  formatCount = formatCount;
+  formatSize = formatSize;
+}

--- a/frontend/src/app/dashboard/component/user/user-workflow/user-workflow.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-workflow/user-workflow.component.spec.ts
@@ -357,4 +357,358 @@ describe("SavedWorkflowSectionComponent", () => {
     expect(testWorkflowFileNameConflictEntries[0].checked).toBe(true);
     expect(testWorkflowFileNameConflictEntries[2].checked).toBe(true);
   });
+<<<<<<< HEAD
+=======
+
+  describe("additional UserWorkflowComponent behaviors", () => {
+    const VIEW_MODE_KEY = "texera.userWorkflow.viewMode";
+
+    const makeDashboardWorkflow = (wid: number | undefined, name: string): DashboardWorkflow => ({
+      workflow: {
+        wid,
+        name,
+        description: "desc",
+        content: testWorkflowContent([]),
+        creationTime: 0,
+        lastModifiedTime: 0,
+        isPublished: 0,
+        readonly: false,
+      },
+      isOwner: true,
+      ownerName: "Texera",
+      accessLevel: "Write",
+      projectIDs: [],
+      ownerId: 1,
+      coverImage: null,
+    });
+
+    const makeEntry = (wid: number | undefined, name: string, checked = false): DashboardEntry => {
+      const entry = new DashboardEntry(makeDashboardWorkflow(wid, name));
+      entry.checked = checked;
+      return entry;
+    };
+
+    const setEntries = (entries: DashboardEntry[]): void => {
+      component.searchResultsComponent.entries = entries;
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      localStorage.removeItem(VIEW_MODE_KEY);
+    });
+
+    describe("deleteWorkflow", () => {
+      it("deletes an entry with a wid and removes it from the results", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.deleteWorkflow = vi.fn().mockReturnValue(of(null));
+        const target = makeEntry(5, "to delete");
+        setEntries([target, makeEntry(6, "keep")]);
+
+        component.deleteWorkflow(target);
+
+        expect(persist.deleteWorkflow).toHaveBeenCalledWith([5]);
+        expect(component.searchResultsComponent.entries.map(e => e.name)).toEqual(["keep"]);
+      });
+
+      it("does nothing when the entry has no wid", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.deleteWorkflow = vi.fn();
+
+        component.deleteWorkflow(makeEntry(undefined, "no wid"));
+
+        expect(persist.deleteWorkflow).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("onClickDuplicateSelectedWorkflows", () => {
+      it("duplicates checked wids without a pid and prepends the new entries", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.duplicateWorkflow = vi
+          .fn()
+          .mockReturnValue(of([makeDashboardWorkflow(101, "dup a"), makeDashboardWorkflow(102, "dup b")]));
+        component.pid = undefined;
+        setEntries([makeEntry(1, "wf 1", true), makeEntry(2, "wf 2", true), makeEntry(3, "wf 3", false)]);
+
+        component.onClickDuplicateSelectedWorkflows();
+
+        expect(persist.duplicateWorkflow).toHaveBeenCalledWith([1, 2]);
+        expect(component.searchResultsComponent.entries.map(e => e.name)).toEqual([
+          "dup a",
+          "dup b",
+          "wf 1",
+          "wf 2",
+          "wf 3",
+        ]);
+      });
+
+      it("passes the pid to duplicateWorkflow when the section belongs to a project", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.duplicateWorkflow = vi.fn().mockReturnValue(of([makeDashboardWorkflow(101, "dup a")]));
+        component.pid = 9;
+        setEntries([makeEntry(1, "wf 1", true), makeEntry(2, "wf 2", true)]);
+
+        component.onClickDuplicateSelectedWorkflows();
+
+        expect(persist.duplicateWorkflow).toHaveBeenCalledWith([1, 2], 9);
+      });
+
+      it("early-returns without calling the service when a checked entry has no wid", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.duplicateWorkflow = vi.fn();
+        setEntries([makeEntry(1, "wf 1", true), makeEntry(undefined, "wf 2", true)]);
+
+        component.onClickDuplicateSelectedWorkflows();
+
+        expect(persist.duplicateWorkflow).not.toHaveBeenCalled();
+      });
+
+      it("alerts on a duplication error", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.duplicateWorkflow = vi.fn().mockReturnValue(throwError(() => "boom"));
+        const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+        component.pid = undefined;
+        setEntries([makeEntry(1, "wf 1", true)]);
+
+        component.onClickDuplicateSelectedWorkflows();
+
+        expect(alertSpy).toHaveBeenCalledWith("boom");
+      });
+    });
+
+    describe("handleConfirmDeleteSelectedWorkflows", () => {
+      it("deletes checked wids and keeps undefined-wid entries", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.deleteWorkflow = vi.fn().mockReturnValue(of(null));
+        setEntries([
+          makeEntry(1, "a", true),
+          makeEntry(2, "b", true),
+          makeEntry(undefined, "c", false),
+          makeEntry(3, "d", false),
+        ]);
+
+        component.handleConfirmDeleteSelectedWorkflows();
+
+        expect(persist.deleteWorkflow).toHaveBeenCalledWith([1, 2]);
+        expect(component.searchResultsComponent.entries.map(e => e.name)).toEqual(["c", "d"]);
+      });
+
+      it("early-returns when a checked entry has no wid", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.deleteWorkflow = vi.fn();
+        setEntries([makeEntry(undefined, "a", true)]);
+
+        component.handleConfirmDeleteSelectedWorkflows();
+
+        expect(persist.deleteWorkflow).not.toHaveBeenCalled();
+      });
+
+      it("alerts on a deletion error", () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.deleteWorkflow = vi.fn().mockReturnValue(throwError(() => "delfail"));
+        const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+        setEntries([makeEntry(1, "a", true)]);
+
+        component.handleConfirmDeleteSelectedWorkflows();
+
+        expect(alertSpy).toHaveBeenCalledWith("delfail");
+      });
+    });
+
+    describe("onClickOpenDownloadZip", () => {
+      it("does not call the download service when nothing is checked", () => {
+        setEntries([makeEntry(1, "a", false)]);
+
+        component.onClickOpenDownloadZip();
+
+        expect(downloadServiceSpy.downloadWorkflowsAsZip).not.toHaveBeenCalled();
+      });
+
+      it("logs an error when the download fails", () => {
+        setEntries([makeEntry(1, "a", true)]);
+        downloadServiceSpy.downloadWorkflowsAsZip.mockReturnValue(throwError(() => "dlfail"));
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        component.onClickOpenDownloadZip();
+
+        expect(downloadServiceSpy.downloadWorkflowsAsZip).toHaveBeenCalledWith([{ id: 1, name: "a" }]);
+        expect(errorSpy).toHaveBeenCalledWith("Error downloading workflows:", "dlfail");
+      });
+    });
+
+    describe("workflow uploads", () => {
+      it("imports a valid .json workflow, appending an entry and toasting success", async () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.createWorkflow = vi.fn().mockReturnValue(of(makeDashboardWorkflow(42, "wf")));
+        const searchSpy = vi.spyOn(component, "search").mockResolvedValue(undefined);
+        const successSpy = vi
+          .spyOn(TestBed.inject(NotificationService), "success")
+          .mockImplementation(() => undefined as any);
+        const content = testWorkflowContent([]);
+        const file = new File([JSON.stringify(content)], "wf.json");
+        setEntries([]);
+
+        const result = await firstValueFrom(component.onClickUploadExistingWorkflowFromLocal(file as any));
+
+        expect(result).toBe(false);
+        expect(persist.createWorkflow).toHaveBeenCalledWith(content, "wf");
+        expect(component.searchResultsComponent.entries.map(e => e.name)).toContain("wf");
+        expect(searchSpy).toHaveBeenCalledWith(true);
+        expect(successSpy).toHaveBeenCalledWith("Upload Successful");
+      });
+
+      it("toasts an error and errors the stream when the file is not JSON", async () => {
+        const errorSpy = vi
+          .spyOn(TestBed.inject(NotificationService), "error")
+          .mockImplementation(() => undefined as any);
+        const file = new File(["this is not json"], "bad.json");
+
+        await expect(firstValueFrom(component.onClickUploadExistingWorkflowFromLocal(file as any))).rejects.toThrow();
+
+        expect(errorSpy).toHaveBeenCalledWith(
+          "An error occurred when importing the workflow. Please import a workflow json file."
+        );
+      });
+
+      it("falls back to DEFAULT_WORKFLOW_NAME when the stripped name is empty", async () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.createWorkflow = vi.fn().mockReturnValue(of(makeDashboardWorkflow(1, "x")));
+        vi.spyOn(component, "search").mockResolvedValue(undefined);
+        const content = testWorkflowContent([]);
+        const file = new File([JSON.stringify(content)], ".json");
+
+        await firstValueFrom(component.onClickUploadExistingWorkflowFromLocal(file as any));
+
+        expect(persist.createWorkflow).toHaveBeenCalledWith(content, DEFAULT_WORKFLOW_NAME);
+      });
+
+      it("imports every workflow file inside an uploaded .zip", async () => {
+        const persist = TestBed.inject(WorkflowPersistService) as any;
+        persist.createWorkflow = vi.fn().mockReturnValue(of(makeDashboardWorkflow(1, "z")));
+        vi.spyOn(component, "search").mockResolvedValue(undefined);
+        const zip = new JSZip();
+        zip.file("a.json", JSON.stringify(testWorkflowContent([])));
+        zip.file("b.json", JSON.stringify(testWorkflowContent([])));
+        const blob = await zip.generateAsync({ type: "blob" });
+        const file = new File([blob], "workflows.zip");
+
+        await firstValueFrom(component.onClickUploadExistingWorkflowFromLocal(file as any));
+
+        // handleZipUploads unpacks the archive and imports each entry.
+        expect(persist.createWorkflow).toHaveBeenCalledTimes(2);
+      });
+
+      it("nameWorkflow resolves name conflicts by suffixing an increasing counter", () => {
+        const fakeZip = { files: { "wf.json": {}, "wf-1.json": {} } } as any;
+
+        expect((component as any).nameWorkflow("wf", fakeZip)).toBe("wf-2");
+      });
+    });
+
+    describe("selection and view type", () => {
+      it("selects all and updates the tooltip when nothing is selected", () => {
+        const a = makeEntry(1, "a", false);
+        const b = makeEntry(2, "b", false);
+        setEntries([a, b]);
+
+        component.toggleSelection();
+
+        expect(a.checked).toBe(true);
+        expect(b.checked).toBe(true);
+        expect(component.selectionTooltip).toBe("Unselect all");
+      });
+
+      it("clears the selection and updates the tooltip when everything is selected", () => {
+        const a = makeEntry(1, "a", true);
+        const b = makeEntry(2, "b", true);
+        setEntries([a, b]);
+
+        component.toggleSelection();
+
+        expect(a.checked).toBe(false);
+        expect(b.checked).toBe(false);
+        expect(component.selectionTooltip).toBe("Select all");
+      });
+
+      it("multiWorkflowsOperationButtonEnabled reflects whether any entry is checked", () => {
+        const a = makeEntry(1, "a", false);
+        setEntries([a]);
+        expect(component.multiWorkflowsOperationButtonEnabled()).toBe(false);
+        a.checked = true;
+        expect(component.multiWorkflowsOperationButtonEnabled()).toBe(true);
+      });
+
+      it("multiWorkflowsOperationButtonEnabled is false before the results view is initialized", () => {
+        (component as any)._searchResultsComponent = undefined;
+        expect(component.multiWorkflowsOperationButtonEnabled()).toBe(false);
+      });
+
+      it("updateTooltip toggles between select-all and unselect-all labels", () => {
+        setEntries([makeEntry(1, "a", true), makeEntry(2, "b", true)]);
+        component.updateTooltip();
+        expect(component.selectionTooltip).toBe("Unselect all");
+
+        component.searchResultsComponent.entries[1].checked = false;
+        component.updateTooltip();
+        expect(component.selectionTooltip).toBe("Select all");
+      });
+
+      it("setViewType persists the new mode and updates viewType", () => {
+        component.viewType = "list";
+
+        component.setViewType("card");
+
+        expect(component.viewType).toBe("card");
+        expect(localStorage.getItem(VIEW_MODE_KEY)).toBe("card");
+      });
+
+      it("setViewType is a no-op when the mode is unchanged", () => {
+        component.viewType = "list";
+        const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+        component.setViewType("list");
+
+        expect(component.viewType).toBe("list");
+        expect(setItemSpy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("project workflow modals", () => {
+      it("opens the add-to-project modal and re-searches after it closes", () => {
+        const modalService = TestBed.inject(NzModalService);
+        const searchSpy = vi.spyOn(component, "search").mockResolvedValue(undefined);
+        const createSpy = vi.spyOn(modalService, "create").mockReturnValue({ afterClose: of(undefined) } as any);
+        component.pid = 7;
+
+        component.onClickOpenAddWorkflow();
+
+        expect(createSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            nzContent: NgbdModalAddProjectWorkflowComponent,
+            nzData: { projectId: 7 },
+            nzTitle: "Add Workflows To Project",
+          })
+        );
+        expect(searchSpy).toHaveBeenCalledWith(true);
+      });
+
+      it("opens the remove-from-project modal and re-searches after it closes", () => {
+        const modalService = TestBed.inject(NzModalService);
+        const searchSpy = vi.spyOn(component, "search").mockResolvedValue(undefined);
+        const createSpy = vi.spyOn(modalService, "create").mockReturnValue({ afterClose: of(undefined) } as any);
+        component.pid = 3;
+
+        component.onClickOpenRemoveWorkflow();
+
+        expect(createSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            nzContent: NgbdModalRemoveProjectWorkflowComponent,
+            nzData: { projectId: 3 },
+            nzTitle: "Remove Workflows From Project",
+          })
+        );
+        expect(searchSpy).toHaveBeenCalledWith(true);
+      });
+    });
+  });
+>>>>>>> ff82fd82f (fix(workflow): include coverImage in search and list API responses (#6280))
 });

--- a/frontend/src/app/dashboard/service/user/search.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/search.service.spec.ts
@@ -71,6 +71,7 @@ function makeWorkflowItem(wid: number, ownerId: number): SearchResultItem {
     projectIDs: [],
     accessLevel: "WRITE",
     ownerId,
+    coverImage: null,
   };
   return { resourceType: "workflow", workflow };
 }

--- a/frontend/src/app/dashboard/type/dashboard-entry.ts
+++ b/frontend/src/app/dashboard/type/dashboard-entry.ts
@@ -83,6 +83,7 @@ export class DashboardEntry {
       this.likeCount = 0;
       this.isLiked = false;
       this.accessibleUserIds = [];
+      this.coverImageUrl = value.coverImage ?? undefined;
     } else if (isDashboardProject(value)) {
       this.type = EntityType.Project;
       this.id = value.pid;

--- a/frontend/src/app/dashboard/type/dashboard-workflow.interface.ts
+++ b/frontend/src/app/dashboard/type/dashboard-workflow.interface.ts
@@ -26,4 +26,5 @@ export interface DashboardWorkflow {
   projectIDs: number[];
   accessLevel: string;
   ownerId: number;
+  coverImage: string | null;
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6280 to `release/v1.2`, cherry-picked from ff82fd82fd7229b7ea27a683af41454eebd74985.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) as part of a backport-coverage audit for fixes merged to `main` since early June that were never labeled for backport.

### Any related issues, documentation, discussions?

Backport of #6280. Originally linked #5920.

### How was this PR tested?

Release-branch CI runs once the conflicts are resolved and this PR is marked ready for review. The cherry-pick **conflicted** and was committed with conflict markers.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; conflicts left as markers for the original author to resolve; the change itself is #6280 by its original author).
