### PR TITLE
feat(amber): wait out Lakekeeper's asynchronous purge when deleting a warehouse

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
@@ -20,8 +20,10 @@
 package org.apache.texera.web.service
 
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
+import com.typesafe.scalalogging.LazyLogging
 import kong.unirest.Unirest
 import org.apache.texera.common.config.StorageConfig
+import org.apache.texera.common.util.RetryUtil
 import org.apache.texera.web.service.LakekeeperClient.PurgeWaitPolicy
 
 import java.net.URLEncoder
@@ -65,7 +67,7 @@ object LakekeeperClient {
 class LakekeeperClient(
     catalogUri: String = StorageConfig.icebergRESTCatalogUri,
     purgeWait: PurgeWaitPolicy = PurgeWaitPolicy()
-) {
+) extends LazyLogging {
 
   // Lakekeeper's default project; single-project deployments (ours) use the nil UUID.
   private val DefaultProjectId = "00000000-0000-0000-0000-000000000000"
@@ -158,25 +160,27 @@ class LakekeeperClient(
     // WarehouseHasUnfinishedTasks until the queue drains (normally within seconds),
     // so ride that out with a bounded retry; every other error, including any other
     // 409, still fails immediately. (#7742)
-    var attempt = 0
-    var delay = purgeWait.initialDelayMillis
-    var deleted = false
-    while (!deleted) {
+    RetryUtil.withBackoff(
+      description = "delete warehouse",
+      maxAttempts = purgeWait.retries + 1,
+      initialDelayMillis = purgeWait.initialDelayMillis,
+      onRetry = attempt => logger.info(attempt.message),
+      maxDelayMillis = purgeWait.maxDelayMillis,
+      shouldRetry = _.isInstanceOf[UnfinishedTasksConflictException]
+    ) {
       val response = Unirest.delete(s"$managementBase/warehouse/$warehouseId").asString()
-      attempt += 1
-      if (response.getStatus == 404 || (response.getStatus >= 200 && response.getStatus < 300)) {
-        deleted = true
-      } else if (
-        attempt <= purgeWait.retries &&
-        isUnfinishedTasksConflict(response.getStatus, response.getBody)
-      ) {
-        Thread.sleep(delay)
-        delay = math.min(delay * 2, purgeWait.maxDelayMillis)
-      } else {
+      if (response.getStatus != 404) {
+        if (isUnfinishedTasksConflict(response.getStatus, response.getBody)) {
+          throw new UnfinishedTasksConflictException(response.getStatus, response.getBody)
+        }
         failOn(response.getStatus, response.getBody, "delete warehouse")
       }
     }
   }
+
+  /** Tags the one retryable delete failure so the backoff predicate can single it out. */
+  private class UnfinishedTasksConflictException(status: Int, body: String)
+      extends RuntimeException(s"Lakekeeper delete warehouse failed (HTTP $status): $body")
 
   /** Lakekeeper's "purge queue still draining" conflict — the only retried error. */
   private def isUnfinishedTasksConflict(status: Int, body: String): Boolean =

--- a/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
@@ -40,12 +40,12 @@ object LakekeeperClient {
     * still draining (#7742). The pause starts at `initialDelayMillis` and doubles up to
     * `maxDelayMillis`: starting small keeps a fast purge (the common case) from costing the
     * caller a full fixed interval, while the growth keeps a slow one from hammering
-    * Lakekeeper. With the defaults the `retries` retries wait 0.2+0.4+0.8+1.6+3.2+5+5s
-    * ≈ 16s in total. Overridable for tests (a 0 initial delay keeps the spec free of
-    * real sleeps — doubling 0 stays 0).
+    * Lakekeeper. With the defaults the waits between the `maxAttempts` attempts sum to
+    * 0.2+0.4+0.8+1.6+3.2+5+5s ≈ 16s. Overridable for tests (a 0 initial delay keeps the
+    * spec free of real sleeps — doubling 0 stays 0).
     */
   final case class PurgeWaitPolicy(
-      retries: Int = 7,
+      maxAttempts: Int = 8,
       initialDelayMillis: Long = 200,
       maxDelayMillis: Long = 5000
   )
@@ -161,34 +161,36 @@ class LakekeeperClient(
     // so ride that out with a bounded retry; every other error, including any other
     // 409, still fails immediately. (#7742)
     RetryUtil.withBackoff(
-      description = "delete warehouse",
-      maxAttempts = purgeWait.retries + 1,
+      description = DeleteWarehouseAction,
+      maxAttempts = purgeWait.maxAttempts,
       initialDelayMillis = purgeWait.initialDelayMillis,
-      onRetry = attempt => logger.info(attempt.message),
+      onRetry = attempt => logger.warn(attempt.message),
       maxDelayMillis = purgeWait.maxDelayMillis,
       shouldRetry = _.isInstanceOf[UnfinishedTasksConflictException]
     ) {
       val response = Unirest.delete(s"$managementBase/warehouse/$warehouseId").asString()
-      if (response.getStatus != 404) {
-        if (isUnfinishedTasksConflict(response.getStatus, response.getBody)) {
-          throw new UnfinishedTasksConflictException(response.getStatus, response.getBody)
-        }
-        failOn(response.getStatus, response.getBody, "delete warehouse")
+      response.getStatus match {
+        case 404 => // already gone — the idempotent goal state
+        case 409 if isUnfinishedTasksBody(response.getBody) =>
+          throw new UnfinishedTasksConflictException(response.getBody)
+        case status => failOn(status, response.getBody, DeleteWarehouseAction)
       }
     }
   }
 
-  /** Tags the one retryable delete failure so the backoff predicate can single it out. */
-  private class UnfinishedTasksConflictException(status: Int, body: String)
-      extends RuntimeException(s"Lakekeeper delete warehouse failed (HTTP $status): $body")
+  private val DeleteWarehouseAction = "delete warehouse"
 
-  /** Lakekeeper's "purge queue still draining" conflict — the only retried error. */
-  private def isUnfinishedTasksConflict(status: Int, body: String): Boolean =
-    status == 409 && (try {
+  /** Tags the one retryable delete failure so the backoff predicate can single it out. */
+  private class UnfinishedTasksConflictException(body: String)
+      extends RuntimeException(s"Lakekeeper $DeleteWarehouseAction failed (HTTP 409): $body")
+
+  /** Lakekeeper's "purge queue still draining" 409 body — the only retried error. */
+  private def isUnfinishedTasksBody(body: String): Boolean =
+    try {
       mapper.readTree(body).path("error").path("type").asText() == "WarehouseHasUnfinishedTasks"
     } catch {
       case _: Exception => false
-    })
+    }
 
   /** Top-level namespaces in the warehouse. Texera's execution namespaces are single-level. */
   private def listNamespaces(warehouseId: UUID): List[String] =

--- a/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
@@ -42,15 +42,22 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   * @param unfinishedTasksRetries how many times the final warehouse delete is retried while
   *                               Lakekeeper reports 409 WarehouseHasUnfinishedTasks — its
   *                               asynchronous purge of the dropped tables' data files is
-  *                               still draining (#7742). With the default delay this bounds
-  *                               the wait at ~20s; the queue normally drains within seconds.
-  * @param unfinishedTasksRetryDelayMillis pause between those retries. Overridable for tests
-  *                                        (0 keeps the spec free of real sleeps).
+  *                               still draining (#7742).
+  * @param unfinishedTasksInitialDelayMillis first pause between those retries; it doubles up
+  *                                          to the cap. Starting small keeps a fast purge
+  *                                          (the common case) from costing the caller a full
+  *                                          fixed interval, while the growth keeps a slow one
+  *                                          from hammering Lakekeeper. Overridable for tests
+  *                                          (0 keeps the spec free of real sleeps — doubling
+  *                                          0 stays 0).
+  * @param unfinishedTasksMaxDelayMillis cap for that doubling. With the defaults the retries
+  *                                      wait 0.2+0.4+0.8+1.6+3.2+5+5s ≈ 16s in total.
   */
 class LakekeeperClient(
     catalogUri: String = StorageConfig.icebergRESTCatalogUri,
-    unfinishedTasksRetries: Int = 10,
-    unfinishedTasksRetryDelayMillis: Long = 2000
+    unfinishedTasksRetries: Int = 7,
+    unfinishedTasksInitialDelayMillis: Long = 200,
+    unfinishedTasksMaxDelayMillis: Long = 5000
 ) {
 
   // Lakekeeper's default project; single-project deployments (ours) use the nil UUID.
@@ -145,6 +152,7 @@ class LakekeeperClient(
     // so ride that out with a bounded retry; every other error, including any other
     // 409, still fails immediately. (#7742)
     var attempt = 0
+    var delay = unfinishedTasksInitialDelayMillis
     var deleted = false
     while (!deleted) {
       val response = Unirest.delete(s"$managementBase/warehouse/$warehouseId").asString()
@@ -155,7 +163,8 @@ class LakekeeperClient(
         isUnfinishedTasksConflict(response.getStatus, response.getBody) &&
         attempt <= unfinishedTasksRetries
       ) {
-        Thread.sleep(unfinishedTasksRetryDelayMillis)
+        Thread.sleep(delay)
+        delay = math.min(delay * 2, unfinishedTasksMaxDelayMillis)
       } else {
         failOn(response.getStatus, response.getBody, "delete warehouse")
       }

--- a/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
@@ -39,8 +39,19 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   *
   * @param catalogUri the Iceberg REST catalog uri (ends with `/catalog`), from which the
   *                   management base is derived. Overridable for tests.
+  * @param unfinishedTasksRetries how many times the final warehouse delete is retried while
+  *                               Lakekeeper reports 409 WarehouseHasUnfinishedTasks — its
+  *                               asynchronous purge of the dropped tables' data files is
+  *                               still draining (#7742). With the default delay this bounds
+  *                               the wait at ~20s; the queue normally drains within seconds.
+  * @param unfinishedTasksRetryDelayMillis pause between those retries. Overridable for tests
+  *                                        (0 keeps the spec free of real sleeps).
   */
-class LakekeeperClient(catalogUri: String = StorageConfig.icebergRESTCatalogUri) {
+class LakekeeperClient(
+    catalogUri: String = StorageConfig.icebergRESTCatalogUri,
+    unfinishedTasksRetries: Int = 10,
+    unfinishedTasksRetryDelayMillis: Long = 2000
+) {
 
   // Lakekeeper's default project; single-project deployments (ours) use the nil UUID.
   private val DefaultProjectId = "00000000-0000-0000-0000-000000000000"
@@ -126,11 +137,38 @@ class LakekeeperClient(catalogUri: String = StorageConfig.icebergRESTCatalogUri)
         failOn(response.getStatus, response.getBody, s"drop namespace '$namespace'")
       }
     }
-    val response = Unirest.delete(s"$managementBase/warehouse/$warehouseId").asString()
-    if (response.getStatus != 404) {
-      failOn(response.getStatus, response.getBody, "delete warehouse")
+    // The drops above purge each table's data files asynchronously (Lakekeeper task
+    // queue `tabular_purge`), and Lakekeeper refuses to delete the warehouse while
+    // any purge is pending — the tasks need the warehouse's storage profile to reach
+    // S3, so deleting it first would orphan them and leak the files. It answers 409
+    // WarehouseHasUnfinishedTasks until the queue drains (normally within seconds),
+    // so ride that out with a bounded retry; every other error, including any other
+    // 409, still fails immediately. (#7742)
+    var attempt = 0
+    var deleted = false
+    while (!deleted) {
+      val response = Unirest.delete(s"$managementBase/warehouse/$warehouseId").asString()
+      attempt += 1
+      if (response.getStatus == 404 || (response.getStatus >= 200 && response.getStatus < 300)) {
+        deleted = true
+      } else if (
+        isUnfinishedTasksConflict(response.getStatus, response.getBody) &&
+        attempt <= unfinishedTasksRetries
+      ) {
+        Thread.sleep(unfinishedTasksRetryDelayMillis)
+      } else {
+        failOn(response.getStatus, response.getBody, "delete warehouse")
+      }
     }
   }
+
+  /** Lakekeeper's "purge queue still draining" conflict — the only retried error. */
+  private def isUnfinishedTasksConflict(status: Int, body: String): Boolean =
+    status == 409 && (try {
+      mapper.readTree(body).path("error").path("type").asText() == "WarehouseHasUnfinishedTasks"
+    } catch {
+      case _: Exception => false
+    })
 
   /** Top-level namespaces in the warehouse. Texera's execution namespaces are single-level. */
   private def listNamespaces(warehouseId: UUID): List[String] =

--- a/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/LakekeeperClient.scala
@@ -22,12 +22,32 @@ package org.apache.texera.web.service
 import com.fasterxml.jackson.databind.{JsonNode, ObjectMapper}
 import kong.unirest.Unirest
 import org.apache.texera.common.config.StorageConfig
+import org.apache.texera.web.service.LakekeeperClient.PurgeWaitPolicy
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import scala.collection.mutable.ListBuffer
 import scala.jdk.CollectionConverters.IteratorHasAsScala
+
+object LakekeeperClient {
+
+  /**
+    * How long the final warehouse delete waits out Lakekeeper's asynchronous purge of the
+    * dropped tables' data files, which it reports as 409 WarehouseHasUnfinishedTasks while
+    * still draining (#7742). The pause starts at `initialDelayMillis` and doubles up to
+    * `maxDelayMillis`: starting small keeps a fast purge (the common case) from costing the
+    * caller a full fixed interval, while the growth keeps a slow one from hammering
+    * Lakekeeper. With the defaults the `retries` retries wait 0.2+0.4+0.8+1.6+3.2+5+5s
+    * ≈ 16s in total. Overridable for tests (a 0 initial delay keeps the spec free of
+    * real sleeps — doubling 0 stays 0).
+    */
+  final case class PurgeWaitPolicy(
+      retries: Int = 7,
+      initialDelayMillis: Long = 200,
+      maxDelayMillis: Long = 5000
+  )
+}
 
 /**
   * Client for the Lakekeeper APIs used to manage per-user warehouses (#6870).
@@ -39,25 +59,12 @@ import scala.jdk.CollectionConverters.IteratorHasAsScala
   *
   * @param catalogUri the Iceberg REST catalog uri (ends with `/catalog`), from which the
   *                   management base is derived. Overridable for tests.
-  * @param unfinishedTasksRetries how many times the final warehouse delete is retried while
-  *                               Lakekeeper reports 409 WarehouseHasUnfinishedTasks — its
-  *                               asynchronous purge of the dropped tables' data files is
-  *                               still draining (#7742).
-  * @param unfinishedTasksInitialDelayMillis first pause between those retries; it doubles up
-  *                                          to the cap. Starting small keeps a fast purge
-  *                                          (the common case) from costing the caller a full
-  *                                          fixed interval, while the growth keeps a slow one
-  *                                          from hammering Lakekeeper. Overridable for tests
-  *                                          (0 keeps the spec free of real sleeps — doubling
-  *                                          0 stays 0).
-  * @param unfinishedTasksMaxDelayMillis cap for that doubling. With the defaults the retries
-  *                                      wait 0.2+0.4+0.8+1.6+3.2+5+5s ≈ 16s in total.
+  * @param purgeWait how long the final warehouse delete waits out Lakekeeper's asynchronous
+  *                  purge of the dropped tables' data files (#7742).
   */
 class LakekeeperClient(
     catalogUri: String = StorageConfig.icebergRESTCatalogUri,
-    unfinishedTasksRetries: Int = 7,
-    unfinishedTasksInitialDelayMillis: Long = 200,
-    unfinishedTasksMaxDelayMillis: Long = 5000
+    purgeWait: PurgeWaitPolicy = PurgeWaitPolicy()
 ) {
 
   // Lakekeeper's default project; single-project deployments (ours) use the nil UUID.
@@ -152,7 +159,7 @@ class LakekeeperClient(
     // so ride that out with a bounded retry; every other error, including any other
     // 409, still fails immediately. (#7742)
     var attempt = 0
-    var delay = unfinishedTasksInitialDelayMillis
+    var delay = purgeWait.initialDelayMillis
     var deleted = false
     while (!deleted) {
       val response = Unirest.delete(s"$managementBase/warehouse/$warehouseId").asString()
@@ -160,11 +167,11 @@ class LakekeeperClient(
       if (response.getStatus == 404 || (response.getStatus >= 200 && response.getStatus < 300)) {
         deleted = true
       } else if (
-        isUnfinishedTasksConflict(response.getStatus, response.getBody) &&
-        attempt <= unfinishedTasksRetries
+        attempt <= purgeWait.retries &&
+        isUnfinishedTasksConflict(response.getStatus, response.getBody)
       ) {
         Thread.sleep(delay)
-        delay = math.min(delay * 2, unfinishedTasksMaxDelayMillis)
+        delay = math.min(delay * 2, purgeWait.maxDelayMillis)
       } else {
         failOn(response.getStatus, response.getBody, "delete warehouse")
       }

--- a/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
@@ -73,6 +73,8 @@ class LakekeeperClientSpec
   private val racingWarehouseId = UUID.randomUUID()
   private val alwaysBusyWarehouseId = UUID.randomUUID()
   private val otherConflictWarehouseId = UUID.randomUUID()
+  private val malformedConflictWarehouseId = UUID.randomUUID()
+  @volatile private var malformedDeleteAttempts = 0
   @volatile private var racingDeleteAttempts = 0
   @volatile private var busyDeleteAttempts = 0
   private val unfinishedTasksBody =
@@ -94,6 +96,10 @@ class LakekeeperClientSpec
       } else if (isDelete && path.endsWith(alwaysBusyWarehouseId.toString)) {
         busyDeleteAttempts += 1
         respond(exchange, 409, unfinishedTasksBody)
+      } else if (isDelete && path.endsWith(malformedConflictWarehouseId.toString)) {
+        // A 409 whose body isn't the JSON envelope the type check reads.
+        malformedDeleteAttempts += 1
+        respond(exchange, 409, "<html>gateway conflict</html>")
       } else if (isDelete && path.endsWith(otherConflictWarehouseId.toString)) {
         respond(
           exchange,
@@ -162,6 +168,7 @@ class LakekeeperClientSpec
     lastCreateBody = ""
     racingDeleteAttempts = 0
     busyDeleteAttempts = 0
+    malformedDeleteAttempts = 0
   }
 
   override protected def afterAll(): Unit = server.stop(0)
@@ -223,6 +230,16 @@ class LakekeeperClientSpec
     error.getMessage should include("WarehouseHasUnfinishedTasks")
     // 1 initial attempt + 3 retries, then fail -- the wait is bounded.
     busyDeleteAttempts shouldBe 4
+  }
+
+  it should "fail immediately on a 409 whose body is not the expected JSON envelope" in {
+    // The type check parses the body; a malformed one must read as "not the
+    // purge conflict" and fail rather than be retried as if it were transient.
+    val error = intercept[RuntimeException] {
+      retryClient.deleteWarehouseEmptyFirst(malformedConflictWarehouseId)
+    }
+    error.getMessage should include("409")
+    malformedDeleteAttempts shouldBe 1
   }
 
   it should "fail immediately on a 409 that is not WarehouseHasUnfinishedTasks" in {

--- a/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
@@ -87,30 +87,27 @@ class LakekeeperClientSpec
     "/management/v1/warehouse",
     (exchange: HttpExchange) => {
       record(exchange)
-      if (exchange.getRequestMethod == "POST") {
-        lastCreateBody = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
-        respond(exchange, 201, s"""{"warehouse-id": "$warehouseId"}""")
-      } else if (exchange.getRequestMethod == "DELETE") {
-        val path = exchange.getRequestURI.getPath
-        if (path.endsWith(racingWarehouseId.toString)) {
+      (exchange.getRequestMethod, exchange.getRequestURI.getPath) match {
+        case ("POST", _) =>
+          lastCreateBody =
+            new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
+          respond(exchange, 201, s"""{"warehouse-id": "$warehouseId"}""")
+        case ("DELETE", path) if path.endsWith(racingWarehouseId.toString) =>
           if (deleteAttempts(racingWarehouseId) <= 2) respond(exchange, 409, unfinishedTasksBody)
           else respond(exchange, 204, "")
-        } else if (path.endsWith(alwaysBusyWarehouseId.toString)) {
+        case ("DELETE", path) if path.endsWith(alwaysBusyWarehouseId.toString) =>
           respond(exchange, 409, unfinishedTasksBody)
-        } else if (path.endsWith(malformedConflictWarehouseId.toString)) {
+        case ("DELETE", path) if path.endsWith(malformedConflictWarehouseId.toString) =>
           // A 409 whose body isn't the JSON envelope the type check reads.
           respond(exchange, 409, "<html>gateway conflict</html>")
-        } else if (path.endsWith(otherConflictWarehouseId.toString)) {
+        case ("DELETE", path) if path.endsWith(otherConflictWarehouseId.toString) =>
           respond(
             exchange,
             409,
             """{"error":{"message":"warehouse is in use","type":"Conflict","code":409}}"""
           )
-        } else {
+        case _ =>
           respond(exchange, 200, "{}")
-        }
-      } else {
-        respond(exchange, 200, "{}")
       }
     }
   )
@@ -154,15 +151,15 @@ class LakekeeperClientSpec
   )
   server.start()
 
-  private val client = new LakekeeperClient(
-    s"http://localhost:${server.getAddress.getPort}/catalog"
-  )
+  private val stubCatalogUri = s"http://localhost:${server.getAddress.getPort}/catalog"
 
-  // Zero retry delay keeps the spec free of real sleeps (deterministic); 3
-  // retries keeps the exhaustion case cheap to assert.
+  private val client = new LakekeeperClient(stubCatalogUri)
+
+  // Zero retry delay keeps the spec free of real sleeps (deterministic); 4
+  // attempts keeps the exhaustion case cheap to assert.
   private val retryClient = new LakekeeperClient(
-    s"http://localhost:${server.getAddress.getPort}/catalog",
-    PurgeWaitPolicy(retries = 3, initialDelayMillis = 0)
+    stubCatalogUri,
+    PurgeWaitPolicy(maxAttempts = 4, initialDelayMillis = 0)
   )
 
   override protected def beforeEach(): Unit = {
@@ -227,25 +224,26 @@ class LakekeeperClientSpec
     }
     error.getMessage should include("409")
     error.getMessage should include("WarehouseHasUnfinishedTasks")
-    // 1 initial attempt + 3 retries, then fail -- the wait is bounded.
     deleteAttempts(alwaysBusyWarehouseId) shouldBe 4
+  }
+
+  // Shared by the non-retryable-409 cases: the delete must fail on the first
+  // attempt, with the status surfaced, rather than be waited out as transient.
+  private def assertFailsWithoutRetry(id: UUID): Unit = {
+    val error = intercept[RuntimeException] {
+      retryClient.deleteWarehouseEmptyFirst(id)
+    }
+    error.getMessage should include("409")
+    deleteAttempts(id) shouldBe 1
   }
 
   it should "fail immediately on a 409 whose body is not the expected JSON envelope" in {
     // The type check parses the body; a malformed one must read as "not the
     // purge conflict" and fail rather than be retried as if it were transient.
-    val error = intercept[RuntimeException] {
-      retryClient.deleteWarehouseEmptyFirst(malformedConflictWarehouseId)
-    }
-    error.getMessage should include("409")
-    deleteAttempts(malformedConflictWarehouseId) shouldBe 1
+    assertFailsWithoutRetry(malformedConflictWarehouseId)
   }
 
   it should "fail immediately on a 409 that is not WarehouseHasUnfinishedTasks" in {
-    val error = intercept[RuntimeException] {
-      retryClient.deleteWarehouseEmptyFirst(otherConflictWarehouseId)
-    }
-    error.getMessage should include("409")
-    deleteAttempts(otherConflictWarehouseId) shouldBe 1
+    assertFailsWithoutRetry(otherConflictWarehouseId)
   }
 }

--- a/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
@@ -21,6 +21,7 @@ package org.apache.texera.web.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.sun.net.httpserver.{HttpExchange, HttpServer}
+import org.apache.texera.web.service.LakekeeperClient.PurgeWaitPolicy
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
@@ -57,6 +58,11 @@ class LakekeeperClientSpec
     line
   }
 
+  // How many warehouse deletes have reached the stub for this id, including the one
+  // being served: `record` logs every request before the handler dispatches on it.
+  private def deleteAttempts(id: UUID): Int =
+    requests.synchronized { requests.count(_ == s"DELETE /management/v1/warehouse/$id") }
+
   private def respond(exchange: HttpExchange, status: Int, body: String): Unit = {
     val bytes = body.getBytes(StandardCharsets.UTF_8)
     exchange.getResponseHeaders.add("Content-Type", "application/json")
@@ -74,9 +80,6 @@ class LakekeeperClientSpec
   private val alwaysBusyWarehouseId = UUID.randomUUID()
   private val otherConflictWarehouseId = UUID.randomUUID()
   private val malformedConflictWarehouseId = UUID.randomUUID()
-  @volatile private var malformedDeleteAttempts = 0
-  @volatile private var racingDeleteAttempts = 0
-  @volatile private var busyDeleteAttempts = 0
   private val unfinishedTasksBody =
     """{"error":{"message":"Warehouse has unfinished tasks. Cannot delete warehouse until all tasks are finished.","type":"WarehouseHasUnfinishedTasks","code":409}}"""
 
@@ -84,28 +87,28 @@ class LakekeeperClientSpec
     "/management/v1/warehouse",
     (exchange: HttpExchange) => {
       record(exchange)
-      val path = exchange.getRequestURI.getPath
-      val isDelete = exchange.getRequestMethod == "DELETE"
       if (exchange.getRequestMethod == "POST") {
         lastCreateBody = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
         respond(exchange, 201, s"""{"warehouse-id": "$warehouseId"}""")
-      } else if (isDelete && path.endsWith(racingWarehouseId.toString)) {
-        racingDeleteAttempts += 1
-        if (racingDeleteAttempts <= 2) respond(exchange, 409, unfinishedTasksBody)
-        else respond(exchange, 204, "")
-      } else if (isDelete && path.endsWith(alwaysBusyWarehouseId.toString)) {
-        busyDeleteAttempts += 1
-        respond(exchange, 409, unfinishedTasksBody)
-      } else if (isDelete && path.endsWith(malformedConflictWarehouseId.toString)) {
-        // A 409 whose body isn't the JSON envelope the type check reads.
-        malformedDeleteAttempts += 1
-        respond(exchange, 409, "<html>gateway conflict</html>")
-      } else if (isDelete && path.endsWith(otherConflictWarehouseId.toString)) {
-        respond(
-          exchange,
-          409,
-          """{"error":{"message":"warehouse is in use","type":"Conflict","code":409}}"""
-        )
+      } else if (exchange.getRequestMethod == "DELETE") {
+        val path = exchange.getRequestURI.getPath
+        if (path.endsWith(racingWarehouseId.toString)) {
+          if (deleteAttempts(racingWarehouseId) <= 2) respond(exchange, 409, unfinishedTasksBody)
+          else respond(exchange, 204, "")
+        } else if (path.endsWith(alwaysBusyWarehouseId.toString)) {
+          respond(exchange, 409, unfinishedTasksBody)
+        } else if (path.endsWith(malformedConflictWarehouseId.toString)) {
+          // A 409 whose body isn't the JSON envelope the type check reads.
+          respond(exchange, 409, "<html>gateway conflict</html>")
+        } else if (path.endsWith(otherConflictWarehouseId.toString)) {
+          respond(
+            exchange,
+            409,
+            """{"error":{"message":"warehouse is in use","type":"Conflict","code":409}}"""
+          )
+        } else {
+          respond(exchange, 200, "{}")
+        }
       } else {
         respond(exchange, 200, "{}")
       }
@@ -159,16 +162,12 @@ class LakekeeperClientSpec
   // retries keeps the exhaustion case cheap to assert.
   private val retryClient = new LakekeeperClient(
     s"http://localhost:${server.getAddress.getPort}/catalog",
-    unfinishedTasksRetries = 3,
-    unfinishedTasksInitialDelayMillis = 0
+    PurgeWaitPolicy(retries = 3, initialDelayMillis = 0)
   )
 
   override protected def beforeEach(): Unit = {
     requests.synchronized { requests.clear() }
     lastCreateBody = ""
-    racingDeleteAttempts = 0
-    busyDeleteAttempts = 0
-    malformedDeleteAttempts = 0
   }
 
   override protected def afterAll(): Unit = server.stop(0)
@@ -219,7 +218,7 @@ class LakekeeperClientSpec
     // warehouse delete with 409 WarehouseHasUnfinishedTasks twice before the
     // queue "drains" and it returns 204. The delete must ride that out.
     noException should be thrownBy retryClient.deleteWarehouseEmptyFirst(racingWarehouseId)
-    racingDeleteAttempts shouldBe 3
+    deleteAttempts(racingWarehouseId) shouldBe 3
   }
 
   it should "give up once the purge-wait retries are exhausted" in {
@@ -229,7 +228,7 @@ class LakekeeperClientSpec
     error.getMessage should include("409")
     error.getMessage should include("WarehouseHasUnfinishedTasks")
     // 1 initial attempt + 3 retries, then fail -- the wait is bounded.
-    busyDeleteAttempts shouldBe 4
+    deleteAttempts(alwaysBusyWarehouseId) shouldBe 4
   }
 
   it should "fail immediately on a 409 whose body is not the expected JSON envelope" in {
@@ -239,7 +238,7 @@ class LakekeeperClientSpec
       retryClient.deleteWarehouseEmptyFirst(malformedConflictWarehouseId)
     }
     error.getMessage should include("409")
-    malformedDeleteAttempts shouldBe 1
+    deleteAttempts(malformedConflictWarehouseId) shouldBe 1
   }
 
   it should "fail immediately on a 409 that is not WarehouseHasUnfinishedTasks" in {
@@ -247,9 +246,6 @@ class LakekeeperClientSpec
       retryClient.deleteWarehouseEmptyFirst(otherConflictWarehouseId)
     }
     error.getMessage should include("409")
-    val deletes = requests.synchronized {
-      requests.count(_ == s"DELETE /management/v1/warehouse/$otherConflictWarehouseId")
-    }
-    deletes shouldBe 1
+    deleteAttempts(otherConflictWarehouseId) shouldBe 1
   }
 }

--- a/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
@@ -65,13 +65,41 @@ class LakekeeperClientSpec
     exchange.close()
   }
 
+  // Lakekeeper purges dropped tables asynchronously (queue `tabular_purge`), and
+  // answers a warehouse delete with 409 WarehouseHasUnfinishedTasks while any
+  // purge task is pending (#7742). These stub warehouses model that queue:
+  // `racing` drains after two attempts, `alwaysBusy` never drains, and
+  // `otherConflict` 409s for an unrelated reason (which must NOT be retried).
+  private val racingWarehouseId = UUID.randomUUID()
+  private val alwaysBusyWarehouseId = UUID.randomUUID()
+  private val otherConflictWarehouseId = UUID.randomUUID()
+  @volatile private var racingDeleteAttempts = 0
+  @volatile private var busyDeleteAttempts = 0
+  private val unfinishedTasksBody =
+    """{"error":{"message":"Warehouse has unfinished tasks. Cannot delete warehouse until all tasks are finished.","type":"WarehouseHasUnfinishedTasks","code":409}}"""
+
   server.createContext(
     "/management/v1/warehouse",
     (exchange: HttpExchange) => {
       record(exchange)
+      val path = exchange.getRequestURI.getPath
+      val isDelete = exchange.getRequestMethod == "DELETE"
       if (exchange.getRequestMethod == "POST") {
         lastCreateBody = new String(exchange.getRequestBody.readAllBytes(), StandardCharsets.UTF_8)
         respond(exchange, 201, s"""{"warehouse-id": "$warehouseId"}""")
+      } else if (isDelete && path.endsWith(racingWarehouseId.toString)) {
+        racingDeleteAttempts += 1
+        if (racingDeleteAttempts <= 2) respond(exchange, 409, unfinishedTasksBody)
+        else respond(exchange, 204, "")
+      } else if (isDelete && path.endsWith(alwaysBusyWarehouseId.toString)) {
+        busyDeleteAttempts += 1
+        respond(exchange, 409, unfinishedTasksBody)
+      } else if (isDelete && path.endsWith(otherConflictWarehouseId.toString)) {
+        respond(
+          exchange,
+          409,
+          """{"error":{"message":"warehouse is in use","type":"Conflict","code":409}}"""
+        )
       } else {
         respond(exchange, 200, "{}")
       }
@@ -121,9 +149,19 @@ class LakekeeperClientSpec
     s"http://localhost:${server.getAddress.getPort}/catalog"
   )
 
+  // Zero retry delay keeps the spec free of real sleeps (deterministic); 3
+  // retries keeps the exhaustion case cheap to assert.
+  private val retryClient = new LakekeeperClient(
+    s"http://localhost:${server.getAddress.getPort}/catalog",
+    unfinishedTasksRetries = 3,
+    unfinishedTasksRetryDelayMillis = 0
+  )
+
   override protected def beforeEach(): Unit = {
     requests.synchronized { requests.clear() }
     lastCreateBody = ""
+    racingDeleteAttempts = 0
+    busyDeleteAttempts = 0
   }
 
   override protected def afterAll(): Unit = server.stop(0)
@@ -167,5 +205,34 @@ class LakekeeperClientSpec
     }
     error.getMessage should include("Lakekeeper")
     error.getMessage should include("500")
+  }
+
+  it should "wait out 409 WarehouseHasUnfinishedTasks from the asynchronous purge (#7742)" in {
+    // Lakekeeper purges dropped tables asynchronously; the stub answers the
+    // warehouse delete with 409 WarehouseHasUnfinishedTasks twice before the
+    // queue "drains" and it returns 204. The delete must ride that out.
+    noException should be thrownBy retryClient.deleteWarehouseEmptyFirst(racingWarehouseId)
+    racingDeleteAttempts shouldBe 3
+  }
+
+  it should "give up once the purge-wait retries are exhausted" in {
+    val error = intercept[RuntimeException] {
+      retryClient.deleteWarehouseEmptyFirst(alwaysBusyWarehouseId)
+    }
+    error.getMessage should include("409")
+    error.getMessage should include("WarehouseHasUnfinishedTasks")
+    // 1 initial attempt + 3 retries, then fail -- the wait is bounded.
+    busyDeleteAttempts shouldBe 4
+  }
+
+  it should "fail immediately on a 409 that is not WarehouseHasUnfinishedTasks" in {
+    val error = intercept[RuntimeException] {
+      retryClient.deleteWarehouseEmptyFirst(otherConflictWarehouseId)
+    }
+    error.getMessage should include("409")
+    val deletes = requests.synchronized {
+      requests.count(_ == s"DELETE /management/v1/warehouse/$otherConflictWarehouseId")
+    }
+    deletes shouldBe 1
   }
 }

--- a/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/LakekeeperClientSpec.scala
@@ -160,7 +160,7 @@ class LakekeeperClientSpec
   private val retryClient = new LakekeeperClient(
     s"http://localhost:${server.getAddress.getPort}/catalog",
     unfinishedTasksRetries = 3,
-    unfinishedTasksRetryDelayMillis = 0
+    unfinishedTasksInitialDelayMillis = 0
   )
 
   override protected def beforeEach(): Unit = {

--- a/common/util/src/main/scala/org/apache/texera/common/util/RetryUtil.scala
+++ b/common/util/src/main/scala/org/apache/texera/common/util/RetryUtil.scala
@@ -51,14 +51,17 @@ object RetryUtil {
   }
 
   /**
-    * Runs `operation`, retrying on failure with exponential backoff (the delay doubles after each
-    * failed attempt) until it succeeds or `maxAttempts` is reached. The final failure is wrapped
-    * with `description` and the last exception as its cause.
+    * Runs `operation`, retrying on failure with exponential backoff (the delay doubles after
+    * each failed attempt, capped at `maxDelayMillis`) until it succeeds or `maxAttempts` is
+    * reached. The final failure is wrapped with `description` and the last exception as its
+    * cause.
     *
-    * Only `NonFatal` failures are treated as transient, which is the same predicate the
-    * non-blocking sibling uses. Note that `NonFatal` admits non-fatal `Error`s -- `AssertionError`,
-    * `java.io.IOError`, `ServiceConfigurationError` -- so those are retried rather than propagated
-    * straight away. An `InterruptedException` -- raised by the operation or by the wait between
+    * Only `NonFatal` failures that `shouldRetry` accepts are treated as transient; a failure it
+    * rejects propagates immediately, unwrapped, spending no further attempts. The default accepts
+    * every `NonFatal` failure, which is the same predicate the non-blocking sibling uses. Note
+    * that `NonFatal` admits non-fatal `Error`s -- `AssertionError`, `java.io.IOError`,
+    * `ServiceConfigurationError` -- so those are retried rather than propagated straight away.
+    * An `InterruptedException` -- raised by the operation or by the wait between
     * attempts -- fails fast with the interrupt status restored, so a caller shutting the thread
     * down is never made to sit through the remaining backoff.
     *
@@ -70,6 +73,11 @@ object RetryUtil {
     *                           caller's own logger, so retries are attributed to the caller rather
     *                           than to this util.
     * @param sleep              how to wait; injectable so tests exercise the backoff without waiting.
+    * @param maxDelayMillis     cap on any single wait: the doubling stops growing there, and an
+    *                           initial delay above it is clamped down. Unbounded by default.
+    * @param shouldRetry        which failures are transient; the default retries every `NonFatal`
+    *                           one. A caller whose retry signal is response content rather than an
+    *                           exception type can throw a private marker and match it here.
     * @param operation          the work to run, re-evaluated on each attempt.
     * @tparam T whatever `operation` returns.
     * @return `operation`'s value from the first attempt that succeeds.
@@ -79,7 +87,9 @@ object RetryUtil {
       maxAttempts: Int,
       initialDelayMillis: Long,
       onRetry: RetryAttempt => Unit,
-      sleep: Long => Unit = Thread.sleep
+      sleep: Long => Unit = Thread.sleep,
+      maxDelayMillis: Long = Long.MaxValue,
+      shouldRetry: Throwable => Boolean = _ => true
   )(operation: => T): T = {
     // Restore the interrupt status and fail fast rather than retrying, whether the interrupt
     // arrives while running `operation` or while waiting between attempts.
@@ -93,8 +103,8 @@ object RetryUtil {
       val outcome: Either[Throwable, T] =
         try Right(operation)
         catch {
-          case ie: InterruptedException => failInterrupted(ie)
-          case NonFatal(cause)          => Left(cause)
+          case ie: InterruptedException              => failInterrupted(ie)
+          case NonFatal(cause) if shouldRetry(cause) => Left(cause)
         }
 
       outcome match {
@@ -109,10 +119,10 @@ object RetryUtil {
           onRetry(RetryAttempt(description, attempt, maxAttempts, delayMillis, cause))
           try sleep(delayMillis)
           catch { case ie: InterruptedException => failInterrupted(ie) }
-          attemptFrom(attempt + 1, delayMillis * 2)
+          attemptFrom(attempt + 1, math.min(delayMillis * 2, maxDelayMillis))
       }
     }
 
-    attemptFrom(attempt = 1, delayMillis = initialDelayMillis)
+    attemptFrom(attempt = 1, delayMillis = math.min(initialDelayMillis, maxDelayMillis))
   }
 }

--- a/common/util/src/test/scala/org/apache/texera/common/util/RetryUtilSpec.scala
+++ b/common/util/src/test/scala/org/apache/texera/common/util/RetryUtilSpec.scala
@@ -29,9 +29,9 @@ import scala.util.control.ControlThrowable
   * Contract of the shared blocking backoff retry. `sleep` is injected everywhere so the backoff
   * progression is asserted exactly without any test waiting.
   *
-  * Coverage is the full contract both blocking callers rely on: the doubling progression, which
-  * failures count as transient, the give-up wrapping, and interrupt fail-fast during the operation
-  * and during a backoff sleep.
+  * Coverage is the full contract the blocking callers rely on: the doubling progression and its
+  * cap, which failures count as transient (the `NonFatal` gate and the `shouldRetry` predicate),
+  * the give-up wrapping, and interrupt fail-fast during the operation and during a backoff sleep.
   */
 class RetryUtilSpec extends AnyFlatSpec {
 
@@ -202,5 +202,72 @@ class RetryUtilSpec extends AnyFlatSpec {
     assert(attempts == 3)
     assert(delays.toList == List(200L, 400L))
     assert(failure.getCause eq cause)
+  }
+
+  it should "stop the doubling at maxDelayMillis" in {
+    val delays = ListBuffer.empty[Long]
+    intercept[RuntimeException] {
+      RetryUtil.withBackoff("reach the store", 5, 200L, noopRetryHook, delays += _, 500L) {
+        throw new RuntimeException("down")
+      }
+    }
+    assert(delays.toList == List(200L, 400L, 500L, 500L))
+  }
+
+  it should "clamp an initial delay that already exceeds maxDelayMillis" in {
+    val delays = ListBuffer.empty[Long]
+    intercept[RuntimeException] {
+      RetryUtil.withBackoff("reach the store", 3, 800L, noopRetryHook, delays += _, 500L) {
+        throw new RuntimeException("down")
+      }
+    }
+    assert(delays.toList == List(500L, 500L))
+  }
+
+  it should "let a failure shouldRetry rejects through unwrapped, spending no further attempts" in {
+    val delays = ListBuffer.empty[Long]
+    var attempts = 0
+    val cause = new IllegalStateException("no such store")
+    val failure = intercept[IllegalStateException] {
+      RetryUtil.withBackoff(
+        "reach the store",
+        5,
+        200L,
+        noopRetryHook,
+        delays += _,
+        shouldRetry = _.getMessage == "transient"
+      ) {
+        attempts += 1
+        throw cause
+      }
+    }
+    assert(failure eq cause)
+    assert(attempts == 1)
+    assert(delays.isEmpty)
+  }
+
+  it should "retry accepted failures yet stop the moment a rejected one appears" in {
+    // A known transient signal is waited out, but any other failure mid-sequence is a real
+    // answer and must surface at once rather than be retried alongside it.
+    val delays = ListBuffer.empty[Long]
+    var attempts = 0
+    val terminal = new IllegalStateException("no such store")
+    val failure = intercept[IllegalStateException] {
+      RetryUtil.withBackoff(
+        "reach the store",
+        5,
+        200L,
+        noopRetryHook,
+        delays += _,
+        shouldRetry = _.getMessage == "transient"
+      ) {
+        attempts += 1
+        if (attempts < 3) throw new RuntimeException("transient")
+        throw terminal
+      }
+    }
+    assert(failure eq terminal)
+    assert(attempts == 3)
+    assert(delays.toList == List(200L, 400L))
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

`LakekeeperClient.deleteWarehouseEmptyFirst` empties the warehouse by dropping every table with `purgeRequested=true`, then immediately deletes the warehouse entity. Lakekeeper purges the dropped tables' **data files asynchronously** (task queue `tabular_purge`) and refuses to delete the warehouse while any purge is pending — the tasks need the warehouse's storage profile to reach S3, so deleting it first would orphan them and leak the files. It answers `409 WarehouseHasUnfinishedTasks` until the queue drains, so in practice the first delete of any warehouse that has ever stored execution results always failed; a retry seconds later succeeded (details in #7742).

- **Retry the final warehouse delete on exactly this conflict**: `409` with `error.type == "WarehouseHasUnfinishedTasks"` is treated as transient and retried with **exponential backoff** — 200ms doubling up to a 5s cap over 7 retries (0.2+0.4+0.8+1.6+3.2+5+5s ≈ 16s bound). A purge that drains almost immediately, the common case, costs the caller ~200ms rather than a full fixed interval; a genuinely slow one issues fewer requests than a fixed pause would. **Every other error — including any other 409, and a 409 whose body isn't the expected JSON envelope — still fails immediately**, and 404 stays the idempotent goal state.
- The bound and delays are constructor parameters with defaults, so production call sites are unchanged and the spec injects a zero initial delay — doubling zero stays zero, so the tests contain no real sleeps and stay deterministic.

Found while testing the flag-gated per-user warehouse feature (#6870); no deployment is affected because the flag defaults to off.

### Any related issues, documentation, discussions?

Closes #7742. Part of #6870; `deleteWarehouseEmptyFirst` introduced in #7473. Verified against the local Lakekeeper (0.11.0) that its management API exposes no task-query endpoint or force-delete option, so waiting out the documented conflict type is the only client-side path.

### How was this PR tested?

- `LakekeeperClientSpec` (in-process HTTP stub, no external infra) gains four cases mirroring the issue's repro: the stub answers the warehouse delete with `409 WarehouseHasUnfinishedTasks` twice and then 204 — **verified failing before the fix** (the first 409 threw) and passing after, with the stub asserting exactly 3 delete attempts; a warehouse whose queue never drains fails after the bounded 1+3 attempts; a 409 of any other type fails on the first attempt with no retry; and a 409 whose body is not JSON (a gateway error page) also fails on the first attempt rather than being waited out.
- Full spec run locally: 8/8 passed; `WorkflowExecutionService/scalafmtCheck` (main + Test) passes.
- The initial retry delay is injected as 0 in all tests — no real sleeps, deterministic across runs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-4-8)
