### PR TITLE
fix(deps, ci): bump sbt/setup-sbt to v1.5.7 to restore CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -241,7 +241,7 @@ jobs:
       - name: Generate Python proto bindings
         run: bash bin/python-proto-gen.sh
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'

--- a/.github/workflows/build-and-push-images.yml
+++ b/.github/workflows/build-and-push-images.yml
@@ -126,7 +126,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
@@ -328,7 +328,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
@@ -408,7 +408,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -228,7 +228,7 @@ jobs:
         env:
           PGPASSWORD: postgres
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
@@ -482,7 +482,7 @@ jobs:
         env:
           PGPASSWORD: postgres
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
@@ -792,7 +792,7 @@ jobs:
           distribution: "temurin"
           java-version: 17
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'
@@ -947,7 +947,7 @@ jobs:
           distribution: "temurin"
           java-version: 17
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
         with:
           extraSbtFiles: '["*.sbt", "project/**.{scala,sbt}", "project/build.properties" ]'

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -48,7 +48,7 @@ jobs:
           java-version: 17
 
       - name: Setup sbt launcher
-        uses: sbt/setup-sbt@6444f4c8111de4b9059c3975def104b03cfaa5f0 # v1.5.2
+        uses: sbt/setup-sbt@8feba82adc7f01ddcf8165b86f778bdb5b82cebc # v1.5.7
 
       - uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 


### PR DESCRIPTION
### What changes were proposed in this PR?

CI has been red repo-wide since 2026-08-16 ~02:00 UTC — `main`, the merge queue, and every PR that runs a Scala stack. The jobs die in 3–7s during *Prepare all required actions*, before checkout, so they produce no test output at all.

The cause is the ASF actions allowlist, not anything in this repository. `sbt/setup-sbt` reaches a nested `carabiner-dev` action that is no longer permitted:

```
.github/workflows/*.yml
  └─ sbt/setup-sbt@6444f4c                              v1.5.2   allowed
       └─ carabiner-dev/actions/ampel/verify@94f2939    v1.2.1   allowed
            └─ carabiner-dev/actions/install/ampel@2a11d59   v1.1.7   BLOCKED
```

> The action carabiner-dev/actions/install/ampel@2a11d59a135c5e291f305f249a92ad7903e3ee0f is not allowed in apache/texera because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: …

Nothing in the tree changed — every link in that chain is SHA-pinned, and the `sbt/setup-sbt` pin last moved in #6710 on 2026-07-22. The same `2a11d59` downloaded successfully at `2026-08-15T02:01Z` (#7674's amber job) and is rejected at `2026-08-17T02:13Z`. Last clean run before the break: merge-queue `pr-7699` at `2026-08-16T01:52:00Z`; first failure: `main` at `2026-08-16T02:04:42Z`.

This bumps all 9 call sites from v1.5.2 to v1.5.7, which resolves down a different path:

| | v1.5.2 (current) | v1.5.7 (this PR) |
| --- | --- | --- |
| `ampel/verify` | `94f2939` (v1.2.1) | `36a39ef` (v1.2.6) |
| `install/ampel` | **`2a11d59` — blocked** | `2fec8bd8` |
| `install/bnd` | `2a11d59` | no longer referenced |

Call sites: `benchmarks.yml` (1), `build-and-push-images.yml` (3), `build.yml` (4), `dependency-graph.yml` (1).

> Reviewer note — one thing I could not verify up front. The org allowlist is not readable without repo-admin (`403`), and the error message truncates the pattern list before the `carabiner-dev` entries, so I could not confirm in advance that `2fec8bd8` is permitted. **This PR's own CI run is the experiment.** If it fails on the same error, the bump is a dead end and the fallback is an INFRA request to re-allow `carabiner-dev/actions@2a11d59a135c5e291f305f249a92ad7903e3ee0f`.

### Any related issues, documentation, discussions?

No issue filed — the regression originates outside the repository and this PR is the unblock. The previous bump of this pin was #6710.

### How was this PR tested?

By this PR's CI, which is the only place the failure reproduces — it depends on the `apache/texera` actions policy and cannot be triggered locally or on a fork.

The change touches `.github/**`, so the labeler applies `ci`, and `ci` maps to every stack in `LABEL_STACKS` (`.github/workflows/precheck.yml`) — `frontend`, `amber`, `amber-integration`, `platform`, `platform-integration`, `pyamber`, `agent-service`, `infra`, `pyright-language-service` — plus `Bench`. Every job that consumes `sbt/setup-sbt` is therefore exercised here.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
