### PR TITLE
fix(ci): list explicit release branches in merge-queue ruleset (wildcards unsupported)

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,7 +77,11 @@ github:
           exclude: []
           include:
             - "~DEFAULT_BRANCH"
-            - "refs/heads/release/*"
+            # Merge queue rules do NOT support wildcard ref patterns, so
+            # release branches must be listed explicitly (not release/*).
+            # Add each release line here as it is cut.
+            - "refs/heads/release/v1.1"
+            - "refs/heads/release/v1.2"
       rules:
         - type: deletion
         - type: non_fast_forward


### PR DESCRIPTION
### What changes were proposed in this PR?

Replace the `refs/heads/release/*` wildcard in the `Merge Queue` ruleset with explicit branches `refs/heads/release/v1.1` and `refs/heads/release/v1.2`.

GitHub merge queue rules do not support wildcard ref patterns, so the wildcard from #7094 was rejected by the API. asfyaml reconciles rulesets in order and aborts on the first error, so that rejection blocked the whole batch — the merge queue never reached release branches, and neither the `Default Branch Protection` edits nor the new `Restrict Branch Creation` ruleset were applied (arbitrary branches stayed creatable). Only the `merge_queue` rule rejects wildcards, so `Default Branch Protection` (`release/*`) and `Restrict Branch Creation` (`~ALL`) keep their patterns; removing the offending entry unblocks the entire reconcile.

### Any related issues, documentation, discussions?

Closes #7120. Follow-up to #7094. GitHub limitation: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

### How was this PR tested?

Ran the asfyaml normalizer (`asfyaml/feature/github/rulesets.py`) over the whole `.asf.yaml` and asserted no ruleset combines a `merge_queue` rule with a wildcard include: `Merge Queue` now resolves to `[~DEFAULT_BRANCH, refs/heads/release/v1.1, refs/heads/release/v1.2]`. `.asf.yaml` has no unit tests; ASF Infra applies it from the default branch.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
