### PR TITLE
feat(visualization): declare the column types Wind Rose and Bubble Chart require

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.amber.operator.visualization.bubbleChart
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.PythonTemplateBuilderStringContext
 import org.apache.texera.amber.pybuilder.PyStringTypes.EncodableString
@@ -39,6 +39,16 @@ import javax.validation.constraints.NotNull
   */
 
 // type can be numerical only
+// The z column is the bubble size, which plotly express divides by a scale
+// factor, so text aborts the run. The x and y axes are positions and take any
+// type, the way a scatter plot's do.
+@JsonSchemaInject(json = """
+{
+  "attributeTypeRules": {
+    "zValue": { "enum": ["integer", "long", "double"] }
+  }
+}
+""")
 class BubbleChartOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "xValue", required = true)

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/windRoseChart/WindRoseChartOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/windRoseChart/WindRoseChartOpDesc.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.amber.operator.visualization.windRoseChart
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.core.workflow.OutputPort.OutputMode
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.PythonTemplateBuilderStringContext
@@ -32,6 +32,16 @@ import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, Operat
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder
 import javax.validation.constraints.NotNull
 
+// The radial value is the length of each wedge, so it has to be a number: given
+// text, plotly turns the radial axis categorical and the wedges stop meaning
+// anything. The angle is a direction label and takes any type.
+@JsonSchemaInject(json = """
+{
+  "attributeTypeRules": {
+    "rColumn": { "enum": ["integer", "long", "double"] }
+  }
+}
+""")
 class WindRoseChartOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "rColumn", required = true)

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/bubbleChart/BubbleChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/bubbleChart/BubbleChartOpDescSpec.scala
@@ -19,8 +19,7 @@
 
 package org.apache.texera.amber.operator.visualization.bubbleChart
 
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
-import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.apache.texera.amber.operator.metadata.OperatorMetadataGenerator
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -104,20 +103,20 @@ class BubbleChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matcher
     plain should include("column3")
   }
 
-  "BubbleChartOpDesc @JsonSchemaInject" should
+  "BubbleChartOpDesc's generated schema" should
     "constrain the bubble size to numeric and leave the axes unconstrained" in {
     // x and y are positions and read as any type, the way a scatter plot's do.
     // Only the size is divided by a scale factor and so has to be a number.
-    val ann = classOf[BubbleChartOpDesc].getAnnotation(classOf[JsonSchemaInject])
-    ann should not be null
-    val rules = objectMapper.readTree(ann.json).path("attributeTypeRules")
+    val schema = OperatorMetadataGenerator.generateOperatorJsonSchema(classOf[BubbleChartOpDesc])
+    val rules = schema.path("attributeTypeRules")
     rules.fieldNames().asScala.toSet shouldBe Set("zValue")
-    rules
-      .path("zValue")
-      .path("enum")
-      .elements()
-      .asScala
-      .map(_.asText())
-      .toSet shouldBe Set("integer", "long", "double")
+
+    // The key has to name a property the form actually renders; one that names
+    // nothing parses fine and constrains nothing.
+    schema.path("properties").has("zValue") shouldBe true
+
+    val allowed = rules.path("zValue").path("enum").elements().asScala.map(_.asText()).toSet
+    allowed shouldBe Set("integer", "long", "double")
+    allowed should not contain "string"
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/bubbleChart/BubbleChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/bubbleChart/BubbleChartOpDescSpec.scala
@@ -19,9 +19,13 @@
 
 package org.apache.texera.amber.operator.visualization.bubbleChart
 
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.jdk.CollectionConverters._
 
 class BubbleChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
   var opDesc: BubbleChartOpDesc = _
@@ -98,5 +102,22 @@ class BubbleChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matcher
     plain should include("column1")
     plain should include("column2")
     plain should include("column3")
+  }
+
+  "BubbleChartOpDesc @JsonSchemaInject" should
+    "constrain the bubble size to numeric and leave the axes unconstrained" in {
+    // x and y are positions and read as any type, the way a scatter plot's do.
+    // Only the size is divided by a scale factor and so has to be a number.
+    val ann = classOf[BubbleChartOpDesc].getAnnotation(classOf[JsonSchemaInject])
+    ann should not be null
+    val rules = objectMapper.readTree(ann.json).path("attributeTypeRules")
+    rules.fieldNames().asScala.toSet shouldBe Set("zValue")
+    rules
+      .path("zValue")
+      .path("enum")
+      .elements()
+      .asScala
+      .map(_.asText())
+      .toSet shouldBe Set("integer", "long", "double")
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/windRoseChart/WindRoseChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/windRoseChart/WindRoseChartOpDescSpec.scala
@@ -19,8 +19,7 @@
 
 package org.apache.texera.amber.operator.visualization.windRoseChart
 
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
-import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.apache.texera.amber.operator.metadata.OperatorMetadataGenerator
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -82,20 +81,20 @@ class WindRoseChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Match
     code should include("class ProcessTableOperator(UDFTableOperator)")
   }
 
-  "WindRoseChartOpDesc @JsonSchemaInject" should
+  "WindRoseChartOpDesc's generated schema" should
     "constrain the radial values to numeric and leave the angle unconstrained" in {
     // The angle is a direction label — "N", "NE" — so a rule there would reject
     // the ordinary case. Only the wedge length has to be a number.
-    val ann = classOf[WindRoseChartOpDesc].getAnnotation(classOf[JsonSchemaInject])
-    ann should not be null
-    val rules = objectMapper.readTree(ann.json).path("attributeTypeRules")
+    val schema = OperatorMetadataGenerator.generateOperatorJsonSchema(classOf[WindRoseChartOpDesc])
+    val rules = schema.path("attributeTypeRules")
     rules.fieldNames().asScala.toSet shouldBe Set("rColumn")
-    rules
-      .path("rColumn")
-      .path("enum")
-      .elements()
-      .asScala
-      .map(_.asText())
-      .toSet shouldBe Set("integer", "long", "double")
+
+    // The key has to name a property the form actually renders; one that names
+    // nothing parses fine and constrains nothing.
+    schema.path("properties").has("rColumn") shouldBe true
+
+    val allowed = rules.path("rColumn").path("enum").elements().asScala.map(_.asText()).toSet
+    allowed shouldBe Set("integer", "long", "double")
+    allowed should not contain "string"
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/windRoseChart/WindRoseChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/windRoseChart/WindRoseChartOpDescSpec.scala
@@ -19,12 +19,16 @@
 
 package org.apache.texera.amber.operator.visualization.windRoseChart
 
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject
+import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
+
+import scala.jdk.CollectionConverters._
 
 class WindRoseChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
 
@@ -76,5 +80,22 @@ class WindRoseChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Match
     assert(carries(code, "r_col"))
     assert(carries(code, "theta_col"))
     code should include("class ProcessTableOperator(UDFTableOperator)")
+  }
+
+  "WindRoseChartOpDesc @JsonSchemaInject" should
+    "constrain the radial values to numeric and leave the angle unconstrained" in {
+    // The angle is a direction label — "N", "NE" — so a rule there would reject
+    // the ordinary case. Only the wedge length has to be a number.
+    val ann = classOf[WindRoseChartOpDesc].getAnnotation(classOf[JsonSchemaInject])
+    ann should not be null
+    val rules = objectMapper.readTree(ann.json).path("attributeTypeRules")
+    rules.fieldNames().asScala.toSet shouldBe Set("rColumn")
+    rules
+      .path("rColumn")
+      .path("enum")
+      .elements()
+      .asScala
+      .map(_.asText())
+      .toSet shouldBe Set("integer", "long", "double")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Wind Rose's radial value and Bubble Chart's z column are both consumed as magnitudes, and neither declared an `attributeTypeRules` entry, so the property form offered every column and accepted a string one. Each now declares `integer`, `long` or `double`, the way Range Slider's y-axis and Radar Chart's value columns already do.
<img width="1433" height="925" alt="Screenshot 2026-08-07 at 2 21 49 PM" src="https://github.com/user-attachments/assets/61e45feb-22ca-4b7d-b447-8785a4ad3695" />
<img width="1432" height="920" alt="Screenshot 2026-08-07 at 2 23 46 PM" src="https://github.com/user-attachments/assets/7336c652-869f-4f92-a075-98b2b55a2c52" />


The other pickers are deliberately left alone: Wind Rose's angle is a direction label and Bubble Chart's x and y are positions, all of which take any type the way a scatter plot's axes do.

### Any related issues, documentation, discussions?

Closes #7324. Same class of gap as #7250, which covered a different set of operators.

### How was this PR tested?

Each spec gains a case that generates its descriptor's schema and asserts the rule on it: keyed to `rColumn` and to `zValue`, each naming a property the schema declares, each allowing exactly `integer`, `long` and `double`, and each stating that `string` is not among them. Reading the annotation text would not have shown this — a key naming no property parses exactly as well and constrains nothing, which is what #7210 collected four instances of.

Removing either annotation leaves exactly those two cases failing. Each asserts the whole key set rather than the presence of its own key, so constraining the angle or the two axes later would fail here too — those read as any type on purpose.

```
sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.visualization.windRoseChart.WindRoseChartOpDescSpec org.apache.texera.amber.operator.visualization.bubbleChart.BubbleChartOpDescSpec"
```

Thirteen cases, all passing.

The behaviour each rule prevents was reproduced first: rendering the same three-row frame with a numeric column and with a string one, Wind Rose's `radialaxis.type` comes out `linear` with range 0 to 4.2 for the numeric column and `category` with range -0.11 to 2.11 for the string one — the wedges drawn at ordinal positions rather than lengths, with no error — and this holds even when every value is a number written as text. Bubble Chart raises `TypeError: unsupported operand type(s) for /: 'str' and 'int'` on either.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
