### PR TITLE
docs(config): fix stale paths in gui.conf add-config guide

### DIFF
--- a/common/config/src/main/resources/gui.conf
+++ b/common/config/src/main/resources/gui.conf
@@ -18,8 +18,8 @@
 # This file is used to configure the GUI shown in users' browser.
 # To add a new configuration:
 #   1. Add a new property, its default value and the environment variable name in the gui section in this file
-#   2. Add the corresponding parsing logic in core/config/src/main/scala/org/apache/texera/config/GuiConfig.scala
-#   3. Add the sending logic in core/src/main/scala/org/apache/texera/web/resource/UserConfigResource.scala
+#   2. Add the corresponding parsing logic in common/config/src/main/scala/org/apache/texera/common/config/GuiConfig.scala
+#   3. Add the sending logic to the matching endpoint in config-service/src/main/scala/org/apache/texera/service/resource/ConfigResource.scala
 #   4. Add the frontend definition in frontend/src/app/common/type/gui-config.ts and frontend/src/app/common/service/gui-config.service.mock.ts
 # To change the default value of a configuration:
 #   1. Change the default value in the gui section in this file


### PR DESCRIPTION
### What changes were proposed in this PR?

The "to add a new configuration" guide atop gui.conf pointed to two paths that no longer exist. Step 2 named a GuiConfig.scala location under core/config, but the parser now lives under common/config. Step 3 named a sending step in an old UserConfigResource.scala, but config values are now served from ConfigResource.scala in the config-service module. Both steps now match the current layout so contributors following the guide edit the right files.

### Any related issues, documentation, discussions?

Closes #7133

### How was this PR tested?

Comment-only change; confirmed the two referenced files exist at the updated paths.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
