### PR TITLE
fix(test, computing-unit): restore ComputingUnitManagingServiceSpec compilation after the avatar rename

### DIFF
--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -176,7 +176,7 @@ class ComputingUnitManagingResourceSpec
     info.isOwner shouldBe true
     info.accessPrivilege shouldBe PrivilegeEnum.WRITE
     info.ownerName shouldBe "owner"
-    info.ownerGoogleAvatar shouldBe "owner-avatar"
+    info.ownerAvatar shouldBe "owner-avatar"
   }
 
   it should "report READ access for a grantee holding READ access" in {
@@ -282,7 +282,7 @@ class ComputingUnitManagingResourceSpec
     created.accessPrivilege shouldBe PrivilegeEnum.WRITE
     created.ownerName shouldBe "creator"
     // makeUser sets no avatar, so the owner-avatar lookup resolves to null
-    created.ownerGoogleAvatar shouldBe null
+    created.ownerAvatar shouldBe null
 
     // The unit is persisted, not just echoed back
     unitName(cuid) shouldBe "local-cu"


### PR DESCRIPTION
### What changes were proposed in this PR?

`ComputingUnitManagingResourceSpec` references a field named `ownerGoogleAvatar` in two assertions, but `DashboardWorkflowComputingUnit` declares it as `ownerAvatar` (`ComputingUnitManagingResource.scala:162`). `main` therefore fails to compile its test sources:

```
[error] .../ComputingUnitManagingResourceSpec.scala:179:10: value ownerGoogleAvatar is not a member of
        org.apache.texera.service.resource.ComputingUnitManagingResource.DashboardWorkflowComputingUnit
[error]     info.ownerGoogleAvatar shouldBe "owner-avatar"
[error] .../ComputingUnitManagingResourceSpec.scala:285:13: value ownerGoogleAvatar is not a member of ...
[error]     created.ownerGoogleAvatar shouldBe null
[error] two errors found
[error] (ComputingUnitManagingService / Test / compileIncremental) Compilation failed
```

This renames the two references. The diff is two lines; no production file is touched and no assertion's meaning changes.

Because Scala test compilation is per module, the impact is wider than two assertions: **no test in `computing-unit-managing-service` has been able to run.** `ComputingUnitHelpersSpec`, `AdminComputingUnitResourceSpec`, `KubernetesClientSpec` and `ComputingUnitAccessResourceSpec` were all taken down with it.

This is merge skew. #7563 (`06845321b`) renamed the field and correctly updated the two specs that referenced it at the time — `AdminComputingUnitResourceSpec` and `ComputingUnitHelpersSpec`, both of which use `ownerAvatar` on `main` today. `ComputingUnitManagingResourceSpec` had no avatar assertions then, so there was nothing to update. #7580 (`c7e7362a4`) then added them from a branch based before the rename, and its CI ran against that older base. `git merge-base --is-ancestor 06845321b c7e7362a4` returns true, so the rename was already on `main` when #7580 landed.

### Any related issues, documentation, discussions?

Closes #7634

Introduced by the interaction of #7563 (the `ownerGoogleAvatar` → `ownerAvatar` rename) and #7580 (which added the avatar assertions from a pre-rename base).

### How was this PR tested?

`sbt "ComputingUnitManagingService/Test/compile"` fails on `main` with the two errors above and succeeds on this branch.

`sbt "ComputingUnitManagingService/test"` on this branch: **116 tests across 8 suites, all passing.** None of those 116 could run on `main`. `ComputingUnitManagingResourceSpec` itself passes 31/31 — the two assertions were already correct, so nothing about their meaning had to change, only the field name they read.

No other module is affected: the change is confined to one test file in one module and renames a field reference to match an existing declaration. A repo-wide `sbt Test/compile` across all sixteen aggregated modules succeeds on this branch.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)