### PR TITLE
feat(local-dev): detect the host LAN IP on Windows

### DIFF
--- a/bin/local-dev/main.sh
+++ b/bin/local-dev/main.sh
@@ -590,9 +590,85 @@ fi
 # docker network. The host's LAN IP works from BOTH (host loopback for the
 # host, docker NAT'd out-and-back for the container).
 #
-# Both platform probes follow the same two steps: the interface backing the
+# All three platform probes follow the same two steps: the interface backing the
 # default route first (most reliable on a laptop that may have wifi +
 # thunderbolt + tailscale all active), then a scan as a fallback.
+_detect_host_lan_ip_windows() {
+    local iface_details="" local_ip="" iface_name="" idx=""
+
+    local virt_excl="vEthernet|WSL|Hyper-V|VirtualBox|Docker|Bridge|tap|tun|cni|flannel|cali|kube|tailscale|zerotier|wg|McAfee"
+    # Use 'netsh interface ip show route' to find the list of interfaces
+    # associated with the 0.0.0.0/0 (default) route and trace the respective indices
+    local idx_list
+    idx_list=$(netsh interface ip show route 2>/dev/null | \
+            awk '{
+                for (i = 1; i < NF; i++) {
+                    if ($i == "0.0.0.0/0") {
+                            print $(i+1)
+                    }
+                }
+            }')
+
+    # Iterate through candidate indices, inspect adapter name and grab the first physical LAN IP
+    for idx in $idx_list; do
+        iface_details=$(netsh interface ip show addresses "$idx" 2>/dev/null)
+
+        # Skip if adapter name is empty or matches virtual/VPN exclusions
+        iface_name=$(echo "$iface_details" | awk -F'"' '/Configuration for interface/ {print $2}')
+        if [[ -z "$iface_name" ]] || echo "$iface_name" | grep -qiE "$virt_excl"; then
+            continue
+        fi
+
+        # Get the IPv4 address of the interface
+        local_ip=$(echo "$iface_details" | awk -F': ' '/IP Address/ {print $2; exit}' | tr -d ' \r')
+        # Validate non-loopback and non-APIPA (169.254.x.x) address
+        if [[ -n "$local_ip" && "$local_ip" != 127.* && "$local_ip" != 169.254.* ]]; then
+            printf '%s\n' "$local_ip"
+            return 0
+        fi
+    done
+
+    # =========================================================================
+    # FALLBACK METHOD: Parse all 'netsh' interface blocks sequentially
+    # =========================================================================
+    # If the default route method fails, we dump all interface configurations.
+    # Parse the output statefully using awk to track which interface block 
+    # we are currently reading, skip explicitly excluded virtual/bridge interfaces, 
+    # and return the first valid, globally routable IPv4 address we find.
+
+    local_ip=$(
+    netsh interface ip show addresses 2>/dev/null |
+    awk -v excl="$virt_excl" '
+        # Identify the start of a new interface block
+        /Configuration for interface/ {
+            split($0, a, "\"")      # Extract the interface name
+            dev = a[2]
+            valid_iface = (tolower(dev) !~ tolower(excl))
+            next
+        }
+
+        # Extract the IP if the current interface is valid
+        /IP Address/ && valid_iface {
+            split($0, b, ":") # Extract the IP address of the interface
+            addr = b[2]
+            gsub(/^[ \t]+|[ \t\r]+$/, "", addr) # Strip leading/trailing whitespace and carriage returns
+
+            if (addr != "" &&
+                addr !~ /^127\./ &&
+                addr !~ /^169\.254\./) {
+                print addr # Print the first valid address
+                exit
+            }
+        }
+    ')
+
+    if [[ -n "$local_ip" ]]; then
+        printf '%s\n' "$local_ip"
+        return 0
+    fi
+    return 1
+}
+
 _detect_host_lan_ip_darwin() {
     local iface="" ip=""
     iface=$(route get default 2>/dev/null | awk '/interface:/{print $2; exit}')
@@ -647,8 +723,9 @@ _detect_host_lan_ip() {
     case "$(uname -s 2>/dev/null)" in
         Darwin) _detect_host_lan_ip_darwin ;;
         Linux)  _detect_host_lan_ip_linux ;;
-        # Anything else (BSD, WSL oddities): try both rather than give up.
-        *)      _detect_host_lan_ip_darwin || _detect_host_lan_ip_linux ;;
+        MINGW*|MSYS*|CYGWIN*|*_NT*) _detect_host_lan_ip_windows ;;
+        # Anything else (BSD, WSL oddities): try all three rather than give up.
+        *)      _detect_host_lan_ip_darwin || _detect_host_lan_ip_linux || _detect_host_lan_ip_windows ;;
     esac
 }
 # Lazy resolver — called from subcommands that actually need to publish a
@@ -664,7 +741,9 @@ _require_host_lan_ip() {
             Darwin) probes="\`route get default\` / en0-en10" ;;
             Linux)  probes="\`ip route show default\` / \`ip -4 addr show scope global\`"
                     bridge_note=" outside the container bridges" ;;
-            *)      probes="the macOS and Linux probes"
+            MINGW*|MSYS*|CYGWIN*|*_NT*) probes="\`netsh interface ip show route\` / \`netsh interface ip show addresses\`" 
+                    bridge_note=" outside the container bridges" ;;
+            *)      probes="the macOS, Windows and Linux probes"
                     bridge_note=" outside the container bridges" ;;
         esac
         echo "FATAL: could not detect a host LAN IP." >&2


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we 
    are following Conventional Commits style for PR titles as well.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?

- Added a dedicated helper function _detect_host_lan_ip_windows() to parse the primary non-loopback IPv4 address on Windows environments using the netsh tool.

- Using the routing table, determined the index of the default gateway interface, followed by finding the IP address of the host machine based on the index.  Ensures Minio can be accessed as an endpoint from the host machine.

- Ensured interface filtering that shares the default gateway of the host machine in the routing table.

- Updated _detect_host_lan_ip() to recognize Windows kernel and shell environments (MINGW*, MSYS*, CYGWIN*, *_NT*) via uname -s and route them to _detect_host_lan_ip_windows().

<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->


### Any related issues, documentation, discussions?

Fixes: #7138 
IP resolution failures when running scripts on Windows host systems (e.g., Git Bash, MSYS2, or Cygwin).

Improves cross-platform parity between macOS (Darwin), Linux, and Windows for container/host networking setup.

<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->


### How was this PR tested?
Verified manually. Attaching a screenshot.
Ran the `test_local_dev_sh.sh` script to verify.
<img width="686" height="304" alt="image" src="https://github.com/user-attachments/assets/3b85495d-ec9b-4420-8515-f17bc941c735" />


<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->


### Was this PR authored or co-authored using generative AI tooling?
No, AI usage reused the existing Darwin method to resolve it.
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
