### PR TITLE
fix(workflow-operator): retry other providers on a 401 instead of aborting the HF fallback

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/huggingFace/codegen/HuggingFaceCodegenBase.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/huggingFace/codegen/HuggingFaceCodegenBase.scala
@@ -195,7 +195,7 @@ object HuggingFaceCodegenBase {
        |        Returns (response, provider_summary). provider_summary is None on
        |        success or a string describing what failed.
        |        '''
-       |        RETRYABLE = (400, 404, 422, 429, 502, 503)
+       |        RETRYABLE = (400, 401, 404, 422, 429, 502, 503)
        |        last_resp = None
        |        errors = []
        |        for prov in providers:
@@ -246,8 +246,6 @@ object HuggingFaceCodegenBase {
        |                errors.append(f"{provider_name}: {type(e).__name__}")
        |                continue
        |            if resp.status_code in (200, 201):
-       |                return resp, None
-       |            if resp.status_code == 401:
        |                return resp, None
        |            try:
        |                detail = resp.json().get("error", resp.text[:200])

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/huggingFace/HuggingFaceInferenceOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/huggingFace/HuggingFaceInferenceOpDescSpec.scala
@@ -647,4 +647,12 @@ class HuggingFaceInferenceOpDescSpec extends AnyFlatSpec with Matchers {
     val outSchema = out(desc.operatorInfo.outputPorts.head.id)
     outSchema.getAttributeNames.contains("hf_response") shouldBe true
   }
+
+  it should "treat a 401 as retryable so one provider's auth failure doesn't abort the fallback" in {
+    val code = makeDesc().generatePythonCode()
+    // 401 is in the retryable set -> the loop tries the next provider instead of bailing.
+    code should include("RETRYABLE = (400, 401, 404, 422, 429, 502, 503)")
+    // The old short-circuit (return immediately on the first 401) must be gone.
+    code should not include ("            if resp.status_code == 401:\n                return resp, None")
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

In the HuggingFace operator's `_post_with_fallback`, a 401 from any single provider immediately aborted the whole fallback chain (reported as "Invalid HF API token"), even when another provider would have served the model with the same token, one provider can 401 (e.g. missing provider-specific permission) while others accept the token.

This removes the 401 short-circuit and adds 401 to the `RETRYABLE` set, so the loop tries the remaining providers. "Invalid HF API token" is now surfaced only when the final provider still returns 401 (i.e. every provider rejected the token).

### Any related issues, documentation, discussions?

Closes #7194.

### How was this PR tested?

`sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.huggingFace.* org.apache.texera.amber.util.PythonCodeRawInvalidTextSpec"`: passes (125 tests). Added a test asserting 401 is retryable and the old short-circuit is gone; `PythonCodeRawInvalidTextSpec` py-compiles the generated Python. scalafmt clean.

### Was this PR authored or co-authored using generative AI tooling?

No, this PR was not authored or co-authored using generative AI tooling.