### PR TITLE
fix(amber, v1.2): carry the loop StateFrame envelope through JVM operators

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/OutputManager.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/messaginglayer/OutputManager.scala
@@ -192,9 +192,16 @@ class OutputManager(
     buffersToFlush.foreach(_.flush())
   }
 
-  def emitState(state: State): Unit = {
-    networkOutputBuffers.foreach(kv => kv._2.sendState(state))
-    saveStateToStorageIfNeeded(state)
+  /**
+    * Emit a State to every network buffer and (if configured) the state
+    * storage. `loopCounter` / `loopStartId` are the loop envelope riding
+    * alongside the State (see `StateFrame`); a JVM hop inside a loop body
+    * passes the incoming envelope through unchanged, while a Scala-originated
+    * state (start/end-channel handlers) uses the "no loop" defaults.
+    */
+  def emitState(state: State, loopCounter: Long = 0L, loopStartId: String = ""): Unit = {
+    networkOutputBuffers.foreach(kv => kv._2.sendState(state, loopCounter, loopStartId))
+    saveStateToStorageIfNeeded(state, loopCounter, loopStartId)
   }
 
   def addPort(portId: PortIdentity, schema: Schema, storageURIBaseOption: Option[URI]): Unit = {
@@ -236,13 +243,23 @@ class OutputManager(
     })
   }
 
-  private def saveStateToStorageIfNeeded(state: State): Unit = {
+  private def saveStateToStorageIfNeeded(
+      state: State,
+      loopCounter: Long,
+      loopStartId: String
+  ): Unit = {
     // The same state row is fanned out to every output port's state
     // table. This mirrors the broadcast-to-all-workers behavior on the
     // emit side: state is shared context, not per-key data, so every
     // downstream operator (and every worker reading the materialization)
+<<<<<<< HEAD
     // needs the full set.
     stateWriterThreads.values.foreach(_.queue.put(Left(state.toTuple)))
+=======
+    // needs the full set. The loop envelope is materialized as its own
+    // columns so the downstream reader can rebuild it.
+    stateWriterThreads.values.foreach(_.queue.put(Left(state.toTuple(loopCounter, loopStartId))))
+>>>>>>> 91a701b7c (fix(amber): carry the loop StateFrame envelope through JVM operators (#6661))
   }
 
   /**

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -124,8 +124,16 @@ class PythonProxyClient(portNumberPromise: Promise[Int], val actorId: ActorVirtu
     dataPayload match {
       case DataFrame(frame) =>
         writeArrowStream(mutable.Queue(ArraySeq.unsafeWrapArray(frame): _*), from, "Data")
+<<<<<<< HEAD
       case StateFrame(state) =>
         writeArrowStream(mutable.Queue(state.toTuple), from, "State")
+=======
+      case StateFrame(state, loopCounter, loopStartId) =>
+        // The Arrow wire format for states IS the State row (content +
+        // loop_counter + loop_start_id), so the envelope rides its own
+        // columns to the Python worker -- see network_receiver.py.
+        writeArrowStream(mutable.Queue(state.toTuple(loopCounter, loopStartId)), from, "State")
+>>>>>>> 91a701b7c (fix(amber): carry the loop StateFrame envelope through JVM operators (#6661))
     }
   }
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyServer.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/pythonworker/PythonProxyServer.scala
@@ -128,7 +128,14 @@ private class AmberProducer(
     dataHeader.payloadType match {
       case "State" =>
         assert(root.getRowCount == 1)
-        outputPort.sendTo(to, StateFrame(State.fromTuple(ArrowUtils.getTexeraTuple(0, root))))
+        // The row is a full State row (content + loop_counter + loop_start_id;
+        // see network_sender.py): rebuild the loop envelope alongside the
+        // content so it survives the hop through this JVM proxy.
+        val row = ArrowUtils.getTexeraTuple(0, root)
+        outputPort.sendTo(
+          to,
+          StateFrame(State.fromTuple(row), State.loopCounterFrom(row), State.loopStartIdFrom(row))
+        )
       case "ECM" =>
         assert(root.getRowCount == 1)
         outputPort.sendTo(

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/sendsemantics/partitioners/Partitioner.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/sendsemantics/partitioners/Partitioner.scala
@@ -49,9 +49,9 @@ class NetworkOutputBuffer(
     }
   }
 
-  def sendState(state: State): Unit = {
+  def sendState(state: State, loopCounter: Long = 0L, loopStartId: String = ""): Unit = {
     flush()
-    dataOutputPort.sendTo(to, StateFrame(state))
+    dataOutputPort.sendTo(to, StateFrame(state, loopCounter, loopStartId))
     flush()
   }
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessor.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessor.scala
@@ -121,11 +121,20 @@ class DataProcessor(
     }
   }
 
-  private[this] def processInputState(state: State, port: Int): Unit = {
+  private[this] def processInputState(
+      state: State,
+      port: Int,
+      loopCounter: Long,
+      loopStartId: String
+  ): Unit = {
     try {
       val outputState = executor.processState(state, port)
       if (outputState.isDefined) {
-        outputManager.emitState(outputState.get)
+        // Carry the incoming loop envelope through unchanged: loop operators
+        // are Python-only, so a JVM operator inside a loop body only ever
+        // forwards the envelope (the +1/-1 bookkeeping lives in the Python
+        // runtime's _process_state_frame).
+        outputManager.emitState(outputState.get, loopCounter, loopStartId)
       }
     } catch safely {
       case e =>
@@ -220,8 +229,8 @@ class DataProcessor(
         )
         inputManager.initBatch(channelId, tuples)
         processInputTuple(inputManager.getNextTuple)
-      case StateFrame(state) =>
-        processInputState(state, portId.id)
+      case StateFrame(state, loopCounter, loopStartId) =>
+        processInputState(state, portId.id, loopCounter, loopStartId)
     }
     statisticsManager.increaseDataProcessingTime(System.nanoTime() - dataProcessingStartTime)
   }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/managers/InputPortMaterializationReaderThread.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/managers/InputPortMaterializationReaderThread.scala
@@ -104,9 +104,17 @@ class InputPortMaterializationReaderThread(
           .asInstanceOf[VirtualDocument[Tuple]]
       val stateReadIterator = stateDocument.get()
       while (stateReadIterator.hasNext) {
-        val state = State.fromTuple(stateReadIterator.next())
+        val row = stateReadIterator.next()
+        // Rebuild the loop envelope (loop_counter / loop_start_id) alongside
+        // the content: a JVM operator inside a loop body must carry it through
+        // unchanged, or the matching LoopEnd loses its back-jump target.
+        val stateFrame = StateFrame(
+          State.fromTuple(row),
+          State.loopCounterFrom(row),
+          State.loopStartIdFrom(row)
+        )
         inputMessageQueue.put(
-          FIFOMessageElement(WorkflowFIFOMessage(channelId, getSequenceNumber, StateFrame(state)))
+          FIFOMessageElement(WorkflowFIFOMessage(channelId, getSequenceNumber, stateFrame))
         )
       }
 

--- a/amber/src/main/scala/org/apache/texera/amber/engine/common/ambermessage/DataPayload.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/common/ambermessage/DataPayload.scala
@@ -24,7 +24,18 @@ import org.apache.texera.amber.core.tuple.Tuple
 
 sealed trait DataPayload extends WorkflowFIFOMessagePayload {}
 
-final case class StateFrame(frame: State) extends DataPayload
+/**
+  * A single State travelling between operators. `loopCounter` / `loopStartId`
+  * are the loop envelope owned by the (Python) worker runtime -- carried
+  * alongside the State payload (not inside it) so it never collides with user
+  * state, and materialized/transported as their own columns parallel to the
+  * content (see `State.toTuple`). Loop operators are Python-only, so a JVM
+  * operator inside a loop body only ever carries the envelope through
+  * unchanged; the defaults are the "no loop" values for all non-loop state.
+  * Mirrors the Python `StateFrame` (core/models/payload.py).
+  */
+final case class StateFrame(frame: State, loopCounter: Long = 0L, loopStartId: String = "")
+    extends DataPayload
 
 final case class DataFrame(frame: Array[Tuple]) extends DataPayload {
   val inMemSize: Long = {

--- a/amber/src/test/integration/org/apache/texera/amber/engine/e2e/LoopIntegrationSpec.scala
+++ b/amber/src/test/integration/org/apache/texera/amber/engine/e2e/LoopIntegrationSpec.scala
@@ -1,0 +1,390 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.e2e
+
+import com.twitter.util.Duration
+import org.apache.pekko.actor.{ActorSystem, Props}
+import org.apache.pekko.testkit.{ImplicitSender, TestKit}
+import org.apache.pekko.util.Timeout
+import org.apache.texera.amber.clustering.SingleNodeListener
+import org.apache.texera.amber.core.virtualidentity.OperatorIdentity
+import org.apache.texera.amber.core.workflow.{
+  ExecutionMode,
+  PortIdentity,
+  WorkflowContext,
+  WorkflowSettings
+}
+import org.apache.texera.amber.engine.common.AmberRuntime
+import org.apache.texera.amber.engine.e2e.TestUtils.{
+  buildWorkflow,
+  cleanupWorkflowExecutionData,
+  initiateTexeraDBForTestCases,
+  runWorkflowAndReadResults,
+  setUpWorkflowExecutionData,
+  workflowContext
+}
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.limit.LimitOpDesc
+import org.apache.texera.amber.operator.loop.{LoopEndOpDesc, LoopStartOpDesc}
+import org.apache.texera.amber.operator.sleep.SleepOpDesc
+import org.apache.texera.amber.operator.source.scan.text.TextInputSourceOpDesc
+import org.apache.texera.amber.tags.IntegrationTest
+import org.apache.texera.workflow.LogicalLink
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Outcome, Retries}
+
+import scala.concurrent.duration.DurationInt
+
+/**
+  * End-to-end loop tests: run a real TextInput -> LoopStart -> LoopEnd workflow
+  * through the engine (controller + Python workers + the DCM back-jump and
+  * region re-execution) and assert both that it terminates AND that it ran the
+  * expected number of iterations.
+  *
+  * Termination alone is too weak: a counter bug that still terminated (e.g.
+  * off-by-one) would pass. So each test asserts the LoopEnd's MATERIALIZED
+  * result-table row count, read from iceberg after the run. LoopEnd is an
+  * identity pass-through on data, so the rows it materializes equal the rows
+  * that flowed through it: a single (outermost) LoopEnd accumulates every
+  * iteration (3 for the single loop; 9 for the terminal outer LoopEnd of the
+  * 3x3 nested loop), and an inner LoopEnd resets once per outer iteration (so
+  * 3, not 9).
+  *
+  * NOTE: the cumulative `ExecutionStatsUpdate` output count is NOT usable as
+  * the iteration count here. A loop region's workers are recreated on every
+  * `JumpToOperatorRegion` re-execution (each iteration spawns a fresh worker
+  * actor), so the per-logical-op output statistic reflects only the final
+  * iteration's worker and does not accumulate. The iceberg result, by
+  * contrast, persists across iterations (the scheduler reuses a LoopEnd's
+  * output document via its output port's `reuseStorage` flag), so it is
+  * the reliable signal.
+  *
+  * Tagged @IntegrationTest because it spawns Python workers; routed to the
+  * `amber-integration` CI job.
+  */
+@IntegrationTest
+class LoopIntegrationSpec
+    extends TestKit(ActorSystem("LoopIntegrationSpec", AmberRuntime.pekkoConfig))
+    with ImplicitSender
+    with AnyFlatSpecLike
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with Retries {
+
+  override def withFixture(test: NoArgTest): Outcome =
+    withRetry { super.withFixture(test) }
+
+  implicit val timeout: Timeout = Timeout(5.seconds)
+
+  // Unique per-suite id so the seeded user/workflow/version/execution rows
+  // (and the context's workflow/execution ids) don't collide with the other
+  // integration suites running against the shared test database (#5888).
+  // 1-4 and 5 are taken by the other e2e/integration specs (5 by
+  // MultiRegionWorkflowIntegrationSpec), so this suite uses 6.
+  private val specId = 6
+
+  override protected def beforeEach(): Unit = setUpWorkflowExecutionData(specId)
+
+  override protected def afterEach(): Unit = cleanupWorkflowExecutionData(specId)
+
+  override def beforeAll(): Unit = {
+    system.actorOf(Props[SingleNodeListener](), "cluster-info")
+    Class.forName("org.postgresql.Driver")
+    initiateTexeraDBForTestCases()
+  }
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  // Loops require MATERIALIZED execution mode (the cross-region state channel
+  // is the loop back-edge). Built on the suite's specId so the context's
+  // workflow/execution ids match the rows seeded by setUpWorkflowExecutionData.
+  private def materializedContext(): WorkflowContext =
+    workflowContext(
+      specId,
+      WorkflowSettings(
+        dataTransferBatchSize = 400,
+        executionMode = ExecutionMode.MATERIALIZED
+      )
+    )
+
+  /**
+    * Run the loop workflow to completion and return each operator's materialized
+    * RESULT-table row count, keyed by operator id. Delegates to the shared
+    * `TestUtils.runWorkflowAndReadResults` harness (a correct loop terminates
+    * within the 3-minute deadline; a broken one hangs until it).
+    */
+  private def runAndGetMaterializedRowCounts(
+      operators: List[LogicalOp],
+      links: List[LogicalLink]
+  ): Map[OperatorIdentity, Long] =
+    runWorkflowAndReadResults(
+      system,
+      buildWorkflow(operators, links, materializedContext()),
+      operators.map(_.operatorIdentifier),
+      _.getCount,
+      Duration.fromMinutes(3)
+    )
+
+  private def textInput(text: String): TextInputSourceOpDesc = {
+    val op = new TextInputSourceOpDesc()
+    op.textInput = text
+    op
+  }
+
+  private def loopStart(initialization: String, output: String): LoopStartOpDesc = {
+    val op = new LoopStartOpDesc()
+    op.initialization = initialization
+    op.output = output
+    op
+  }
+
+  private def loopEnd(update: String, condition: String): LoopEndOpDesc = {
+    val op = new LoopEndOpDesc()
+    op.update = update
+    op.condition = condition
+    op
+  }
+
+  private def limit(n: Int): LimitOpDesc = {
+    val op = new LimitOpDesc()
+    op.limit = n
+    op
+  }
+
+  private def sleep(seconds: Int): SleepOpDesc = {
+    val op = new SleepOpDesc()
+    op.sleepTime = seconds
+    op
+  }
+
+  // NOTE: a JavaUDF (runtime-compiled Java) case cannot run in this suite.
+  // The integration tests run forkless under sbt (fork := false), where
+  // `javax.tools` sees only the sbt launcher on `java.class.path` -- the
+  // Texera classes live in sbt's layered classloaders, so
+  // JavaRuntimeCompilation fails with "package ... does not exist" before
+  // any loop logic runs. Production workers launch with a real classpath,
+  // so this is a harness limitation, not an engine one.
+
+  private def link(from: LogicalOp, to: LogicalOp): LogicalLink =
+    LogicalLink(from.operatorIdentifier, PortIdentity(), to.operatorIdentifier, PortIdentity())
+
+  "Engine" should "run a single TextInput -> LoopStart -> LoopEnd loop for exactly 3 iterations" in {
+    val src = textInput("1\n2\n3")
+    val start = loopStart("i = 0", "table.iloc[i]")
+    val end = loopEnd("i += 1", "i < len(table)")
+    val materialized = runAndGetMaterializedRowCounts(
+      List(src, start, end),
+      List(link(src, start), link(start, end))
+    )
+    // LoopStart emits one row per iteration (table.iloc[i]); i advances 0,1,2
+    // and stops at i == 3, so the body runs exactly 3 times. The outermost
+    // LoopEnd never resets, so its materialized result holds all 3 rows. An
+    // off-by-one counter bug that still terminated would land on 2 or 4.
+    val endRows = materialized.getOrElse(end.operatorIdentifier, -1L)
+    assert(
+      endRows == 3,
+      s"single LoopEnd must accumulate all 3 iterations in its materialized " +
+        s"result: expected 3, got $endRows (all: $materialized)"
+    )
+  }
+
+  it should "run a nested loop for exactly 9 inner iterations (3 outer x 3 inner)" in {
+    // TextInput -> OuterStart -> InnerStart -> InnerEnd -> OuterEnd.
+    //
+    // The outer LoopStart emits the WHOLE 3-row table on each outer iteration
+    // (output = "table"), so the inner loop iterates over 3 rows; with 3 outer
+    // iterations the inner body runs 3 x 3 = 9 times. Because every LoopEnd is
+    // an identity pass-through on data, the same 9 rows flow out of the
+    // terminal outer LoopEnd.
+    //
+    // This is the case that exercises the loop_counter increment/decrement and
+    // the loop_start_id routing on the StateFrame envelope (write addresses:
+    // see InitializeExecutorRequest.loopStartStateUris): the outer loop's state
+    // passes THROUGH the inner LoopStart (+1) and inner LoopEnd (-1) untouched,
+    // and is consumed only at the outer LoopEnd (counter == 0). A routing or
+    // counter bug would change the 9, or mis-consume and hang.
+    val src = textInput("1\n2\n3")
+    val outerStart = loopStart("i = 0", "table")
+    val innerStart = loopStart("j = 0", "table.iloc[j]")
+    val innerEnd = loopEnd("j += 1", "j < len(table)")
+    val outerEnd = loopEnd("i += 1", "i < len(table)")
+    val materialized = runAndGetMaterializedRowCounts(
+      List(src, outerStart, innerStart, innerEnd, outerEnd),
+      List(
+        link(src, outerStart),
+        link(outerStart, innerStart),
+        link(innerStart, innerEnd),
+        link(innerEnd, outerEnd)
+      )
+    )
+    // The outer LoopEnd accumulates all 9 rows; the INNER LoopEnd resets once
+    // per outer iteration (see main_loop's reset_output_storage call site), so
+    // it holds only the last outer iteration's 3 rows. The inner == 3
+    // assertion is the one that fails against the pre-fix code.
+    val outerRows = materialized.getOrElse(outerEnd.operatorIdentifier, -1L)
+    val innerRows = materialized.getOrElse(innerEnd.operatorIdentifier, -1L)
+    assert(
+      outerRows == 9,
+      s"outer LoopEnd must accumulate all 9 inner-iteration rows: " +
+        s"expected 9, got $outerRows (all: $materialized)"
+    )
+    assert(
+      innerRows == 3,
+      s"inner LoopEnd must reset per outer iteration (3 rows, not 9): " +
+        s"expected 3, got $innerRows (all: $materialized)"
+    )
+  }
+
+  it should "run a loop whose body contains a JVM (Scala) operator" in {
+    // TextInput -> LoopStart -> Limit (a Scala built-in) -> LoopEnd.
+    //
+    // The loop envelope (loop_counter / loop_start_id) must survive the hop
+    // through a JVM operator: the Scala worker replays the materialized state,
+    // forwards it through the default processState, and re-materializes it for
+    // the LoopEnd. Before the envelope was carried through on the Scala side
+    // (StateFrame fields + reader/emit/save plumbing), this hop zeroed the
+    // counter and blanked the id, so the LoopEnd captured loop_start_id = ""
+    // and the back-jump failed with "no loop-back state URI configured for
+    // LoopStart ''" -- the loop never iterated. Limit(10) passes every row
+    // through, so the loop semantics are identical to the single-loop test.
+    val src = textInput("1\n2\n3")
+    val start = loopStart("i = 0", "table.iloc[i]")
+    val mid = limit(10)
+    val end = loopEnd("i += 1", "i < len(table)")
+    val materialized = runAndGetMaterializedRowCounts(
+      List(src, start, mid, end),
+      List(link(src, start), link(start, mid), link(mid, end))
+    )
+    val endRows = materialized.getOrElse(end.operatorIdentifier, -1L)
+    assert(
+      endRows == 3,
+      s"LoopEnd must accumulate all 3 iterations with a Scala operator in the " +
+        s"loop body: expected 3, got $endRows (all: $materialized)"
+    )
+  }
+
+  it should "run a nested loop whose inner body contains a JVM (Scala) operator" in {
+    // TextInput -> OuterStart -> InnerStart -> Limit -> InnerEnd -> OuterEnd.
+    //
+    // The nested variant of the JVM-hop test: the OUTER loop's state crosses
+    // the Scala operator stamped (loop_counter = 1, loop_start_id = outer), so
+    // this pins that the JVM hop preserves the counter MAGNITUDE too, not just
+    // the id. A zeroed counter would make the inner LoopEnd mis-consume the
+    // outer state (KeyError on the missing 'table' key / clobbered jump id)
+    // instead of passing it through with -1.
+    val src = textInput("1\n2\n3")
+    val outerStart = loopStart("i = 0", "table")
+    val innerStart = loopStart("j = 0", "table.iloc[j]")
+    val mid = limit(10)
+    val innerEnd = loopEnd("j += 1", "j < len(table)")
+    val outerEnd = loopEnd("i += 1", "i < len(table)")
+    val materialized = runAndGetMaterializedRowCounts(
+      List(src, outerStart, innerStart, mid, innerEnd, outerEnd),
+      List(
+        link(src, outerStart),
+        link(outerStart, innerStart),
+        link(innerStart, mid),
+        link(mid, innerEnd),
+        link(innerEnd, outerEnd)
+      )
+    )
+    val outerRows = materialized.getOrElse(outerEnd.operatorIdentifier, -1L)
+    val innerRows = materialized.getOrElse(innerEnd.operatorIdentifier, -1L)
+    assert(
+      outerRows == 9,
+      s"outer LoopEnd must accumulate all 9 inner-iteration rows with a Scala " +
+        s"operator in the inner body: expected 9, got $outerRows (all: $materialized)"
+    )
+    assert(
+      innerRows == 3,
+      s"inner LoopEnd must reset per outer iteration (3 rows, not 9): " +
+        s"expected 3, got $innerRows (all: $materialized)"
+    )
+  }
+
+  it should "run a nested loop whose inner body chains multiple JVM operators" in {
+    // TextInput -> OuterStart -> InnerStart -> Limit -> Sleep(0) -> InnerEnd -> OuterEnd.
+    //
+    // The strongest combination: nested (the OUTER loop's state crosses the
+    // JVM hops stamped with loop_counter = 1, so the counter MAGNITUDE must
+    // survive both hops) x multi-hop (the JVM-to-JVM state handoff between
+    // the two Scala workers) x both operator kinds. A zeroed counter or a
+    // blanked id at either hop would mis-route the outer state at the inner
+    // LoopEnd.
+    val src = textInput("1\n2\n3")
+    val outerStart = loopStart("i = 0", "table")
+    val innerStart = loopStart("j = 0", "table.iloc[j]")
+    val first = limit(10)
+    val second = sleep(0)
+    val innerEnd = loopEnd("j += 1", "j < len(table)")
+    val outerEnd = loopEnd("i += 1", "i < len(table)")
+    val materialized = runAndGetMaterializedRowCounts(
+      List(src, outerStart, innerStart, first, second, innerEnd, outerEnd),
+      List(
+        link(src, outerStart),
+        link(outerStart, innerStart),
+        link(innerStart, first),
+        link(first, second),
+        link(second, innerEnd),
+        link(innerEnd, outerEnd)
+      )
+    )
+    val outerRows = materialized.getOrElse(outerEnd.operatorIdentifier, -1L)
+    val innerRows = materialized.getOrElse(innerEnd.operatorIdentifier, -1L)
+    assert(
+      outerRows == 9,
+      s"outer LoopEnd must accumulate all 9 inner-iteration rows with two " +
+        s"chained JVM operators in the inner body: expected 9, got $outerRows " +
+        s"(all: $materialized)"
+    )
+    assert(
+      innerRows == 3,
+      s"inner LoopEnd must reset per outer iteration (3 rows, not 9): " +
+        s"expected 3, got $innerRows (all: $materialized)"
+    )
+  }
+
+  it should "run a loop whose body chains multiple JVM operators" in {
+    // TextInput -> LoopStart -> Limit -> Sleep(0) -> LoopEnd.
+    //
+    // Two consecutive JVM hops pin the JVM-to-JVM state handoff: the first
+    // Scala worker WRITES the envelope columns to its output state table and
+    // the second Scala worker READS them back. The single-JVM-op tests never
+    // exercise that pairing (there, each hop faces a Python worker on at
+    // least one side). Sleep(0) is a pure identity pass-through.
+    val src = textInput("1\n2\n3")
+    val start = loopStart("i = 0", "table.iloc[i]")
+    val first = limit(10)
+    val second = sleep(0)
+    val end = loopEnd("i += 1", "i < len(table)")
+    val materialized = runAndGetMaterializedRowCounts(
+      List(src, start, first, second, end),
+      List(link(src, start), link(start, first), link(first, second), link(second, end))
+    )
+    val endRows = materialized.getOrElse(end.operatorIdentifier, -1L)
+    assert(
+      endRows == 3,
+      s"LoopEnd must accumulate all 3 iterations with two chained JVM " +
+        s"operators in the loop body: expected 3, got $endRows (all: $materialized)"
+    )
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
@@ -96,4 +96,277 @@ class OutputManagerSpec extends AnyFlatSpec with MockFactory {
     outputManager.flush()
   }
 
+<<<<<<< HEAD
+=======
+  // -- OutputManager.toPartitioner / getBatchSize --------------------------
+
+  "OutputManager.toPartitioner" should "map OneToOnePartitioning to OneToOnePartitioner" in {
+    val partitioning = OneToOnePartitioning(11, Seq(channelTo(ActorVirtualIdentity("o2o-rec"))))
+    assert(toPartitioner(partitioning, identifier).isInstanceOf[OneToOnePartitioner])
+    assert(getBatchSize(partitioning) == 11)
+  }
+
+  it should "map RoundRobinPartitioning to RoundRobinPartitioner" in {
+    val partitioning = RoundRobinPartitioning(12, Seq(channelTo(ActorVirtualIdentity("rr-rec"))))
+    assert(toPartitioner(partitioning, identifier).isInstanceOf[RoundRobinPartitioner])
+    assert(getBatchSize(partitioning) == 12)
+  }
+
+  it should "map HashBasedShufflePartitioning to HashBasedShufflePartitioner" in {
+    val partitioning = HashBasedShufflePartitioning(
+      13,
+      Seq(channelTo(ActorVirtualIdentity("hash-rec"))),
+      Seq("field1")
+    )
+    assert(toPartitioner(partitioning, identifier).isInstanceOf[HashBasedShufflePartitioner])
+    assert(getBatchSize(partitioning) == 13)
+  }
+
+  it should "map RangeBasedShufflePartitioning to RangeBasedShufflePartitioner" in {
+    val partitioning = RangeBasedShufflePartitioning(
+      14,
+      Seq(channelTo(ActorVirtualIdentity("range-rec"))),
+      Seq("field1"),
+      0,
+      100
+    )
+    assert(toPartitioner(partitioning, identifier).isInstanceOf[RangeBasedShufflePartitioner])
+    assert(getBatchSize(partitioning) == 14)
+  }
+
+  it should "map BroadcastPartitioning to BroadcastPartitioner" in {
+    val partitioning = BroadcastPartitioning(15, Seq(channelTo(ActorVirtualIdentity("bc-rec"))))
+    assert(toPartitioner(partitioning, identifier).isInstanceOf[BroadcastPartitioner])
+    assert(getBatchSize(partitioning) == 15)
+  }
+
+  it should "throw for an unsupported partitioning" in {
+    // Partitioning.Empty is a valid Partitioning that is none of the five
+    // concrete cases, so it exercises the `_ =>` default of both methods.
+    val unsupported: Partitioning = Partitioning.Empty
+    assertThrows[RuntimeException](toPartitioner(unsupported, identifier))
+    assertThrows[RuntimeException](getBatchSize(unsupported))
+  }
+
+  // -- passTupleToDownstream port routing ----------------------------------
+
+  "passTupleToDownstream" should "route only to the partitioner whose fromPortId matches" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portA = PortIdentity(1)
+    val portB = PortIdentity(2)
+    outputManager.addPort(portA, schema, None)
+    outputManager.addPort(portB, schema, None)
+
+    val recA = ActorVirtualIdentity("route-recA")
+    val recB = ActorVirtualIdentity("route-recB")
+    val linkA = PhysicalLink(physicalOpId(), portA, physicalOpId(), portA)
+    val linkB = PhysicalLink(physicalOpId(), portB, physicalOpId(), portB)
+
+    outputManager.addPartitionerWithPartitioning(
+      linkA,
+      OneToOnePartitioning(10, Seq(channelTo(recA)))
+    )
+    outputManager.addPartitionerWithPartitioning(
+      linkB,
+      OneToOnePartitioning(10, Seq(channelTo(recB)))
+    )
+
+    val tuple = sampleTuple()
+    // Only recA's buffer should receive the tuple; recB gets nothing.
+    (mockHandler.apply _).expects(
+      mkDataMessage(recA, identifier, 0, DataFrame(Array(tuple)))
+    )
+    outputManager.passTupleToDownstream(tuple, Some(portA))
+    outputManager.flush()
+  }
+
+  it should "broadcast to all partitioners when no port is specified" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portA = PortIdentity(3)
+    val portB = PortIdentity(4)
+    outputManager.addPort(portA, schema, None)
+    outputManager.addPort(portB, schema, None)
+
+    val recA = ActorVirtualIdentity("bcast-recA")
+    val recB = ActorVirtualIdentity("bcast-recB")
+    val linkA = PhysicalLink(physicalOpId(), portA, physicalOpId(), portA)
+    val linkB = PhysicalLink(physicalOpId(), portB, physicalOpId(), portB)
+
+    outputManager.addPartitionerWithPartitioning(
+      linkA,
+      OneToOnePartitioning(10, Seq(channelTo(recA)))
+    )
+    outputManager.addPartitionerWithPartitioning(
+      linkB,
+      OneToOnePartitioning(10, Seq(channelTo(recB)))
+    )
+
+    val tuple = sampleTuple()
+    inAnyOrder {
+      (mockHandler.apply _).expects(mkDataMessage(recA, identifier, 0, DataFrame(Array(tuple))))
+      (mockHandler.apply _).expects(mkDataMessage(recB, identifier, 0, DataFrame(Array(tuple))))
+    }
+    outputManager.passTupleToDownstream(tuple, None)
+    outputManager.flush()
+  }
+
+  // -- flush(onlyFor) ------------------------------------------------------
+
+  "flush" should "flush only the buffers matching the given channel ids" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portA = PortIdentity(5)
+    val portB = PortIdentity(6)
+    outputManager.addPort(portA, schema, None)
+    outputManager.addPort(portB, schema, None)
+
+    val recA = ActorVirtualIdentity("flush-recA")
+    val recB = ActorVirtualIdentity("flush-recB")
+    val linkA = PhysicalLink(physicalOpId(), portA, physicalOpId(), portA)
+    val linkB = PhysicalLink(physicalOpId(), portB, physicalOpId(), portB)
+
+    // batchSize large enough that tuples stay buffered until flush.
+    outputManager.addPartitionerWithPartitioning(
+      linkA,
+      OneToOnePartitioning(100, Seq(channelTo(recA)))
+    )
+    outputManager.addPartitionerWithPartitioning(
+      linkB,
+      OneToOnePartitioning(100, Seq(channelTo(recB)))
+    )
+
+    val tuple = sampleTuple()
+    outputManager.passTupleToDownstream(tuple, None) // buffers both A and B
+
+    // Only recA's buffer should be flushed.
+    (mockHandler.apply _).expects(mkDataMessage(recA, identifier, 0, DataFrame(Array(tuple))))
+    outputManager.flush(Some(Set(channelTo(recA))))
+
+    // The remaining recB buffer is flushed here.
+    (mockHandler.apply _).expects(mkDataMessage(recB, identifier, 0, DataFrame(Array(tuple))))
+    outputManager.flush()
+  }
+
+  // -- emitState -----------------------------------------------------------
+
+  "emitState" should "fan the state out to every network buffer" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portA = PortIdentity(7)
+    val portB = PortIdentity(8)
+    outputManager.addPort(portA, schema, None)
+    outputManager.addPort(portB, schema, None)
+
+    val recA = ActorVirtualIdentity("state-recA")
+    val recB = ActorVirtualIdentity("state-recB")
+    val linkA = PhysicalLink(physicalOpId(), portA, physicalOpId(), portA)
+    val linkB = PhysicalLink(physicalOpId(), portB, physicalOpId(), portB)
+
+    outputManager.addPartitionerWithPartitioning(
+      linkA,
+      OneToOnePartitioning(10, Seq(channelTo(recA)))
+    )
+    outputManager.addPartitionerWithPartitioning(
+      linkB,
+      OneToOnePartitioning(10, Seq(channelTo(recB)))
+    )
+
+    val state = State(Map("k" -> 1))
+    // Each buffer's sendState flushes (no-op, empty), sends a StateFrame, then
+    // flushes again (no-op). With no writer threads configured,
+    // saveStateToStorageIfNeeded is a no-op over the empty writer map.
+    inAnyOrder {
+      (mockHandler.apply _).expects(
+        WorkflowFIFOMessage(channelTo(recA), 0, StateFrame(state))
+      )
+      (mockHandler.apply _).expects(
+        WorkflowFIFOMessage(channelTo(recB), 0, StateFrame(state))
+      )
+    }
+    outputManager.emitState(state)
+  }
+
+  it should "carry the loop envelope onto every emitted StateFrame" in {
+    // The loop envelope (loop_counter / loop_start_id) is owned by the Python
+    // runtime; a JVM hop only forwards it. emitState must stamp the incoming
+    // envelope onto the outgoing frames (and the storage write -- covered by
+    // State.toTuple in StateSpec), not reset it to the no-loop defaults.
+    val outputManager: OutputManager = wire[OutputManager]
+    val portA = PortIdentity(7)
+    outputManager.addPort(portA, schema, None)
+    // Fresh receiver: the spec-level gateway tracks sequence numbers per
+    // channel, so reusing another test's receiver would start at seq 1.
+    val rec = ActorVirtualIdentity("state-recEnvelope")
+    outputManager.addPartitionerWithPartitioning(
+      PhysicalLink(physicalOpId(), portA, physicalOpId(), portA),
+      OneToOnePartitioning(10, Seq(channelTo(rec)))
+    )
+
+    val state = State(Map("k" -> 1))
+    (mockHandler.apply _).expects(
+      WorkflowFIFOMessage(channelTo(rec), 0, StateFrame(state, 2L, "outer-loop"))
+    )
+    outputManager.emitState(state, loopCounter = 2L, loopStartId = "outer-loop")
+  }
+
+  // -- addPort / storage no-ops / getSingleOutputPortIdentity --------------
+
+  "addPort" should "be idempotent for a duplicate port id" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portId = PortIdentity(9)
+    outputManager.addPort(portId, schema, None)
+    val firstPort = outputManager.getPort(portId)
+    // A second addPort with the same id must early-return without replacing.
+    outputManager.addPort(portId, Schema().add("other", AttributeType.STRING), None)
+    assert(outputManager.getPort(portId) eq firstPort)
+    assert(outputManager.getPort(portId).schema == schema)
+  }
+
+  it should "create no storage writer when the storage URI base is None" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portId = PortIdentity(10)
+    // None storage base means no writer thread is set up; the tuple- and
+    // state-storage paths below must therefore be no-ops.
+    outputManager.addPort(portId, schema, None)
+    val tuple = sampleTuple()
+    // No exception, no handler interaction: empty writer maps.
+    outputManager.saveTupleToStorageIfNeeded(tuple, Some(portId))
+    outputManager.saveTupleToStorageIfNeeded(tuple, None)
+    outputManager.emitState(State(Map("k" -> 2)))
+  }
+
+  "saveTupleToStorageIfNeeded" should "be a no-op over an empty writer map" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portId = PortIdentity(11)
+    outputManager.addPort(portId, schema, None)
+    val tuple = sampleTuple()
+    // Some(portId) with no writer -> Map.empty branch; None -> whole (empty) map.
+    outputManager.saveTupleToStorageIfNeeded(tuple, Some(portId))
+    outputManager.saveTupleToStorageIfNeeded(tuple, Some(PortIdentity(999)))
+    outputManager.saveTupleToStorageIfNeeded(tuple, None)
+  }
+
+  "closeOutputStorageWriterIfNeeded" should "do nothing when the port has no writer" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portId = PortIdentity(12)
+    outputManager.addPort(portId, schema, None)
+    // No writer thread was created, so both the result-writer and state-writer
+    // branches are the None/absent case: no exception, no join.
+    outputManager.closeOutputStorageWriterIfNeeded(portId)
+    outputManager.closeOutputStorageWriterIfNeeded(PortIdentity(998))
+  }
+
+  "getSingleOutputPortIdentity" should "return the sole port when exactly one is present" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    val portId = PortIdentity(13)
+    outputManager.addPort(portId, schema, None)
+    assert(outputManager.getSingleOutputPortIdentity == portId)
+  }
+
+  it should "assert when there is more than one output port" in {
+    val outputManager: OutputManager = wire[OutputManager]
+    outputManager.addPort(PortIdentity(14), schema, None)
+    outputManager.addPort(PortIdentity(15), schema, None)
+    assertThrows[AssertionError](outputManager.getSingleOutputPortIdentity)
+  }
+
+>>>>>>> 91a701b7c (fix(amber): carry the loop StateFrame envelope through JVM operators (#6661))
 }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/sendsemantics/partitioners/NetworkOutputBufferSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/sendsemantics/partitioners/NetworkOutputBufferSpec.scala
@@ -177,6 +177,18 @@ class NetworkOutputBufferSpec extends AnyFlatSpec {
     assert(cap.messages.head.payload == StateFrame(state))
   }
 
+  it should "stamp the loop envelope onto the sent StateFrame" in {
+    // A JVM hop inside a loop body forwards the loop envelope unchanged
+    // (loop operators are Python-only); sendState must put the caller's
+    // loop_counter / loop_start_id on the frame instead of the no-loop
+    // defaults, or the matching LoopEnd's back-jump loses its target.
+    val (buf, cap) = newBuffer()
+    val state = State(Map("k" -> "v"))
+    buf.sendState(state, loopCounter = 2L, loopStartId = "outer-loop")
+    assert(cap.messages.size == 1)
+    assert(cap.messages.head.payload == StateFrame(state, 2L, "outer-loop"))
+  }
+
   it should "leave the tuple buffer empty after sendState (trailing flush no-op)" in {
     // sendState calls flush() AFTER sending the state too. Pin that the
     // trailing flush doesn't double-send and that subsequent addTuple

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -241,4 +241,217 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     }
   }
 
+<<<<<<< HEAD
+=======
+  "data processor" should "process a state frame and emit the produced state" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    val emitted = scala.collection.mutable.ArrayBuffer[WorkflowFIFOMessage]()
+    (outputHandler.apply _)
+      .expects(*)
+      .onCall { (m: Either[MainThreadDelegateMessage, WorkflowFIFOMessage]) =>
+        m.foreach(emitted += _); ()
+      }
+      .anyNumberOfTimes()
+    val inputState = State(Map("field1" -> 1))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .returning(Some(inputState))
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    // A downstream partitioner makes emitState observable: the produced state is sent
+    // downstream as a StateFrame, captured via the output handler.
+    dp.outputManager.addPartitionerWithPartitioning(
+      PhysicalLink(testOpId, outputPortId, upstreamOpId, inputPortId),
+      OneToOnePartitioning(1, Seq(ChannelIdentity(testWorkerId, senderWorkerId, isControl = false)))
+    )
+    dp.processDataPayload(
+      ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+      StateFrame(inputState)
+    )
+    assert(emitted.exists(_.payload.isInstanceOf[StateFrame]))
+  }
+
+  "data processor" should "carry the loop envelope through a state pass-through unchanged" in {
+    // Loop operators are Python-only, so a JVM operator inside a loop body
+    // only ever FORWARDS the StateFrame loop envelope (loop_counter /
+    // loop_start_id); the +1/-1 bookkeeping lives in the Python runtime.
+    // A dropped envelope zeroes the counter and blanks the id, which breaks
+    // the matching LoopEnd's back-jump ("no loop-back state URI configured
+    // for LoopStart ''") -- so pin exact envelope equality on the emitted
+    // frame, not just that a StateFrame came out.
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    val emitted = scala.collection.mutable.ArrayBuffer[WorkflowFIFOMessage]()
+    (outputHandler.apply _)
+      .expects(*)
+      .onCall { (m: Either[MainThreadDelegateMessage, WorkflowFIFOMessage]) =>
+        m.foreach(emitted += _); ()
+      }
+      .anyNumberOfTimes()
+    val inputState = State(Map("i" -> 1))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .returning(Some(inputState))
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    dp.outputManager.addPartitionerWithPartitioning(
+      PhysicalLink(testOpId, outputPortId, upstreamOpId, inputPortId),
+      OneToOnePartitioning(1, Seq(ChannelIdentity(testWorkerId, senderWorkerId, isControl = false)))
+    )
+    dp.processDataPayload(
+      ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+      StateFrame(inputState, loopCounter = 2L, loopStartId = "outer-loop")
+    )
+    val stateFrames = emitted.map(_.payload).collect { case sf: StateFrame => sf }
+    assert(
+      stateFrames.toList == List(StateFrame(inputState, 2L, "outer-loop")),
+      s"envelope must ride through unchanged, got: $stateFrames"
+    )
+  }
+
+  "data processor" should "not emit when processState yields None" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    val emitted = scala.collection.mutable.ArrayBuffer[WorkflowFIFOMessage]()
+    (outputHandler.apply _)
+      .expects(*)
+      .onCall { (m: Either[MainThreadDelegateMessage, WorkflowFIFOMessage]) =>
+        m.foreach(emitted += _); ()
+      }
+      .anyNumberOfTimes()
+    val inputState = State(Map("field1" -> 2))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .returning(None)
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    // Same downstream partitioner as the emit test; because processState returns None,
+    // no StateFrame must be emitted.
+    dp.outputManager.addPartitionerWithPartitioning(
+      PhysicalLink(testOpId, outputPortId, upstreamOpId, inputPortId),
+      OneToOnePartitioning(1, Seq(ChannelIdentity(testWorkerId, senderWorkerId, isControl = false)))
+    )
+    dp.processDataPayload(
+      ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+      StateFrame(inputState)
+    )
+    assert(!emitted.exists(_.payload.isInstanceOf[StateFrame]))
+  }
+
+  "data processor" should "handle an exception thrown while processing a state frame" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    val inputState = State(Map("field1" -> 3))
+    (
+        (
+            state: State,
+            port: Int
+        ) => executor.processState(state, port)
+    )
+      .expects(inputState, 0)
+      .throwing(new RuntimeException("boom on state"))
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    noException should be thrownBy {
+      dp.processDataPayload(
+        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+        StateFrame(inputState)
+      )
+    }
+    // handleExecutorException must engage an operator-logic pause.
+    dp.pauseManager.isPaused shouldBe true
+  }
+
+  "data processor" should "handle an exception thrown while processing an input tuple" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    (
+        (
+            tuple: Tuple,
+            input: Int
+        ) => executor.processTupleMultiPort(tuple, input)
+    )
+      .expects(tuples.head, 0)
+      .throwing(new RuntimeException("boom on tuple"))
+    (adaptiveBatchingMonitor.startAdaptiveBatching _).expects().anyNumberOfTimes()
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    noException should be thrownBy {
+      dp.processDataPayload(
+        ChannelIdentity(senderWorkerId, testWorkerId, isControl = false),
+        DataFrame(Array(tuples.head))
+      )
+    }
+    // handleExecutorException must engage an operator-logic pause.
+    dp.pauseManager.isPaused shouldBe true
+  }
+
+  "data processor" should "handle an exception thrown while advancing the output iterator" in {
+    val dp = mkDataProcessor
+    dp.executor = executor
+    dp.stateManager.transitTo(READY)
+    (outputHandler.apply _).expects(*).anyNumberOfTimes()
+    (adaptiveBatchingMonitor.startAdaptiveBatching _).expects().anyNumberOfTimes()
+    dp.inputManager.addPort(inputPortId, schema, List.empty, List.empty)
+    dp.inputGateway
+      .getChannel(ChannelIdentity(senderWorkerId, testWorkerId, isControl = false))
+      .setPortId(inputPortId)
+    dp.outputManager.addPort(outputPortId, schema, None)
+    // Poison the output iterator: hasNext is true so continueDataProcessing routes
+    // into outputOneTuple, but next() throws to exercise the catch branch.
+    dp.outputManager.outputIterator.setTupleOutput(
+      new Iterator[(TupleLike, Option[PortIdentity])] {
+        override def hasNext: Boolean = true
+        override def next(): (TupleLike, Option[PortIdentity]) =
+          throw new RuntimeException("boom on next")
+      }
+    )
+    assert(dp.outputManager.hasUnfinishedOutput)
+    noException should be thrownBy {
+      dp.continueDataProcessing()
+    }
+    // handleExecutorException must pause the operator and reset the output iterator to empty.
+    dp.pauseManager.isPaused shouldBe true
+    dp.outputManager.hasUnfinishedOutput shouldBe false
+  }
+
+>>>>>>> 91a701b7c (fix(amber): carry the loop StateFrame envelope through JVM operators (#6661))
 }

--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/state/State.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/state/State.scala
@@ -37,6 +37,23 @@ final case class State(values: Map[String, Any]) {
 
 object State {
   private val Content = "content"
+<<<<<<< HEAD
+=======
+  // loop-control bookkeeping owned by the (Python) worker runtime; not user
+  // state and never in the content JSON. Materialized as its own columns,
+  // parallel to content. Scala never ORIGINATES loop state (loop operators are
+  // Python-only), so toTuple defaults these to the "no loop" values -- but a
+  // JVM operator inside a loop body must CARRY them through unchanged, so the
+  // extractors below read them back off a materialized/transported row.
+  private val LoopCounter = "loop_counter"
+  private val LoopStartId = "loop_start_id"
+
+  /** Read the loop-envelope counter off a State row (see `toTuple`). */
+  def loopCounterFrom(row: Tuple): Long = row.getField[java.lang.Long](LoopCounter).longValue()
+
+  /** Read the loop-envelope LoopStart id off a State row (see `toTuple`). */
+  def loopStartIdFrom(row: Tuple): String = row.getField[String](LoopStartId)
+>>>>>>> 91a701b7c (fix(amber): carry the loop StateFrame envelope through JVM operators (#6661))
   private val BytesTypeMarker = "__texera_type__"
   private val BytesValue = "bytes"
   private val PayloadMarker = "payload"

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/state/StateSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/state/StateSpec.scala
@@ -117,6 +117,23 @@ class StateSpec extends AnyFlatSpec {
     assert(tuple.getField[String]("content") == """{"x":1}""")
   }
 
+  it should "read the loop envelope back off a materialized tuple" in {
+    // A JVM operator inside a loop body replays materialized states and must
+    // carry loop_counter / loop_start_id through unchanged -- the columns
+    // exist precisely so the envelope survives storage. These extractors are
+    // what InputPortMaterializationReaderThread / PythonProxyServer read; a
+    // rename of the columns on either side must break this.
+    val tuple = State(Map("i" -> 1L)).toTuple(2L, "outer-loop")
+    assert(State.loopCounterFrom(tuple) == 2L)
+    assert(State.loopStartIdFrom(tuple) == "outer-loop")
+  }
+
+  it should "default the loop envelope to the no-loop values" in {
+    val tuple = State(Map("i" -> 1L)).toTuple()
+    assert(State.loopCounterFrom(tuple) == 0L)
+    assert(State.loopStartIdFrom(tuple) == "")
+  }
+
   it should "decode a payload encoded by the Python serializer" in {
     // Wire-format compatibility check: the bytes-marker keys and the
     // single-row "content" column must match what core/models/state.py


### PR DESCRIPTION
### What changes were proposed in this PR?

Backport of #6661 to `release/v1.2`, cherry-picked from 91a701b7c1dc16f3a896971ddef4c1859a50e51f.

Follows the Direct Backport Push convention; opened as a PR (rather than a direct push) as part of a backport-coverage audit for fixes merged to `main` since early June that were never labeled for backport.

### Any related issues, documentation, discussions?

Backport of #6661. Originally linked #6660.

### How was this PR tested?

Release-branch CI runs once the conflicts are resolved and this PR is marked ready for review. The cherry-pick **conflicted** and was committed with conflict markers.

### Was this PR authored or co-authored using generative AI tooling?

Yes — backport prepared with Claude Code (mechanical cherry-pick; conflicts left as markers for the original author to resolve; the change itself is #6661 by its original author).
