### PR TITLE
fix(frontend): report coverage from the browser-mode tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,19 @@ jobs:
       - name: Install Playwright Chromium
         run: yarn --cwd frontend playwright install ${{ matrix.os == 'ubuntu-latest' && '--with-deps' || '' }} chromium
       - name: Run frontend browser-mode tests
-        run: yarn --cwd frontend ng run gui:test-browser
+        run: yarn --cwd frontend ng run gui:test-browser --coverage --coverage-reporters=lcovonly
+      - name: Upload frontend browser-mode coverage to Codecov
+        # These tests already exercise code the jsdom run cannot reach (Monaco, real
+        # pointer input); without this upload those lines are reported as uncovered.
+        # vitest.browser.config.ts writes to coverage-browser/ so this does not collide
+        # with the jsdom run's coverage/gui/lcov.info.
+        if: matrix.os == 'ubuntu-latest' && always()
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./frontend/coverage-browser/**/lcov.info
+          flags: frontend
+          fail_ci_if_error: false
       - name: Upload frontend browser-mode test results to Codecov
         # vitest.browser.config.ts emits junit-browser.xml (distinct from
         # the unit-test report). Same `frontend` flag — Codecov merges

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,7 @@
 
 # test coverage
 /coverage
+/coverage-browser
 
 # vitest browser-mode snapshot baselines
 **/__screenshots__/

--- a/frontend/vitest.browser.config.ts
+++ b/frontend/vitest.browser.config.ts
@@ -47,8 +47,14 @@ export default defineConfig({
   // `require()` calls inside the CJS package crash on first import.
   // Explicit-include forces esbuild to pre-bundle it (alongside its
   // `base64-js` + `ieee754` transitive deps) into a browser-runnable ESM.
+  //
+  // `@vitest/coverage-v8/browser` is loaded dynamically by the coverage provider once
+  // `--coverage` is passed, and it is not in the import graph either, so it needs the same
+  // hint. Without it the run fails with "Failed to fetch dynamically imported module:
+  // /@id/@vitest/coverage-v8/browser" and no coverage is produced -- the tests still pass,
+  // which is why the gap went unnoticed.
   optimizeDeps: {
-    include: ["buffer"],
+    include: ["buffer", "@vitest/coverage-v8/browser"],
   },
   test: {
     // Emit a JUnit-XML report alongside the default console reporter so
@@ -56,6 +62,12 @@ export default defineConfig({
     // flakies on main. Written to a distinct filename so the upload step
     // can disambiguate it from the unit-test report.
     reporters: ["default", ["junit", { outputFile: "junit-browser.xml" }]],
+    // Written to its own directory so it does not overwrite the jsdom run's
+    // coverage/gui/lcov.info. Codecov merges multiple uploads under one flag, so both
+    // records count and the lines these tests already exercise stop reading as uncovered.
+    coverage: {
+      reportsDirectory: "coverage-browser",
+    },
     globals: true,
     // browser-buffer-polyfill must run FIRST: it puts Buffer/process on
     // globalThis before any test module loads, which is required for


### PR DESCRIPTION
### What changes were proposed in this PR?

The browser-mode suite runs in CI and uploads its JUnit results, but never its **coverage** — so every line those tests exercise is reported as untested. This closes that gap. No test is added or changed.

Measured on `code-editor.component.ts` by intersecting the two lcov records:

| | Lines |
|---|---|
| uncovered by the jsdom run (what Codecov reports today) | 115 |
| of those, **already hit** by the browser spec | **67** |
| genuinely untested by either | 48 |
| merged coverage | 181/229 = **79.0%**, up from 49.8% |

So roughly three-fifths of that file's advertised gap is already tested. Any PR written off the Codecov ranking would have duplicated seven existing tests to move a number.

**Passing `--coverage` alone does not work.** The run fails with:

```
TypeError: Failed to fetch dynamically imported module:
  http://localhost:PORT/@id/@vitest/coverage-v8/browser?import
```

The coverage provider is imported dynamically once `--coverage` is set, so it is not in the import graph Vite's scan crawls — the same reason `buffer` already needed an explicit hint in this config. Adding `@vitest/coverage-v8/browser` to `optimizeDeps.include` fixes it. Note the failure mode: **the tests still pass while the coverage step errors**, which is why this went unnoticed.

Three changes:

- `vitest.browser.config.ts` — add the `optimizeDeps` include, and write coverage to `coverage-browser/` so it cannot overwrite the jsdom run's `coverage/gui/lcov.info` (that upload happens earlier in the job).
- `build.yml` — pass `--coverage --coverage-reporters=lcovonly` to the browser step and upload the result under the existing `frontend` flag, which Codecov merges with the jsdom upload.
- `frontend/.gitignore` — ignore the new output directory.

### How was this PR tested?

Reproduced the failure on `main` first: `ng run gui:test-browser --coverage` exits 1 with three errors (Prepare / Run / Coverage) and produces no lcov, while the 7 tests pass.

With the fix, the full browser suite:

```
yarn --cwd frontend ng run gui:test-browser --coverage --coverage-reporters=lcovonly
```

```
 Test Files  3 passed (3)
      Tests  18 passed (18)
```

exit 0, no errors, and `coverage-browser/lcov.info` written with 98 files / 1942 lines recorded. The jsdom path is unaffected — `ng test --coverage` still passes 25 tests and still writes `coverage/gui/lcov.info`. `yarn format:ci` passes.

### Any related issues, documentation, discussions?

Closes #7462

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
