### PR TITLE
refactor(agent-service): remove unused targetOperatorId from toLogicalPlan

### DIFF
--- a/agent-service/src/agent/workflow-state.ts
+++ b/agent-service/src/agent/workflow-state.ts
@@ -415,7 +415,7 @@ export class WorkflowState {
     this.settings = content.settings ? { ...content.settings } : { ...DEFAULT_WORKFLOW_SETTINGS };
   }
 
-  toLogicalPlan(targetOperatorId?: string): LogicalPlan {
+  toLogicalPlan(): LogicalPlan {
     const enabledOperators = this.getAllEnabledOperators();
 
     const operators: LogicalOperator[] = enabledOperators.map(op => ({


### PR DESCRIPTION
### What changes were proposed in this PR?
It Refactors `WorkflowState.toLogicalPlan()` by removing the unused `targetOperatorId` parameter. 

The parameter was never referenced in the method (it always built the whole-graph plan) and the only caller (`texera-agent.ts`) passed no arguments to it. The need to fetch a sub-graph of a target is already properly served by `getSubDAG(targetOperatorId)`.
 
### Any related issues, documentation, discussions?
Closes #7170

### How was this PR tested?
Run the TypeScript compiler checks and existing agent-service unit tests to verify no callers or types were broken.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Gemini 3.1 Pro (High)