### PR TITLE
refactor(services): use the shared request-logging filter and SQL-state constant

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/pythonvirtualenvironment/PveResource.scala
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.typesafe.scalalogging.LazyLogging
 import io.dropwizard.auth.Auth
 import org.apache.texera.auth.SessionUser
+import org.apache.texera.dao.SqlStates
 import org.jooq.exception.DataAccessException
 
 import javax.ws.rs._
@@ -107,7 +108,7 @@ class PveResource extends LazyLogging {
       if (updated) Response.ok(Map("veid" -> veid).asJava).build()
       else Response.status(Response.Status.NOT_FOUND).build()
     } catch {
-      case e: DataAccessException if e.sqlState() == "23505" =>
+      case e: DataAccessException if e.sqlState() == SqlStates.UNIQUE_VIOLATION =>
         Response
           .status(Response.Status.CONFLICT)
           .entity(s"""An environment named "$name" already exists.""")
@@ -145,7 +146,7 @@ class PveResource extends LazyLogging {
       val veid = PveManager.savePve(sessionUser.getUid.intValue(), name, packagesJson)
       Response.status(Response.Status.CREATED).entity(Map("veid" -> veid).asJava).build()
     } catch {
-      case e: DataAccessException if e.sqlState() == "23505" =>
+      case e: DataAccessException if e.sqlState() == SqlStates.UNIQUE_VIOLATION =>
         Response
           .status(Response.Status.CONFLICT)
           .entity(s"""An environment named "$name" already exists.""")

--- a/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
+++ b/file-service/src/main/scala/org/apache/texera/service/resource/DatasetResource.scala
@@ -33,6 +33,7 @@ import org.apache.texera.auth.SessionUser
 import org.apache.texera.dao.SiteSettings
 import org.apache.texera.dao.SqlServer
 import org.apache.texera.dao.SqlServer.withTransaction
+import org.apache.texera.dao.SqlStates
 import org.apache.texera.dao.jooq.generated.enums.{PrivilegeEnum, UserRoleEnum}
 import org.apache.texera.dao.jooq.generated.tables.Dataset.DATASET
 import org.apache.texera.dao.jooq.generated.tables.DatasetContributor.DATASET_CONTRIBUTOR
@@ -1641,7 +1642,7 @@ class DatasetResource extends LazyLogging {
     try op
     catch {
       case e: DataAccessException =>
-        if (e.sqlState() == "23505") {
+        if (e.sqlState() == SqlStates.UNIQUE_VIOLATION) {
           throw new BadRequestException("Dataset with the same name already exists")
         }
         throw e

--- a/notebook-migration-service/src/main/scala/org/apache/texera/service/resource/NotebookMigrationResource.scala
+++ b/notebook-migration-service/src/main/scala/org/apache/texera/service/resource/NotebookMigrationResource.scala
@@ -26,6 +26,7 @@ import jakarta.ws.rs._
 import jakarta.ws.rs.core._
 import org.apache.texera.auth.SessionUser
 import org.apache.texera.dao.SqlServer
+import org.apache.texera.dao.SqlStates
 import org.jooq.JSONB
 import org.jooq.exception.DataAccessException
 import org.apache.texera.dao.jooq.generated.tables.Notebook
@@ -328,7 +329,7 @@ object NotebookMigrationResource extends LazyLogging {
       // Backstop for the pre-check TOCTOU race: two writers on a shared workflow can both
       // pass the existence check, then one INSERT trips the UNIQUE(wid) constraint. Translate
       // that (Postgres SQLState 23505) to a 409 rather than a generic 500.
-      case e: DataAccessException if e.sqlState == "23505" =>
+      case e: DataAccessException if e.sqlState == SqlStates.UNIQUE_VIOLATION =>
         Response
           .status(Response.Status.CONFLICT)
           .entity(errorJson("A notebook is already stored for this workflow"))

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/service/WorkflowCompilingService.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/service/WorkflowCompilingService.scala
@@ -25,10 +25,9 @@ import io.dropwizard.core.Application
 import io.dropwizard.core.setup.{Bootstrap, Environment}
 import org.apache.texera.common.config.StorageConfig
 import org.apache.texera.amber.util.ObjectMapperUtils
-import org.apache.texera.auth.{AuthFeatures, RoleAnnotationEnforcer}
+import org.apache.texera.auth.{AuthFeatures, RequestLoggingFilter, RoleAnnotationEnforcer}
 import org.apache.texera.dao.SqlServer
 import org.apache.texera.service.resource.{HealthCheckResource, WorkflowCompilationResource}
-import org.eclipse.jetty.servlet.FilterHolder
 
 import java.nio.file.Path
 
@@ -73,27 +72,7 @@ class WorkflowCompilingService extends Application[WorkflowCompilingServiceConfi
     )
 
     // Route request logs through SLF4J, controlled by TEXERA_SERVICE_LOG_LEVEL
-    val requestLogger = org.slf4j.LoggerFactory.getLogger("org.eclipse.jetty.server.RequestLog")
-    environment.getApplicationContext.addFilter(
-      new FilterHolder(new jakarta.servlet.Filter {
-        override def doFilter(
-            request: jakarta.servlet.ServletRequest,
-            response: jakarta.servlet.ServletResponse,
-            chain: jakarta.servlet.FilterChain
-        ): Unit = {
-          chain.doFilter(request, response)
-          if (requestLogger.isInfoEnabled) {
-            val req = request.asInstanceOf[jakarta.servlet.http.HttpServletRequest]
-            val resp = response.asInstanceOf[jakarta.servlet.http.HttpServletResponse]
-            requestLogger.info(
-              s"""${req.getRemoteAddr} - "${req.getMethod} ${req.getRequestURI} ${req.getProtocol}" ${resp.getStatus}"""
-            )
-          }
-        }
-      }),
-      "/*",
-      java.util.EnumSet.allOf(classOf[jakarta.servlet.DispatcherType])
-    )
+    RequestLoggingFilter.register(environment.getApplicationContext)
   }
 }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Two places where a shared helper already existed but a local copy or literal was used instead. **9 insertions, 27 deletions.**

**1. `WorkflowCompilingService` now calls the shared `RequestLoggingFilter`.** It was the only Dropwizard-4 service still inlining its own anonymous request-logging filter; the other five (access-control, computing-unit-managing, config, file, notebook-migration) all call `RequestLoggingFilter.register(environment.getApplicationContext)` at exactly this point.

The two implementations were compared line by line before swapping, not assumed equivalent. Normalising fully-qualified prefixes and the logger's local name, every observable matches: logger name `"org.eclipse.jetty.server.RequestLog"`, the `isInfoEnabled` guard, the same access-log format string, url pattern `"/*"`, and `EnumSet.allOf(classOf[DispatcherType])`. The inline copy also sat immediately after `RoleAnnotationEnforcer.enforce`, which is exactly where the siblings place the `register` call — so this is a body-only replacement.

**2. Four sites now use `SqlStates.UNIQUE_VIOLATION` instead of the literal `"23505"`.**

| Site | Was |
|---|---|
| `PveResource.scala:110`, `:148` | `e.sqlState() == "23505"` |
| `DatasetResource.scala:1644` | `if (e.sqlState() == "23505")` |
| `NotebookMigrationResource.scala:331` | `e.sqlState == "23505"` |

Each module's `dependsOn` was checked first: `NotebookMigrationService` has a direct DAO dependency, and the other two reach it transitively (`WorkflowCompiler → WorkflowOperator → WorkflowCore → DAO`, and `WorkflowCore → DAO`). No build change was needed, and no module was given one. The constant was already in use by `ExternalAuthProvisioner` and `LocalAuthProvisioner`.

The remaining `23505` occurrences are CSV test fixtures, a `yarn.lock` checksum, `SqlStates.scala` itself, and two comments that explain what the code means — those are left alone.

### amber's two inline copies are deliberately untouched

Worth recording so they are not "fixed" later: amber's remaining inline filters **cannot** use the shared one. They are `javax.servlet`, because amber pins Jetty 9.4.20, while `RequestLoggingFilter` is `jakarta.servlet`. Their existing TODO — replace once Dropwizard is upgraded — is accurate, and this PR does not touch them.

### Verification

- `WorkflowCompilingService/test`: **2 suites, 13 tests, 0 failures.** This matters because `WorkflowCompilingServiceRunSpec` has cases asserting the filter's registration, its dispatch set, and that it forwards the request while logging one access line. They read the filter back out of the captured `FilterHolder` rather than by class, so they survived the swap unchanged — and they are what confirms the shared filter behaves identically in place.
- `NotebookMigrationResourceSpec`: **28 passed.** It drives a real unique-constraint violation against embedded Postgres, so it exercises the changed comparison.
- `FileService/compile` succeeds. `DatasetResourceSpec` extends `MockLakeFS` (testcontainers) and cannot run without Docker, which is unavailable here — for that site the evidence is compilation plus the provable value identity of the constant.
- `PveResourceSpec` fails 6 tests **both with and without this change** (37 succeeded / 6 failed / 1 canceled either way, verified by stashing the `PveResource.scala` edit and re-running). Pre-existing on this machine, unrelated to this PR.
- `WorkflowCompilingService/scalafmtCheck` and `Test/scalafmtCheck` pass; no imports were left orphaned (`FilterHolder` removed, `RequestLoggingFilter` added).

### Any related issues, documentation, discussions?

Closes #7792

### How was this PR tested?

```
sbt "WorkflowCompilingService/test" "FileService/compile" "NotebookMigrationService/testOnly org.apache.texera.service.resource.NotebookMigrationResourceSpec"
```

```
[info] Suites: completed 2, aborted 0
[info] Tests: succeeded 13, failed 0, canceled 0, ignored 0, pending 0
[info] Tests: succeeded 28, failed 0, canceled 0, ignored 0, pending 0
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
