### PR TITLE
fix(workflow-operator): add missing defaultValue to HF temperature property

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/huggingFace/HuggingFaceInferenceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/huggingFace/HuggingFaceInferenceOpDesc.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.amber.operator.huggingFace
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import org.apache.texera.amber.operator.PythonOperatorDescriptor
@@ -142,9 +142,10 @@ class HuggingFaceInferenceOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("Maximum number of tokens to generate (1-4096)")
   var maxNewTokens: java.lang.Integer = 256
 
-  @JsonProperty(value = "temperature", required = false, defaultValue = "0.7")
+  @JsonProperty(value = "temperature", required = false)
   @JsonSchemaTitle("Temperature")
   @JsonPropertyDescription("Sampling temperature (0.0 = deterministic, up to 2.0)")
+  @JsonSchemaInject(json = """{ "minimum": 0.0, "maximum": 2.0, "default": 0.7 }""")
   var temperature: java.lang.Double = 0.7
 
   @JsonProperty(

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/huggingFace/HuggingFaceInferenceOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/huggingFace/HuggingFaceInferenceOpDesc.scala
@@ -142,7 +142,7 @@ class HuggingFaceInferenceOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("Maximum number of tokens to generate (1-4096)")
   var maxNewTokens: java.lang.Integer = 256
 
-  @JsonProperty(value = "temperature", required = false)
+  @JsonProperty(value = "temperature", required = false, defaultValue = "0.7")
   @JsonSchemaTitle("Temperature")
   @JsonPropertyDescription("Sampling temperature (0.0 = deterministic, up to 2.0)")
   var temperature: java.lang.Double = 0.7


### PR DESCRIPTION
### What changes were proposed in this PR?

The temperature field's default (0.7) and valid range weren't advertised in the operator's JSON schema. It can't be done with @JsonProperty(defaultValue = "0.7"): the schema generator (mbknor jackson-jsonSchema) parses a numeric field's defaultValue with .toInt, so a floating-point value throws NumberFormatException and breaks operator-metadata generation, which is why "0.7" was the only float defaultValue in the repo. Instead this uses @JsonSchemaInject (the pattern already used for Double fields in RadarChartOpDesc/ScatterplotOpDesc), injecting { "minimum": 0.0, "maximum": 2.0, "default": 0.7 } to match the field's runtime clamp and description.

### Any related issues, documentation, discussions?
Closes #7201.

### How was this PR tested?
sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.huggingFace.* org.apache.texera.amber.operator.metadata.*", the Hugging Face suite plus the operator-metadata specs pass (147 tests), including PythonCodeRawInvalidTextSpec (py-compiles every operator's generated Python) and the schema-generation path this change touches. scalafmt clean.

Schema-metadata-only change: it doesn't affect the generated Python or any runtime behavior, so no new test was added.

### Was this PR authored or co-authored using generative AI tooling?
No, this PR wasn't authored or co-authored using generative AI tooling.
