### PR TITLE
chore(config): remove two orphaned GUI config flags with no consumers

### DIFF
--- a/common/config/src/main/resources/gui.conf
+++ b/common/config/src/main/resources/gui.conf
@@ -54,11 +54,6 @@ gui {
     export-execution-result-enabled = false
     export-execution-result-enabled = ${?GUI_WORKFLOW_WORKSPACE_EXPORT_EXECUTION_RESULT_ENABLED}
 
-    # whether automatically correcting attribute name on change is enabled
-    # see AutoAttributeCorrectionService for more details
-    auto-attribute-correction-enabled = true
-    auto-attribute-correction-enabled = ${?GUI_WORKFLOW_WORKSPACE_AUTO_ATTRIBUTE_CORRECTION_ENABLED}
-
     # default execution mode for workflows, can be either MATERIALIZED or PIPELINED
     default-execution-mode = PIPELINED
     default-execution-mode = ${?GUI_WORKFLOW_WORKSPACE_DEFAULT_EXECUTION_MODE}

--- a/common/config/src/main/scala/org/apache/texera/common/config/GuiConfig.scala
+++ b/common/config/src/main/scala/org/apache/texera/common/config/GuiConfig.scala
@@ -43,8 +43,6 @@ object GuiConfig {
     conf.getBoolean("gui.workflow-workspace.user-preset-enabled")
   val guiWorkflowWorkspaceExportExecutionResultEnabled: Boolean =
     conf.getBoolean("gui.workflow-workspace.export-execution-result-enabled")
-  val guiWorkflowWorkspaceAutoAttributeCorrectionEnabled: Boolean =
-    conf.getBoolean("gui.workflow-workspace.auto-attribute-correction-enabled")
   val guiWorkflowWorkspaceDefaultExecutionMode: String =
     conf.getString("gui.workflow-workspace.default-execution-mode")
   val guiWorkflowWorkspaceSelectingFilesFromDatasetsEnabled: Boolean =

--- a/common/config/src/test/scala/org/apache/texera/common/config/GuiConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/GuiConfigSpec.scala
@@ -41,9 +41,6 @@ class GuiConfigSpec extends AnyFlatSpec with Matchers {
     ifUnset("GUI_WORKFLOW_WORKSPACE_EXPORT_EXECUTION_RESULT_ENABLED")(
       GuiConfig.guiWorkflowWorkspaceExportExecutionResultEnabled shouldBe false
     )
-    ifUnset("GUI_WORKFLOW_WORKSPACE_AUTO_ATTRIBUTE_CORRECTION_ENABLED")(
-      GuiConfig.guiWorkflowWorkspaceAutoAttributeCorrectionEnabled shouldBe true
-    )
     ifUnset("GUI_WORKFLOW_WORKSPACE_SELECTING_FILES_FROM_DATASETS_ENABLED")(
       GuiConfig.guiWorkflowWorkspaceSelectingFilesFromDatasetsEnabled shouldBe true
     )

--- a/config-service/src/main/scala/org/apache/texera/service/resource/ConfigResource.scala
+++ b/config-service/src/main/scala/org/apache/texera/service/resource/ConfigResource.scala
@@ -27,7 +27,6 @@ import jakarta.ws.rs.{Consumes, GET, POST, PUT, Path, PathParam, Produces}
 import org.apache.texera.auth.SessionUser
 import org.apache.texera.common.config.{
   ApplicationConfig,
-  AuthConfig,
   ComputingUnitConfig,
   DefaultsConfig,
   GuiConfig,
@@ -80,7 +79,6 @@ class ConfigResource {
     Map(
       // flags from the gui.conf
       "exportExecutionResultEnabled" -> GuiConfig.guiWorkflowWorkspaceExportExecutionResultEnabled,
-      "autoAttributeCorrectionEnabled" -> GuiConfig.guiWorkflowWorkspaceAutoAttributeCorrectionEnabled,
       "selectingFilesFromDatasetsEnabled" -> GuiConfig.guiWorkflowWorkspaceSelectingFilesFromDatasetsEnabled,
       "userPresetEnabled" -> GuiConfig.guiWorkflowWorkspaceUserPresetEnabled,
       "workflowExecutionsTrackingEnabled" -> GuiConfig.guiWorkflowWorkspaceWorkflowExecutionsTrackingEnabled,
@@ -96,9 +94,7 @@ class ConfigResource {
       "activeTimeInMinutes" -> GuiConfig.guiWorkflowWorkspaceActiveTimeInMinutes,
       "copilotEnabled" -> GuiConfig.guiWorkflowWorkspaceCopilotEnabled,
       "limitColumns" -> GuiConfig.guiWorkflowWorkspaceLimitColumns,
-      "pythonNotebookMigrationEnabled" -> GuiConfig.guiWorkflowWorkspacePythonNotebookMigrationEnabled,
-      // flags from the auth.conf if needed
-      "expirationTimeInMinutes" -> AuthConfig.jwtExpirationMinutes
+      "pythonNotebookMigrationEnabled" -> GuiConfig.guiWorkflowWorkspacePythonNotebookMigrationEnabled
     )
 
   // Engine configs.

--- a/frontend/src/app/common/service/gui-config.service.mock.ts
+++ b/frontend/src/app/common/service/gui-config.service.mock.ts
@@ -30,7 +30,6 @@ import { ExecutionMode } from "../type/workflow";
 export class MockGuiConfigService {
   private _config: GuiConfig = {
     exportExecutionResultEnabled: false,
-    autoAttributeCorrectionEnabled: false,
     selectingFilesFromDatasetsEnabled: false,
     localLogin: true,
     googleLogin: true,
@@ -48,7 +47,6 @@ export class MockGuiConfigService {
     sharingComputingUnitEnabled: false,
     operatorConsoleMessageBufferSize: 1000,
     defaultLocalUser: { username: "", password: "" },
-    expirationTimeInMinutes: 2880,
     activeTimeInMinutes: 15,
     copilotEnabled: false,
     limitColumns: 15,

--- a/frontend/src/app/common/type/gui-config.ts
+++ b/frontend/src/app/common/type/gui-config.ts
@@ -21,7 +21,6 @@ import { ExecutionMode } from "./workflow";
 // Please refer to core/config/src/main/resources/gui.conf for the definition of each config item
 export interface GuiConfig {
   exportExecutionResultEnabled: boolean;
-  autoAttributeCorrectionEnabled: boolean;
   selectingFilesFromDatasetsEnabled: boolean;
   localLogin: boolean;
   googleLogin: boolean;
@@ -39,7 +38,6 @@ export interface GuiConfig {
   sharingComputingUnitEnabled: boolean;
   operatorConsoleMessageBufferSize: number;
   defaultLocalUser?: { username?: string; password?: string };
-  expirationTimeInMinutes: number;
   activeTimeInMinutes: number;
   copilotEnabled: boolean;
   limitColumns: number;


### PR DESCRIPTION
### What changes were proposed in this PR?

Two GUI config flags were still defined and sent to the frontend but read by nobody. `autoAttributeCorrectionEnabled` lost its consumer when the schema auto-correct service was removed in #2578. `expirationTimeInMinutes` lost its only reader when token refresh was removed for security in #3765; the frontend now derives session expiry from the JWT itself. This removes both across every layer they touched: `gui.conf`, `GuiConfig` and its spec, the `/gui` config endpoint (dropping the now-unused `AuthConfig` import), and the frontend `GuiConfig` interface and mock. `AuthConfig.jwtExpirationMinutes` stays untouched — `JwtAuth` still uses it to sign real tokens.

### Any related issues, documentation, discussions?

Closes #7135

### How was this PR tested?

Dead-code removal, grep-verified no remaining references to either flag. Existing config specs (GuiConfigSpec, ConfigResourceSpec) continue to cover the config surface.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.8)
