### PR TITLE
fix(amber): classify wrapped sync timeouts

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/SyncExecutionResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/SyncExecutionResource.scala
@@ -833,13 +833,15 @@ class SyncExecutionResource extends LazyLogging {
   }
 
   private def isCausedByTimeout(error: Throwable): Boolean = {
+    val visited = new java.util.IdentityHashMap[Throwable, java.lang.Boolean]()
+
     @scala.annotation.tailrec
     def loop(current: Throwable): Boolean =
       current match {
-        case null                                         => false
-        case _: java.util.concurrent.TimeoutException     => true
-        case throwable if throwable.getCause eq throwable => false
-        case throwable                                    => loop(throwable.getCause)
+        case null                                                                => false
+        case _: java.util.concurrent.TimeoutException                            => true
+        case throwable if visited.put(throwable, java.lang.Boolean.TRUE) != null => false
+        case throwable                                                           => loop(throwable.getCause)
       }
 
     loop(error)

--- a/amber/src/main/scala/org/apache/texera/web/resource/SyncExecutionResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/SyncExecutionResource.scala
@@ -256,7 +256,7 @@ class SyncExecutionResource extends LazyLogging {
               .timeout(timeoutSeconds.toLong, TimeUnit.SECONDS)
               .blockingGet()
           } catch {
-            case _: java.util.concurrent.TimeoutException =>
+            case e: Exception if isCausedByTimeout(e) =>
               killExecution(executionService)
               return SyncExecutionResult(
                 success = false,
@@ -830,6 +830,19 @@ class SyncExecutionResource extends LazyLogging {
       case COMPLETED | FAILED | KILLED | TERMINATED => true
       case _                                        => false
     }
+  }
+
+  private def isCausedByTimeout(error: Throwable): Boolean = {
+    @scala.annotation.tailrec
+    def loop(current: Throwable): Boolean =
+      current match {
+        case null                                         => false
+        case _: java.util.concurrent.TimeoutException     => true
+        case throwable if throwable.getCause eq throwable => false
+        case throwable                                    => loop(throwable.getCause)
+      }
+
+    loop(error)
   }
 
   private def hasConsoleError(consoleState: ExecutionConsoleStore): Boolean = {

--- a/amber/src/test/scala/org/apache/texera/web/resource/SyncExecutionResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/SyncExecutionResourceSpec.scala
@@ -82,6 +82,7 @@ import org.scalatest.{BeforeAndAfterAll, PrivateMethodTester}
 
 import java.net.URI
 import java.sql.Timestamp
+import java.util.concurrent.{FutureTask, TimeUnit}
 import scala.jdk.CollectionConverters._
 
 /**
@@ -420,6 +421,21 @@ class SyncExecutionResourceSpec
   it should "reject unrelated and empty cause chains" in {
     resource invokePrivate isCausedByTimeout(new RuntimeException("other")) shouldBe false
     resource invokePrivate isCausedByTimeout(null.asInstanceOf[Throwable]) shouldBe false
+  }
+
+  it should "reject a cyclic cause chain without hanging" in {
+    val first = new RuntimeException("first")
+    val second = new RuntimeException("second")
+    first.initCause(second)
+    second.initCause(first)
+
+    val classification =
+      new FutureTask[Boolean](() => resource invokePrivate isCausedByTimeout(first))
+    val classificationThread = new Thread(classification)
+    classificationThread.setDaemon(true)
+    classificationThread.start()
+
+    classification.get(1, TimeUnit.SECONDS) shouldBe false
   }
 
   "stateToString" should "name every aggregated state and fall back to Unknown" in {

--- a/amber/src/test/scala/org/apache/texera/web/resource/SyncExecutionResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/SyncExecutionResourceSpec.scala
@@ -120,10 +120,10 @@ import scala.jdk.CollectionConverters._
   *   - the document-reading half of `collectConsoleLogs`. Reachable by the same fixture technique
   *     (a console-messages document whose single column holds ASCII-serialized `ConsoleMessage`
   *     protos), just not done here; its database half, `getConsoleMessageUri`, is pinned below.
-  *   - the `Observable.amb` wait and its timeout/error handlers (lines 231-277), plus the
-  *     `ConsoleErrorDetected` / `TargetResultsReady` termination arms (284-298). Reaching them
-  *     needs an execution that is still non-terminal when `executeWorkflowSync` looks at it, i.e.
-  *     a live engine.
+  *   - the `Observable.amb` wait and construction of its timeout/error responses (lines 231-277),
+  *     plus the `ConsoleErrorDetected` / `TargetResultsReady` termination arms (284-298). Reaching
+  *     them needs an execution that is still non-terminal when `executeWorkflowSync` looks at it,
+  *     i.e. a live engine. Timeout cause classification is pinned independently below.
   */
 class SyncExecutionResourceSpec
     extends AnyFlatSpec
@@ -154,6 +154,7 @@ class SyncExecutionResourceSpec
 
   private val stateToString = PrivateMethod[String](Symbol("stateToString"))
   private val isTerminalState = PrivateMethod[Boolean](Symbol("isTerminalState"))
+  private val isCausedByTimeout = PrivateMethod[Boolean](Symbol("isCausedByTimeout"))
   private val hasConsoleError = PrivateMethod[Boolean](Symbol("hasConsoleError"))
   private val symmetricTruncateCellValue =
     PrivateMethod[String](Symbol("symmetricTruncateCellValue"))
@@ -403,6 +404,22 @@ class SyncExecutionResourceSpec
 
   "healthCheck" should "report ok under the key the caller polls" in {
     resource.healthCheck shouldBe Map("status" -> "ok")
+  }
+
+  "isCausedByTimeout" should "detect direct and nested timeout exceptions" in {
+    val direct = new java.util.concurrent.TimeoutException("direct")
+    val nested = new RuntimeException(
+      "outer",
+      new RuntimeException("blockingGet wrapper", new java.util.concurrent.TimeoutException("wait"))
+    )
+
+    resource invokePrivate isCausedByTimeout(direct) shouldBe true
+    resource invokePrivate isCausedByTimeout(nested) shouldBe true
+  }
+
+  it should "reject unrelated and empty cause chains" in {
+    resource invokePrivate isCausedByTimeout(new RuntimeException("other")) shouldBe false
+    resource invokePrivate isCausedByTimeout(null.asInstanceOf[Throwable]) shouldBe false
   }
 
   "stateToString" should "name every aggregated state and fall back to Unknown" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

RxJava's `blockingGet` can wrap a checked `TimeoutException`. The previous catch matched only a direct timeout, so a wrapped timeout fell through to the generic error handler and returned `Error` instead of `Killed`.

```text
Before: timeout -> wrapper exception -> generic handler -> Error
After:  timeout -> cause-chain check -> timeout handler -> Killed
```

This change classifies an exception as a timeout when any safe, finite link in its cause chain is a `TimeoutException`. Tests cover direct and nested timeouts as positive cases, plus unrelated exceptions and `null` as negative cases.

### Any related issues, documentation, discussions?

Closes #6198

### How was this PR tested?

```bash
sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.SyncExecutionResourceSpec -- -z isCausedByTimeout"
sbt scalafmtCheckAll
sbt "scalafixAll --check"
```

The focused timeout-classification tests passed. Scala formatting and Scalafix checks also passed.

I also ran the complete `SyncExecutionResourceSpec`. The new timeout cases passed; 8 pre-existing storage-result cases could not complete because the local Iceberg REST catalog expected at `localhost:8181` was not running. Those cases are outside this change and will be exercised by the repository CI environment.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
