### PR TITLE
chore(amber): correct three invalid R tuple UDF examples

### DIFF
--- a/amber/src/main/python/pytexera/udf/examples/rudf/r_tuple_operator.py
+++ b/amber/src/main/python/pytexera/udf/examples/rudf/r_tuple_operator.py
@@ -30,11 +30,11 @@ r_tuple_source_one_tuple = """
 library(coro)
 coro::generator(function() {
     yield (list(
-            attr1 = 1L, # R integer
-            attr2 = "A", # R string
-            attr3 = TRUE, # R logical (boolean)
-            ))
-    })
+        attr1 = 1L,   # R integer
+        attr2 = "A",  # R string
+        attr3 = TRUE  # R logical (boolean)
+    ))
+})
 """
 
 r_tuple_source_multiple_tuples = """
@@ -42,11 +42,12 @@ library(coro)
 coro::generator(function() {
     for (i in 1:5) {
         yield (list(
-            attr1 = 1L, # R integer
-            attr2 = "A", # R string
-            attr3 = TRUE, # R logical (boolean)
-            ))
-    })
+            attr1 = i,    # R integer
+            attr2 = "A",  # R string
+            attr3 = TRUE  # R logical (boolean)
+        ))
+    }
+})
 """
 
 # --- UDF Operator ---
@@ -69,5 +70,6 @@ library(coro)
 coro::generator(function(tuple, port) {
     for (i in 1:5) {
         yield (tuple)
-    })
+    }
+})
 """


### PR DESCRIPTION
### What changes were proposed in this PR?

Three of the six R example templates in `amber/src/main/python/pytexera/udf/examples/rudf/r_tuple_operator.py` were invalid R:

- `r_tuple_source_multiple_tuples` and `r_tuple_udf_echo_multiple_tuples` were missing a closing `}` — the final `})` only closed the `for` block, so R fails to parse them (`unexpected ')'`).
- `r_tuple_source_one_tuple` and `r_tuple_source_multiple_tuples` had a trailing comma in their `list(...)` call, which fails at eval time (`argument 4 is empty`).

This PR adds the missing braces, removes the trailing commas, and makes the multiple-tuples source yield `attr1 = i` so the five rows differ.

These templates are reference examples only — nothing in the repo imports them, and the operators' actual default code is unaffected.

### Any related issues, documentation, discussions?

Closes #7372

### How was this PR tested?

Ran every template in both rudf example files through `Rscript parse()` — all pass after the fix (the two broken ones failed before) — and eval-checked the fixed `list(...)` call. `ruff check` and `ruff format --check` pass. No test is added because CI has no R and nothing imports this file.

### Was this PR authored or co-authored using generative AI tooling?

Co-authored by: Claude Code