### PR TITLE
test(amber): extend PveResource unit test coverage

### DIFF
--- a/amber/src/test/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveResourceSpec.scala
@@ -429,4 +429,45 @@ class PveResourceSpec
     val resp = new PveResource().deletePveFromDb(-1, sessionUser)
     resp.getStatus shouldBe Response.Status.NOT_FOUND.getStatusCode
   }
+
+  "PveResource.getSystemPackages" should "wrap the manager's list under a 'system' key" in {
+    // PveManager.systemPackages is a lazy val resolved via a (mocked) `pip freeze`,
+    // so allow the process call in case this test is the first to force resolution.
+    expectProcessCalls()
+    val result = new PveResource().getSystemPackages
+    result.keySet.asScala shouldBe Set("system")
+    result.get("system") shouldBe PveManager.getSystemPackages.toList.asJava
+  }
+
+  "PveResource.fetchPVEs" should "return 400 when the cuid query parameter is missing" in {
+    val resp = new PveResource().fetchPVEs(null)
+    resp.getStatus shouldBe Response.Status.BAD_REQUEST.getStatusCode
+  }
+
+  it should "return the environments of a computing unit" in {
+    expectProcessCalls()
+    PveManager.createNewPve(testCuid, queue, testPveName)
+
+    val resp = new PveResource().fetchPVEs(Int.box(testCuid))
+    resp.getStatus shouldBe Response.Status.OK.getStatusCode
+    val pves = resp.getEntity.asInstanceOf[java.util.List[java.util.Map[String, Object]]].asScala
+    pves.map(_.get("pveName")) should contain(testPveName)
+  }
+
+  "PveResource.deletePackage" should "return 200 when the uninstall succeeds" in {
+    expectProcessCalls()
+    PveManager.createNewPve(testCuid, queue, testPveName)
+    PveManager.installUserPackages(List("colorama==0.4.6"), testCuid, queue, testPveName)
+
+    val resp = new PveResource().deletePackage(testCuid, testPveName, "colorama")
+    resp.getStatus shouldBe Response.Status.OK.getStatusCode
+  }
+
+  it should "return 400 when the package is part of the system set" in {
+    expectProcessCalls()
+    PveManager.createNewPve(testCuid, queue, testPveName)
+
+    val resp = new PveResource().deletePackage(testCuid, testPveName, "pyarrow")
+    resp.getStatus shouldBe Response.Status.BAD_REQUEST.getStatusCode
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `MockTexeraDB`-backed `PveResourceSpec` to cover the
`PveResource` endpoints that were still untested. The spec already covered
`savePve`, `listPves`, `updatePve`, `deletePveFromDb`, and `deleteEnvironments`,
so this adds the remaining three (5 tests), staying on the metadata / mocked-process
path (no real virtualenv):

- `getSystemPackages` — wraps the manager's list under a `"system"` key.
- `fetchPVEs` — returns 400 when the `cuid` query parameter is missing, and the
  computing unit's environments otherwise.
- `deletePackage` — returns 200 when the uninstall succeeds and 400 when the
  target is a system package.

No production code was changed.

### Any related issues, documentation, discussions?

Closes #7179.

### How was this PR tested?

`sbt "WorkflowExecutionService/testOnly *PveResourceSpec"` — 30 passed (25 existing
+ 5 new), run twice for determinism against the embedded Postgres with
`PveManager.runProcess` mocked (no real pip/venv). The failure path was verified by
breaking an assertion (1 failed, non-zero exit), and `Test/scalafmtCheck` +
`Test/scalafix --check` are clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
