### PR TITLE
fix(ci): use **/* excludes in branch-creation ruleset to unfreeze the merge queue

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -137,13 +137,14 @@ github:
           include:
             - "~ALL"
           exclude:
+            # Globs don't cross '/' (even a trailing **), so use **/* to
+            # match branches at any depth under a prefix.
             - "refs/heads/main"
-            - "refs/heads/release/*"
-            - "refs/heads/backport/*"
+            - "refs/heads/release/**/*"
+            - "refs/heads/backport/**/*"
             - "refs/heads/gh-pages"
-            # Temporary branches GitHub's merge queue creates to test
-            # queued groups; must stay creatable or the queue breaks.
-            - "refs/heads/gh-readonly-queue/*"
+            - "refs/heads/dependabot/**/*"
+            - "refs/heads/gh-readonly-queue/**/*"
       bypass_actors:
         # apache/root — ASF Infra team.
         - actor_id: 118420


### PR DESCRIPTION
### What changes were proposed in this PR?

Fix the `Restrict Branch Creation` ruleset excludes so all allowlisted prefixes match at any depth: `release/**/*`, `backport/**/*`, `dependabot/**/*`, and `gh-readonly-queue/**/*` (previously `gh-readonly-queue/*`; `main` and `gh-pages` stay exact).

GitHub ruleset globs do not cross `/`, and — contrary to intuition — even a trailing `**` still only matches a single segment. The merge queue's temp branches nest the base ref and are multi-segment (`gh-readonly-queue/main/pr-N`, `gh-readonly-queue/release/v1.2/pr-N`), so `gh-readonly-queue/*` (and `**`) never matched them; the `creation` rule blocked the queue from creating its temp branch, freezing merges to `main` and every release branch. `**/*` matches at any depth (and still matches single-segment refs), so the queue can form again. Dependabot branches are multi-segment too, hence `dependabot/**/*`.

### Any related issues, documentation, discussions?

Regression from #7121, which activated the `Restrict Branch Creation` ruleset. Unblocks backport PRs such as #7101.

### How was this PR tested?

Verified empirically against the live GitHub rulesets API on a fork: built the ruleset from this exact `.asf.yaml` and queried `GET /rules/branches/...`. `creation` is no longer active on `gh-readonly-queue/main/pr-1`, `gh-readonly-queue/release/v1.2/pr-7101`, `release/v1.2`, `release/v1.1`, `backport/*`, `dependabot/npm/*`, `main`, or `gh-pages` (all allowed); unrelated branches (`feature/*`) stay blocked. The earlier `gh-readonly-queue/**` was confirmed to still leave `creation` active on those multi-segment refs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
