### PR TITLE
feat(visualization): declare the column type Sankey Diagram's value requires

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.amber.operator.visualization.sankeyDiagram
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.PythonTemplateBuilderStringContext
 import org.apache.texera.amber.pybuilder.PyStringTypes.EncodableString
@@ -32,6 +32,17 @@ import org.apache.texera.amber.pybuilder.PythonTemplateBuilder
 
 import javax.validation.constraints.NotNull
 
+// The value column is summed per source/target pair and becomes the width of
+// the link, so it has to be a number: strings concatenate instead of adding and
+// plotly accepts the result without complaint. Source and target are node
+// labels and take any type.
+@JsonSchemaInject(json = """
+{
+  "attributeTypeRules": {
+    "Value Attribute": { "enum": ["integer", "long", "double"] }
+  }
+}
+""")
 class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "Source Attribute", required = true)


### PR DESCRIPTION
### What changes were proposed in this PR?

Sankey Diagram's value column is grouped by source and target and summed into the width of each link, so it accepts only a number, but it declared no `attributeTypeRules` and the form therefore offered every column. It now declares `integer`, `long` or `double`, the way Range Slider's y-axis and Radar Chart's value columns already do.

Source and target stay unconstrained: they are node labels, and any type reads as one.

### Any related issues, documentation, discussions?

Closes #7319. Same class as #7341, for a different operator.

### How was this PR tested?

`SankeyDiagramOpDescSpec` passes. The behaviour the rule prevents was reproduced first: with a string value column the group-and-sum concatenates rather than adds, so a three-row frame reaches plotly as `link.value = ('ab', 'c')`, and plotly accepts non-numeric link values without raising — the diagram renders with widths that mean nothing, and no error is reported anywhere. The rule key was checked against the property it names, since a key matching no property is silently inert (#7210); `Value Attribute` carries a space, which the property editor handles the same way it already handles Range Slider's `Y-axis`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
