### PR TITLE
feat(workflow-operator): vectorize every named text column, not just one

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sklearn/SklearnClassifierOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sklearn/SklearnClassifierOpDesc.scala
@@ -33,6 +33,7 @@ abstract class SklearnClassifierOpDesc extends SklearnModelOpDesc {
     pyb"""$getImportStatements
        |from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score
        |from sklearn.pipeline import make_pipeline
+       |from sklearn.compose import ColumnTransformer
        |from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
        |import numpy as np
        |from pytexera import *
@@ -41,10 +42,11 @@ abstract class SklearnClassifierOpDesc extends SklearnModelOpDesc {
        |    def process_table(self, table: Table, port: int) -> Iterator[Optional[TableLike]]:
        |        Y = table[$target]
        |        X = table.drop($target, axis=1)
-       |        X = ${if (countVectorizer) pyb"X[$text]" else "X"}
        |        if port == 0:
-       |            self.model = make_pipeline(${if (countVectorizer) "CountVectorizer(),"
-    else ""} ${if (tfidfTransformer) "TfidfTransformer()," else ""} ${getImportStatements
+       |            self.model = make_pipeline(${vectorizerStage(c => pyb"$c".toString)} ${if (
+      tfidfTransformer
+    ) "TfidfTransformer(),"
+    else ""} ${getImportStatements
       .split(" ")
       .last}()).fit(X, Y)
        |        else:

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sklearn/SklearnModelOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sklearn/SklearnModelOpDesc.scala
@@ -19,7 +19,12 @@
 
 package org.apache.texera.amber.operator.sklearn
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
+import com.fasterxml.jackson.annotation.{
+  JsonFormat,
+  JsonIgnore,
+  JsonProperty,
+  JsonPropertyDescription
+}
 import com.kjetland.jackson.jsonSchema.annotations.{
   JsonSchemaInject,
   JsonSchemaInt,
@@ -50,12 +55,15 @@ abstract class SklearnModelOpDesc extends PythonOperatorDescriptor {
   var countVectorizer: Boolean = false
 
   @JsonSchemaTitle("Text Attribute")
-  @JsonPropertyDescription("Attribute in your dataset with text to vectorize.")
+  @JsonPropertyDescription("Attributes in your dataset with text to vectorize.")
+  // A workflow written before this field took several columns holds a bare string
+  // here, which reads as a list of one.
+  @JsonFormat(`with` = Array(JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY))
   @JsonSchemaInject(
     strings = Array(
       new JsonSchemaString(
         path = CommonOpDescAnnotation.autofill,
-        value = CommonOpDescAnnotation.attributeName
+        value = CommonOpDescAnnotation.attributeNameList
       ),
       new JsonSchemaString(path = HideAnnotation.hideTarget, value = "countVectorizer"),
       new JsonSchemaString(path = HideAnnotation.hideType, value = HideAnnotation.Type.equals),
@@ -65,7 +73,7 @@ abstract class SklearnModelOpDesc extends PythonOperatorDescriptor {
       new JsonSchemaInt(path = CommonOpDescAnnotation.autofillAttributeOnPort, value = 0)
     )
   )
-  var text: EncodableString = _
+  var text: List[EncodableString] = List()
 
   @JsonSchemaTitle("Tfidf Transformer")
   @JsonPropertyDescription("Transform a count matrix to a normalized tf or tf-idf representation.")
@@ -78,6 +86,30 @@ abstract class SklearnModelOpDesc extends PythonOperatorDescriptor {
     )
   )
   var tfidfTransformer: Boolean = false
+
+  /** The pipeline step that turns the named text columns into features, empty when
+    * Count Vectorizer is off.
+    *
+    * One `CountVectorizer` per column rather than one over all of them:
+    * `CountVectorizer` takes a flat sequence of documents, so handing it several
+    * columns reads them as one document each rather than as the rows. A
+    * `ColumnTransformer` gives each its own and concatenates the results, keeping
+    * the column a word came from distinguishable through the feature's prefix.
+    *
+    * The steps are named by position, not after the column, so that a column whose
+    * name carries a double underscore cannot collide with the separator
+    * `get_feature_names_out` puts between step and feature.
+    *
+    * `renderColumn` writes one column name in the caller's dialect: an encoded
+    * expression for the operator, a literal for the standalone script.
+    */
+  @JsonIgnore
+  protected def vectorizerStage(renderColumn: EncodableString => String): String =
+    if (!countVectorizer) ""
+    else
+      text.zipWithIndex
+        .map { case (column, i) => s"""("text$i", CountVectorizer(), ${renderColumn(column)})""" }
+        .mkString("ColumnTransformer([", ", ", "]),")
 
   @JsonIgnore
   def getImportStatements: String

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingOpDesc.scala
@@ -33,6 +33,7 @@ class SklearnTrainingOpDesc extends SklearnModelOpDesc {
   override def generatePythonCode(): String =
     pyb"""$getImportStatements
        |from sklearn.pipeline import make_pipeline
+       |from sklearn.compose import ColumnTransformer
        |from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
        |import numpy as np
        |from pytexera import *
@@ -41,8 +42,7 @@ class SklearnTrainingOpDesc extends SklearnModelOpDesc {
        |    def process_table(self, table: Table, port: int) -> Iterator[Optional[TableLike]]:
        |        Y = table[$target]
        |        X = table.drop($target, axis=1)
-       |        X = ${if (countVectorizer) pyb"X[$text]" else "X"}
-       |        model = make_pipeline(${if (countVectorizer) "CountVectorizer()," else ""} ${if (
+       |        model = make_pipeline(${vectorizerStage(c => pyb"$c".toString)} ${if (
       tfidfTransformer
     ) "TfidfTransformer(),"
     else ""} ${getImportStatements.split(" ").last}()).fit(X, Y)

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnAdaptiveBoostingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnAdaptiveBoostingOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnAdaptiveBoostingOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnAdaptiveBoostingOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnBaggingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnBaggingOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnBaggingOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnBaggingOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnBernoulliNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnBernoulliNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnBernoulliNaiveBayesOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnBernoulliNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnClassifierOpDescCodegenSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnClassifierOpDescCodegenSpec.scala
@@ -56,7 +56,7 @@ class SklearnClassifierOpDescCodegenSpec extends AnyFlatSpec with Matchers {
   ): SklearnKNNOpDesc = {
     val d = new SklearnKNNOpDesc
     d.target = "label"
-    d.text = "docs"
+    d.text = List("docs")
     d.countVectorizer = countVectorizer
     d.tfidfTransformer = tfidfTransformer
     d
@@ -69,7 +69,7 @@ class SklearnClassifierOpDescCodegenSpec extends AnyFlatSpec with Matchers {
     code should include(s"Y = table[${decodeExpr("label")}]")
     code should include(s"X = table.drop(${decodeExpr("label")}, axis=1)")
     // Feature-column path: X is kept whole, the text attribute is never read.
-    code should include("X = X\n")
+    code should not include "ColumnTransformer("
     code should not include decodeExpr("docs")
     normalized(code) should include(
       "self.model = make_pipeline( KNeighborsClassifier()).fit(X, Y)"
@@ -81,27 +81,45 @@ class SklearnClassifierOpDescCodegenSpec extends AnyFlatSpec with Matchers {
 
   it should "select the text column and prepend CountVectorizer when countVectorizer is on" in {
     val code = descriptor(countVectorizer = true).generatePythonCode()
-    code should include(s"X = X[${decodeExpr("docs")}]")
-    code should not include "X = X\n"
+    // ColumnTransformer selects the columns itself, so X stays the whole frame.
     normalized(code) should include(
-      "self.model = make_pipeline(CountVectorizer(), KNeighborsClassifier()).fit(X, Y)"
+      s"""self.model = make_pipeline(ColumnTransformer([("text0", CountVectorizer(), ${decodeExpr(
+        "docs"
+      )})]), KNeighborsClassifier()).fit(X, Y)"""
     )
     code should not include "TfidfTransformer()"
+  }
+
+  // One CountVectorizer per column: it reads a flat sequence of documents, so
+  // several columns handed to one would be read as a document each. The steps are
+  // named by position, keeping a column named with a double underscore away from
+  // the separator get_feature_names_out uses.
+  it should "give each named column its own CountVectorizer" in {
+    val d = descriptor(countVectorizer = true)
+    d.text = List("title", "body")
+    normalized(d.generatePythonCode()) should include(
+      s"""self.model = make_pipeline(ColumnTransformer([("text0", CountVectorizer(), ${decodeExpr(
+        "title"
+      )}), ("text1", CountVectorizer(), ${decodeExpr(
+        "body"
+      )})]), KNeighborsClassifier()).fit(X, Y)"""
+    )
   }
 
   it should "chain CountVectorizer before TfidfTransformer when both flags are on" in {
     val code =
       descriptor(countVectorizer = true, tfidfTransformer = true).generatePythonCode()
-    code should include(s"X = X[${decodeExpr("docs")}]")
     normalized(code) should include(
-      "self.model = make_pipeline(CountVectorizer(), TfidfTransformer(), KNeighborsClassifier()).fit(X, Y)"
+      s"""self.model = make_pipeline(ColumnTransformer([("text0", CountVectorizer(), ${decodeExpr(
+        "docs"
+      )})]), TfidfTransformer(), KNeighborsClassifier()).fit(X, Y)"""
     )
   }
 
   it should "prepend only TfidfTransformer and keep all features when tfidfTransformer is on alone" in {
     val code = descriptor(tfidfTransformer = true).generatePythonCode()
     // Without countVectorizer there is no text-column selection.
-    code should include("X = X\n")
+    code should not include "ColumnTransformer("
     code should not include decodeExpr("docs")
     normalized(code) should include(
       "self.model = make_pipeline( TfidfTransformer(), KNeighborsClassifier()).fit(X, Y)"

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnComplementNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnComplementNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnComplementNaiveBayesOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnComplementNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnDecisionTreeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnDecisionTreeOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnDecisionTreeOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnDecisionTreeOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnDummyClassifierOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnDummyClassifierOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnDummyClassifierOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnDummyClassifierOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnExtraTreeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnExtraTreeOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnExtraTreeOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnExtraTreeOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnExtraTreesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnExtraTreesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnExtraTreesOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnExtraTreesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnGaussianNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnGaussianNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnGaussianNaiveBayesOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnGaussianNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnGradientBoostingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnGradientBoostingOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnGradientBoostingOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnGradientBoostingOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnKNNOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnKNNOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnKNNOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnKNNOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnLinearSVMOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnLinearSVMOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnLinearSVMOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnLinearSVMOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnLogisticRegressionCVOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnLogisticRegressionCVOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnLogisticRegressionCVOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnLogisticRegressionCVOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnLogisticRegressionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnLogisticRegressionOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnLogisticRegressionOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnLogisticRegressionOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnMultiLayerPerceptronOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnMultiLayerPerceptronOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnMultiLayerPerceptronOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnMultiLayerPerceptronOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnMultinomialNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnMultinomialNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnMultinomialNaiveBayesOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnMultinomialNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnNearestCentroidOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnNearestCentroidOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnNearestCentroidOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnNearestCentroidOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnPassiveAggressiveOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnPassiveAggressiveOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnPassiveAggressiveOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnPassiveAggressiveOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnPerceptronOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnPerceptronOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnPerceptronOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnPerceptronOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnProbabilityCalibrationOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnProbabilityCalibrationOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnProbabilityCalibrationOpDescSpec extends AnyFlatSpec with Matchers 
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnProbabilityCalibrationOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnRandomForestOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnRandomForestOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnRandomForestOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnRandomForestOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnRidgeCVOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnRidgeCVOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnRidgeCVOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnRidgeCVOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnRidgeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnRidgeOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnRidgeOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnRidgeOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnSDGOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnSDGOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnSDGOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnSDGOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnSVMOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/SklearnSVMOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnSVMOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnSVMOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingAdaptiveBoostingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingAdaptiveBoostingOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingAdaptiveBoostingOpDescSpec extends AnyFlatSpec with Matcher
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingAdaptiveBoostingOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingBaggingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingBaggingOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingBaggingOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingBaggingOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingBernoulliNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingBernoulliNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingBernoulliNaiveBayesOpDescSpec extends AnyFlatSpec with Matc
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingBernoulliNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingComplementNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingComplementNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingComplementNaiveBayesOpDescSpec extends AnyFlatSpec with Mat
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingComplementNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingDecisionTreeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingDecisionTreeOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingDecisionTreeOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingDecisionTreeOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingDummyClassifierOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingDummyClassifierOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingDummyClassifierOpDescSpec extends AnyFlatSpec with Matchers
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingDummyClassifierOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingExtraTreeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingExtraTreeOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingExtraTreeOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingExtraTreeOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingExtraTreesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingExtraTreesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingExtraTreesOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingExtraTreesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingGaussianNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingGaussianNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingGaussianNaiveBayesOpDescSpec extends AnyFlatSpec with Match
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingGaussianNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingGradientBoostingOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingGradientBoostingOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingGradientBoostingOpDescSpec extends AnyFlatSpec with Matcher
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingGradientBoostingOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingKNNOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingKNNOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingKNNOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingKNNOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLinearRegressionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLinearRegressionOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingLinearRegressionOpDescSpec extends AnyFlatSpec with Matcher
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingLinearRegressionOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLinearSVMOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLinearSVMOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingLinearSVMOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingLinearSVMOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLogisticRegressionCVOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLogisticRegressionCVOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingLogisticRegressionCVOpDescSpec extends AnyFlatSpec with Mat
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingLogisticRegressionCVOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLogisticRegressionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingLogisticRegressionOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingLogisticRegressionOpDescSpec extends AnyFlatSpec with Match
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingLogisticRegressionOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingMultiLayerPerceptronOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingMultiLayerPerceptronOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingMultiLayerPerceptronOpDescSpec extends AnyFlatSpec with Mat
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingMultiLayerPerceptronOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingMultinomialNaiveBayesOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingMultinomialNaiveBayesOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingMultinomialNaiveBayesOpDescSpec extends AnyFlatSpec with Ma
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingMultinomialNaiveBayesOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingNearestCentroidOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingNearestCentroidOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingNearestCentroidOpDescSpec extends AnyFlatSpec with Matchers
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingNearestCentroidOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingOpDescCodegenSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingOpDescCodegenSpec.scala
@@ -56,7 +56,7 @@ class SklearnTrainingOpDescCodegenSpec extends AnyFlatSpec with Matchers {
   ): SklearnTrainingKNNOpDesc = {
     val d = new SklearnTrainingKNNOpDesc
     d.target = "label"
-    d.text = "docs"
+    d.text = List("docs")
     d.countVectorizer = countVectorizer
     d.tfidfTransformer = tfidfTransformer
     d
@@ -69,7 +69,7 @@ class SklearnTrainingOpDescCodegenSpec extends AnyFlatSpec with Matchers {
     code should include(s"Y = table[${decodeExpr("label")}]")
     code should include(s"X = table.drop(${decodeExpr("label")}, axis=1)")
     // Feature-column path: X is kept whole, the text attribute is never read.
-    code should include("X = X\n")
+    code should not include "ColumnTransformer("
     code should not include decodeExpr("docs")
     normalized(code) should include("make_pipeline( KNeighborsClassifier()).fit(X, Y)")
     code should not include "CountVectorizer()"
@@ -78,27 +78,45 @@ class SklearnTrainingOpDescCodegenSpec extends AnyFlatSpec with Matchers {
 
   it should "select the text column and prepend CountVectorizer when countVectorizer is on" in {
     val code = descriptor(countVectorizer = true).generatePythonCode()
-    code should include(s"X = X[${decodeExpr("docs")}]")
-    code should not include "X = X\n"
+    // ColumnTransformer selects the columns itself, so X stays the whole frame.
     normalized(code) should include(
-      "make_pipeline(CountVectorizer(), KNeighborsClassifier()).fit(X, Y)"
+      s"""make_pipeline(ColumnTransformer([("text0", CountVectorizer(), ${decodeExpr(
+        "docs"
+      )})]), KNeighborsClassifier()).fit(X, Y)"""
     )
     code should not include "TfidfTransformer()"
+  }
+
+  // One CountVectorizer per column: it reads a flat sequence of documents, so
+  // several columns handed to one would be read as a document each. The steps are
+  // named by position, keeping a column named with a double underscore away from
+  // the separator get_feature_names_out uses.
+  it should "give each named column its own CountVectorizer" in {
+    val d = descriptor(countVectorizer = true)
+    d.text = List("title", "body")
+    normalized(d.generatePythonCode()) should include(
+      s"""make_pipeline(ColumnTransformer([("text0", CountVectorizer(), ${decodeExpr(
+        "title"
+      )}), ("text1", CountVectorizer(), ${decodeExpr(
+        "body"
+      )})]), KNeighborsClassifier()).fit(X, Y)"""
+    )
   }
 
   it should "chain CountVectorizer before TfidfTransformer when both flags are on" in {
     val code =
       descriptor(countVectorizer = true, tfidfTransformer = true).generatePythonCode()
-    code should include(s"X = X[${decodeExpr("docs")}]")
     normalized(code) should include(
-      "make_pipeline(CountVectorizer(), TfidfTransformer(), KNeighborsClassifier()).fit(X, Y)"
+      s"""make_pipeline(ColumnTransformer([("text0", CountVectorizer(), ${decodeExpr(
+        "docs"
+      )})]), TfidfTransformer(), KNeighborsClassifier()).fit(X, Y)"""
     )
   }
 
   it should "prepend only TfidfTransformer and keep all features when tfidfTransformer is on alone" in {
     val code = descriptor(tfidfTransformer = true).generatePythonCode()
     // Without countVectorizer there is no text-column selection.
-    code should include("X = X\n")
+    code should not include "ColumnTransformer("
     code should not include decodeExpr("docs")
     normalized(code) should include(
       "make_pipeline( TfidfTransformer(), KNeighborsClassifier()).fit(X, Y)"

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingPassiveAggressiveOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingPassiveAggressiveOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingPassiveAggressiveOpDescSpec extends AnyFlatSpec with Matche
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingPassiveAggressiveOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingPerceptronOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingPerceptronOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingPerceptronOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingPerceptronOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingProbabilityCalibrationOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingProbabilityCalibrationOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingProbabilityCalibrationOpDescSpec extends AnyFlatSpec with M
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingProbabilityCalibrationOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRandomForestOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRandomForestOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingRandomForestOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingRandomForestOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeCVOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeCVOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingRidgeCVOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingRidgeCVOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingRidgeOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingRidgeOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingRidgeOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingSDGOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingSDGOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingSDGOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingSDGOpDesc.getOutputSchemas" should

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingSVMOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/sklearn/training/SklearnTrainingSVMOpDescSpec.scala
@@ -44,7 +44,7 @@ class SklearnTrainingSVMOpDescSpec extends AnyFlatSpec with Matchers {
     d.countVectorizer shouldBe false
     d.tfidfTransformer shouldBe false
     d.target shouldBe null
-    d.text shouldBe null
+    d.text shouldBe empty
   }
 
   "SklearnTrainingSVMOpDesc.getOutputSchemas" should


### PR DESCRIPTION
### What changes were proposed in this PR?

`Text Attribute` named one column, so a dataset whose text is spread over several could not be used as it stands. A title beside a body, or a description beside a comment, is ordinary, and the only way through was a Concat upstream, which merges the columns into one string and gives up which column each word came from.

Naming several columns was not an alternative either. `CountVectorizer` takes a flat sequence of documents, so a two-column frame reaches it as two documents rather than as the rows, and it learns a vocabulary of the column names:

```
>>> CountVectorizer().fit(df[["title", "body"]]).vocabulary_
{'body': 0, 'title': 1}
```

The field now takes a list, and the generated pipeline opens with a `ColumnTransformer` that gives each named column its own `CountVectorizer` and concatenates the results, so a word keeps the column it came from through the feature's prefix:

```python
make_pipeline(ColumnTransformer([("text0", CountVectorizer(), <col>),
                                 ("text1", CountVectorizer(), <col>)]),
              TfidfTransformer(), estimator()).fit(X, Y)
```

The steps are named by position rather than after the column, which keeps a column whose name carries a double underscore away from the separator `get_feature_names_out` puts between step and feature. The transformer names the columns it reads, so the frame no longer has to be narrowed before the pipeline and that line goes.

`Tfidf Transformer` stays one switch over the whole matrix, leaving the shape of the pipeline as it was. Turning `Count Vectorizer` on still discards the numeric columns, as before: carrying them along needs a way to say which columns are features, which these two families do not have, and that is a separate change.

The operator's output is unchanged, one row of `model_name` and `model`.

A workflow written before this holds a bare string in the field. The engine reads it: `ACCEPT_SINGLE_VALUE_AS_ARRAY` turns it into a list of one, so execution is unaffected. The UI does not. It validates the saved properties against the operator's JSON schema, where the field is now `{"type": "array"}`, and a string fails that check regardless of the field being optional. The operator is marked invalid, the field renders empty, and Run is disabled until the column is picked again.

So an existing workflow that turned `Count Vectorizer` on needs its text column re-selected once, and the only signal the user gets is a greyed-out Run button. Verified on a workflow saved before this change: stored as `"text": "note"` it fails validation with `'note' is not of type 'array'`, and re-picking the same column stores `["note"]` and clears it.

The field is declared on `SklearnModelOpDesc`, so this reaches all fifty-one operators of the Sklearn and Sklearn Training groups.

### Any related issues, documentation, discussions?

Closes #7667

This touches the same line of the two codegen templates as #7645, which rewrites it while this deletes it. Whichever merges second needs that line resolved by hand: the `else` branch #7645 introduces is kept, and the `if` branch this removes stays removed.

### How was this PR tested?

`SklearnClassifierOpDescCodegenSpec` and `SklearnTrainingOpDescCodegenSpec` pinned the generated pipeline and were updated to the new one, each gaining a case for several columns getting a vectorizer apiece. The fifty-one per-operator specs that pinned the field's default were updated to the empty list. `WorkflowOperator/test` passes: 2287 tests.

The emitted line was also run as it stands, with the base64 decoding stubbed, against a frame of two text columns and a numeric one: it fits, and the feature names carry the `text0__` and `text1__` prefixes.

It was also run as a real workflow: two CSV File Scans into Logistic Regression's training and testing ports, `label` as target, Count Vectorizer on. The spam signal is split across `title` and `body`, so neither column alone separates the classes. `title` alone gives 0.75, missing the test row whose signal is in `body`. Adding `body` gives 1.0.

<img width="1398" height="879" alt="pr7668-run1-title-only-0 75" src="https://github.com/user-attachments/assets/494002ae-e8fd-45e1-80d3-eda08898b30a" />

<img width="1398" height="879" alt="pr7668-run2-title-body-1 0" src="https://github.com/user-attachments/assets/2f2a34a6-8123-4e3a-abc0-b8f604f5bb27" />

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)


