### PR TITLE
test(amber): cover WebSocket payload tuning

### DIFF
--- a/amber/src/test/scala/org/apache/texera/web/resource/WebsocketPayloadSizeTunerSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/WebsocketPayloadSizeTunerSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.resource
+
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import javax.servlet.{ServletContext, ServletContextEvent}
+import javax.websocket.server.ServerContainer
+
+class WebsocketPayloadSizeTunerSpec extends AnyFlatSpec with Matchers with MockFactory {
+
+  private def eventWith(container: ServerContainer): ServletContextEvent = {
+    val servletContext = mock[ServletContext]
+    (servletContext
+      .getAttribute(_: String))
+      .expects(classOf[ServerContainer].getName)
+      .returning(container)
+      .once()
+    new ServletContextEvent(servletContext)
+  }
+
+  "contextInitialized" should "look up the server container by its class name and tune both limits" in {
+    val maxKB = 64
+    val container = mock[ServerContainer]
+    (container.setDefaultMaxTextMessageBufferSize(_: Int)).expects(maxKB * 1024).once()
+    (container.setDefaultMaxBinaryMessageBufferSize(_: Int)).expects(maxKB * 1024).once()
+
+    new WebsocketPayloadSizeTuner(maxKB).contextInitialized(eventWith(container))
+  }
+
+  it should "convert a one-KiB payload limit to exactly 1024 bytes" in {
+    val container = mock[ServerContainer]
+    (container.setDefaultMaxTextMessageBufferSize(_: Int)).expects(1024).once()
+    (container.setDefaultMaxBinaryMessageBufferSize(_: Int)).expects(1024).once()
+
+    new WebsocketPayloadSizeTuner(1).contextInitialized(eventWith(container))
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/web/resource/WebsocketPayloadSizeTunerSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/WebsocketPayloadSizeTunerSpec.scala
@@ -39,10 +39,10 @@ class WebsocketPayloadSizeTunerSpec extends AnyFlatSpec with Matchers with MockF
   }
 
   "contextInitialized" should "look up the server container by its class name and tune both limits" in {
-    val maxKB = 64
+    val maxKiB = 64
     val container = mock[ServerContainer]
-    (container.setDefaultMaxTextMessageBufferSize(_: Int)).expects(maxKB * 1024).once()
-    (container.setDefaultMaxBinaryMessageBufferSize(_: Int)).expects(maxKB * 1024).once()
+    (container.setDefaultMaxTextMessageBufferSize(_: Int)).expects(maxKiB * 1024).once()
+    (container.setDefaultMaxBinaryMessageBufferSize(_: Int)).expects(maxKiB * 1024).once()
 
     new WebsocketPayloadSizeTuner(maxKB).contextInitialized(eventWith(container))
   }

--- a/amber/src/test/scala/org/apache/texera/web/resource/WebsocketPayloadSizeTunerSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/WebsocketPayloadSizeTunerSpec.scala
@@ -44,7 +44,7 @@ class WebsocketPayloadSizeTunerSpec extends AnyFlatSpec with Matchers with MockF
     (container.setDefaultMaxTextMessageBufferSize(_: Int)).expects(maxKiB * 1024).once()
     (container.setDefaultMaxBinaryMessageBufferSize(_: Int)).expects(maxKiB * 1024).once()
 
-    new WebsocketPayloadSizeTuner(maxKB).contextInitialized(eventWith(container))
+    new WebsocketPayloadSizeTuner(maxKiB).contextInitialized(eventWith(container))
   }
 
   it should "convert a one-KiB payload limit to exactly 1024 bytes" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds focused unit coverage for servlet WebSocket container lookup and the configured text and binary payload limits, including exact one-KiB byte conversion.

### Any related issues, documentation, discussions?

Closes #7217

### How was this PR tested?

- `WorkflowExecutionService/testOnly org.apache.texera.web.resource.WebsocketPayloadSizeTunerSpec` — 2 passed.
- `WorkflowExecutionService/Test/scalafmtCheck`
- `WorkflowExecutionService/Test/scalafix --check`

Mutation proof (each production mutation was reverted):

| Production mutation | Focused test result |
| --- | --- |
| Changed the text-buffer multiplier from `1024` to `1000` | 0 passed, 2 failed |
| Removed the binary-buffer setter | 0 passed, 2 failed |

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex (GPT-5)
