### PR TITLE
fix(k8s): make the Helm chart work under any release name

### DIFF
--- a/bin/k8s/Chart.lock
+++ b/bin/k8s/Chart.lock
@@ -1,0 +1,21 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 16.5.6
+- name: minio
+  repository: https://charts.bitnami.com/bitnami
+  version: 15.0.7
+- name: lakefs
+  repository: https://charts.lakefs.io
+  version: 1.8.1
+- name: gateway-helm
+  repository: oci://docker.io/envoyproxy
+  version: 1.6.3
+- name: lakekeeper
+  repository: https://lakekeeper.github.io/lakekeeper-charts/
+  version: 0.9.0
+- name: metrics-server
+  repository: https://kubernetes-sigs.github.io/metrics-server/
+  version: 3.12.2
+digest: sha256:6e6c03812902f93980b70506fad66e9b3182d2adeaafaa4eace46f3170bdbe00
+generated: "2026-08-19T12:19:20.413392713-07:00"

--- a/bin/k8s/templates/aws/s3-credentials-secret.yaml
+++ b/bin/k8s/templates/aws/s3-credentials-secret.yaml
@@ -23,7 +23,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-s3-credentials
+  name: texera-s3-credentials
   namespace: {{ .Release.Namespace }}
 type: Opaque
 stringData:

--- a/bin/k8s/templates/base/_helpers.tpl
+++ b/bin/k8s/templates/base/_helpers.tpl
@@ -18,13 +18,32 @@ under the License.
 */}}
 
 {{/*
+Sub-chart resource names.
+
+The postgresql and minio sub-charts are pinned to fixed names via
+fullnameOverride in values.yaml, because sibling sub-charts (lakefs,
+lakekeeper) must address them from *their own* values -- and Helm does not
+template values files, so those references cannot be release-derived. These
+helpers resolve the same name the sub-chart itself computes, falling back to
+the default "<release>-<chart>" when the override is cleared.
+*/}}
+
+{{- define "texera.postgresql.fullname" -}}
+{{- .Values.postgresql.fullnameOverride | default (printf "%s-postgresql" .Release.Name) -}}
+{{- end -}}
+
+{{- define "texera.minio.fullname" -}}
+{{- .Values.minio.fullnameOverride | default (printf "%s-minio" .Release.Name) -}}
+{{- end -}}
+
+{{/*
 Object-storage (S3) resolution helpers.
 
 When storage.s3.endpoint is set the services talk to that external
-S3-compatible store (credentials come from storage.s3.existingSecret, or a
-chart-generated "<release>-s3-credentials" Secret). When it is empty the
-services fall back to the in-cluster MinIO Service and its auto-generated
-"<release>-minio" Secret, so the default install is unchanged.
+S3-compatible store (credentials come from storage.s3.existingSecret, or the
+chart-generated "texera-s3-credentials" Secret). When it is empty the services
+fall back to the in-cluster MinIO Service and its auto-generated Secret, so the
+default install is unchanged.
 */}}
 
 {{/* S3 endpoint URL. */}}
@@ -32,16 +51,16 @@ services fall back to the in-cluster MinIO Service and its auto-generated
 {{- if .Values.storage.s3.endpoint -}}
 {{- .Values.storage.s3.endpoint -}}
 {{- else -}}
-{{- printf "http://%s-minio:9000" .Release.Name -}}
+{{- printf "http://%s:9000" (include "texera.minio.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
 {{/* Name of the Secret holding the S3 credentials. */}}
 {{- define "texera.s3.secretName" -}}
 {{- if .Values.storage.s3.endpoint -}}
-{{- .Values.storage.s3.existingSecret | default (printf "%s-s3-credentials" .Release.Name) -}}
+{{- .Values.storage.s3.existingSecret | default "texera-s3-credentials" -}}
 {{- else -}}
-{{- printf "%s-minio" .Release.Name -}}
+{{- include "texera.minio.fullname" . -}}
 {{- end -}}
 {{- end -}}
 

--- a/bin/k8s/templates/base/access-control-service/access-control-service-deployment.yaml
+++ b/bin/k8s/templates/base/access-control-service/access-control-service-deployment.yaml
@@ -40,11 +40,11 @@ spec:
             - containerPort: {{ .Values.accessControlService.service.port }}
           env:
             - name: STORAGE_JDBC_URL
-              value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public
+              value: jdbc:postgresql://{{ include "texera.postgresql.fullname" . }}:5432/texera_db?currentSchema=texera_db,public
             - name: STORAGE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ include "texera.postgresql.fullname" . }}
                   key: postgres-password
             - name: KUBERNETES_COMPUTE_UNIT_POOL_NAME
               value: {{ .Values.workflowComputingUnitPool.name }}

--- a/bin/k8s/templates/base/config-service/config-service-deployment.yaml
+++ b/bin/k8s/templates/base/config-service/config-service-deployment.yaml
@@ -41,11 +41,11 @@ spec:
           env:
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
-              value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public
+              value: jdbc:postgresql://{{ include "texera.postgresql.fullname" . }}:5432/texera_db?currentSchema=texera_db,public
             - name: STORAGE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ include "texera.postgresql.fullname" . }}
                   key: postgres-password
             {{- range .Values.texeraEnvVars }}
             - name: {{ .name }}

--- a/bin/k8s/templates/base/external-names/external-names.yaml
+++ b/bin/k8s/templates/base/external-names/external-names.yaml
@@ -60,9 +60,9 @@ to access services in the main namespace using the same service names.
 ---
 {{/* PostgreSQL ExternalName */}}
 {{- include "external-name-service" (dict 
-  "name" (printf "%s-postgresql" .Release.Name)
+  "name" (include "texera.postgresql.fullname" .)
   "namespace" $workflowComputingUnitPoolNamespace
-  "externalName" (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name $namespace)
+  "externalName" (printf "%s.%s.svc.cluster.local" (include "texera.postgresql.fullname" .) $namespace)
 ) | nindent 0 }}
 
 ---
@@ -78,9 +78,9 @@ to access services in the main namespace using the same service names.
 {{/* MinIO ExternalName -- only when the in-cluster MinIO is enabled; with an
      external S3 store the CU pods reach it directly via STORAGE_S3_ENDPOINT. */}}
 {{- include "external-name-service" (dict
-  "name" (printf "%s-minio" .Release.Name)
+  "name" (include "texera.minio.fullname" .)
   "namespace" $workflowComputingUnitPoolNamespace
-  "externalName" (printf "%s-minio.%s.svc.cluster.local" .Release.Name $namespace)
+  "externalName" (printf "%s.%s.svc.cluster.local" (include "texera.minio.fullname" .) $namespace)
 ) | nindent 0 }}
 {{- end }}
 

--- a/bin/k8s/templates/base/file-service/file-service-deployment.yaml
+++ b/bin/k8s/templates/base/file-service/file-service-deployment.yaml
@@ -70,11 +70,11 @@ spec:
                   key: secret_key
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
-              value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public
+              value: jdbc:postgresql://{{ include "texera.postgresql.fullname" . }}:5432/texera_db?currentSchema=texera_db,public
             - name: STORAGE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ include "texera.postgresql.fullname" . }}
                   key: postgres-password
             {{- range .Values.texeraEnvVars }}
             - name: {{ .name }}

--- a/bin/k8s/templates/base/litellm/litellm-deployment.yaml
+++ b/bin/k8s/templates/base/litellm/litellm-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             # model config there, so state survives pod restarts. Defaults to the
             # in-cluster Postgres; set litellm.databaseUrl to point at an external one.
             - name: DATABASE_URL
-              value: {{ .Values.litellm.databaseUrl | default (printf "postgresql://postgres:%s@%s-postgresql:5432/%s" .Values.postgresql.auth.postgresPassword .Release.Name .Values.litellm.databaseName) | quote }}
+              value: {{ .Values.litellm.databaseUrl | default (printf "postgresql://postgres:%s@%s:5432/%s" .Values.postgresql.auth.postgresPassword (include "texera.postgresql.fullname" .) .Values.litellm.databaseName) | quote }}
             - name: STORE_MODEL_IN_DB
               value: "{{ .Values.litellm.storeModelInDb }}"
             {{- range $key, $value := .Values.litellm.providerApiKeys }}

--- a/bin/k8s/templates/base/webserver/webserver-deployment.yaml
+++ b/bin/k8s/templates/base/webserver/webserver-deployment.yaml
@@ -41,11 +41,11 @@ spec:
           env:
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
-              value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public
+              value: jdbc:postgresql://{{ include "texera.postgresql.fullname" . }}:5432/texera_db?currentSchema=texera_db,public
             - name: STORAGE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ include "texera.postgresql.fullname" . }}
                   key: postgres-password
             # LakeFS Access (should be removed in production environment)
             - name: STORAGE_LAKEFS_ENDPOINT

--- a/bin/k8s/templates/base/workflow-compiling-service/workflow-compiling-service-deployment.yaml
+++ b/bin/k8s/templates/base/workflow-compiling-service/workflow-compiling-service-deployment.yaml
@@ -57,11 +57,11 @@ spec:
                   key: secret_key
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
-              value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public
+              value: jdbc:postgresql://{{ include "texera.postgresql.fullname" . }}:5432/texera_db?currentSchema=texera_db,public
             - name: STORAGE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ include "texera.postgresql.fullname" . }}
                   key: postgres-password
             {{- range .Values.texeraEnvVars }}
             - name: {{ .name }}

--- a/bin/k8s/templates/base/workflow-computing-unit-manager/workflow-computing-unit-manager-deployment.yaml
+++ b/bin/k8s/templates/base/workflow-computing-unit-manager/workflow-computing-unit-manager-deployment.yaml
@@ -68,11 +68,11 @@ spec:
               value: {{ .Values.texera.imageRegistry }}/{{ .Values.workflowComputingUnitPool.imageName }}:{{ .Values.texera.imageTag }}
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
-              value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public
+              value: jdbc:postgresql://{{ include "texera.postgresql.fullname" . }}:5432/texera_db?currentSchema=texera_db,public
             - name: STORAGE_JDBC_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Release.Name }}-postgresql
+                  name: {{ include "texera.postgresql.fullname" . }}
                   key: postgres-password
             # FileService Access
             - name: FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT

--- a/bin/k8s/values-aws.yaml
+++ b/bin/k8s/values-aws.yaml
@@ -40,7 +40,7 @@ storage:
     # Recommended: reference a pre-created Secret with keys access-key-id /
     # secret-access-key (e.g. one synced from AWS Secrets Manager), and leave
     # accessKeyId / secretAccessKey empty. Otherwise the chart creates a Secret
-    # named "<release>-s3-credentials" from the inline values below.
+    # named "texera-s3-credentials" from the inline values below.
     existingSecret: ""
     accessKeyId: "REPLACE_WITH_ACCESS_KEY_ID"
     secretAccessKey: "REPLACE_WITH_SECRET_ACCESS_KEY"
@@ -49,11 +49,10 @@ storage:
 # the endpoint from the region) with credentials injected via the same Secret
 # the chart/app uses.
 #
-# NOTE: the secretKeyRef "name" below is "texera-s3-credentials", which assumes
-# the Helm release is named "texera" (the chart generates the credentials Secret
-# as "<release>-s3-credentials"). If you install with a different release name,
-# or set storage.s3.existingSecret above, update both "name:" fields below to
-# match that Secret.
+# NOTE: the secretKeyRef "name" below is the chart-generated Secret
+# "texera-s3-credentials" (a fixed name, independent of the Helm release name).
+# If you set storage.s3.existingSecret above, update both "name:" fields below
+# to match that Secret instead.
 lakefs:
   lakefsConfig: |
     database:

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -39,6 +39,12 @@ persistence:
 
 # Part 1: the configuration of Postgres, Minio and LakeFS
 postgresql:
+  # Pinned so the name does not depend on the Helm release name. The lakefs and
+  # lakekeeper sub-charts address this database from their own values blocks
+  # below, and Helm does not template values files -- so the name they point at
+  # has to be a constant. Chart templates resolve it via the
+  # "texera.postgresql.fullname" helper, so both sides always agree.
+  fullnameOverride: texera-postgresql
   image:
     repository: groonga/pgroonga
     tag: latest
@@ -82,6 +88,9 @@ minio:
   # external S3 store instead (configure storage.s3 above and the lakefs/
   # lakekeeperInit blocks below). See values-aws.yaml for a complete example.
   enabled: true
+  # Pinned for the same reason as postgresql.fullnameOverride above: the lakefs
+  # blockstore endpoint is set from the lakefs sub-chart's own values.
+  fullnameOverride: texera-minio
   mode: standalone
   image:
     repository: bitnamilegacy/minio


### PR DESCRIPTION
### What changes were proposed in this PR?

The chart derives in-cluster hostnames from `.Release.Name`, but the `lakefs` and
`lakekeeper` sub-charts have to address Postgres and MinIO from **their own** values
blocks — and Helm does not template values files, so those references are hardcoded to
`texera-postgresql` / `texera-minio`:

```yaml
# bin/k8s/values.yaml
lakefs:
  secrets:
    databaseConnectionString: postgres://postgres:root_password@texera-postgresql:5432/...
  lakefsConfig: |
    blockstore:
      s3:
        endpoint: http://texera-minio:9000
lakekeeper:
  externalDatabase:
    host_read: texera-postgresql
    host_write: texera-postgresql
```

Those names only exist when the Helm release happens to be named `texera`. Install under
any other release name and they dangle — LakeFS cannot reach the database or the object
store, and Lakekeeper cannot reach the database, while every other service (which goes
through `{{ .Release.Name }}-postgresql` in the templates) works fine. The failure is
confusing because the chart installs cleanly and only the storage tier misbehaves.

Rendering `helm template myrel bin/k8s` on `main` today:

| Reference | Points at | Service actually created |
|---|---|---|
| `Secret/myrel-lakefs` → `database_connection_string` | `texera-postgresql` | `myrel-postgresql` |
| `ConfigMap/myrel-lakefs` → `blockstore.endpoint` | `texera-minio:9000` | `myrel-minio` |
| `Secret/myrel-lakekeeper-config-envs` → `LAKEKEEPER__PG_HOST_R` / `_W` | `texera-postgresql` | `myrel-postgresql` |

**The fix.** Since the referencing side cannot be templated, make the referenced side a
constant: pin the two sub-charts with `fullnameOverride`, and resolve the same names in
chart templates through two new helpers so both sides always agree.

```yaml
postgresql:
  fullnameOverride: texera-postgresql
minio:
  fullnameOverride: texera-minio
```

```gotemplate
{{- define "texera.postgresql.fullname" -}}
{{- .Values.postgresql.fullnameOverride | default (printf "%s-postgresql" .Release.Name) -}}
{{- end -}}
```

The helpers keep the previous `<release>-<chart>` form as a fallback, so clearing the
override restores the old naming rather than breaking the chart. The 12 template
references to `{{ .Release.Name }}-postgresql` (JDBC URLs + the password `secretKeyRef`),
the two MinIO references in `_helpers.tpl`, the LiteLLM `DATABASE_URL`, and the
`ExternalName` mirrors in the computing-unit namespace all go through the helpers now.

The chart-generated S3 credentials Secret gets a fixed name for the same reason:
`values-aws.yaml` wires it into `lakefs.extraEnvVars` and carried a note telling the
reader to hand-edit both `name:` fields when the release is not called `texera`. That
note is no longer needed and has been dropped.

One consequence worth calling out for reviewers: the pinned names make the chart
release-name independent, but they also mean two Texera releases can no longer coexist in
a single namespace. That was already effectively true — `workflowComputingUnitPool.namespace`
and the `ExternalName` mirrors collide between releases regardless, and `values.yaml`
already warns about it — so this codifies an existing constraint rather than adding one.

### Any related issues, documentation, discussions?

No separate issue was filed; the problem was found while writing cluster deployment
notes for the chart. Comments in `values.yaml`, `values-aws.yaml` and `_helpers.tpl` are
updated in this PR to explain why the names are pinned, so the constraint is documented
where someone would next be tempted to un-pin it.

### How was this PR tested?

The chart has no automated render tests, so this was verified by rendering and diffing.

**1. Existing deployments are unaffected — release `texera` renders byte-identically.**
Rendered `helm template texera bin/k8s` before and after the change, for all three values
files, and diffed (filtering only Lakekeeper's `encryptionKey`, which the sub-chart
regenerates randomly on every render):

```
IDENTICAL  release=texera  values.yaml
IDENTICAL  release=texera  values-aws.yaml
IDENTICAL  release=texera  values-development.yaml
```

**2. The bug is fixed for other release names.** A script parses the rendered manifests,
base64-decodes Secret values (so `LAKEKEEPER__PG_HOST_*` and the LakeFS connection string
are visible), collects every reference to a `*-postgresql` / `*-minio` /
`*-s3-credentials` object, and checks each one against the set of resources the render
actually creates:

```
===== BASELINE (main) =====
DANGLING  release=myrel
            -> texera-minio        (referenced, never created)
            -> texera-postgresql   (referenced, never created)

===== AFTER FIX =====
CLEAN  release=texera / myrel / other-name   x   values.yaml, values-aws.yaml, values-development.yaml
```

All nine combinations (3 release names x 3 values files) render with no dangling
references, and `helm lint` passes.

Not covered: this is a static render check, so it verifies the names now agree; it does
not exercise a live LakeFS/Lakekeeper connection under a non-`texera` release. Given the
only change is which hostname string is emitted, and release `texera` is unchanged, an
in-cluster run seemed disproportionate — happy to add one if a reviewer prefers.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5
