### PR TITLE
test(frontend): render the TypeCastingDisplay schema table for coverage

### DIFF
--- a/frontend/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.spec.ts
+++ b/frontend/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.spec.ts
@@ -18,6 +18,7 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { Subject } from "rxjs";
 import { WorkflowCompilingService } from "../../../service/compile-workflow/workflow-compiling.service";
@@ -32,7 +33,12 @@ import { WorkflowUtilService } from "../../../service/workflow-graph/util/workfl
 import { commonTestProviders } from "../../../../common/testing/test-utils";
 import { OperatorPredicate } from "../../../types/workflow-common.interface";
 import { WorkflowGraph, WorkflowGraphReadonly } from "../../../service/workflow-graph/model/workflow-graph";
-import { AttributeType, CompilationState, OperatorPortSchemaMap } from "../../../types/workflow-compiling.interface";
+import {
+  AttributeType,
+  CompilationState,
+  OperatorPortSchemaMap,
+  SchemaAttribute,
+} from "../../../types/workflow-compiling.interface";
 import { ValidationWorkflowService } from "../../../service/validation/validation-workflow.service";
 
 describe("TypecastingDisplayComponent", () => {
@@ -263,6 +269,59 @@ describe("TypecastingDisplayComponent", () => {
       compilationStateInfoChangedStream.next(CompilationState.Succeeded);
 
       expect(rerenderSpy).toHaveBeenCalled();
+    });
+  });
+
+  // ─── template rendering ────────────────────────────────────────────────────
+  // The schema table is only rendered once the component decides to display the
+  // type-casting information, so these drive that state and assert the markup.
+  describe("template rendering", () => {
+    const renderSchema = (schema: Partial<SchemaAttribute>[], display = true): void => {
+      component.schemaToDisplay = schema;
+      component.displayTypeCastingSchemaInformation = display;
+      fixture.detectChanges();
+    };
+
+    const rowCells = (): string[][] =>
+      fixture.debugElement
+        .queryAll(By.css("tbody tr"))
+        .map(row => row.queryAll(By.css("td")).map(cell => (cell.nativeElement.textContent ?? "").trim()));
+
+    it("renders no table while the type-casting information is hidden", () => {
+      renderSchema([{ attributeName: "a", attributeType: "string" as AttributeType }], false);
+
+      expect(fixture.debugElement.query(By.css("nz-table"))).toBeNull();
+    });
+
+    it("renders the header cells once the table is displayed", () => {
+      renderSchema([]);
+
+      const headers = fixture.debugElement.queryAll(By.css("thead th")).map(th => th.nativeElement.textContent.trim());
+      expect(headers).toEqual(["Attribute Name", "Attribute Type"]);
+    });
+
+    it("renders the table's no-data arm for an empty schema", () => {
+      renderSchema([]);
+
+      // nz-table renders a single placeholder row instead of attribute rows; assert on
+      // the shape (one row, one spanning cell) rather than the localized placeholder text.
+      const rows = rowCells();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toHaveLength(1);
+    });
+
+    it("renders one row per attribute with its name and type", () => {
+      renderSchema([
+        { attributeName: "id", attributeType: "long" as AttributeType },
+        { attributeName: "label", attributeType: "string" as AttributeType },
+        { attributeName: "score", attributeType: "double" as AttributeType },
+      ]);
+
+      expect(rowCells()).toEqual([
+        ["id", "long"],
+        ["label", "string"],
+        ["score", "double"],
+      ]);
     });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends the existing `TypeCastingDisplayComponent` spec so the schema table
actually renders, covering the template that was previously never executed
(`frontend/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.html`).
No production code was changed.

4 tests cover every branch of the template:

- the outer `*ngIf` — no `nz-table` is rendered while the type-casting
  information is hidden;
- the header cells (`Attribute Name` / `Attribute Type`);
- the table's no-data arm for an empty schema;
- the `*ngFor` row — one row per attribute, asserting each row's name and type
  cell text against the seeded schema (mixed `long` / `string` / `double`).

One note on the empty-schema case: `nz-table` renders a single placeholder row
rather than no rows at all. The test asserts the *shape* of that arm (one row
with one spanning cell) instead of the placeholder's text, which comes from the
active locale bundle and would make the assertion brittle.

Per the usual constraints: no fake timers, and no layout or geometry assertions.

### Any related issues, documentation, discussions?

Closes #7465

### How was this PR tested?

Extended unit tests, run locally in `frontend/` (all green; the failure path was
verified by breaking an assertion to confirm the suite goes red):

```
ng test --watch=false --include src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.spec.ts
# Test Files 1 passed (1) | Tests 16 passed (16)
prettier --write <spec>   # clean
eslint  <spec>            # clean
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
