### PR TITLE
chore(pyamber): interpolate the offending type in the BATCH_SIZE validation error

### DIFF
--- a/amber/src/main/python/core/models/operator.py
+++ b/amber/src/main/python/core/models/operator.py
@@ -206,7 +206,7 @@ class BatchOperator(TupleOperatorV2):
         if value is None:
             raise ValueError("BATCH_SIZE cannot be None.")
         if type(value) is not int:
-            raise ValueError("BATCH_SIZE cannot be {type(value))}.")
+            raise ValueError(f"BATCH_SIZE cannot be {type(value)}.")
         if value <= 0:
             raise ValueError("BATCH_SIZE should be positive.")
 

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -208,6 +208,28 @@ class TestBatchOperatorValidation:
         with pytest.raises(ValueError):
             BatchOperator._validate_batch_size("10")
 
+    def test_validate_batch_size_non_int_message_names_the_float_type(self):
+        # The message must name the offending type, not a template literal.
+        with pytest.raises(ValueError) as excinfo:
+            BatchOperator._validate_batch_size(10.0)
+        assert str(excinfo.value) == "BATCH_SIZE cannot be <class 'float'>."
+
+    def test_validate_batch_size_non_int_message_names_the_str_type(self):
+        with pytest.raises(ValueError) as excinfo:
+            BatchOperator._validate_batch_size("10")
+        assert str(excinfo.value) == "BATCH_SIZE cannot be <class 'str'>."
+
+    def test_concrete_batch_operator_with_float_size_reports_type_in_message(self):
+        class _FloatBatch(BatchOperator):
+            BATCH_SIZE = 10.0
+
+            def process_batch(self, batch, port):
+                yield batch
+
+        with pytest.raises(ValueError) as excinfo:
+            _FloatBatch()
+        assert str(excinfo.value) == "BATCH_SIZE cannot be <class 'float'>."
+
     def test_validate_batch_size_rejects_zero(self):
         with pytest.raises(ValueError, match="positive"):
             BatchOperator._validate_batch_size(0)


### PR DESCRIPTION
### What changes were proposed in this PR?

When a user sets a non-integer `BATCH_SIZE` on a Python `BatchOperator`, the validation error they get back is the template text itself:

```
BATCH_SIZE cannot be {type(value))}.
```

The string literal in `BatchOperator._validate_batch_size` (`amber/src/main/python/core/models/operator.py`) is missing the `f` prefix, so `{type(value)}` is never interpolated and it additionally contains a stray `)` inside the braces. The type of the supplied value is exactly the piece of information the message is meant to convey, so as written the error tells the user nothing about what they did wrong.

This PR corrects both defects in one line:

```python
raise ValueError(f"BATCH_SIZE cannot be {type(value)}.")
```

so the user now sees, e.g., `BATCH_SIZE cannot be <class 'float'>.` The wording is kept consistent with the sibling messages in the same validator (`BATCH_SIZE cannot be None.`).

### Any related issues, documentation, discussions?

Closes #7565

### How was this PR tested?

Three tests were added to the existing `TestBatchOperatorValidation` class in `amber/src/test/python/core/models/test_operator.py`, pinning the exact message by string equality:

- `_validate_batch_size(10.0)` raises `ValueError` with message `BATCH_SIZE cannot be <class 'float'>.`
- `_validate_batch_size("10")` raises `ValueError` with message `BATCH_SIZE cannot be <class 'str'>.`
- constructing a concrete `BatchOperator` subclass with `BATCH_SIZE = 10.0` raises the same float message end-to-end.

Full run: `cd amber && pytest src/test/python/core/models/test_operator.py` — 32 passed. `ruff check` and `ruff format --check` pass on `src/main/python` and `src/test/python` (the same commands CI runs).

### Was this PR authored or co-authored using generative AI tooling?

Co-authred by: Claude Code (Claude Fable 5)