### PR TITLE
fix(test, frontend): stop the agent-panel tab test depending on nz-tabs click timing

### DIFF
--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.spec.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-panel.component.spec.ts
@@ -24,6 +24,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { By } from "@angular/platform-browser";
 import { CdkDrag, CdkDragHandle, CdkDragStart } from "@angular/cdk/drag-drop";
 import { NzResizableDirective } from "ng-zorro-antd/resizable";
+import { NzTabsComponent } from "ng-zorro-antd/tabs";
 import { NzModalService } from "ng-zorro-antd/modal";
 import { MarkdownModule } from "ngx-markdown";
 import { Observable, Subject, of, throwError } from "rxjs";
@@ -838,13 +839,26 @@ describe("AgentPanelComponent", () => {
       expect(fixture.nativeElement.querySelectorAll("texera-agent-registration .model-card").length).toBe(1);
     });
 
-    it("clicking an agent's tab header activates that agent and marks only its chat active", () => {
+    it("selecting an agent's tab activates that agent and marks only its chat active", () => {
       service.agentList = [makeAgent("a"), makeAgent("b")];
       createComponent();
       expect(chats().map(c => c.isActive)).toEqual([false, false]);
 
-      // Header 0 is the registration tab, so agent "b" sits behind header 2.
-      (tabHeaders()[2].querySelector(".ant-tabs-tab-btn") as HTMLElement).click();
+      // The tab has to be selectable for the rest of this to mean anything: were [nzDisabled]
+      // true, nz-tabs would swallow the selection and the assertions below would pass for the
+      // wrong reason. Header 0 is the registration tab, so agent "b" sits behind header 2.
+      expect(tabHeaders()[2].classList.contains("ant-tabs-tab-disabled")).toBe(false);
+
+      // Drive the output the template binds rather than clicking the header. nz-tabs emits
+      // nzSelectedIndexChange from its own change-detection pass, not from the click handler, so
+      // a header click is not guaranteed to have reached onTabSelectChange by the time
+      // detectChanges() returns -- it held locally but failed on CI with "Number of calls: 0",
+      // and fixture.whenStable() cannot be used to wait for it because the panel keeps a
+      // long-lived subscription open. Emitting the output still pins the
+      // (nzSelectedIndexChange)="onTabSelectChange($event)" binding: point it elsewhere or drop
+      // it and activateAgent is never called. Same idiom as the nzResize test above.
+      const tabSet = fixture.debugElement.query(By.directive(NzTabsComponent)).componentInstance as NzTabsComponent;
+      tabSet.nzSelectedIndexChange.emit(2);
       fixture.detectChanges();
 
       expect(service.activateAgent).toHaveBeenCalledWith("b");


### PR DESCRIPTION
### What changes were proposed in this PR?

`agent-panel.component.spec.ts`'s tab-selection test fails intermittently on CI with:

```
AssertionError: expected "vi.fn()" to be called with arguments: [ 'b' ]
Number of calls: 0
```

It has now failed on both `ubuntu-latest` and `windows-latest` while passing locally — including a clean local run of the full 201-file suite — so it is a timing dependency, not a real regression. It is currently red on unrelated PRs.

**Cause.** The test clicked the tab header and then called `fixture.detectChanges()` once:

```ts
(tabHeaders()[2].querySelector(".ant-tabs-tab-btn") as HTMLElement).click();
fixture.detectChanges();
expect(service.activateAgent).toHaveBeenCalledWith("b");
```

`nz-tabs` does not emit `nzSelectedIndexChange` from its click handler — it emits during its own change-detection pass. So a single `detectChanges()` is not guaranteed to have run `onTabSelectChange` yet. Locally one pass happened to catch it; on CI it did not, and `activateAgent` had not been called.

**Fix.** Drive the output the template binds, which is the same idiom the `nzResize` test a few cases above already uses:

```ts
const tabSet = fixture.debugElement.query(By.directive(NzTabsComponent)).componentInstance;
tabSet.nzSelectedIndexChange.emit(2);
fixture.detectChanges();
```

The DOM-level check that the tab is selectable is kept, so the case cannot pass for the wrong reason if `[nzDisabled]` ever inverts:

```ts
expect(tabHeaders()[2].classList.contains("ant-tabs-tab-disabled")).toBe(false);
```

`fixture.whenStable()` is **not** usable here: the panel keeps a long-lived subscription open, so awaiting stability hangs the test to its 20s timeout. That was tried first and is recorded in the comment so nobody repeats it.

### The fix is not vacuous

Emitting the output still pins the binding. Two mutations of the template, applied one at a time and reverted with the production diff verified empty:

| Mutation | Result | Failing test |
|---|---|---|
| delete the `(nzSelectedIndexChange)="onTabSelectChange($event)"` binding | **red**, 1 failed / 50 passed | `selecting an agent's tab activates that agent and marks only its chat active` |
| point the binding at `onTabSelectChange(0)` instead of `$event` | **red**, 1 failed / 50 passed | same test |

The test is renamed from "clicking an agent's tab header…" to "selecting an agent's tab…" so the name matches what it now does.

### Any related issues, documentation, discussions?

Closes #7755

### How was this PR tested?

```
npx ng test --watch=false --include="**/agent-panel.component.spec.ts"
```

```
 Test Files  1 passed (1)
      Tests  51 passed (51)
```

The full frontend suite is green: 201 files, 4731 passed, 1 skipped. `yarn format:ci` passes. No production file is touched.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
