### PR TITLE
chore(amber): remove the unused ReportCurrentProcessingTuple client event

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/coordinator/ClientEvent.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/coordinator/ClientEvent.scala
@@ -19,7 +19,6 @@
 
 package org.apache.texera.amber.engine.architecture.coordinator
 
-import org.apache.texera.amber.core.tuple.Tuple
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
 import org.apache.texera.amber.core.workflow.GlobalPortIdentity
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
@@ -41,11 +40,6 @@ case class ExecutionStatsUpdate(operatorMetrics: Map[String, OperatorMetrics]) e
 
 case class RuntimeStatisticsPersist(operatorMetrics: Map[String, OperatorMetrics])
     extends ClientEvent
-
-case class ReportCurrentProcessingTuple(
-    operatorID: String,
-    tuple: Array[(Tuple, ActorVirtualIdentity)]
-) extends ClientEvent
 
 case class WorkerAssignmentUpdate(workerMapping: Map[String, Seq[String]]) extends ClientEvent
 

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/coordinator/ClientEventSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/coordinator/ClientEventSpec.scala
@@ -22,7 +22,6 @@ package org.apache.texera.amber.engine.architecture.coordinator
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.serialization.{Serialization, SerializationExtension}
 import org.apache.pekko.testkit.TestKit
-import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema, Tuple}
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import org.apache.texera.amber.engine.common.AmberRuntime
@@ -120,41 +119,6 @@ class ClientEventSpec extends AnyFlatSpec with BeforeAndAfterAll {
     val original = RuntimeStatisticsPersist(Map("op-1" -> OperatorMetrics.defaultInstance))
     val restored = roundTrip(original)
     assert(restored == original)
-  }
-
-  // Build a tiny Tuple fixture for the ReportCurrentProcessingTuple
-  // round-trip — a real (Tuple, AVI) pair (not the empty-array degenerate
-  // case) so the serializer is actually exercised on the inner elements.
-  private val intAttr = new Attribute("v", AttributeType.INTEGER)
-  private val schema: Schema = Schema().add(intAttr)
-  private def intTuple(value: Int): Tuple =
-    Tuple.builder(schema).add(intAttr, Integer.valueOf(value)).build()
-
-  "ReportCurrentProcessingTuple" should "round-trip a single (Tuple, AVI) element through AmberRuntime.serde" in {
-    // Pin the actual element-survival contract: build a non-empty array,
-    // round-trip, and verify the recovered Tuple's schema + field values
-    // and the AVI both survive. (Case-class equality on Array is
-    // reference-based, so element-wise verification is the right pin.)
-    val sender = ActorVirtualIdentity("worker-1")
-    val arr: Array[(Tuple, ActorVirtualIdentity)] = Array((intTuple(42), sender))
-    val original = ReportCurrentProcessingTuple("op-x", arr)
-    assert(original.operatorID == "op-x")
-    assert(original.tuple.length == 1)
-    val restored = roundTrip(original)
-    assert(restored.operatorID == "op-x")
-    assert(restored.tuple.length == 1)
-    val (restoredTuple, restoredAvi) = restored.tuple.head
-    assert(restoredTuple == intTuple(42))
-    assert(restoredAvi == sender)
-  }
-
-  it should "round-trip an empty tuple array" in {
-    // Empty-array edge case: pin that the serializer doesn't choke on
-    // an empty Array[(Tuple, AVI)] and that operatorID still survives.
-    val original = ReportCurrentProcessingTuple("op-empty", Array.empty)
-    val restored = roundTrip(original)
-    assert(restored.operatorID == "op-empty")
-    assert(restored.tuple.isEmpty)
   }
 
   "WorkerAssignmentUpdate" should "expose its workerMapping field and round-trip" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Deletes the `ReportCurrentProcessingTuple` client event, which has neither a producer nor a consumer. Pure deletion, no behaviour change: **−42 lines**.

Both sides of the channel were enumerated on current `main`:

| Side | What exists | Includes this type? |
| --- | --- | --- |
| Producers | every `sendToClient(...)` argument in `amber/src/main` — `ExecutionStateUpdate`, `ExecutionStatsUpdate`, `FatalError`, `OperatorPortResultUriAvailable`, `RuntimeStatisticsPersist`, `UpdateExecutorCompleted`, `WorkerAssignmentUpdate`, `ConsoleMessage`, `EmptyReturn` | no |
| Consumers | every `registerCallback[T]` — `ConsoleMessage`, `ExecutionStateUpdate`, `ExecutionStatsUpdate`, `FatalError`, `OperatorPortResultUriAvailable`, `RuntimeStatisticsPersist`, `UpdateExecutorCompleted`, `WorkerAssignmentUpdate`, `WorkflowRecoveryStatus` | no |

`ClientActor` dispatches `ClientEvent`s through those `ClassTag`-keyed callbacks, so nothing can construct this event and nothing would receive it if something did.

Removing it also frees the `core.tuple.Tuple` import in `ClientEvent.scala` — no other event in that file uses it. The `ClientEvent` trait and its nine live subtypes are untouched.

> Reviewer note: the two round-trip serde tests it had came from the 2026 coverage work, which is why it currently looks live. They cover this event and nothing else, so they go with it; the spec's other 15 tests are unchanged and still pass.

### History

| | |
| --- | --- |
| **Introduced by** | the initial amber import (2020-08-20); the declaration was then **re-added** by #2950 (2024-10-31), "Migrate scala control messages to protobuf" |
| **Usage removed by** | #2970 (2024-10-25) — "Remove unused RPCs and disable reconfiguration" deleted the producer **and** the case class, at which point the name existed nowhere in the repo |

The two PRs were in flight together, so #2950 brought the declaration back six days later without the producer that used it. #5440 (2026-06-06) then gave the orphan round-trip serde tests, which is why it looks live.

### Any related issues, documentation, discussions?

Closes #7778

### How was this PR tested?

Existing tests only — this PR adds none, since it removes code and the tests that covered it.

Locally, from the repo root with Java 17:

- `sbt "WorkflowExecutionService/Test/compile"` — success.
- `sbt "WorkflowExecutionService/testOnly *ClientEventSpec"` — 15 tests, all pass.
- `sbt scalafmtCheckAll "scalafixAll --check"` — clean (this PR edits surviving files, so the unused-import gate matters).

Verification, re-runnable by a reviewer:

```
git grep -n ReportCurrentProcessingTuple    # only the deleted declaration and its tests
git grep -ho 'registerCallback\[[A-Za-z]*\]' -- amber/src/main | sort -u   # no registration for it
```

> CI note: build jobs may fail repo-wide at workflow startup while the injected `carabiner-dev/actions/install/ampel` action is off the ASF allowlist — `main` fails identically. Same class as #6989 and #7572, unrelated to this change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)


