### PR TITLE
fix(license): refresh amber/LICENSE-binary-python for transitive drift on main

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -212,13 +212,13 @@ Dependencies under the Apache License, Version 2.0
 
 Python packages:
   - aiobotocore==3.7.0
-  - aiohttp==3.14.1
+  - aiohttp==3.14.3
   - aiosignal==1.4.0
   - boto3==1.42.90
   - botocore==1.42.90
   - frozenlist==1.8.0
-  - hf-xet==1.5.1
-  - huggingface-hub==1.23.0
+  - hf-xet==1.5.2
+  - huggingface-hub==1.26.0
   - multidict==6.7.1
   - overrides==7.7.0
   - packaging==26.2
@@ -227,7 +227,7 @@ Python packages:
   - pyiceberg==0.11.1
   - pympler==1.1
   - python-dateutil==2.9.0.post0
-  - regex==2026.7.10
+  - regex==2026.7.19
   - requests==2.34.2
   - s3transfer==0.16.1
   - safetensors==0.8.0
@@ -236,7 +236,7 @@ Python packages:
   - transformers==5.5.0
   - tzdata==2026.3
   - websocket-client==1.9.0
-  - yarl==1.24.2
+  - yarl==1.24.5
 
 --------------------------------------------------------------------------------
 Dependencies under the MIT License
@@ -244,8 +244,8 @@ Dependencies under the MIT License
 
 Python packages:
   - aioitertools==0.13.0
-  - annotated-doc==0.0.4
-  - annotated-types==0.7.0
+  - annotated-doc==0.0.5
+  - annotated-types==0.8.0
   - anyio==4.14.2
   - appdirs==1.4.4
   - asn1crypto==1.5.1
@@ -253,12 +253,12 @@ Python packages:
   - betterproto==2.0.0b7
   - cachetools==6.2.6
   - charset-normalizer==3.4.9
-  - filelock==3.29.7
+  - filelock==3.32.2
   - fonttools==4.63.0
   - fs==2.4.16
-  - greenlet==3.5.3
+  - greenlet==3.5.4
   - h11==0.16.0
-  - h2==4.3.0
+  - h2==4.4.0
   - hpack==4.2.0
   - hyperframe==6.1.0
   - jmespath==1.1.0
@@ -272,15 +272,15 @@ Python packages:
   - pydantic-core==2.46.4
   - pyparsing==3.3.2
   - pyroaring==1.1.0
-  - pytz==2026.2
+  - pytz==2026.3.post1
   - pyyaml==6.0.3
   - readerwriterlock==1.0.9
   - rich==14.3.4
-  - scramp==1.4.12
+  - scramp==1.4.15
   - six==1.17.0
   - sqlalchemy==2.0.51
   - strictyaml==1.7.3
-  - typer==0.26.8
+  - typer==0.27.0
   - typing-inspection==0.4.2
   - tzlocal==2.1
   - urllib3==2.7.0
@@ -317,7 +317,7 @@ Python packages:
   - scipy==1.18.0
   - sympy==1.14.0
   - threadpoolctl==3.6.0
-  - tifffile==2026.6.1
+  - tifffile==2026.7.14
   - torch==2.13.0
   - zstandard==0.25.0
 
@@ -326,12 +326,12 @@ Dependencies under the BSD 2-Clause License
 --------------------------------------------------------------------------------
 
 Python packages:
-  - imageio==2.37.3
+  - imageio==2.37.4
   - praw==7.6.1
   - prawcore==2.4.0
   - pygments==2.20.0
   - update-checker==1.0.0
-  - wrapt==2.2.2
+  - wrapt==2.3.0
 
 --------------------------------------------------------------------------------
 Dependencies under the ISC License
@@ -346,8 +346,8 @@ Dependencies under the Mozilla Public License, Version 2.0
 
 Python packages:
   - bidict==0.22.0
-  - certifi==2026.6.17
-  - tqdm==4.68.4
+  - certifi==2026.7.22
+  - tqdm==4.70.0
 
 --------------------------------------------------------------------------------
 Dependencies under the Python Software Foundation License
@@ -355,7 +355,7 @@ Dependencies under the Python Software Foundation License
 
 Python packages:
   - aiohappyeyeballs==2.7.1
-  - matplotlib==3.11.0
+  - matplotlib==3.11.1
   - typing-extensions==4.14.1
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this PR?
Refresh 19 transitive Python dependency versions in
`amber/LICENSE-binary-python` to match the versions actually bundled,
resolving the License Binary Checker failure on `main`
(`build / pyamber (ubuntu-latest, 3.12)`). Versions only; license
categories unchanged.

### Any related issues, documentation, discussions?
Closes #6605
Run: https://github.com/apache/texera/actions/runs/30576872953

### How was this PR tested?
Text-only version bumps in the LICENSE-binary manifest; the pyamber license
check passes once the claimed versions match the bundled ones.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 4.8)