### PR TITLE
fix(frontend): sort cache size ascending, drop the broken preset updater

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-quota/user-quota.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-quota/user-quota.component.spec.ts
@@ -366,13 +366,13 @@ describe("UserQuotaComponent", () => {
    * produces a different sequence than the full sum does.
    */
   describe("sortBySize", () => {
-    // Largest-first is what the comparator returns today. Note that this is inverted relative to the
-    // NzTableSortFn contract (`a - b`, which nz-table negates for 'descend'); see the header-click
-    // test below, which pins the resulting caret/order mismatch as the user actually sees it.
-    it("orders executions by total cache size, largest first", () => {
+    // Ascending, as NzTableSortFn requires (`a - b`): nz-table takes the comparator's result as-is
+    // for 'ascend' and negates it for 'descend', so a `b - a` comparator lights the up caret while
+    // rendering largest-first. The header-click test below pins the caret and the order together.
+    it("orders executions by total cache size, smallest first", () => {
       const scrambled = [SIZE_SORT_MIDDLE, SIZE_SORT_SMALL, SIZE_SORT_BIG];
 
-      expect([...scrambled].sort(component.sortBySize).map(e => e.eid)).toEqual([30, 10, 20]);
+      expect([...scrambled].sort(component.sortBySize).map(e => e.eid)).toEqual([20, 10, 30]);
     });
   });
 
@@ -560,19 +560,18 @@ describe("UserQuotaComponent", () => {
       };
 
       await clickSort();
-      // NOTE: the direction indicator and the row order disagree, and that is recorded here rather
-      // than blessed. nzSortDirections defaults to ['ascend', 'descend', null], so the first click
-      // selects 'ascend' and lights the up caret — but the rows come out LARGEST first, because
-      // sortBySize returns `b - a` while NzTableSortFn expects `a - b` (nz-table negates the result
-      // itself for 'descend'). Correcting the comparator is meant to flip both halves below.
+      // nzSortDirections defaults to ['ascend', 'descend', null] and this header does not override
+      // it, so the first click selects 'ascend' and lights the up caret. The caret and the row order
+      // have to agree: up means smallest-first. Asserting the order on its own would still pass
+      // against a comparator inverted the other way, so both halves are pinned in both directions.
       expect(caretActive("up")).toBe(true);
       expect(caretActive("down")).toBe(false);
-      expect(eids()).toEqual(["30", "10", "20"]);
+      expect(eids()).toEqual(["20", "10", "30"]);
 
       await clickSort();
       expect(caretActive("down")).toBe(true);
       expect(caretActive("up")).toBe(false);
-      expect(eids()).toEqual(["20", "10", "30"]);
+      expect(eids()).toEqual(["30", "10", "20"]);
     });
   });
 });

--- a/frontend/src/app/dashboard/component/user/user-quota/user-quota.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-quota/user-quota.component.ts
@@ -342,5 +342,5 @@ export class UserQuotaComponent implements OnInit {
   formatSize = formatSize;
 
   public sortBySize: NzTableSortFn<ExecutionQuota> = (a: ExecutionQuota, b: ExecutionQuota) =>
-    b.resultBytes + b.logBytes + b.runTimeStatsBytes - a.resultBytes - a.logBytes - a.runTimeStatsBytes;
+    a.resultBytes + a.logBytes + a.runTimeStatsBytes - (b.resultBytes + b.logBytes + b.runTimeStatsBytes);
 }

--- a/frontend/src/app/workspace/component/hugging-face-image-upload/hugging-face-image-upload.component.html
+++ b/frontend/src/app/workspace/component/hugging-face-image-upload/hugging-face-image-upload.component.html
@@ -32,7 +32,7 @@
       [src]="previewSrc"
       alt="Uploaded Hugging Face task input" />
     <div class="hf-image-meta">
-      <span>{{ displayFileName || "Selected image" }}</span>
+      <span>{{ displayFileName }}</span>
       <button
         nz-button
         nzSize="small"

--- a/frontend/src/app/workspace/service/preset/preset.service.spec.ts
+++ b/frontend/src/app/workspace/service/preset/preset.service.spec.ts
@@ -256,18 +256,6 @@ describe("PresetService", () => {
       expect((errors[0] as Error).message).toMatch(/already exists/);
     });
 
-    it("updatePreset does not write the preset back when the original preset is missing", async () => {
-      userConfigStub.fetchKey.mockReturnValue(of(JSON.stringify([{ presetProperty: "v1" }])));
-
-      const errors = await captureRxjsUnhandled(() =>
-        presetService.updatePreset(presetType, presetTarget, { presetProperty: "missing" }, { presetProperty: "v3" })
-      );
-
-      expect(userConfigStub.set).not.toHaveBeenCalled();
-      expect(errors).toHaveLength(1);
-      expect((errors[0] as Error).message).toMatch(/doesn't exist/);
-    });
-
     it("deletePreset removes the matching preset via savePresets", () => {
       const a: Preset = { presetProperty: "v1" };
       const b: Preset = { presetProperty: "v2" };

--- a/frontend/src/app/workspace/service/preset/preset.service.ts
+++ b/frontend/src/app/workspace/service/preset/preset.service.ts
@@ -19,7 +19,7 @@
 
 import { Injectable } from "@angular/core";
 import Ajv from "ajv";
-import { cloneDeep, has, indexOf, isEqual, merge, pickBy } from "lodash";
+import { cloneDeep, has, isEqual, merge, pickBy } from "lodash";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { Observable, of, Subject } from "rxjs";
 import { UserConfigService } from "src/app/common/service/user/config/user-config.service";
@@ -154,39 +154,6 @@ export class PresetService {
           throw new Error("attempting to create preset that already exists");
         }
         presets.push(preset);
-        this.savePresets(type, target, presets, displayMessage, messageType);
-      });
-  }
-
-  /**
-   * broadcast savePresets event and also save preset to presetDict, which is a *view* (in the database sense) of DictionaryService's dictionary that only stores presets
-   * @param type string, usually "operator"
-   * @param target string, usualy operatorType
-   * @param presets Preset[]
-   * @param displayMessage message to display when saving presets
-   * @param messageType see AlertMessageType, determines icon used in popup message
-   */
-  public updatePreset(
-    type: string,
-    target: string,
-    originalPreset: Preset,
-    replacementPreset: Preset,
-    displayMessage?: string | null,
-    messageType: AlertMessageType = "success"
-  ) {
-    this.userConfigService
-      .fetchKey(`${type}-${target}`)
-      .pipe(first())
-      .subscribe(presetsString => {
-        let presets = JSON.parse(presetsString ?? "[]") as Preset[];
-        if (!contains(presets, originalPreset)) {
-          throw new Error("attempting to update preset that doesn't exist");
-        } else if (contains(presets, replacementPreset)) {
-          // implicit deletion by replacing original with existing preset
-          presets.splice(indexOf(presets, originalPreset), 1);
-        } else {
-          presets[indexOf(presets, originalPreset)] = replacementPreset;
-        }
         this.savePresets(type, target, presets, displayMessage, messageType);
       });
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

Three frontend defects. **5 files, +14 / −60.**

**1. `sortBySize` now matches the `NzTableSortFn` contract.** It returned `b - a`, but ng-zorro uses the comparator's result as-is for `ascend` and negates it for `descend` (`ng-zorro-antd-table.mjs:822`), with `nzSortDirections` defaulting to `['ascend','descend',null]` (`:1063`) — which this header does not override. So the first click **lit the up-caret while rendering largest-first**. `admin-user.component.ts:268` already uses the contract-correct form, so this was a one-off, not a convention.

**2. `PresetService.updatePreset` removed — dead *and* broken.** No caller repo-wide outside its own spec, and it could not have worked: `indexOf(presets, originalPreset)` is lodash **reference** equality against a freshly `JSON.parse`d array. Reproduced by execution:

```
contains(presets, originalPreset) = true   (the guard passes)
indexOf(presets, originalPreset) = -1
splice branch -> [{"p":"a"},{"p":"b"}]              // deleted the LAST preset, not the target
assign branch -> [{"p":"a"},{"p":"b"},{"p":"c"}]    // the replacement was dropped entirely
```

Its sibling `updateOrCreatePreset` carries the explanatory comment and uses `findIndex(isEqual)` — the fix was applied there and not here. Removed the method, its doc block, the now-unused `indexOf` import, and the one spec test that existed solely for it.

**3. An unreachable template fallback simplified.** `{{ displayFileName || "Selected image" }}` → `{{ displayFileName }}`. Guard dominance confirmed: the enclosing div is `*ngIf="previewSrc"`, `previewSrc` returns `hasImage ? formControl.value : ""`, so a truthy `previewSrc` implies `hasImage`, and `displayFileName` then returns a non-empty filename or `"Uploaded image"` — never empty. No subclass, single template consumer. The spec already asserted the span reads `"Uploaded image"` in the no-filename case, which is direct evidence the fallback was dead.

### The sort fix is pinned in both directions

The spec already held a **characterization** test recording the broken caret/order pairing, with a comment saying a fix "is meant to flip both halves". Both halves are now flipped to assert correct behaviour, and verified with the production file reverted and restored:

| | production reverted | with fix |
|---|---|---|
| `user-quota.component.spec.ts` | **2 failed, 23 passed** | **25 passed** |

The failure that matters:

```
AssertionError: expected [ '30', '10', '20' ] to deeply equal [ '20', '10', '30' ]
```

And the detail that makes this a real user-facing bug rather than a comparator nit: in the before-state the **caret assertions passed** (`caretActive("up") === true`) while the rows came out largest-first. That is exactly what a user sees. Asserting row order alone would still pass against a comparator inverted the other way, so the test pins the caret and the order together, in both directions.

### Verification

- `user-quota.component.spec.ts` + `preset.service.spec.ts` + `hugging-face-image-upload.component.spec.ts`: **124 passed (124)**.
- `npx ng build`: **exit 0**, zero errors and zero NG####/TS diagnostics. Worth running because `ng test` and `tsc --noEmit` both miss Angular template errors — and the bundle was grepped to confirm the template change was genuinely AOT-compiled: `"Uploaded image"` appears in 2 chunks, `"Selected image"` in **0**.
- `yarn format:ci`: exit 0.

### A follow-up worth filing separately

The same defect class appears six more times in `admin-user.component.ts`: `sortByName`, `sortByEmail`, `sortByComment`, `sortByRole`, `sortByAffiliation` and `sortByJoiningReason` all use `b.localeCompare(a)`, and their headers set `nzSortDirections="['ascend','descend']"`, so they also start at `ascend` and render reversed. Not touched here — different component, and it deserves its own change with its own tests.

### Any related issues, documentation, discussions?

Closes #7805

### How was this PR tested?

```
npx ng test --watch=false --include="**/user-quota.component.spec.ts" --include="**/preset.service.spec.ts" --include="**/hugging-face-image-upload.component.spec.ts"
```

```
 Test Files  3 passed (3)
      Tests  124 passed (124)
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
