### PR TITLE
refactor(amber): remove dead members and unreachable guards

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/common/PekkoActorService.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/common/PekkoActorService.scala
@@ -21,18 +21,15 @@ package org.apache.texera.amber.engine.architecture.common
 
 import org.apache.pekko
 import pekko.actor.{ActorContext, ActorRef, Address, Cancellable, Props}
-import pekko.util.Timeout
 import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
-import org.apache.texera.amber.engine.common.FutureBijection._
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.FiniteDuration
 
 class PekkoActorService(val id: ActorVirtualIdentity, actorContext: ActorContext) {
 
   implicit def ec: ExecutionContext = actorContext.dispatcher
 
-  implicit val timeout: Timeout = 5.seconds
   implicit val self: ActorRef = actorContext.self
 
   def parent: ActorRef = actorContext.parent
@@ -61,10 +58,6 @@ class PekkoActorService(val id: ActorVirtualIdentity, actorContext: ActorContext
     actorContext.system.scheduler.scheduleWithFixedDelay(initialDelay, delay)(() => callable())
   }
 
-  def sendToSelfOnce(delay: FiniteDuration, msg: Any): Cancellable = {
-    actorContext.system.scheduler.scheduleOnce(delay, actorContext.self, msg)
-  }
-
   def sendToSelfWithFixedDelay(
       initialDelay: FiniteDuration,
       delay: FiniteDuration,
@@ -76,10 +69,6 @@ class PekkoActorService(val id: ActorVirtualIdentity, actorContext: ActorContext
       actorContext.self,
       msg
     )
-  }
-
-  def ask(ref: ActorRef, message: Any): com.twitter.util.Future[Any] = {
-    pekko.pattern.ask(ref, message).asTwitter()
   }
 
 }

--- a/amber/src/main/scala/org/apache/texera/amber/engine/common/rpc/AsyncRPCClient.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/common/rpc/AsyncRPCClient.scala
@@ -69,7 +69,6 @@ import scala.reflect.ClassTag
   */
 object AsyncRPCClient {
 
-  final val IgnoreReply = -1
   final val IgnoreReplyAndDoNotLog = -2
 
   object ControlInvocation {

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/quota/UserQuotaResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/quota/UserQuotaResource.scala
@@ -132,7 +132,7 @@ object UserQuotaResource {
       .orderBy(WORKFLOW_EXECUTIONS.EID.desc)
       .fetch()
 
-    if (executions == null || executions.isEmpty) {
+    if (executions.isEmpty) {
       return Array.empty
     }
 

--- a/amber/src/main/scala/org/apache/texera/web/service/ExecutionResultService.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/ExecutionResultService.scala
@@ -260,11 +260,6 @@ object ExecutionResultService {
           case SetDeltaMode() =>
             val deltaList = storage.getAfter(oldTupleCount).toList
             tuplesToWebData(webOutputMode, deltaList)
-
-          case _ =>
-            throw new RuntimeException(
-              "update mode combination not supported: " + (webOutputMode, outputMode)
-            )
         }
         webUpdate
       case None =>

--- a/amber/src/main/scala/org/apache/texera/web/service/ResultExportService.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/ResultExportService.scala
@@ -134,9 +134,6 @@ class ResultExportService(workflowIdentity: WorkflowIdentity, computingUnitId: I
   def exportToLocal(request: ResultExportRequest): Response = {
     if (request.operators.size > 1) {
       val (zipStream, zipFileNameOpt) = exportOperatorsAsZip(request)
-      if (zipStream == null) {
-        throw new RuntimeException("Zip stream is null")
-      }
       val fileName = zipFileNameOpt.getOrElse("operators.zip")
 
       Response

--- a/amber/src/main/scala/org/apache/texera/web/service/WorkflowService.scala
+++ b/amber/src/main/scala/org/apache/texera/web/service/WorkflowService.scala
@@ -38,10 +38,7 @@ import org.apache.texera.amber.core.workflow.WorkflowContext
 import org.apache.texera.amber.core.workflowruntimestate.FatalErrorType.EXECUTION_FAILURE
 import org.apache.texera.amber.core.workflowruntimestate.WorkflowFatalError
 import org.apache.texera.amber.engine.architecture.coordinator.CoordinatorConfig
-import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
-  COMPLETED,
-  FAILED
-}
+import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.FAILED
 import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.{
   FaultToleranceConfig,
   StateRestoreConfig
@@ -59,7 +56,6 @@ import org.apache.texera.web.service.WorkflowService.mkWorkflowStateId
 import org.apache.texera.web.storage.ExecutionStateStore.updateWorkflowState
 import org.apache.texera.web.storage.{ExecutionStateStore, WorkflowStateStore}
 import org.apache.texera.web.{SubscriptionManager, WorkflowLifecycleManager}
-import org.apache.texera.common.compiler.model.LogicalPlan
 import play.api.libs.json.Json
 
 import java.net.URI
@@ -159,22 +155,6 @@ class WorkflowService(
       unsubscribeAll()
     }
   )
-
-  var lastCompletedLogicalPlan: Option[LogicalPlan] = Option.empty
-
-  executionService.subscribe { executionService: WorkflowExecutionService =>
-    {
-      executionService.executionStateStore.metadataStore.registerDiffHandler {
-        (oldState, newState) =>
-          {
-            if (oldState.state != COMPLETED && newState.state == COMPLETED) {
-              lastCompletedLogicalPlan = Option.apply(executionService.workflow.logicalPlan)
-            }
-            Iterable.empty
-          }
-      }
-    }
-  }
 
   def connect(onNext: TexeraWebSocketEvent => Unit): Disposable = {
     lifeCycleManager.increaseUserCount()

--- a/amber/src/test/scala/org/apache/texera/web/service/WorkflowServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/service/WorkflowServiceSpec.scala
@@ -144,12 +144,6 @@ import scala.collection.mutable.ArrayBuffer
   *   - the fault-tolerance block of `initExecutionService`, gated on
   *     `ApplicationConfig.faultToleranceLogRootFolder`: a `val` on a Scala `object` with no
   *     override seam, read at class-initialization time in a JVM shared with every other suite.
-  *   - `lastCompletedLogicalPlan` and the constructor's `executionService.subscribe` block that
-  *     maintains it. Nothing in the repository ever reads that field, so a test could only assert
-  *     which plan a write-only var holds — cementing code that should be deleted instead. Worth
-  *     knowing if it ever acquires a reader: the completion diff handler runs only while something
-  *     consumes the metadata store's websocket-event stream, so the snapshot silently does not
-  *     happen when no client is connected.
   *   - `resolveLakekeeperWarehouseName`, owned by `WorkflowServiceWarehouseSpec`.
   */
 class WorkflowServiceSpec


### PR DESCRIPTION
### What changes were proposed in this PR?

Removes eight unreachable or unused regions in amber. **49 lines deleted, 3 inserted** across 7 files. Every claim was verified by grep across all file types, including the Python side and `.proto` files where an RPC constant could plausibly be mirrored.

| Removed | Evidence |
|---|---|
| `PekkoActorService.sendToSelfOnce`, `ask` | zero call sites; `ask`'s only other hit is the `pekko.pattern.ask` inside its own body |
| `PekkoActorService`'s `implicit val timeout` | existed only to supply `pekko.pattern.ask`; with `ask` gone no member of the class or of its three subclasses takes an implicit `Timeout`, and nothing outside resolves one from here — the two surviving ask-pattern sites declare their own (`WorkflowActor.scala:90`, `AmberClient.scala:61`). Frees the `Timeout` import and `DurationInt` |
| `AsyncRPCClient.IgnoreReply = -1` | unreferenced; every other hit is the distinct `IgnoreReplyAndDoNotLog = -2` |
| `ExecutionResultService`'s `case _ => throw` | `WebOutputMode` is `sealed abstract` with exactly three `final case class` subtypes, all matched above |
| `UserQuotaResource`'s `executions == null` | jOOQ `fetch()` returns a non-null `Result`; simplified to `isEmpty` |
| `ResultExportService`'s `zipStream == null` | `exportOperatorsAsZip` either throws or returns a `new StreamingOutput { … }` literal |
| `WorkflowService.lastCompletedLogicalPlan` | write-only var: declaration, one write, zero readers |

### Checks that changed the outcome

**Subclasses, not just call sites.** Three test classes extend `PekkoActorService`, so a plain call-site grep would not have been enough. They override three members between them — `parent` (`PekkoActorRefMappingServiceSpec.scala:229`), `scheduleWithFixedDelay` (`PekkoMessageTransferServiceSpec.scala:209`) and `sendToSelfWithFixedDelay` (`CoordinatorTimerServiceSpec.scala:420`) — none of them a removed member, and no subclass body needs an implicit `Timeout` either.

**The Python side and the proto.** `IgnoreReply` could have been mirrored in the Python worker or as a proto sentinel. It is not: `grep -rni "ignore_reply|ignorereply|do_not_log"` over `amber/src/main/python` and `src/test/python` returns nothing, and `commandId` is a plain `int64` field in `controlcommands.proto` / `controlreturns.proto` with no named sentinel.

Python does still build `ControlInvocation`s with a literal `-1` commandId — `main_loop.py:752`, `start_worker_handler.py:71` and `:91`, `backpressure_handler.py:57` — but it has never referenced the Scala constant, and neither language compares against the value. Both servers gate the reply on the **sign**: `noReplyNeeded(id) = id < 0` (`AsyncRPCServer.scala:113`) and `_no_reply_needed(command_id) = command_id < 0` (`async_rpc_server.py:153`). Deleting the unreferenced Scala name therefore changes no dispatch decision on either side.

**Exhaustivity was confirmed by the compiler, not by reading.** Removing the `case _` arm produced **no** `match may not be exhaustive` warning, and the total warning count is unchanged from the pre-edit baseline (8 test-compile warnings before and after, all pre-existing and in unrelated files).

**The sibling guard is genuinely live.** `ResultExportService` has a second `== null` guard on the adjacent path; `exportOperatorResultAsStream` really can return null, and two `ResultExportServiceSpec` tests assert the error it raises. That one is untouched.

### One judgement call worth reviewing

For `lastCompletedLogicalPlan` I removed the whole enclosing `executionService.subscribe { … registerDiffHandler { … } }` block rather than only the assignment. With the write gone the handler body reduces to `Iterable.empty`, and `StateStore.registerDiffHandler` **appends** to `diffHandlers` rather than replacing, so dropping a handler that emits nothing is behaviour-preserving. It also disposes of a `Disposable` that was previously being discarded. `WorkflowServiceSpec`'s own doc-comment described the var "and the constructor's `executionService.subscribe` block that maintains it" as one unit that "should be deleted instead", so this follows the documented intent — but it is the one change here that is more than a strict deletion, so it deserves a look.

Orphaned imports were removed with each deletion (`FutureBijection._`, `COMPLETED`, `LogicalPlan`), since amber sets `-Ywarn-unused:imports`.

### No tests were removed

No spec exercised any deleted member. One stale 6-line "Deliberately not covered" comment in `WorkflowServiceSpec` documented code that no longer exists, so it is gone; the tests around it are untouched.

### Verification

- `WorkflowExecutionService/Test/compile` succeeds with the warning count identical to baseline — no new exhaustivity or unused-import warnings.
- The 10 affected suites run green: **Suites completed 10, aborted 0; Tests succeeded 153, failed 0.** Re-verified independently at 6 suites / 119 tests.
- `scalafmtCheck` (276 sources), `Test/scalafmtCheck` (202 sources) and `scalafixAll --check` across the whole build all pass.
- Residual-reference greps for every removed symbol come back empty.
- **Rebased onto `57a4230`**, which took one scaladoc line that #7754 had renamed (`resolveWarehouseName` → `resolveLakekeeperWarehouseName`); the rest of the patch merged unchanged.
- **After adding the `implicit val timeout` removal**: `compile`, `Test/compile`, both `scalafmtCheck`s and `scalafixAll --check` pass — the compiler is the real check here, since anything that had been resolving that implicit would now fail to build. Eleven suites run, including `WorkflowActorSpec`, which exercises the one production ask-pattern site: **169 succeeded, 18 failed**. All 18 failures are `ExecutionResultServiceSpec` (11) and `ResultExportServiceSpec` (7) raising `NotFoundException: Failed to open input stream` on a relative local-filesystem Iceberg path, and the same eleven suites on plain `57a4230` give the identical set — 169/18, test for test.

### Deliberately left alone

Two nearby findings are behavioural questions rather than cleanups, and are **not** touched here:

- **`WorkerTimerService.resumeAdaptiveBatching` is a permanent no-op.** `pauseAdaptiveBatching` has no call sites, and `isPaused` is only ever set `true` inside it — so the live `resumeAdaptiveBatching` (called from `ResumeHandler.scala:44`) resumes from a state nothing can enter. Whether pause was meant to be wired into `PauseHandler` needs a maintainer's call.
- **`WorkflowExecution.getState`'s `READY` arm is unreachable**, because `ExecutionUtils.aggregateStates` folds its all-ready case into `RUNNING` and never returns `READY`. Whether that aggregation is intended is likewise not a cleanup decision.

### History

Where each removal came from, whether it was ever reachable, and which PR removed the usage:

| Removed | Introduced by | Ever reachable? | Usage removed by |
|---|---|---|---|
| `PekkoActorService.sendToSelfOnce` | #2208 (2023-11-15) | yes — one `actorService.sendToSelfOnce(...)` call site | #2344 (2024-02-03, "Remove TimeInterleaved scheduling policy") deleted that caller along with the policy that used the timer |
| `PekkoActorService.ask` | #2208 (2023-11-15) | **never** — no file has referenced it at any point in the history | dead on arrival |
| `PekkoActorService`'s `implicit val timeout` | #2208 (2023-11-15) | **never** — same commit as `ask` (`2f89af4ad5`), and its only reader was ever the `pekko.pattern.ask` inside `ask`'s body | dead on arrival, with `ask` |
| `AsyncRPCClient.IgnoreReply` | #1000 (2021-01-30) | yes — `ControlInvocation(AsyncRPCClient.IgnoreReply, ...)` | #2271 (2024-01-18, "Integrating Interaction marker propagation into Amber") removed the last use |
| `ExecutionResultService`'s `case _ => throw` | #1213 (2021-07-05) | **never** — the same PR introduced `WebOutputMode` with exactly three subtypes, and no commit since has touched `extends WebOutputMode` | unreachable from the day it was written |
| `UserQuotaResource`'s `executions == null` | #3402 (2025-05-06) | **never** — jOOQ's `fetch()` has always returned a non-null `Result` | unreachable from birth |
| `ResultExportService`'s `zipStream == null` | #3241 (2025-03-04) | **never** | unreachable from birth |
| `WorkflowService.lastCompletedLogicalPlan` | #2154 (2023-09-25, "Add back operator caching feature") | yes — it was read and passed onward | #3306 (2025-03-07, "Move Email Notification Logic to ExecutionRuntimeService") removed the last reader, leaving the var write-only |

Two patterns worth naming. **Five of the eight were never reachable.** Three are the guards — defensive branches written against invariants that already held, not code that rotted. The other two are `ask` and the `implicit val timeout` that existed only to type it: both arrived dead in #2208 and stayed that way for two years and nine months. **The remaining three were genuinely live**, and each has a specific PR that orphaned it, the oldest (`IgnoreReply`) having been dead for about two and a half years.

### Any related issues, documentation, discussions?

Closes #7784

### How was this PR tested?

```
STORAGE_ICEBERG_CATALOG_TYPE=postgres sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.architecture.common.PekkoActorRefMappingServiceSpec org.apache.texera.amber.engine.common.rpc.AsyncRPCClientSpec org.apache.texera.web.service.ExecutionResultServiceSpec org.apache.texera.web.resource.dashboard.user.quota.UserQuotaResourceSpec org.apache.texera.web.service.ResultExportServiceSpec org.apache.texera.web.service.WorkflowServiceSpec"
```

```
[info] Suites: completed 6, aborted 0
[info] Tests: succeeded 119, failed 0, canceled 0, ignored 0, pending 0
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)





