### PR TITLE
fix(pyamber): wait out a pause before completing the worker

### DIFF
--- a/amber/src/main/python/core/runnables/main_loop.py
+++ b/amber/src/main/python/core/runnables/main_loop.py
@@ -671,6 +671,24 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 self._async_rpc_client.coordinator_stub().port_completed(
                     PortCompletedRequest(port_id=port_id, input=False)
                 )
+            # A PauseWorker command can land anywhere above -- the coordinator
+            # pauses on its own schedule, and nothing between the last control
+            # check and here drains control -- leaving the worker PAUSED.
+            # complete() would then attempt PAUSED -> COMPLETED, which the
+            # transition graph forbids (WORKER_STATE_TRANSITIONS, mirroring
+            # Scala's WorkerStateManager), raising InvalidTransitionException
+            # and killing this thread. Wait the pause out instead, matching
+            # Scala's DPThread: while paused it only picks control channels, so
+            # a paused worker never advances to completion.
+            #
+            # Guarded on is_paused() rather than draining control
+            # unconditionally: _check_and_process_control blocks while the data
+            # lane is disabled, and backpressure disables it too, so an
+            # unguarded drain here could park a worker that is merely
+            # backpressured. While paused the same call blocks until Resume
+            # re-enables the lane and returns the worker to RUNNING.
+            while self.context.pause_manager.is_paused():
+                self._check_and_process_control()
             self.complete()
 
     def _process_ecm(self, ecm_element: ECMElement):

--- a/amber/src/test/python/core/runnables/test_main_loop.py
+++ b/amber/src/test/python/core/runnables/test_main_loop.py
@@ -1856,6 +1856,125 @@ class TestMainLoop:
         return collected
 
     @pytest.mark.timeout(30)
+    def test_pause_landing_before_completion_defers_it_until_resume(
+        self,
+        mock_link,
+        mock_control_output_channel,
+        input_queue,
+        output_queue,
+        main_loop,
+        main_loop_thread,
+        mock_assign_input_port,
+        mock_assign_output_port,
+        mock_add_input_channel,
+        mock_add_partitioning,
+        mock_initialize_executor,
+        mock_start_channel,
+        mock_end_of_upstream,
+        mock_resume,
+        command_sequence,
+        monkeypatch,
+        reraise,
+    ):
+        # A PauseWorker command can land in the window between the last control
+        # check inside _process_end_channel and the complete() at its tail --
+        # the coordinator pauses on its own schedule, and nothing in that window
+        # drains control. The worker is then PAUSED when complete() runs, and
+        # PAUSED -> COMPLETED is forbidden by the transition graph (in BOTH
+        # runtimes -- see WorkerStateManager.scala, which this graph mirrors),
+        # so transit_to raised InvalidTransitionException and killed the main
+        # loop thread. Observed as flaky ReconfigurationIntegrationSpec failures
+        # on the amber-integration job (issue #5913).
+        #
+        # Completion must instead wait for Resume, matching Scala's DPThread:
+        # while paused it only picks control channels, so a paused worker never
+        # advances to completion.
+        #
+        # The race is made deterministic by pausing inside all_ports_completed()
+        # -- the last thing _process_end_channel calls before complete(), with
+        # no control check in between, i.e. exactly the production window.
+        main_loop_thread.daemon = True
+        main_loop_thread.start()
+
+        for setup_msg in [
+            mock_assign_input_port,
+            mock_assign_output_port,
+            mock_add_input_channel,
+            mock_add_partitioning,
+            mock_initialize_executor,
+        ]:
+            input_queue.put(setup_msg)
+            assert output_queue.get() == DCMElement(
+                tag=mock_control_output_channel,
+                payload=DirectControlMessagePayloadV2(
+                    return_invocation=ReturnInvocation(
+                        command_id=command_sequence,
+                        return_value=ControlReturn(empty_return=EmptyReturn()),
+                    )
+                ),
+            )
+
+        original_all_ports_completed = (
+            main_loop.context.input_manager.all_ports_completed
+        )
+
+        def pause_in_the_pre_completion_window():
+            completed = original_all_ports_completed()
+            if completed:
+                main_loop.context.pause_manager.pause(PauseType.USER_PAUSE)
+            return completed
+
+        monkeypatch.setattr(
+            main_loop.context.input_manager,
+            "all_ports_completed",
+            pause_in_the_pre_completion_window,
+        )
+
+        input_queue.put(mock_start_channel)
+        input_queue.put(mock_end_of_upstream)
+
+        expected_worker_completed = self._expected_worker_completed_dcm(
+            mock_control_output_channel
+        )
+
+        # Negative direction: while paused the worker must hold short of
+        # completion -- still alive, not COMPLETED, and no WorkerExecutionCompleted
+        # announced to the coordinator.
+        held = self._drain_until(
+            output_queue,
+            lambda items: expected_worker_completed in items,
+            timeout=2.0,
+        )
+        assert main_loop_thread.is_alive(), (
+            "main loop thread died while paused -- complete() attempted the "
+            "forbidden PAUSED -> COMPLETED transition instead of waiting for Resume"
+        )
+        assert expected_worker_completed not in held, (
+            "worker announced completion while paused; it must wait for Resume"
+        )
+        assert main_loop.context.state_manager.confirm_state(WorkerState.PAUSED), (
+            "expected the worker to sit in PAUSED, got "
+            f"{main_loop.context.state_manager.get_current_state()}"
+        )
+
+        # Positive direction: Resume releases the held completion.
+        input_queue.put(mock_resume)
+        collected = self._drain_until(
+            output_queue,
+            lambda items: expected_worker_completed in items,
+        )
+
+        if not main_loop.context.state_manager.confirm_state(WorkerState.COMPLETED):
+            pytest.fail(
+                "worker did not reach COMPLETED after Resume. "
+                f"state={main_loop.context.state_manager.get_current_state()}, "
+                f"collected={collected}"
+            )
+        assert expected_worker_completed in collected
+
+        reraise()
+
+    @pytest.mark.timeout(30)
     def test_zero_tuple_channel_completes_worker(
         self,
         mock_link,


### PR DESCRIPTION
### What changes were proposed in this PR?

**Root cause.** `MainLoop._process_end_channel` ends with `self.complete()`, which transits the worker to `COMPLETED`. Nothing between that call and the last control check above it drains control, but the coordinator pauses on its own schedule — so a `PauseWorker` command can land in that window and leave the worker `PAUSED`. `PAUSED -> COMPLETED` is forbidden by the transition graph, so `transit_to` raised `InvalidTransitionException`, which killed the main loop thread:

```
main_loop.py:674  _process_end_channel -> self.complete()
main_loop.py:305  complete()           -> state_manager.transit_to(COMPLETED)
state_manager.py:80                    -> InvalidTransitionException:
                                          Cannot transit from PAUSED to COMPLETED
```

```
Before:  pause lands before complete() -> PAUSED -> COMPLETED -> InvalidTransition, thread dies
After:   pause lands before complete() -> wait for Resume -> RUNNING -> COMPLETED
```

The worker now waits the pause out before completing, which is what the Scala runtime already does: `DPThread`'s input selection only picks *control* channels while `pauseManager.isPaused`, so a paused Scala worker never advances to completion.

The wait is guarded on `pause_manager.is_paused()` rather than draining control unconditionally. `_check_and_process_control` blocks while the data lane is disabled, and **backpressure disables that lane too** (`DisableType.DISABLE_BY_BACKPRESSURE`) — an unguarded drain here would park a worker that is merely backpressured. Guarded, the happy path is untouched: not paused, loop body never runs.

Deliberately *not* changed: the transition graph. Adding `PAUSED -> COMPLETED` would be the smaller diff, but `WORKER_STATE_TRANSITIONS` mirrors Scala's `WorkerStateManager` (`PAUSED -> Set(RUNNING)`) by contract, and the two must agree.

> Note for #5913: its stated cause is now stale. It attributes the flake to a 100-row `smallCsvScanOpDesc` finishing before the pause lands and prescribes a larger source; #5915 already did that, and the spec has used `slowRegionSourceOpDesc(numTuple = 30, delaySeconds = 0.25)` since. The surviving race is this one, in pyamber, and is independent of how long the source runs.

### Any related issues, documentation, discussions?

Closes #5913

### How was this PR tested?

New regression test, written first and confirmed to fail red against unmodified source with the exact production traceback (`Cannot transit from PAUSED to COMPLETED` at `_process_end_channel` -> `complete()`).

`test_pause_landing_before_completion_defers_it_until_resume` makes the race deterministic by pausing inside `all_ports_completed()` — the last call before `complete()`, with no control check in between, i.e. exactly the production window. It pins both directions:

- **negative** — while paused: the main loop thread stays alive, the worker sits in `PAUSED`, and no `WorkerExecutionCompleted` is announced;
- **positive** — after `Resume`: the worker reaches `COMPLETED` and announces it.

From `amber/`:

- `python -m pytest src/test/python/core/runnables/test_main_loop.py` — 35 passed (34 pre-existing + the new one).
- The new test run 5x consecutively — passed every time (it is a race regression, so repetition matters).
- `ruff check src/main/python src/test/python && ruff format --check src/main/python src/test/python` — clean.

Pre-existing local failures in `test_iceberg_document.py`, `test_tuple.py::test_hash` and `test_expression_evaluator.py` were confirmed identical with this change stashed, so they are unrelated to it.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
