### PR TITLE
fix(dashboard, v1.2): sort datasets by creation time (newest first)

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.spec.ts
@@ -130,6 +130,13 @@ describe("UserDatasetComponent", () => {
     });
   });
 
+  describe("default sort", () => {
+    it("defaults to CreateTimeDesc so newest datasets appear first", () => {
+      // Datasets have no last-modified time, so EditTimeDesc would leave the sort key NULL.
+      expect(component.sortMethod).toBe(SortMethod.CreateTimeDesc);
+    });
+  });
+
   describe("ngAfterViewInit", () => {
     it("subscribes to userChanged and calls search on each emission", () => {
       const searchSpy = vi.spyOn(component, "search").mockResolvedValue();

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -64,7 +64,9 @@ import { FormsModule } from "@angular/forms";
   ],
 })
 export class UserDatasetComponent implements AfterViewInit {
-  public sortMethod = SortMethod.EditTimeDesc;
+  // Datasets have no "last modified" timestamp, so EditTimeDesc leaves the sort key NULL for every
+  // row and produces an undefined order. Default to CreateTimeDesc so newly created datasets appear first.
+  public sortMethod = SortMethod.CreateTimeDesc;
   lastSortMethod: SortMethod | null = null;
   public isLogin = this.userService.isLogin();
   public currentUid = this.userService.getCurrentUser()?.uid;

--- a/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/frontend/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -110,6 +110,9 @@ export class HubSearchResultComponent implements OnInit, AfterViewInit {
     const url = this.router.url;
     if (url.includes("dataset")) {
       this.searchType = "dataset";
+      // Datasets have no last-modified/execution time, so EditTimeDesc leaves the sort key NULL.
+      // Default to CreateTimeDesc so newly created datasets appear first.
+      this.sortMethod = SortMethod.CreateTimeDesc;
     } else if (url.includes("workflow")) {
       this.searchType = "workflow";
     }


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6320 to `release/v1.2`, cherry-picked from cc016adb6d5854cd2beca21eb2bedcfe2e486a41.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) as part of a backport-coverage audit for fixes merged to `main` since early June that were never labeled for backport.

### Any related issues, documentation, discussions?

Backport of #6320. Originally linked #6215.

### How was this PR tested?

Release-branch CI runs once the conflicts are resolved and this PR is marked ready for review. The cherry-pick **conflicted** and was committed with conflict markers.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; conflicts left as markers for the original author to resolve; the change itself is #6320 by its original author).
