### PR TITLE
feat(operator-demo-video): add DemoVideoGenerator module and Playwright automation foundation

### DIFF
--- a/.github/workflows/sync-docs-to-site.yml
+++ b/.github/workflows/sync-docs-to-site.yml
@@ -26,6 +26,8 @@ on:
       - main
     paths:
       - 'docs/**'
+      # Build tooling, not website content.
+      - '!docs/operator-demo-videos/**'
   workflow_dispatch:
 
 # Run one sync at a time.
@@ -96,11 +98,16 @@ jobs:
           source_rels = set()
           created = updated = deleted = 0
 
+          # Build tooling, not website content; never mirrored.
+          excluded_dirs = ("operator-demo-videos",)
+
           # Mirror every file: .md keeps the target front matter, others copied as-is.
           for sfile in sorted(source.rglob("*")):
               if sfile.is_dir():
                   continue
               rel = sfile.relative_to(source)
+              if rel.parts and rel.parts[0] in excluded_dirs:
+                  continue
               source_rels.add(rel)
               tfile = target / rel
               existed = tfile.exists()

--- a/build.sbt
+++ b/build.sbt
@@ -279,6 +279,9 @@ lazy val NotebookMigrationService = (project in file("notebook-migration-service
   )
   .dependsOn(DAO % "test->test") // test scope dependency
 
+// Playwright automation recording the per-operator demo videos linked from docs/reference/operators/.
+lazy val DemoVideoGenerator = (project in file("docs/operator-demo-videos"))
+
 // root project definition
 lazy val TexeraProject = (project in file("."))
   .aggregate(
@@ -299,7 +302,8 @@ lazy val TexeraProject = (project in file("."))
     FileService,
     WorkflowCompilingService,
     WorkflowExecutionService,
-    NotebookMigrationService
+    NotebookMigrationService,
+    DemoVideoGenerator
   )
   .settings(
     name := "texera",

--- a/docs/operator-demo-videos/build.sbt
+++ b/docs/operator-demo-videos/build.sbt
@@ -23,9 +23,9 @@ import scala.collection.Seq
 
 name := "operator-demo-videos"
 
-// Enable semanticdb for Scalafix
-ThisBuild / semanticdbEnabled := true
-ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
+// Enable semanticdb for Scalafix, scoped to this subproject of the root build.
+semanticdbEnabled := true
+semanticdbVersion := scalafixSemanticdb.revision
 
 // Restrict parallel execution of tests to avoid conflicts
 Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)

--- a/docs/operator-demo-videos/build.sbt
+++ b/docs/operator-demo-videos/build.sbt
@@ -48,5 +48,5 @@ Compile / scalacOptions ++= Seq(
 libraryDependencies ++= Seq(
   // Drives a real browser to record the operator demos.
   "com.microsoft.playwright" % "playwright" % "1.57.0",
-  "org.scalatest" %% "scalatest" % "3.2.15" % Test
+  "org.scalatest" %% "scalatest" % "3.2.20" % Test
 )

--- a/docs/operator-demo-videos/build.sbt
+++ b/docs/operator-demo-videos/build.sbt
@@ -1,0 +1,52 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import scala.collection.Seq
+
+/////////////////////////////////////////////////////////////////////////////
+// Project Settings
+/////////////////////////////////////////////////////////////////////////////
+
+name := "operator-demo-videos"
+
+// Enable semanticdb for Scalafix
+ThisBuild / semanticdbEnabled := true
+ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
+
+// Restrict parallel execution of tests to avoid conflicts
+Global / concurrentRestrictions += Tags.limit(Tags.Test, 1)
+
+/////////////////////////////////////////////////////////////////////////////
+// Compiler Options
+/////////////////////////////////////////////////////////////////////////////
+
+Compile / scalacOptions ++= Seq(
+  "-Xelide-below", "WARNING",       // Turn on optimizations with "WARNING" as the threshold
+  "-feature",                       // Check feature warnings
+  "-deprecation",                   // Check deprecation warnings
+  "-Ywarn-unused:imports"           // Check for unused imports
+)
+
+/////////////////////////////////////////////////////////////////////////////
+// Dependencies
+/////////////////////////////////////////////////////////////////////////////
+
+libraryDependencies ++= Seq(
+  // Drives a real browser to record the operator demos.
+  "com.microsoft.playwright" % "playwright" % "1.57.0",
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test
+)

--- a/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/config/TestDataConfig.scala
+++ b/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/config/TestDataConfig.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.demovideos.config
+
+case class UiConfig(
+    recordWidth: Int,
+    recordHeight: Int,
+    slowMo: Int,
+    resultPanelHoldMs: Int,
+    propertyPanelResizeHeight: Double,
+    operatorPosX: Double,
+    operatorPosY: Double
+)
+
+object TestDataConfig {
+  val baseUrl = "http://localhost:4200"
+
+  val uiConfig = UiConfig(
+    // 1080p: the canvas, the left operator panel, and the property panel all have to be
+    // usable at once. Below this the operator list needs scrolling before an item can be
+    // dragged, and the recording is cramped to watch.
+    recordWidth = 1920,
+    recordHeight = 1080,
+    slowMo = 400,
+    resultPanelHoldMs = 5000,
+    propertyPanelResizeHeight = 300.0,
+    operatorPosX = 0.33,
+    operatorPosY = 0.4
+  )
+
+  val videoOutputDir = "docs/operator-demo-videos/generated"
+}

--- a/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/ControllerContext.scala
+++ b/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/ControllerContext.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.demovideos.controllers
+
+import com.microsoft.playwright.Page
+import scala.collection.mutable.ArrayBuffer
+
+/**
+  * Shared context wrapping Playwright Page, passed through all builders.
+  */
+class ControllerContext(val page: Page) {
+  private var _fakeCursorInstalled: Boolean = false
+
+  def ensureFakeCursor(): Unit = {
+    if (!_fakeCursorInstalled) {
+      Utils.installFakeCursor(page)
+      _fakeCursorInstalled = true
+    }
+  }
+}
+
+/** A single named step that runs against a ControllerContext. */
+trait ControllerStep {
+  def name: String
+  def run(ctx: ControllerContext): Unit
+}
+
+object ControllerStep {
+  def apply(stepName: String)(action: ControllerContext => Unit): ControllerStep =
+    new ControllerStep {
+      override def name: String = stepName
+      override def run(ctx: ControllerContext): Unit = action(ctx)
+    }
+}
+
+/**
+  * Base builder — subclasses accumulate steps via fluent API, then execute().
+  *
+  * Usage:
+  *   new LoginControllerBuilder(ctx).login("u","p").logout().execute()
+  */
+abstract class ControllerBuilder(protected val context: ControllerContext) {
+  private val steps: ArrayBuffer[ControllerStep] = ArrayBuffer.empty
+
+  protected def addStep(step: ControllerStep): this.type = {
+    steps += step
+    this
+  }
+
+  def execute(): Unit = {
+    steps.foreach { step =>
+      println(s"[${step.name}] Executing...")
+      step.run(context)
+      println(s"[${step.name}] Done")
+    }
+  }
+}

--- a/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/Utils.scala
+++ b/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/Utils.scala
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.demovideos.controllers
+
+import com.microsoft.playwright.options.WaitForSelectorState
+import com.microsoft.playwright.{Locator, Mouse, Page}
+
+// ═══════════════════════════════════════════════════════════════════
+// Utils
+// ═══════════════════════════════════════════════════════════════════
+
+object Utils {
+  def waitVisible(loc: Locator): Locator = {
+    loc.waitFor(new Locator.WaitForOptions().setState(WaitForSelectorState.VISIBLE))
+    loc
+  }
+
+  def installFakeCursor(page: Page): Unit = {
+    // Both the styles and the cursor element are wiped on every page navigation
+    // (e.g., `page.navigate(".../dashboard")` in createNewWorkflow). `addInitScript`
+    // re-runs after every load so the cursor follows the user across pages.
+    val script =
+      """
+      () => {
+        if (document.getElementById('pw-cursor-style')) return;
+        const style = document.createElement('style');
+        style.id = 'pw-cursor-style';
+        style.textContent = `
+          #pw-cursor {
+            position: fixed; left: 0; top: 0;
+            width: 14px; height: 14px; border-radius: 50%;
+            background: rgba(255, 0, 0, 0.9);
+            box-shadow: 0 0 0 3px rgba(255, 0, 0, 0.25);
+            pointer-events: none; z-index: 2147483647;
+            transform: translate(-50%, -50%);
+          }
+          .pw-click {
+            position: fixed; left: 0; top: 0;
+            width: 18px; height: 18px; border-radius: 50%;
+            border: 3px solid rgba(255, 0, 0, 0.85);
+            pointer-events: none; z-index: 2147483647;
+            transform: translate(-50%, -50%);
+            animation: pw-click-pop 600ms ease-out forwards;
+          }
+          @keyframes pw-click-pop {
+            0%   { opacity: 0.9; transform: translate(-50%, -50%) scale(0.6); }
+            70%  { opacity: 0.6; transform: translate(-50%, -50%) scale(2.2); }
+            100% { opacity: 0.0; transform: translate(-50%, -50%) scale(2.8); }
+          }
+        `;
+        (document.head || document.documentElement).appendChild(style);
+
+        const ensureCursor = () => {
+          if (document.getElementById('pw-cursor')) return document.getElementById('pw-cursor');
+          const cursor = document.createElement('div');
+          cursor.id = 'pw-cursor';
+          (document.body || document.documentElement).appendChild(cursor);
+          return cursor;
+        };
+
+        const move = (x, y) => {
+          const c = ensureCursor();
+          c.style.left = x + 'px';
+          c.style.top  = y + 'px';
+        };
+
+        document.addEventListener('mousemove',  (e) => move(e.clientX, e.clientY), true);
+        document.addEventListener('pointermove', (e) => move(e.clientX, e.clientY), true);
+
+        const clickRing = (x, y) => {
+          const ring = document.createElement('div');
+          ring.className = 'pw-click';
+          ring.style.left = x + 'px';
+          ring.style.top  = y + 'px';
+          (document.body || document.documentElement).appendChild(ring);
+          setTimeout(() => ring.remove(), 650);
+        };
+
+        document.addEventListener('mousedown',  (e) => { move(e.clientX, e.clientY); clickRing(e.clientX, e.clientY); }, true);
+        document.addEventListener('pointerdown', (e) => { move(e.clientX, e.clientY); clickRing(e.clientX, e.clientY); }, true);
+      }
+      """
+
+    // Persistent across navigations.
+    page.addInitScript(script)
+    // Run once now so the cursor is visible immediately on the current page
+    // (addInitScript only fires on subsequent loads, not retroactively).
+    page.evaluate(script)
+  }
+
+  // `holdMs` is the gap between mousedown and mouseup. The default 0 fires both in the same
+  // tick, which some Angular handlers (notably the Run/Pause toolbar button) can miss, so
+  // callers that need a click to reliably register pass a short hold.
+  def clickWithCursor(page: Page, loc: Locator, steps: Int = 20, holdMs: Int = 0): Unit = {
+    waitVisible(loc)
+    val box = loc.boundingBox()
+    if (box == null) throw new RuntimeException("No bounding box")
+    val x = box.x + box.width / 2.0
+    val y = box.y + box.height / 2.0
+    page.mouse().move(x, y, new Mouse.MoveOptions().setSteps(steps))
+    if (holdMs > 0) page.mouse().click(x, y, new Mouse.ClickOptions().setDelay(holdMs.toDouble))
+    else page.mouse().click(x, y)
+  }
+
+  def hoverWithCursor(page: Page, loc: Locator, steps: Int = 20): Unit = {
+    waitVisible(loc)
+    val box = loc.boundingBox()
+    if (box == null) throw new RuntimeException("No bounding box")
+    val x = box.x + box.width / 2.0
+    val y = box.y + box.height / 2.0
+    page.mouse().move(x, y, new Mouse.MoveOptions().setSteps(steps))
+  }
+}

--- a/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/Utils.scala
+++ b/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/Utils.scala
@@ -96,7 +96,8 @@ object Utils {
           setTimeout(() => ring.remove(), 650);
         };
 
-        document.addEventListener('mousedown',  (e) => { move(e.clientX, e.clientY); clickRing(e.clientX, e.clientY); }, true);
+        // Chromium fires pointerdown followed by the compatibility mousedown for each
+        // click; listening to both would render the ring twice per click.
         document.addEventListener('pointerdown', (e) => { move(e.clientX, e.clientY); clickRing(e.clientX, e.clientY); }, true);
         };
         // Init scripts run before the document exists; the DOM work must wait.

--- a/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/Utils.scala
+++ b/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/controllers/Utils.scala
@@ -36,9 +36,12 @@ object Utils {
     // Both the styles and the cursor element are wiped on every page navigation
     // (e.g., `page.navigate(".../dashboard")` in createNewWorkflow). `addInitScript`
     // re-runs after every load so the cursor follows the user across pages.
+    // An IIFE (addInitScript executes raw source, so a bare function expression would
+    // never run), deferring DOM setup until the document exists.
     val script =
       """
-      () => {
+      (() => {
+        const setup = () => {
         if (document.getElementById('pw-cursor-style')) return;
         const style = document.createElement('style');
         style.id = 'pw-cursor-style';
@@ -95,7 +98,14 @@ object Utils {
 
         document.addEventListener('mousedown',  (e) => { move(e.clientX, e.clientY); clickRing(e.clientX, e.clientY); }, true);
         document.addEventListener('pointerdown', (e) => { move(e.clientX, e.clientY); clickRing(e.clientX, e.clientY); }, true);
-      }
+        };
+        // Init scripts run before the document exists; the DOM work must wait.
+        if (document.readyState === 'loading') {
+          document.addEventListener('DOMContentLoaded', setup);
+        } else {
+          setup();
+        }
+      })()
       """
 
     // Persistent across navigations.

--- a/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/scripts/OperatorScript.scala
+++ b/docs/operator-demo-videos/src/main/scala/org/apache/texera/demovideos/scripts/OperatorScript.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.demovideos.scripts
+
+import org.apache.texera.demovideos.controllers.ControllerContext
+
+/** `prepare` (create + import, unrecorded) runs before recording starts; `execute` is the
+  * recorded demo. Login is the runner's job — once per run, session shared across scenarios.
+  */
+trait OperatorScript {
+  def operatorName: String
+  def operatorType: String = operatorName.replaceAll("\\s+", "")
+  def category: String
+  def outputFileName: String
+
+  def prepare(ctx: ControllerContext): Unit = ()
+  def execute(ctx: ControllerContext): Unit
+}

--- a/docs/operator-demo-videos/src/test/scala/org/apache/texera/demovideos/controllers/ControllerBuilderSpec.scala
+++ b/docs/operator-demo-videos/src/test/scala/org/apache/texera/demovideos/controllers/ControllerBuilderSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.demovideos.controllers
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable.ArrayBuffer
+
+class ControllerBuilderSpec extends AnyFlatSpec with Matchers {
+
+  // The steps under test never touch the page, so no Playwright instance is needed.
+  private def newContext: ControllerContext = new ControllerContext(null)
+
+  private class TestBuilder(ctx: ControllerContext) extends ControllerBuilder(ctx) {
+    def add(name: String)(action: ControllerContext => Unit): this.type =
+      addStep(ControllerStep(name)(action))
+  }
+
+  "execute" should "run each accumulated step exactly once, in insertion order" in {
+    val ran = ArrayBuffer.empty[String]
+    val builder = new TestBuilder(newContext)
+    builder
+      .add("first")(_ => ran += "first")
+      .add("second")(_ => ran += "second")
+      .add("third")(_ => ran += "third")
+    builder.execute()
+    ran.toList shouldBe List("first", "second", "third")
+  }
+
+  it should "stop at a failing step and not run the steps after it" in {
+    val ran = ArrayBuffer.empty[String]
+    val builder = new TestBuilder(newContext)
+    builder
+      .add("before")(_ => ran += "before")
+      .add("boom")(_ => throw new IllegalStateException("boom"))
+      .add("after")(_ => ran += "after")
+    val e = intercept[IllegalStateException] {
+      builder.execute()
+    }
+    e.getMessage shouldBe "boom"
+    ran.toList shouldBe List("before")
+  }
+
+  it should "pass the builder's own context to every step" in {
+    val ctx = newContext
+    val seen = ArrayBuffer.empty[ControllerContext]
+    val builder = new TestBuilder(ctx)
+    builder.add("capture")(seen += _).add("capture again")(seen += _)
+    builder.execute()
+    seen.forall(_ eq ctx) shouldBe true
+    seen should have size 2
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR adds the foundation for an operator demo video generator: a Playwright-based tool that records a short demo video per operator, to be linked from the operator docs under `docs/reference/operators/`.

Changes:
- A new `DemoVideoGenerator` sbt module at `docs/operator-demo-videos/` with the Playwright dependency. It is standalone. It compiles without the rest of the build.
- The automation abstractions the tool is built from: fluent builders that accumulate named steps (`ControllerBuilder`/`ControllerStep`), a two-phase per-operator script trait (`prepare` = unrecorded scaffolding, `execute` = the recorded demo), and a fake on-screen cursor so recordings show where the automation is clicking.
- Adds the recording configuration in `TestDataConfig` (base URL, viewport and video size, pacing, output directory); later PRs will add more defaults such as the datasets and template workflows.
- Excludes `docs/operator-demo-videos/` from the docs-to-website sync workflow: the module is build tooling, not docs content, so its sources are never published to the website and module-only pushes do not trigger a site sync.

Follow-up PRs add the UI controllers (login, navigation, drag-and-connect, form filling, execution), per-operator sample values, and the generator and runner that make the tool runnable end-to-end.

### Any related issues, documentation, discussions?

Closes #7519

### How was this PR tested?

No behavior change to any existing module. `sbt DemoVideoGenerator/compile`, `scalafmtCheck`, and `scalafix --check` all pass.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Fable 5)
