### PR TITLE
test(amber): cover the DB-backed TryLockRequest branches in CollaborationResource

### DIFF
--- a/amber/src/test/scala/org/apache/texera/web/resource/CollaborationResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/CollaborationResourceSpec.scala
@@ -41,12 +41,12 @@ import java.util.concurrent.{Future => JFuture}
 import javax.websocket.{RemoteEndpoint, Session}
 import scala.collection.mutable.ArrayBuffer
 
-// Unit tests for CollaborationResource's session bookkeeping and message
-// fan-out. The only collaborator is the javax.websocket.Session interface, so
-// everything here runs in-process against mocks — no database, filesystem or
-// network. The two branches that reach WorkflowAccessResource.hasWriteAccess
-// (the read-only TryLockRequest rejection and the lock hand-off inside
-// myOnClose) need SqlServer and are deliberately left uncovered.
+// Unit tests for CollaborationResource's session bookkeeping, message fan-out
+// and lock-request handling. Most cases drive a mocked javax.websocket.Session
+// with no external collaborators; the TryLockRequest cases that reach
+// WorkflowAccessResource.hasWriteAccess additionally mix in MockTexeraDB and
+// seed a workflow_user_access row so the privilege check reads a real value.
+// The lock hand-off inside myOnClose still needs SqlServer and is left uncovered.
 class CollaborationResourceSpec
     extends AnyFlatSpec
     with Matchers

--- a/amber/src/test/scala/org/apache/texera/web/resource/CollaborationResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/CollaborationResourceSpec.scala
@@ -20,14 +20,23 @@
 package org.apache.texera.web.resource
 
 import org.apache.texera.amber.util.JSONUtils
-import org.apache.texera.dao.jooq.generated.tables.pojos.User
+import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.jooq.generated.Tables.{USER, WORKFLOW, WORKFLOW_USER_ACCESS}
+import org.apache.texera.dao.jooq.generated.enums.{PrivilegeEnum, UserRoleEnum}
+import org.apache.texera.dao.jooq.generated.tables.daos.{
+  UserDao,
+  WorkflowDao,
+  WorkflowUserAccessDao
+}
+import org.apache.texera.dao.jooq.generated.tables.pojos.{User, Workflow, WorkflowUserAccess}
 import org.apache.texera.web.model.collab.request._
 import org.apache.texera.web.resource.CollaborationResource._
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.BeforeAndAfterEach
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import java.sql.Timestamp
 import java.util.concurrent.{Future => JFuture}
 import javax.websocket.{RemoteEndpoint, Session}
 import scala.collection.mutable.ArrayBuffer
@@ -42,9 +51,25 @@ class CollaborationResourceSpec
     extends AnyFlatSpec
     with Matchers
     with MockFactory
-    with BeforeAndAfterEach {
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with MockTexeraDB {
 
   private var resource: CollaborationResource = _
+
+  // Fixed ids for the DB-backed lock tests; a user, a workflow and one
+  // workflow_user_access row are seeded per test so checkIsReadOnly ->
+  // WorkflowAccessResource.hasWriteAccess reads a real privilege.
+  private val accessUid = 8201
+  private val accessWid = 8301
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+  }
+
+  override protected def afterAll(): Unit = {
+    closeConnectionPool()
+  }
 
   // The five maps live on the companion object, i.e. they are JVM-wide mutable
   // state shared by every test in the suite. Clearing them here is what keeps
@@ -55,7 +80,56 @@ class CollaborationResourceSpec
     sessionIdUIdMap.clear()
     wIdSessionIdsMap.clear()
     wIdLockHolderSessionIdMap.clear()
+    cleanupAccess()
     resource = new CollaborationResource()
+  }
+
+  override def afterEach(): Unit = {
+    cleanupAccess()
+  }
+
+  // Seeds user accessUid + workflow accessWid + a workflow_user_access row with
+  // the given privilege, so WorkflowAccessResource.getPrivilege(accessWid,
+  // accessUid) returns it.
+  private def seedAccess(privilege: PrivilegeEnum): Unit = {
+    val user = new User
+    user.setUid(Integer.valueOf(accessUid))
+    user.setName("collab_lock_user")
+    user.setRole(UserRoleEnum.REGULAR)
+    user.setPassword("pw")
+    new UserDao(getDSLContext.configuration()).insert(user)
+
+    val workflow = new Workflow
+    workflow.setWid(Integer.valueOf(accessWid))
+    workflow.setName("collab-lock-wf")
+    workflow.setContent("{}")
+    workflow.setDescription("")
+    workflow.setCreationTime(new Timestamp(System.currentTimeMillis()))
+    workflow.setLastModifiedTime(new Timestamp(System.currentTimeMillis()))
+    new WorkflowDao(getDSLContext.configuration()).insert(workflow)
+
+    new WorkflowUserAccessDao(getDSLContext.configuration())
+      .insert(
+        new WorkflowUserAccess(Integer.valueOf(accessUid), Integer.valueOf(accessWid), privilege)
+      )
+  }
+
+  private def cleanupAccess(): Unit = {
+    getDSLContext
+      .deleteFrom(WORKFLOW_USER_ACCESS)
+      .where(WORKFLOW_USER_ACCESS.WID.eq(accessWid))
+      .execute()
+    getDSLContext.deleteFrom(WORKFLOW).where(WORKFLOW.WID.eq(accessWid)).execute()
+    getDSLContext.deleteFrom(USER).where(USER.UID.eq(accessUid)).execute()
+  }
+
+  // A session already registered on accessWid as accessUid, ready to TryLock.
+  private def lockingSession(id: String): (Session, ArrayBuffer[String]) = {
+    val (session, sent) = mockSession(id, uId = Some(accessUid))
+    resource.myOnOpen(session)
+    resource.myOnMsg(session, send(WIdRequest(accessWid)))
+    sent.clear()
+    (session, sent)
   }
 
   /**
@@ -293,5 +367,49 @@ class CollaborationResourceSpec
 
     a[NoSuchElementException] should be thrownBy
       resource.myOnMsg(session, send(AcquireLockRequest()))
+  }
+
+  // -- locking that consults WorkflowAccessResource (DB-backed) ---------------
+
+  "TryLockRequest from a read-only user" should "reject the lock and mark the workflow read-only" in {
+    seedAccess(PrivilegeEnum.READ)
+    val (session, sent) = lockingSession("s1")
+
+    resource.myOnMsg(session, send(TryLockRequest()))
+
+    sent should have size 2
+    sent.head should include("LockRejectedEvent")
+    sent(1) should include("WorkflowAccessEvent")
+    sent(1) should include("\"workflowReadonly\":true")
+    // a read-only attempt records the null sentinel so the holder slot exists
+    wIdLockHolderSessionIdMap should contain key accessWid
+    wIdLockHolderSessionIdMap(accessWid) shouldBe null
+  }
+
+  "TryLockRequest from a writable user with no current holder" should "grant the lock" in {
+    seedAccess(PrivilegeEnum.WRITE)
+    val (session, sent) = lockingSession("s1")
+
+    resource.myOnMsg(session, send(TryLockRequest()))
+
+    sent should have size 2
+    sent.head should include("WorkflowAccessEvent")
+    sent.head should include("\"workflowReadonly\":false")
+    sent(1) should include("LockGrantedEvent")
+    wIdLockHolderSessionIdMap(accessWid) shouldBe "s1"
+  }
+
+  "TryLockRequest from a writable user" should "be rejected when another session holds the lock" in {
+    seedAccess(PrivilegeEnum.WRITE)
+    val (session, sent) = lockingSession("s1")
+    wIdLockHolderSessionIdMap(accessWid) = "other-session" // a different holder
+
+    resource.myOnMsg(session, send(TryLockRequest()))
+
+    sent should have size 2
+    sent.head should include("WorkflowAccessEvent")
+    sent.head should include("\"workflowReadonly\":false")
+    sent(1) should include("LockRejectedEvent")
+    wIdLockHolderSessionIdMap(accessWid) shouldBe "other-session" // unchanged
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `CollaborationResourceSpec` to cover the `TryLockRequest`
branches that consult the database
(`amber/src/main/scala/org/apache/texera/web/resource/CollaborationResource.scala`).
The prior spec (#6904) left these uncovered because they reach
`WorkflowAccessResource.hasWriteAccess`, which needs `SqlServer`. No production
code was changed.

The suite now also mixes in `MockTexeraDB`: for these three tests a user, a
workflow and one `workflow_user_access` row are seeded so
`checkIsReadOnly` → `hasWriteAccess` reads a real privilege. The session is still
driven through `myOnMsg` with the existing mocked `javax.websocket.Session`, and
outgoing events are asserted from the captured send buffer. +3 tests:

- read-only user (`workflow_user_access` = READ) → `LockRejectedEvent` +
  `WorkflowAccessEvent(workflowReadonly=true)`, and the holder slot is set to the
  `null` sentinel.
- writable user (WRITE) with no current holder → `WorkflowAccessEvent(readonly=false)`
  + `LockGrantedEvent`, and the holder becomes the sender.
- writable user when a different session already holds the lock →
  `WorkflowAccessEvent(readonly=false)` + `LockRejectedEvent`, holder unchanged.

### Any related issues, documentation, discussions?

Closes #7228

### How was this PR tested?

Extended unit tests, run locally against embedded Postgres (`MockTexeraDB`). All
pass, and the failure path was verified by breaking an assertion to confirm the
suite goes red:

```
sbt "WorkflowExecutionService/testOnly *CollaborationResourceSpec"
# Tests: succeeded 16, failed 0
sbt "WorkflowExecutionService/Test/scalafmtCheck"       # clean
sbt "WorkflowExecutionService/Test/scalafix --check"    # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
