### PR TITLE
fix(frontend): find the preset to replace by value, not by reference

### DIFF
--- a/frontend/src/app/workspace/service/preset/preset.service.spec.ts
+++ b/frontend/src/app/workspace/service/preset/preset.service.spec.ts
@@ -268,6 +268,42 @@ describe("PresetService", () => {
       expect((errors[0] as Error).message).toMatch(/doesn't exist/);
     });
 
+    it("updatePreset reports the original as missing when nothing is stored yet", async () => {
+      // the absent-entry default: without it the null would be parsed instead of
+      // reading as an empty list
+      userConfigStub.fetchKey.mockReturnValue(of(null));
+
+      const errors = await captureRxjsUnhandled(() =>
+        presetService.updatePreset(presetType, presetTarget, { presetProperty: "v1" }, { presetProperty: "v2" })
+      );
+
+      expect(userConfigStub.set).not.toHaveBeenCalled();
+      expect((errors[0] as Error).message).toMatch(/doesn't exist/);
+    });
+
+    it("updatePreset replaces the original in place, keeping the surrounding order", () => {
+      userConfigStub.fetchKey.mockReturnValue(
+        of(JSON.stringify([{ presetProperty: "v1" }, { presetProperty: "v2" }, { presetProperty: "v3" }]))
+      );
+
+      presetService.updatePreset(presetType, presetTarget, { presetProperty: "v2" }, { presetProperty: "v2-edited" });
+
+      expect(userConfigStub.set).toHaveBeenCalledWith(
+        presetDictKey,
+        JSON.stringify([{ presetProperty: "v1" }, { presetProperty: "v2-edited" }, { presetProperty: "v3" }])
+      );
+    });
+
+    it("updatePreset drops the original when the replacement already exists", () => {
+      // editing a preset into one that is already stored merges the two rather than
+      // leaving a duplicate behind
+      userConfigStub.fetchKey.mockReturnValue(of(JSON.stringify([{ presetProperty: "v1" }, { presetProperty: "v2" }])));
+
+      presetService.updatePreset(presetType, presetTarget, { presetProperty: "v1" }, { presetProperty: "v2" });
+
+      expect(userConfigStub.set).toHaveBeenCalledWith(presetDictKey, JSON.stringify([{ presetProperty: "v2" }]));
+    });
+
     it("deletePreset removes the matching preset via savePresets", () => {
       const a: Preset = { presetProperty: "v1" };
       const b: Preset = { presetProperty: "v2" };

--- a/frontend/src/app/workspace/service/preset/preset.service.ts
+++ b/frontend/src/app/workspace/service/preset/preset.service.ts
@@ -19,7 +19,7 @@
 
 import { Injectable } from "@angular/core";
 import Ajv from "ajv";
-import { cloneDeep, has, indexOf, isEqual, merge, pickBy } from "lodash";
+import { cloneDeep, has, isEqual, merge, pickBy } from "lodash";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { Observable, of, Subject } from "rxjs";
 import { UserConfigService } from "src/app/common/service/user/config/user-config.service";
@@ -183,9 +183,13 @@ export class PresetService {
           throw new Error("attempting to update preset that doesn't exist");
         } else if (contains(presets, replacementPreset)) {
           // implicit deletion by replacing original with existing preset
-          presets.splice(indexOf(presets, originalPreset), 1);
+          // deep-equality index: presets are freshly JSON-parsed, so reference-based indexOf would miss
+          presets.splice(
+            presets.findIndex(preset => isEqual(preset, originalPreset)),
+            1
+          );
         } else {
-          presets[indexOf(presets, originalPreset)] = replacementPreset;
+          presets[presets.findIndex(preset => isEqual(preset, originalPreset))] = replacementPreset;
         }
         this.savePresets(type, target, presets, displayMessage, messageType);
       });


### PR DESCRIPTION
### What changes were proposed in this PR?

`PresetService.updatePreset` located the preset to replace with lodash `indexOf`, which compares by reference. The list it searches comes straight out of `JSON.parse`, so the lookup always returned `-1` while the `contains` guard above it — which compares with `isEqual` — still let execution through. Both arms then did the wrong thing:

- `presets[-1] = replacementPreset` writes a non-index property on the array, so the edit was silently discarded and the unchanged list written back.
- `presets.splice(-1, 1)` removes the **last** element, so replacing a preset with one that already existed deleted the wrong preset.

The sibling `updateOrCreatePreset` directly below already used a deep-equality `findIndex`, with a comment naming this cause; this applies the same lookup to `updatePreset`. `indexOf` is no longer used in the file, so the import drops with it.

Three tests come with it — the two that reproduce the defect (an in-place replace, and a replace onto an existing preset), plus the absent-entry case that reaches the `?? "[]"` default. They fail against the old code with exactly the wrong values described above.

### Any related issues, documentation, discussions?

Closes #7795

Both lines were unhit, which is how this went unnoticed; they are among the gaps listed in #7777, so that issue's `PresetService` portion is handled here.

### How was this PR tested?

Unit tests, run locally in `frontend/`:

```
ng test --watch=false --include .../preset.service.spec.ts
# Test Files 1 passed (1) | Tests 61 passed (61)
prettier --write / eslint   # clean
```

The failure path was verified by reverting the production change and re-running: the run exits non-zero with `2 failed | 59 passed`, the in-place replace writing back the unchanged list and the merge case deleting `v2` instead of `v1`. The coverage report over this spec now shows no unhit line and no partial branch in `preset.service.ts`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
