### PR TITLE
fix(workflow-operator): MAX aggregation checks the wrong empty-group sentinel

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/aggregate/AggregationOperation.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/aggregate/AggregationOperation.scala
@@ -237,7 +237,7 @@ class AggregationOperation {
       (partial1, partial2) =>
         if (AttributeTypeUtils.compare(partial1, partial2, attributeType) > 0) partial1
         else partial2,
-      partial => if (partial == AttributeTypeUtils.maxValue(attributeType)) null else partial
+      partial => if (partial == AttributeTypeUtils.minValue(attributeType)) null else partial
     )
   }
 

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/aggregate/AggregateOpSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/aggregate/AggregateOpSpec.scala
@@ -23,6 +23,8 @@ import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema, Tup
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.funsuite.AnyFunSuite
 
+import java.sql.Timestamp
+
 class AggregateOpSpec extends AnyFunSuite {
 
   /** Helpers */
@@ -436,6 +438,67 @@ class AggregateOpSpec extends AnyFunSuite {
 
     val result = agg.finalAgg(partial).asInstanceOf[java.lang.Double].doubleValue()
     assert(result == maxValue)
+  }
+
+  test("MAX aggregation finds largest INTEGER and returns null when given no values") {
+    val schema = makeSchema("temperature" -> AttributeType.INTEGER)
+    val tuple1 = makeTuple(schema, 10)
+    val tuple2 = makeTuple(schema, -2)
+    val tuple3 = makeTuple(schema, 5)
+
+    val operation = makeAggregationOp(AggregationFunction.MAX, "temperature", "max_temp")
+    val agg = operation.getAggFunc(AttributeType.INTEGER)
+
+    // Empty case: never iterate, just finalize init
+    val emptyPartial = agg.init()
+    val emptyResult = agg.finalAgg(emptyPartial)
+    assert(emptyResult == null)
+
+    // Non-empty case
+    var partial = agg.init()
+    partial = agg.iterate(partial, tuple1)
+    partial = agg.iterate(partial, tuple2)
+    partial = agg.iterate(partial, tuple3)
+
+    val result = agg.finalAgg(partial).asInstanceOf[Number].intValue()
+    assert(result == 10)
+  }
+
+  test("MAX aggregation returns null when all values are null") {
+    val schema = makeSchema("temperature" -> AttributeType.INTEGER)
+
+    val operation = makeAggregationOp(AggregationFunction.MAX, "temperature", "max_temp")
+    val agg = operation.getAggFunc(AttributeType.INTEGER)
+
+    var partial = agg.init()
+    Seq.fill(3)(makeTuple(schema, null)).foreach(tp => partial = agg.iterate(partial, tp))
+    assert(agg.finalAgg(partial) == null)
+  }
+
+  test("MAX aggregation keeps the type's maximum value when it is the true maximum") {
+    // Regression: the finalizer used to mistake a partial equal to
+    // maxValue(attributeType) for the "no value seen" sentinel and emit null.
+    val cases: Seq[(AttributeType, Seq[Any], Any)] = Seq(
+      (AttributeType.INTEGER, Seq(1, 5, Int.MaxValue), Int.MaxValue),
+      (AttributeType.LONG, Seq(1L, 5L, Long.MaxValue), Long.MaxValue),
+      (AttributeType.DOUBLE, Seq(1.0, 5.0, Double.MaxValue), Double.MaxValue),
+      (
+        AttributeType.TIMESTAMP,
+        Seq(new Timestamp(1L), new Timestamp(Long.MaxValue)),
+        new Timestamp(Long.MaxValue)
+      )
+    )
+
+    for ((attrType, values, expected) <- cases) {
+      val schema = makeSchema("v" -> attrType)
+      val operation = makeAggregationOp(AggregationFunction.MAX, "v", "max_v")
+      val agg = operation.getAggFunc(attrType)
+
+      var partial = agg.init()
+      values.foreach(v => partial = agg.iterate(partial, makeTuple(schema, v)))
+
+      assert(agg.finalAgg(partial) == expected, s"MAX over $attrType must keep $expected")
+    }
   }
 
   test("AVERAGE aggregation ignores nulls and returns null when all values are null") {

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/aggregate/AggregationOperationSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/aggregate/AggregationOperationSpec.scala
@@ -175,6 +175,35 @@ class AggregationOperationSpec extends AnyFlatSpec {
     assert(finalSum == 36, "single-pass SUM(1+2+3+10+20) == 36")
   }
 
+  it should
+    "keep the type's maximum value when partial MAX results are re-aggregated via getFinal" in {
+    // Regression: the local stage used to finalize a partial equal to
+    // maxValue(attributeType) to null, so the final stage reported the largest
+    // value from the other worker instead of the true maximum.
+    val workerOp = op(AggregationFunction.MAX, attribute = "v", resultAttribute = "max_v")
+    val workerAgg = workerOp.getAggFunc(AttributeType.INTEGER)
+
+    val w1State = Seq[AnyRef](Int.box(1), Int.box(Int.MaxValue))
+      .map(v => tupleOf("v", AttributeType.INTEGER, v))
+      .foldLeft(workerAgg.init())(workerAgg.iterate)
+    val w1Out = workerAgg.finalAgg(w1State)
+    assert(w1Out == Int.box(Int.MaxValue), "worker 1's true maximum is Int.MaxValue")
+
+    val w2State = Seq[AnyRef](Int.box(5), Int.box(2))
+      .map(v => tupleOf("v", AttributeType.INTEGER, v))
+      .foldLeft(workerAgg.init())(workerAgg.iterate)
+    val w2Out = workerAgg.finalAgg(w2State)
+    assert(w2Out == Int.box(5))
+
+    val finalOp = workerOp.getFinal
+    assert(finalOp.aggFunction == AggregationFunction.MAX)
+    val finalAgg = finalOp.getAggFunc(AttributeType.INTEGER)
+    val finalState = Seq(w1Out, w2Out)
+      .map(p => tupleOf("max_v", AttributeType.INTEGER, p))
+      .foldLeft(finalAgg.init())(finalAgg.iterate)
+    assert(finalAgg.finalAgg(finalState) == Int.box(Int.MaxValue))
+  }
+
   // --- AveragePartialObj -----------------------------------------------------
 
   "AveragePartialObj" should "expose its sum and count fields and support value equality" in {
@@ -336,6 +365,17 @@ class AggregationOperationSpec extends AnyFlatSpec {
     val seen = agg.iterate(agg.init(), tupleOf("v", AttributeType.INTEGER, Int.box(7)))
 
     // An empty partial is the sentinel maxValue, so it must lose the comparison.
+    assert(agg.finalAgg(agg.merge(seen, agg.init())) == Int.box(7))
+    assert(agg.finalAgg(agg.merge(agg.init(), seen)) == Int.box(7))
+    // Two empty partials still finalize to null (no rows anywhere).
+    assert(agg.finalAgg(agg.merge(agg.init(), agg.init())) == null)
+  }
+
+  "MAX aggregation merge" should "stay neutral when one side saw no values" in {
+    val agg = op(AggregationFunction.MAX).getAggFunc(AttributeType.INTEGER)
+    val seen = agg.iterate(agg.init(), tupleOf("v", AttributeType.INTEGER, Int.box(7)))
+
+    // An empty partial is the sentinel minValue, so it must lose the comparison.
     assert(agg.finalAgg(agg.merge(seen, agg.init())) == Int.box(7))
     assert(agg.finalAgg(agg.merge(agg.init(), seen)) == Int.box(7))
     // Two empty partials still finalize to null (no rows anywhere).


### PR DESCRIPTION
### What changes were proposed in this PR?

One-line fix in `AggregationOperation.scala`: the `max` aggregation starts its running maximum from the type's minimum value, so its final "was this group empty?" check must compare against that same minimum value, but it compared against the type's maximum value instead (the line was copied from `min`, where that comparison is correct because `min` starts from the maximum).

Because the check looked at the wrong sentinel, two results were silently wrong while the workflow completed with no error:

- A group with only null values returned the sentinel itself instead of `null`, e.g. `-2147483648` for INTEGER or `1970-01-01 00:00:00` for TIMESTAMP.
- A true maximum equal to the type's maximum value was mistaken for "no value seen" and discarded, so `max` over `{1, 5, 2147483647}` reported `5` (the largest value from the other local aggregation worker) instead of `2147483647`.

#### Before-and-after

Test data: group `g1` has only nulls, `g2` contains `{1, 5, 2147483647}`, `g3` contains `{10, 42}`.

<img width="1347" height="900" alt="Screenshot 2026-08-07 at 2 27 40 PM" src="https://github.com/user-attachments/assets/faac65fd-e83f-4952-a0dd-b8109d56334d" />

Before the fix, `max(v)` grouped by `k` returns `-2147483648` for `g1` (expected `null`) and `5` for `g2` (expected `2147483647`):

<img width="1341" height="866" alt="Screenshot 2026-08-07 at 2 27 51 PM" src="https://github.com/user-attachments/assets/fdf7f045-aa34-44eb-adee-6e722839d7eb" />

`min(v)` on the same data is correct (`null` for `g1`, `1` for `g2`, `10` for `g3`), confirming only `max`'s empty-group check is broken:

<img width="1342" height="868" alt="Screenshot 2026-08-07 at 2 28 00 PM" src="https://github.com/user-attachments/assets/3df9c390-626f-4f01-9ca6-7e634927386b" />

After the fix, `max(v)` returns `null` for `g1`, `2147483647` for `g2`, and `42` for `g3`:

<img width="1131" height="756" alt="Screenshot 2026-08-07 at 5 54 17 PM" src="https://github.com/user-attachments/assets/68ba757c-8b4b-4682-b04e-8db740d1583c" />

### Any related issues, documentation, discussions?

Closes #7531

The regression was introduced by #1840, which generalised the hard-coded `Double` sentinels to per-type `minValue`/`maxValue` helpers and updated `maxAgg`'s initialiser but not its finaliser.

### How was this PR tested?

Added 5 regression tests, all of which fail without the one-line fix and pass with it (verified in both directions):

- `AggregateOpSpec`: `max` over empty input and over all-null input returns `null`; `max` keeps a true maximum equal to the type's maximum value, covering INTEGER, LONG, DOUBLE, and TIMESTAMP.
- `AggregationOperationSpec`: a worker-to-final pipeline via `getFinal` keeps `Int.MaxValue` when partial results are re-aggregated, reproducing the two-worker scenario shown above; `max`'s merge stays neutral when one side saw no values.

Full aggregate suite: `sbt "WorkflowOperator/testOnly org.apache.texera.amber.operator.aggregate.*"` — 68 tests, all passing.

Also verified end to end in the UI with the workflow shown above (screenshots are from before and after rebuilding the backend with this fix).

### Was this PR authored or co-authored using generative AI tooling?

Co-authored by: Claude Code (Claude Fable 5)