### PR TITLE
chore(amber): remove the unused ClosureRequest from ClientActor

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/common/client/ClientActor.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/common/client/ClientActor.scala
@@ -53,7 +53,6 @@ import org.apache.texera.amber.engine.common.ambermessage.{
   WorkflowRecoveryMessage
 }
 import org.apache.texera.amber.engine.common.client.ClientActor.{
-  ClosureRequest,
   CommandRequest,
   InitializeRequest,
   ObservableRequest
@@ -73,8 +72,6 @@ private[client] object ClientActor {
   )
 
   case class ObservableRequest(pf: PartialFunction[Any, Unit])
-
-  case class ClosureRequest[T](closure: () => T)
 
   case class CommandRequest(
       methodName: String,
@@ -109,13 +106,6 @@ private[client] class ClientActor extends Actor with AmberLogging {
       sender() ! Ack
     case CreditRequest(channelId: ChannelIdentity) =>
       sender() ! CreditResponse(channelId, getQueuedCredit(channelId))
-    case ClosureRequest(closure) =>
-      try {
-        sender() ! closure()
-      } catch {
-        case e: Throwable =>
-          sender() ! e
-      }
     case commandRequest: CommandRequest =>
       coordinator ! AsyncRPCClient.ControlInvocation(
         commandRequest.methodName,

--- a/amber/src/test/scala/org/apache/texera/amber/engine/common/client/ClientActorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/common/client/ClientActorSpec.scala
@@ -44,7 +44,6 @@ import org.apache.texera.amber.engine.common.ambermessage.{
   WorkflowFIFOMessage,
   WorkflowRecoveryMessage
 }
-import org.apache.texera.amber.engine.common.client.ClientActor.ClosureRequest
 import org.apache.texera.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import org.apache.texera.amber.engine.common.virtualidentity.util.{CLIENT, COORDINATOR}
 import org.scalatest.BeforeAndAfterAll
@@ -53,7 +52,7 @@ import org.scalatest.matchers.should.Matchers
 
 // This spec lives in `...engine.common.client` on purpose: `ClientActor`, its
 // companion, and their members are `private[client]`, so a spec in any other
-// package could not construct the actor or reference `ClosureRequest`.
+// package could not construct the actor or reference its members.
 class ClientActorSpec
     extends TestKit(ActorSystem("ClientActorSpec"))
     with ImplicitSender
@@ -81,21 +80,6 @@ class ClientActorSpec
     // The client never queues credits, so getQueuedCredit is hard-coded to 0.
     ref ! CreditRequest(channelId)
     expectMsg(CreditResponse(channelId, 0L))
-  }
-
-  it should "reply with the closure's result on a successful ClosureRequest" in {
-    val ref = newClientActor()
-
-    ref ! ClosureRequest(() => 42)
-    expectMsg(42)
-  }
-
-  it should "reply with the thrown exception on a failing ClosureRequest" in {
-    val ref = newClientActor()
-
-    ref ! ClosureRequest(() => throw new RuntimeException("boom"))
-    val e = expectMsgType[RuntimeException]
-    e.getMessage shouldBe "boom"
   }
 
   it should "ack the sender and forward to coordinator on WorkflowRecoveryMessage" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Deletes `ClientActor.ClosureRequest` and its unreachable `receive` arm. Pure deletion, no behaviour change: **−27 lines**.

`AmberClient` is the only thing that messages `ClientActor`, and it sends exactly two things — `PoisonPill` on shutdown and `CommandRequest` for RPC calls. A repo-wide search for `ClosureRequest` returns only the companion-object declaration, the import pulling it into `ClientActor`, its `receive` arm, and two tests. Nothing sends it, so the arm never runs:

```scala
case ClosureRequest(closure) =>          // unreachable
  try   sender() ! closure()
  catch { case e: Throwable => sender() ! e }
```

It was a run-arbitrary-closure-on-the-actor-thread escape hatch that the engine no longer uses.

> Reviewer note: the spec's header comment explaining why it lives in `...engine.common.client` — the members are `private[client]`, so no other package could construct the actor — is kept and reworded to drop the `ClosureRequest` mention, since the rationale still holds for `ClientActor` itself. That is the one added line in this diff. `InitializeRequest`, `CommandRequest` and `ObservableRequest` are untouched.

### History

| | |
| --- | --- |
| **Introduced by** | #1351 (2021-10-27) — "Detach workflow execution from frontend with reconnection support" |
| **Usage removed by** | #2950 (2024-10-31) — "Migrate scala control messages to protobuf" replaced the path and removed the only sender, `Await.result(clientActor ? ClosureRequest(...), ...)` |

Dead for about two years.

### Any related issues, documentation, discussions?

Closes #7779

### How was this PR tested?

Existing tests only — this PR adds none, since it removes code and the tests that covered it.

Locally, from the repo root with Java 17:

- `sbt "WorkflowExecutionService/Test/compile"` — success.
- `sbt "WorkflowExecutionService/testOnly *ClientActorSpec"` — 4 tests, all pass.
- `sbt scalafmtCheckAll "scalafixAll --check"` — clean (this PR edits surviving files, so the unused-import gate matters).

Verification, re-runnable by a reviewer:

```
git grep -n ClosureRequest      # only the deleted declaration, arm, import and tests
git grep -n 'clientActor !'     # AmberClient sends only PoisonPill and CommandRequest
```

> CI note: build jobs may fail repo-wide at workflow startup while the injected `carabiner-dev/actions/install/ampel` action is off the ASF allowlist — `main` fails identically. Same class as #6989 and #7572, unrelated to this change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)


