### PR TITLE
test(dao): extend SiteSettings unit test coverage with MockTexeraDB

### DIFF
--- a/common/dao/src/test/scala/org/apache/texera/dao/SiteSettingsSpec.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/SiteSettingsSpec.scala
@@ -18,10 +18,41 @@
 
 package org.apache.texera.dao
 
+import org.apache.texera.dao.jooq.generated.Tables.SITE_SETTINGS
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class SiteSettingsSpec extends AnyFlatSpec with Matchers {
+class SiteSettingsSpec
+    extends AnyFlatSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with MockTexeraDB {
+
+  // Point SqlServer (used by SiteSettings.getInt/getLong internally) and the test's
+  // own getDSLContext at the same embedded Postgres.
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    initializeDBAndReplaceDSLContext()
+  }
+
+  override protected def afterAll(): Unit =
+    try closeConnectionPool()
+    finally super.afterAll()
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    getDSLContext.deleteFrom(SITE_SETTINGS).execute()
+  }
+
+  private def storedUpdatedBy(key: String): String =
+    getDSLContext
+      .select(SITE_SETTINGS.UPDATED_BY)
+      .from(SITE_SETTINGS)
+      .where(SITE_SETTINGS.KEY.eq(key))
+      .fetchOneInto(classOf[String])
 
   "parseOrDefault" should "return the parsed value when the raw string is present and valid" in {
     SiteSettings.parseOrDefault(Some("42"), 0)(_.toInt) shouldBe 42
@@ -41,5 +72,42 @@ class SiteSettingsSpec extends AnyFlatSpec with Matchers {
 
   it should "work for Long values" in {
     SiteSettings.parseOrDefault(Some("9999999999"), 0L)(_.toLong) shouldBe 9999999999L
+  }
+
+  "getInt" should "return the stored value when the key is present" in {
+    SiteSettings.upsert(getDSLContext, "max_x", "42", "admin")
+    SiteSettings.getInt("max_x", 0) shouldBe 42
+  }
+
+  it should "return the default when the key is absent" in {
+    SiteSettings.getInt("missing_key", 7) shouldBe 7
+  }
+
+  it should "return the default when the stored value is not numeric" in {
+    SiteSettings.upsert(getDSLContext, "bad_int", "not-a-number", "admin")
+    SiteSettings.getInt("bad_int", 7) shouldBe 7
+  }
+
+  "getLong" should "return the stored long value when the key is present" in {
+    SiteSettings.upsert(getDSLContext, "big", "9999999999", "admin")
+    SiteSettings.getLong("big", 0L) shouldBe 9999999999L
+  }
+
+  "upsert" should "insert a new row and then overwrite it with the latest value and writer" in {
+    SiteSettings.upsert(getDSLContext, "k", "1", "admin")
+    SiteSettings.getInt("k", 0) shouldBe 1
+
+    SiteSettings.upsert(getDSLContext, "k", "2", "admin2")
+    SiteSettings.getInt("k", 0) shouldBe 2
+    storedUpdatedBy("k") shouldBe "admin2"
+  }
+
+  "insertIfAbsent" should "insert when absent but leave an existing value untouched" in {
+    SiteSettings.insertIfAbsent(getDSLContext, "seed", "10", "seeder")
+    SiteSettings.getInt("seed", 0) shouldBe 10
+
+    SiteSettings.insertIfAbsent(getDSLContext, "seed", "20", "seeder2")
+    SiteSettings.getInt("seed", 0) shouldBe 10
+    storedUpdatedBy("seed") shouldBe "seeder"
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends `SiteSettingsSpec` (previously only exercised the pure `parseOrDefault`
helper) onto `MockTexeraDB` so `SqlServer.createDSLContext()` resolves to the
embedded Postgres, then covers the DB-hit paths that were red. 6 new tests take
`SiteSettings` to 100% (jacoco: 98/98 instructions, 23/23 lines):

- `getInt` — returns the stored value when the key is present, the default when
  the key is absent, and the default when the stored value is non-numeric
  (the parse-failure branch).
- `getLong` — returns the stored long value.
- `upsert` — inserts a new row, then overwrites its value and `updated_by`.
- `insertIfAbsent` — inserts when absent and leaves an existing value untouched.

The existing `parseOrDefault` cases are kept as-is. No production code changed.

### Any related issues, documentation, discussions?

Closes #7253.

### How was this PR tested?

`sbt "DAO/testOnly *SiteSettingsSpec"` — 11 passed (5 existing + 6 new) against
the embedded Postgres, with `upsert` re-run in isolation to rule out
order-dependence. `sbt "DAO/jacoco"` confirms `SiteSettings` is fully covered.
The failure path was verified by breaking an assertion (1 failed, non-zero exit),
and `Test/scalafmtCheck` + `Test/scalafix --check` are clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
