### PR TITLE
feat(gui): warehouse dashboard tab

### DIFF
--- a/frontend/src/app/app-routing.constant.ts
+++ b/frontend/src/app/app-routing.constant.ts
@@ -36,6 +36,7 @@ export const USER_WORKFLOW = `${USER}/workflow`;
 export const USER_DATASET = `${USER}/dataset`;
 export const USER_DATASET_CREATE = `${USER_DATASET}/create`;
 export const USER_COMPUTING_UNIT = `${USER}/compute`;
+export const USER_WAREHOUSE = `${USER}/warehouse`;
 export const USER_PYTHON_VENV = `${USER}/python-venv`;
 export const USER_QUOTA = `${USER}/quota`;
 export const USER_DISCUSSION = `${USER}/discussion`;

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -25,6 +25,7 @@ import { UserQuotaComponent } from "./dashboard/component/user/user-quota/user-q
 import { UserProjectSectionComponent } from "./dashboard/component/user/user-project/user-project-section/user-project-section.component";
 import { UserProjectComponent } from "./dashboard/component/user/user-project/user-project.component";
 import { UserComputingUnitComponent } from "./dashboard/component/user/user-computing-unit/user-computing-unit.component";
+import { UserWarehouseComponent } from "./dashboard/component/user/user-warehouse/user-warehouse.component";
 import { UserVenvComponent } from "./dashboard/component/user/user-venv/user-venv.component";
 import { WorkspaceComponent } from "./workspace/component/workspace.component";
 import { AboutComponent } from "./hub/component/about/about.component";
@@ -138,6 +139,10 @@ routes.push({
         {
           path: "compute",
           component: UserComputingUnitComponent,
+        },
+        {
+          path: "warehouse",
+          component: UserWarehouseComponent,
         },
         {
           path: "python-venv",

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.html
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.html
@@ -1,0 +1,52 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<nz-modal
+  [nzVisible]="visible"
+  nzTitle="Create Warehouse"
+  [nzContent]="createWarehouseModalContent"
+  [nzFooter]="createWarehouseModalFooter"
+  (nzOnCancel)="handleCreateWarehouseModalCancel()">
+  <ng-template #createWarehouseModalContent>
+    <input
+      nz-input
+      placeholder="Warehouse name"
+      maxlength="64"
+      [(ngModel)]="newWarehouseName"
+      (keyup.enter)="createWarehouse()" />
+    <p class="warehouse-name-hint">Letters, digits, '-' and '_' only; must start with a letter or digit.</p>
+  </ng-template>
+  <ng-template #createWarehouseModalFooter>
+    <button
+      nz-button
+      nzType="default"
+      (click)="handleCreateWarehouseModalCancel()">
+      Cancel
+    </button>
+    <button
+      nz-button
+      nzType="primary"
+      id="confirm-create-warehouse-btn"
+      [disabled]="!newWarehouseName.trim()"
+      [nzLoading]="creating"
+      (click)="createWarehouse()">
+      Create
+    </button>
+  </ng-template>
+</nz-modal>

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.html
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.html
@@ -24,13 +24,20 @@
   [nzFooter]="createWarehouseModalFooter"
   (nzOnCancel)="handleCreateWarehouseModalCancel()">
   <ng-template #createWarehouseModalContent>
-    <input
-      nz-input
-      placeholder="Warehouse name"
-      maxlength="64"
-      [(ngModel)]="newWarehouseName"
-      (keyup.enter)="createWarehouse()" />
-    <p class="warehouse-name-hint">Letters, digits, '-' and '_' only; must start with a letter or digit.</p>
+    <div class="create-warehouse-container">
+      <div class="select-unit name-field">
+        <span>Warehouse Name</span>
+        <input
+          [required]="true"
+          nz-input
+          placeholder="Enter the name of your warehouse (required)"
+          maxlength="64"
+          class="warehouse-name-input"
+          [(ngModel)]="newWarehouseName"
+          (keyup.enter)="createWarehouse()" />
+        <p class="warehouse-name-hint">Letters, digits, '-' and '_' only; must start with a letter or digit.</p>
+      </div>
+    </div>
   </ng-template>
   <ng-template #createWarehouseModalFooter>
     <button

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.scss
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.scss
@@ -17,6 +17,28 @@
  * under the License.
  */
 
+.create-warehouse-container {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  align-items: center;
+}
+
+.select-unit {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  align-items: flex-start;
+
+  &.name-field {
+    grid-column: span 2;
+  }
+}
+
+.warehouse-name-input {
+  width: 100%;
+}
+
 .warehouse-name-hint {
   margin: 8px 0 0;
   color: rgba(0, 0, 0, 0.45);

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.scss
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.scss
@@ -1,0 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.warehouse-name-hint {
+  margin: 8px 0 0;
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 12px;
+}

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.spec.ts
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.spec.ts
@@ -25,14 +25,14 @@ import { NzModalService } from "ng-zorro-antd/modal";
 import { of, throwError } from "rxjs";
 import { WarehouseCreateModalComponent } from "./warehouse-create-modal.component";
 import { NotificationService } from "../../service/notification/notification.service";
-import { WarehouseService } from "../../service/warehouse/warehouse.service";
+import { WarehouseActionsService } from "../../service/warehouse/warehouse-actions.service";
 import { DashboardWarehouse } from "../../type/warehouse";
 import { commonTestProviders } from "../../testing/test-utils";
 
 describe("WarehouseCreateModalComponent", () => {
   let fixture: ComponentFixture<WarehouseCreateModalComponent>;
   let component: WarehouseCreateModalComponent;
-  let warehouseService: { createWarehouse: ReturnType<typeof vi.fn> };
+  let warehouseActions: { create: ReturnType<typeof vi.fn> };
   let notificationService: { error: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn> };
 
   const created: DashboardWarehouse = {
@@ -46,7 +46,7 @@ describe("WarehouseCreateModalComponent", () => {
   };
 
   beforeEach(async () => {
-    warehouseService = { createWarehouse: vi.fn().mockReturnValue(of(created)) };
+    warehouseActions = { create: vi.fn().mockReturnValue(of(created)) };
     notificationService = { error: vi.fn(), success: vi.fn() };
 
     await TestBed.configureTestingModule({
@@ -54,7 +54,7 @@ describe("WarehouseCreateModalComponent", () => {
       providers: [
         // The rendered <nz-modal> injects NzModalService itself.
         NzModalService,
-        { provide: WarehouseService, useValue: warehouseService },
+        { provide: WarehouseActionsService, useValue: warehouseActions },
         { provide: NotificationService, useValue: notificationService },
         ...commonTestProviders,
       ],
@@ -93,7 +93,7 @@ describe("WarehouseCreateModalComponent", () => {
 
     component.createWarehouse();
 
-    expect(warehouseService.createWarehouse).toHaveBeenCalledWith("mybucket");
+    expect(warehouseActions.create).toHaveBeenCalledWith("mybucket");
     expect(notificationService.success).toHaveBeenCalledWith('Warehouse "mybucket" created.');
     expect(createdSpy).toHaveBeenCalledWith(created);
     expect(component.visible).toBe(false);
@@ -106,7 +106,7 @@ describe("WarehouseCreateModalComponent", () => {
 
     component.createWarehouse();
 
-    expect(warehouseService.createWarehouse).not.toHaveBeenCalled();
+    expect(warehouseActions.create).not.toHaveBeenCalled();
   });
 
   it("does not double-submit while a create is in flight", () => {
@@ -115,11 +115,11 @@ describe("WarehouseCreateModalComponent", () => {
 
     component.createWarehouse();
 
-    expect(warehouseService.createWarehouse).not.toHaveBeenCalled();
+    expect(warehouseActions.create).not.toHaveBeenCalled();
   });
 
   it("keeps the modal open and surfaces the backend message when the create fails", () => {
-    warehouseService.createWarehouse.mockReturnValue(
+    warehouseActions.create.mockReturnValue(
       throwError(() => ({ error: "a warehouse named 'mybucket' already exists" }))
     );
     const visibleSpy = vi.fn();
@@ -132,16 +132,22 @@ describe("WarehouseCreateModalComponent", () => {
     expect(component.visible).toBe(true);
     expect(visibleSpy).not.toHaveBeenCalled();
     expect(component.creating).toBe(false);
-    expect(notificationService.error).toHaveBeenCalledWith("a warehouse named 'mybucket' already exists");
+    expect(notificationService.error).toHaveBeenCalledWith(
+      "Failed to create warehouse: a warehouse named 'mybucket' already exists"
+    );
   });
 
-  it("clears the previous name when the modal opens", () => {
+  it("clears the previous name and any stuck loading state when the modal opens", () => {
     component.newWarehouseName = "leftover";
+    // Cancelling mid-flight leaves creating set; reopening must not show a Create
+    // button stuck in its loading state.
+    component.creating = true;
     component.visible = true;
 
     component.ngOnChanges({ visible: new SimpleChange(false, true, false) });
 
     expect(component.newWarehouseName).toBe("");
+    expect(component.creating).toBe(false);
   });
 
   it("cancel closes without creating", () => {
@@ -153,6 +159,6 @@ describe("WarehouseCreateModalComponent", () => {
 
     expect(component.visible).toBe(false);
     expect(visibleSpy).toHaveBeenCalledWith(false);
-    expect(warehouseService.createWarehouse).not.toHaveBeenCalled();
+    expect(warehouseActions.create).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.spec.ts
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.spec.ts
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { SimpleChange } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { of, throwError } from "rxjs";
+import { WarehouseCreateModalComponent } from "./warehouse-create-modal.component";
+import { NotificationService } from "../../service/notification/notification.service";
+import { WarehouseService } from "../../service/warehouse/warehouse.service";
+import { DashboardWarehouse } from "../../type/warehouse";
+import { commonTestProviders } from "../../testing/test-utils";
+
+describe("WarehouseCreateModalComponent", () => {
+  let fixture: ComponentFixture<WarehouseCreateModalComponent>;
+  let component: WarehouseCreateModalComponent;
+  let warehouseService: { createWarehouse: ReturnType<typeof vi.fn> };
+  let notificationService: { error: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn> };
+
+  const created: DashboardWarehouse = {
+    whid: 7,
+    name: "mybucket",
+    lakekeeperWarehouseName: "user-1-mybucket",
+    flavor: "local",
+    createdAtMillis: 0,
+    ownerName: "Alice",
+    ownerAvatar: "",
+  };
+
+  beforeEach(async () => {
+    warehouseService = { createWarehouse: vi.fn().mockReturnValue(of(created)) };
+    notificationService = { error: vi.fn(), success: vi.fn() };
+
+    await TestBed.configureTestingModule({
+      imports: [WarehouseCreateModalComponent, NoopAnimationsModule, HttpClientTestingModule],
+      providers: [
+        // The rendered <nz-modal> injects NzModalService itself.
+        NzModalService,
+        { provide: WarehouseService, useValue: warehouseService },
+        { provide: NotificationService, useValue: notificationService },
+        ...commonTestProviders,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WarehouseCreateModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  it("renders the name input and a disabled Create button once opened", () => {
+    component.visible = true;
+    fixture.detectChanges();
+
+    // nz-modal renders into the CDK overlay on document, not into the fixture.
+    expect(document.querySelector("input[nz-input]")).toBeTruthy();
+    const createButton = document.querySelector<HTMLButtonElement>("#confirm-create-warehouse-btn");
+    expect(createButton?.disabled).toBe(true);
+
+    component.newWarehouseName = "mybucket";
+    fixture.detectChanges();
+    expect(createButton?.disabled).toBe(false);
+  });
+
+  it("creates the trimmed name, then emits the warehouse and closes", () => {
+    const createdSpy = vi.fn();
+    const visibleSpy = vi.fn();
+    component.warehouseCreated.subscribe(createdSpy);
+    component.visibleChange.subscribe(visibleSpy);
+    component.visible = true;
+    component.newWarehouseName = "  mybucket  ";
+
+    component.createWarehouse();
+
+    expect(warehouseService.createWarehouse).toHaveBeenCalledWith("mybucket");
+    expect(notificationService.success).toHaveBeenCalledWith('Warehouse "mybucket" created.');
+    expect(createdSpy).toHaveBeenCalledWith(created);
+    expect(component.visible).toBe(false);
+    expect(visibleSpy).toHaveBeenCalledWith(false);
+    expect(component.creating).toBe(false);
+  });
+
+  it("does nothing for a blank name", () => {
+    component.newWarehouseName = "   ";
+
+    component.createWarehouse();
+
+    expect(warehouseService.createWarehouse).not.toHaveBeenCalled();
+  });
+
+  it("does not double-submit while a create is in flight", () => {
+    component.newWarehouseName = "mybucket";
+    component.creating = true;
+
+    component.createWarehouse();
+
+    expect(warehouseService.createWarehouse).not.toHaveBeenCalled();
+  });
+
+  it("keeps the modal open and surfaces the backend message when the create fails", () => {
+    warehouseService.createWarehouse.mockReturnValue(
+      throwError(() => ({ error: "a warehouse named 'mybucket' already exists" }))
+    );
+    const visibleSpy = vi.fn();
+    component.visibleChange.subscribe(visibleSpy);
+    component.visible = true;
+    component.newWarehouseName = "mybucket";
+
+    component.createWarehouse();
+
+    expect(component.visible).toBe(true);
+    expect(visibleSpy).not.toHaveBeenCalled();
+    expect(component.creating).toBe(false);
+    expect(notificationService.error).toHaveBeenCalledWith("a warehouse named 'mybucket' already exists");
+  });
+
+  it("clears the previous name when the modal opens", () => {
+    component.newWarehouseName = "leftover";
+    component.visible = true;
+
+    component.ngOnChanges({ visible: new SimpleChange(false, true, false) });
+
+    expect(component.newWarehouseName).toBe("");
+  });
+
+  it("cancel closes without creating", () => {
+    const visibleSpy = vi.fn();
+    component.visibleChange.subscribe(visibleSpy);
+    component.visible = true;
+
+    component.handleCreateWarehouseModalCancel();
+
+    expect(component.visible).toBe(false);
+    expect(visibleSpy).toHaveBeenCalledWith(false);
+    expect(warehouseService.createWarehouse).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.spec.ts
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.spec.ts
@@ -22,7 +22,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { NzModalService } from "ng-zorro-antd/modal";
-import { of, throwError } from "rxjs";
+import { Subject, of, throwError } from "rxjs";
 import { WarehouseCreateModalComponent } from "./warehouse-create-modal.component";
 import { NotificationService } from "../../service/notification/notification.service";
 import { WarehouseActionsService } from "../../service/warehouse/warehouse-actions.service";
@@ -67,6 +67,11 @@ describe("WarehouseCreateModalComponent", () => {
 
   afterEach(() => {
     fixture?.destroy();
+  });
+
+  it("renders nothing while closed", () => {
+    // detectChanges already ran in beforeEach with visible=false.
+    expect(document.querySelector("#confirm-create-warehouse-btn")).toBeNull();
   });
 
   it("renders the name input and a disabled Create button once opened", () => {
@@ -147,6 +152,27 @@ describe("WarehouseCreateModalComponent", () => {
     component.ngOnChanges({ visible: new SimpleChange(false, true, false) });
 
     expect(component.newWarehouseName).toBe("");
+    expect(component.creating).toBe(false);
+  });
+
+  it("cancel abandons an in-flight create instead of letting it land later", () => {
+    // The component outlives the dialog, so without an explicit teardown the
+    // request would still succeed: creating the warehouse the user cancelled and
+    // closing the dialog they had already reopened.
+    const inFlight = new Subject<DashboardWarehouse>();
+    warehouseActions.create.mockReturnValue(inFlight.asObservable());
+    const createdSpy = vi.fn();
+    component.warehouseCreated.subscribe(createdSpy);
+    component.visible = true;
+    component.newWarehouseName = "first";
+    component.createWarehouse();
+
+    component.handleCreateWarehouseModalCancel();
+    inFlight.next(created);
+    inFlight.complete();
+
+    expect(createdSpy).not.toHaveBeenCalled();
+    expect(notificationService.success).not.toHaveBeenCalled();
     expect(component.creating).toBe(false);
   });
 

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.ts
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.ts
@@ -20,6 +20,7 @@
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from "@angular/core";
 import { FormsModule } from "@angular/forms";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { Subject, takeUntil } from "rxjs";
 import { NzButtonComponent } from "ng-zorro-antd/button";
 import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
 import { NzWaveDirective } from "ng-zorro-antd/core/wave";
@@ -59,6 +60,12 @@ export class WarehouseCreateModalComponent implements OnChanges {
   newWarehouseName = "";
   creating = false;
 
+  // Closing the dialog ends the attempt it was showing. Without this the request
+  // outlives the dialog (the component itself is never torn down), so Cancel
+  // would still create the warehouse and a late response would close — and
+  // discard — whatever the user had typed after reopening.
+  private readonly closed$ = new Subject<void>();
+
   constructor(
     private warehouseActionsService: WarehouseActionsService,
     private notificationService: NotificationService
@@ -81,7 +88,7 @@ export class WarehouseCreateModalComponent implements OnChanges {
     this.creating = true;
     this.warehouseActionsService
       .create(name)
-      .pipe(untilDestroyed(this))
+      .pipe(takeUntil(this.closed$), untilDestroyed(this))
       .subscribe({
         next: created => {
           this.creating = false;
@@ -102,6 +109,8 @@ export class WarehouseCreateModalComponent implements OnChanges {
   }
 
   private closeModal(): void {
+    this.closed$.next();
+    this.creating = false;
     this.visible = false;
     this.visibleChange.emit(false);
   }

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.ts
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.ts
@@ -26,15 +26,15 @@ import { NzWaveDirective } from "ng-zorro-antd/core/wave";
 import { NzInputDirective } from "ng-zorro-antd/input";
 import { NzModalComponent } from "ng-zorro-antd/modal";
 import { NotificationService } from "../../service/notification/notification.service";
-import { WarehouseService } from "../../service/warehouse/warehouse.service";
+import { WarehouseActionsService } from "../../service/warehouse/warehouse-actions.service";
 import { DashboardWarehouse } from "../../type/warehouse";
 import { extractErrorMessage } from "../../util/error";
 
 /**
- * Shared create-warehouse modal (#6933), embedded by the dashboard tab and the
- * workspace picker the same way ComputingUnitCreateModalComponent is: two-way
- * `[(visible)]` controls the dialog and `(warehouseCreated)` returns the
- * created warehouse.
+ * Shared create-warehouse modal (#6933), embedded the same way
+ * ComputingUnitCreateModalComponent is — two-way `[(visible)]` controls the
+ * dialog and `(warehouseCreated)` returns the created warehouse — by the
+ * dashboard tab today and by the workspace picker once it lands (#7817).
  */
 @UntilDestroy()
 @Component({
@@ -60,13 +60,16 @@ export class WarehouseCreateModalComponent implements OnChanges {
   creating = false;
 
   constructor(
-    private warehouseService: WarehouseService,
+    private warehouseActionsService: WarehouseActionsService,
     private notificationService: NotificationService
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes["visible"] && this.visible) {
+    if (changes["visible"]?.currentValue === true) {
       this.newWarehouseName = "";
+      // Cancelling mid-flight leaves creating set; without this the Create button
+      // reopens stuck in its loading state.
+      this.creating = false;
     }
   }
 
@@ -76,8 +79,8 @@ export class WarehouseCreateModalComponent implements OnChanges {
       return;
     }
     this.creating = true;
-    this.warehouseService
-      .createWarehouse(name)
+    this.warehouseActionsService
+      .create(name)
       .pipe(untilDestroyed(this))
       .subscribe({
         next: created => {
@@ -89,7 +92,7 @@ export class WarehouseCreateModalComponent implements OnChanges {
         error: (err: unknown) => {
           // Keep the modal open so the name can be corrected.
           this.creating = false;
-          this.notificationService.error(extractErrorMessage(err));
+          this.notificationService.error(`Failed to create warehouse: ${extractErrorMessage(err)}`);
         },
       });
   }

--- a/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.ts
+++ b/frontend/src/app/common/component/warehouse-create-modal/warehouse-create-modal.component.ts
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
+import { NzWaveDirective } from "ng-zorro-antd/core/wave";
+import { NzInputDirective } from "ng-zorro-antd/input";
+import { NzModalComponent } from "ng-zorro-antd/modal";
+import { NotificationService } from "../../service/notification/notification.service";
+import { WarehouseService } from "../../service/warehouse/warehouse.service";
+import { DashboardWarehouse } from "../../type/warehouse";
+import { extractErrorMessage } from "../../util/error";
+
+/**
+ * Shared create-warehouse modal (#6933), embedded by the dashboard tab and the
+ * workspace picker the same way ComputingUnitCreateModalComponent is: two-way
+ * `[(visible)]` controls the dialog and `(warehouseCreated)` returns the
+ * created warehouse.
+ */
+@UntilDestroy()
+@Component({
+  selector: "texera-warehouse-create-modal",
+  templateUrl: "./warehouse-create-modal.component.html",
+  styleUrls: ["./warehouse-create-modal.component.scss"],
+  imports: [
+    FormsModule,
+    NzModalComponent,
+    NzButtonComponent,
+    NzWaveDirective,
+    ɵNzTransitionPatchDirective,
+    NzInputDirective,
+  ],
+})
+export class WarehouseCreateModalComponent implements OnChanges {
+  // Must be bound two-way ([(visible)]): the modal closes itself.
+  @Input() visible = false;
+  @Output() visibleChange = new EventEmitter<boolean>();
+  @Output() warehouseCreated = new EventEmitter<DashboardWarehouse>();
+
+  newWarehouseName = "";
+  creating = false;
+
+  constructor(
+    private warehouseService: WarehouseService,
+    private notificationService: NotificationService
+  ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes["visible"] && this.visible) {
+      this.newWarehouseName = "";
+    }
+  }
+
+  createWarehouse(): void {
+    const name = this.newWarehouseName.trim();
+    if (!name || this.creating) {
+      return;
+    }
+    this.creating = true;
+    this.warehouseService
+      .createWarehouse(name)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: created => {
+          this.creating = false;
+          this.notificationService.success(`Warehouse "${created.name}" created.`);
+          this.warehouseCreated.emit(created);
+          this.closeModal();
+        },
+        error: (err: unknown) => {
+          // Keep the modal open so the name can be corrected.
+          this.creating = false;
+          this.notificationService.error(extractErrorMessage(err));
+        },
+      });
+  }
+
+  handleCreateWarehouseModalCancel(): void {
+    this.closeModal();
+  }
+
+  private closeModal(): void {
+    this.visible = false;
+    this.visibleChange.emit(false);
+  }
+}

--- a/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.spec.ts
+++ b/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.spec.ts
@@ -53,12 +53,12 @@ describe("WarehouseMetadataComponent", () => {
     expect(text).toContain(new Date(1723300000000).toLocaleString());
   });
 
-  it("shows a dash for an owner with no display name", () => {
+  it("shows None for an owner with no display name", () => {
     TestBed.overrideProvider(NZ_MODAL_DATA, { useValue: { ...warehouse, ownerName: null } });
     const fixture = TestBed.createComponent(WarehouseMetadataComponent);
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.textContent).toContain("\u2014");
+    expect(fixture.nativeElement.textContent).toContain("None");
   });
 
   it("leaves out the catalog name, which locates data the user cannot reach yet", () => {

--- a/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.spec.ts
+++ b/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { WarehouseMetadataComponent } from "./warehouse-metadata.component";
+import { DashboardWarehouse } from "../../type/warehouse";
+
+describe("WarehouseMetadataComponent", () => {
+  const warehouse: DashboardWarehouse = {
+    whid: 3,
+    name: "sales",
+    lakekeeperWarehouseName: "user-1-sales",
+    flavor: "local",
+    createdAtMillis: 1723300000000,
+    ownerName: "Alice",
+    ownerAvatar: "",
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WarehouseMetadataComponent],
+      providers: [{ provide: NZ_MODAL_DATA, useValue: warehouse }],
+    }).compileComponents();
+  });
+
+  it("renders every field of the injected warehouse", () => {
+    const fixture = TestBed.createComponent(WarehouseMetadataComponent);
+    fixture.detectChanges();
+
+    const text = fixture.nativeElement.textContent;
+    expect(text).toContain("sales");
+    expect(text).toContain("Alice");
+    expect(text).toContain("local");
+    // The absolute timestamp is locale-dependent; assert against the same
+    // conversion the component performs rather than a hard-coded string.
+    expect(text).toContain(new Date(1723300000000).toLocaleString());
+  });
+
+  it("shows a dash for an owner with no display name", () => {
+    TestBed.overrideProvider(NZ_MODAL_DATA, { useValue: { ...warehouse, ownerName: null } });
+    const fixture = TestBed.createComponent(WarehouseMetadataComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("\u2014");
+  });
+
+  it("leaves out the catalog name, which locates data the user cannot reach yet", () => {
+    const fixture = TestBed.createComponent(WarehouseMetadataComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain("user-1-sales");
+  });
+});

--- a/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.ts
+++ b/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.ts
@@ -41,7 +41,7 @@ import { DashboardWarehouse } from "../../type/warehouse";
         </tr>
         <tr>
           <th>Owner</th>
-          <td>{{ warehouse.ownerName || "—" }}</td>
+          <td>{{ warehouse.ownerName || "None" }}</td>
         </tr>
         <tr>
           <th>Flavor</th>

--- a/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.ts
+++ b/frontend/src/app/common/component/warehouse-metadata/warehouse-metadata.component.ts
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject } from "@angular/core";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { DashboardWarehouse } from "../../type/warehouse";
+
+/**
+ * Read-only warehouse details dialog (#6933), mirroring
+ * ComputingUnitMetadataComponent. Opened via NzModalService with the
+ * warehouse as NZ_MODAL_DATA.
+ *
+ * The Lakekeeper catalog name is deliberately left out: it is an internal
+ * catalog identifier that happens to double as the storage key prefix. What a
+ * user could act on, once warehouses live in their own bucket (#6870, Phase 1),
+ * is the storage location itself — a separate field.
+ */
+@Component({
+  template: `
+    <table class="ant-table">
+      <tbody>
+        <tr>
+          <th style="width: 150px;">Name</th>
+          <td>{{ warehouse.name }}</td>
+        </tr>
+        <tr>
+          <th>Owner</th>
+          <td>{{ warehouse.ownerName || "—" }}</td>
+        </tr>
+        <tr>
+          <th>Flavor</th>
+          <td>{{ warehouse.flavor }}</td>
+        </tr>
+        <tr>
+          <th>Created</th>
+          <td>{{ createdAt }}</td>
+        </tr>
+      </tbody>
+    </table>
+  `,
+})
+export class WarehouseMetadataComponent {
+  readonly warehouse: DashboardWarehouse = inject(NZ_MODAL_DATA);
+  readonly createdAt = new Date(this.warehouse.createdAtMillis).toLocaleString();
+}

--- a/frontend/src/app/common/service/warehouse/warehouse-actions.service.spec.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse-actions.service.spec.ts
@@ -110,7 +110,7 @@ describe("WarehouseActionsService", () => {
     // Resolves rather than rejects: the dialog closes and the error rides a toast.
     await modalService.confirm.mock.calls[0][0].nzOnOk();
 
-    expect(notificationService.error).toHaveBeenCalledWith("Lakekeeper unreachable");
+    expect(notificationService.error).toHaveBeenCalledWith("Failed to delete warehouse: Lakekeeper unreachable");
     expect(notificationService.success).not.toHaveBeenCalled();
     expect(onDeleted).not.toHaveBeenCalled();
   });

--- a/frontend/src/app/common/service/warehouse/warehouse-actions.service.spec.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse-actions.service.spec.ts
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { Subject, of, throwError } from "rxjs";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { WarehouseActionsService } from "./warehouse-actions.service";
+import { WarehouseService } from "./warehouse.service";
+import { NotificationService } from "../notification/notification.service";
+import { DashboardWarehouse } from "../../type/warehouse";
+
+describe("WarehouseActionsService", () => {
+  let service: WarehouseActionsService;
+  let modalService: { confirm: ReturnType<typeof vi.fn> };
+  let warehouseService: { deleteWarehouse: ReturnType<typeof vi.fn> };
+  let notificationService: { error: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn> };
+
+  const warehouse: DashboardWarehouse = {
+    whid: 3,
+    name: "sales",
+    lakekeeperWarehouseName: "user-1-sales",
+    flavor: "local",
+    createdAtMillis: 0,
+    ownerName: "Alice",
+    ownerAvatar: "",
+  };
+
+  beforeEach(() => {
+    modalService = { confirm: vi.fn() };
+    warehouseService = { deleteWarehouse: vi.fn().mockReturnValue(of(void 0)) };
+    notificationService = { error: vi.fn(), success: vi.fn() };
+
+    TestBed.configureTestingModule({
+      providers: [
+        WarehouseActionsService,
+        { provide: NzModalService, useValue: modalService },
+        { provide: WarehouseService, useValue: warehouseService },
+        { provide: NotificationService, useValue: notificationService },
+      ],
+    });
+    service = TestBed.inject(WarehouseActionsService);
+  });
+
+  it("asks for confirmation with the danger wording, without deleting yet", () => {
+    const onDeleted = vi.fn();
+
+    service.confirmAndDelete(warehouse, onDeleted);
+
+    expect(modalService.confirm).toHaveBeenCalledTimes(1);
+    const config = modalService.confirm.mock.calls[0][0];
+    expect(config.nzTitle).toBe('Delete warehouse "sales"?');
+    expect(config.nzOkText).toBe("Delete");
+    expect(config.nzOkDanger).toBe(true);
+    expect(warehouseService.deleteWarehouse).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
+  it("deletes on confirm, then notifies and runs onDeleted", async () => {
+    const onDeleted = vi.fn();
+    service.confirmAndDelete(warehouse, onDeleted);
+
+    await modalService.confirm.mock.calls[0][0].nzOnOk();
+
+    expect(warehouseService.deleteWarehouse).toHaveBeenCalledWith(3);
+    expect(notificationService.success).toHaveBeenCalledWith("Warehouse deleted.");
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the dialog busy until the delete settles", async () => {
+    // The backend waits out Lakekeeper's asynchronous purge (#7742), so nzOnOk must
+    // hand nz-modal a promise — that is what keeps the OK button spinning instead of
+    // closing the dialog onto a row that is still there.
+    const deleted = new Subject<void>();
+    warehouseService.deleteWarehouse.mockReturnValue(deleted.asObservable());
+    const onDeleted = vi.fn();
+    service.confirmAndDelete(warehouse, onDeleted);
+
+    const pending = modalService.confirm.mock.calls[0][0].nzOnOk();
+    expect(pending).toBeInstanceOf(Promise);
+    expect(onDeleted).not.toHaveBeenCalled();
+
+    deleted.next();
+    deleted.complete();
+    await pending;
+
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the backend message and skips onDeleted when the delete fails", async () => {
+    warehouseService.deleteWarehouse.mockReturnValue(throwError(() => ({ error: "Lakekeeper unreachable" })));
+    const onDeleted = vi.fn();
+    service.confirmAndDelete(warehouse, onDeleted);
+
+    // Resolves rather than rejects: the dialog closes and the error rides a toast.
+    await modalService.confirm.mock.calls[0][0].nzOnOk();
+
+    expect(notificationService.error).toHaveBeenCalledWith("Lakekeeper unreachable");
+    expect(notificationService.success).not.toHaveBeenCalled();
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/common/service/warehouse/warehouse-actions.service.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse-actions.service.ts
@@ -26,9 +26,10 @@ import { extractErrorMessage } from "../../util/error";
 import { WarehouseService } from "./warehouse.service";
 
 /**
- * Shared warehouse actions (#6933), mirroring ComputingUnitActionsService: the
- * dashboard tab and the workspace picker both delete warehouses, so the confirm
- * dialog and its wording live in one place.
+ * Shared warehouse actions (#6933), mirroring ComputingUnitActionsService:
+ * create and delete sit behind one service so the confirm dialog and its
+ * wording live in one place, shared with the workspace picker once it lands
+ * (#7817).
  */
 @Injectable({
   providedIn: "root",
@@ -71,7 +72,7 @@ export class WarehouseActionsService {
             onDeleted();
           })
           .catch((err: unknown) => {
-            this.notificationService.error(extractErrorMessage(err));
+            this.notificationService.error(`Failed to delete warehouse: ${extractErrorMessage(err)}`);
           }),
     });
   }

--- a/frontend/src/app/common/service/warehouse/warehouse-actions.service.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse-actions.service.ts
@@ -19,7 +19,7 @@
 
 import { Injectable } from "@angular/core";
 import { NzModalService } from "ng-zorro-antd/modal";
-import { firstValueFrom } from "rxjs";
+import { Observable, firstValueFrom } from "rxjs";
 import { NotificationService } from "../notification/notification.service";
 import { DashboardWarehouse } from "../../type/warehouse";
 import { extractErrorMessage } from "../../util/error";
@@ -39,6 +39,11 @@ export class WarehouseActionsService {
     private warehouseService: WarehouseService,
     private notificationService: NotificationService
   ) {}
+
+  /** Creates a warehouse, so create and delete both sit behind this service. */
+  create(name: string): Observable<DashboardWarehouse> {
+    return this.warehouseService.createWarehouse(name);
+  }
 
   /**
    * Asks for confirmation, then deletes the warehouse and all data stored in it.

--- a/frontend/src/app/common/service/warehouse/warehouse-actions.service.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse-actions.service.ts
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { firstValueFrom } from "rxjs";
+import { NotificationService } from "../notification/notification.service";
+import { DashboardWarehouse } from "../../type/warehouse";
+import { extractErrorMessage } from "../../util/error";
+import { WarehouseService } from "./warehouse.service";
+
+/**
+ * Shared warehouse actions (#6933), mirroring ComputingUnitActionsService: the
+ * dashboard tab and the workspace picker both delete warehouses, so the confirm
+ * dialog and its wording live in one place.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class WarehouseActionsService {
+  constructor(
+    private modalService: NzModalService,
+    private warehouseService: WarehouseService,
+    private notificationService: NotificationService
+  ) {}
+
+  /**
+   * Asks for confirmation, then deletes the warehouse and all data stored in it.
+   * Runs `onDeleted` after a successful delete so the caller can refresh its
+   * list (warehouses have no push stream to do that for them, unlike computing
+   * units).
+   *
+   * `nzOnOk` returns a promise so the dialog keeps its OK button spinning until
+   * the request settles: deleting a warehouse that still holds data waits out
+   * Lakekeeper's asynchronous purge (#7742), which can take tens of seconds,
+   * and closing the dialog immediately would read as a frozen row.
+   */
+  confirmAndDelete(warehouse: DashboardWarehouse, onDeleted: () => void): void {
+    this.modalService.confirm({
+      nzTitle: `Delete warehouse "${warehouse.name}"?`,
+      nzContent: "This permanently deletes the warehouse and all data stored in it.",
+      nzOkText: "Delete",
+      nzOkDanger: true,
+      // Resolves on failure too: the error is reported as a toast, and leaving the
+      // confirm dialog open on top of it would just have to be dismissed twice.
+      nzOnOk: () =>
+        firstValueFrom(this.warehouseService.deleteWarehouse(warehouse.whid))
+          .then(() => {
+            this.notificationService.success("Warehouse deleted.");
+            onDeleted();
+          })
+          .catch((err: unknown) => {
+            this.notificationService.error(extractErrorMessage(err));
+          }),
+    });
+  }
+}

--- a/frontend/src/app/common/service/warehouse/warehouse.service.spec.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse.service.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { AppSettings } from "../../app-setting";
+import { WarehouseService } from "./warehouse.service";
+import { DashboardWarehouse, WarehouseStatus } from "../../type/warehouse";
+
+describe("WarehouseService", () => {
+  let service: WarehouseService;
+  let httpMock: HttpTestingController;
+
+  const warehouse: DashboardWarehouse = {
+    whid: 7,
+    name: "mybucket",
+    lakekeeperWarehouseName: "user-3-mybucket",
+    flavor: "local",
+    createdAtMillis: 1723300000000,
+    ownerName: "Alice",
+    ownerAvatar: "",
+  };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WarehouseService],
+    });
+    service = TestBed.inject(WarehouseService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it("fetches the warehouse status", () => {
+    let received: WarehouseStatus | undefined;
+    service.getStatus().subscribe(status => (received = status));
+
+    const req = httpMock.expectOne(`${AppSettings.getApiEndpoint()}/warehouse/status`);
+    expect(req.request.method).toBe("GET");
+    req.flush({ enabled: true, warehouses: [warehouse] });
+
+    expect(received).toEqual({ enabled: true, warehouses: [warehouse] });
+  });
+
+  it("creates a warehouse with the given name", () => {
+    let received: DashboardWarehouse | undefined;
+    service.createWarehouse("mybucket").subscribe(created => (received = created));
+
+    const req = httpMock.expectOne(`${AppSettings.getApiEndpoint()}/warehouse`);
+    expect(req.request.method).toBe("POST");
+    expect(req.request.body).toEqual({ name: "mybucket" });
+    req.flush(warehouse);
+
+    expect(received).toEqual(warehouse);
+  });
+
+  it("deletes a warehouse by id", () => {
+    let completed = false;
+    service.deleteWarehouse(7).subscribe({ complete: () => (completed = true) });
+
+    const req = httpMock.expectOne(`${AppSettings.getApiEndpoint()}/warehouse/7`);
+    expect(req.request.method).toBe("DELETE");
+    req.flush(null);
+
+    expect(completed).toBe(true);
+  });
+
+  it("holds the per-execution warehouse pick; undefined means no pick", () => {
+    expect(service.getSelectedWarehouseIdValue()).toBeUndefined();
+
+    const seen: (number | undefined)[] = [];
+    service.getSelectedWarehouseId().subscribe(whid => seen.push(whid));
+
+    service.selectWarehouse(7);
+    expect(service.getSelectedWarehouseIdValue()).toBe(7);
+
+    service.selectWarehouse(undefined);
+    expect(service.getSelectedWarehouseIdValue()).toBeUndefined();
+
+    expect(seen).toEqual([undefined, 7, undefined]);
+  });
+});

--- a/frontend/src/app/common/service/warehouse/warehouse.service.spec.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse.service.spec.ts
@@ -83,19 +83,4 @@ describe("WarehouseService", () => {
 
     expect(completed).toBe(true);
   });
-
-  it("holds the per-execution warehouse pick; undefined means no pick", () => {
-    expect(service.getSelectedWarehouseIdValue()).toBeUndefined();
-
-    const seen: (number | undefined)[] = [];
-    service.getSelectedWarehouseId().subscribe(whid => seen.push(whid));
-
-    service.selectWarehouse(7);
-    expect(service.getSelectedWarehouseIdValue()).toBe(7);
-
-    service.selectWarehouse(undefined);
-    expect(service.getSelectedWarehouseIdValue()).toBeUndefined();
-
-    expect(seen).toEqual([undefined, 7, undefined]);
-  });
 });

--- a/frontend/src/app/common/service/warehouse/warehouse.service.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse.service.ts
@@ -19,7 +19,7 @@
 
 import { Injectable } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
-import { BehaviorSubject, Observable } from "rxjs";
+import { Observable } from "rxjs";
 import { AppSettings } from "../../app-setting";
 import { DashboardWarehouse, WarehouseStatus } from "../../type/warehouse";
 
@@ -28,20 +28,12 @@ export const WAREHOUSE_STATUS_URL = `${WAREHOUSE_BASE_URL}/status`;
 
 /**
  * Client of the per-user warehouse API (#6870): feature status + the caller's
- * warehouses, create, and delete. Also holds the workflow-level "which warehouse
- * does the next execution write to" pick, so the on-canvas picker (writer) and
- * ExecuteWorkflowService (reader) don't need to know each other.
+ * warehouses, create, and delete.
  */
 @Injectable({
   providedIn: "root",
 })
 export class WarehouseService {
-  // The warehouse the next execution writes to; undefined = no pick. The
-  // backend still treats an absent warehouseId as the shared default storage;
-  // #7751 tightens that to a rejection while the feature is enabled — the
-  // picker's preselect and the Run gate keep it defined there.
-  private selectedWarehouseIdSubject = new BehaviorSubject<number | undefined>(undefined);
-
   constructor(private http: HttpClient) {}
 
   public getStatus(): Observable<WarehouseStatus> {
@@ -54,17 +46,5 @@ export class WarehouseService {
 
   public deleteWarehouse(whid: number): Observable<void> {
     return this.http.delete<void>(`${AppSettings.getApiEndpoint()}/${WAREHOUSE_BASE_URL}/${whid}`);
-  }
-
-  public selectWarehouse(whid: number | undefined): void {
-    this.selectedWarehouseIdSubject.next(whid);
-  }
-
-  public getSelectedWarehouseId(): Observable<number | undefined> {
-    return this.selectedWarehouseIdSubject.asObservable();
-  }
-
-  public getSelectedWarehouseIdValue(): number | undefined {
-    return this.selectedWarehouseIdSubject.value;
   }
 }

--- a/frontend/src/app/common/service/warehouse/warehouse.service.ts
+++ b/frontend/src/app/common/service/warehouse/warehouse.service.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { BehaviorSubject, Observable } from "rxjs";
+import { AppSettings } from "../../app-setting";
+import { DashboardWarehouse, WarehouseStatus } from "../../type/warehouse";
+
+export const WAREHOUSE_BASE_URL = "warehouse";
+export const WAREHOUSE_STATUS_URL = `${WAREHOUSE_BASE_URL}/status`;
+
+/**
+ * Client of the per-user warehouse API (#6870): feature status + the caller's
+ * warehouses, create, and delete. Also holds the workflow-level "which warehouse
+ * does the next execution write to" pick, so the on-canvas picker (writer) and
+ * ExecuteWorkflowService (reader) don't need to know each other.
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class WarehouseService {
+  // The warehouse the next execution writes to; undefined = no pick. The
+  // backend still treats an absent warehouseId as the shared default storage;
+  // #7751 tightens that to a rejection while the feature is enabled — the
+  // picker's preselect and the Run gate keep it defined there.
+  private selectedWarehouseIdSubject = new BehaviorSubject<number | undefined>(undefined);
+
+  constructor(private http: HttpClient) {}
+
+  public getStatus(): Observable<WarehouseStatus> {
+    return this.http.get<WarehouseStatus>(`${AppSettings.getApiEndpoint()}/${WAREHOUSE_STATUS_URL}`);
+  }
+
+  public createWarehouse(name: string): Observable<DashboardWarehouse> {
+    return this.http.post<DashboardWarehouse>(`${AppSettings.getApiEndpoint()}/${WAREHOUSE_BASE_URL}`, { name });
+  }
+
+  public deleteWarehouse(whid: number): Observable<void> {
+    return this.http.delete<void>(`${AppSettings.getApiEndpoint()}/${WAREHOUSE_BASE_URL}/${whid}`);
+  }
+
+  public selectWarehouse(whid: number | undefined): void {
+    this.selectedWarehouseIdSubject.next(whid);
+  }
+
+  public getSelectedWarehouseId(): Observable<number | undefined> {
+    return this.selectedWarehouseIdSubject.asObservable();
+  }
+
+  public getSelectedWarehouseIdValue(): number | undefined {
+    return this.selectedWarehouseIdSubject.value;
+  }
+}

--- a/frontend/src/app/common/type/warehouse.ts
+++ b/frontend/src/app/common/type/warehouse.ts
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * A per-user warehouse registration (#6870), as served by `GET /warehouse/status`.
+ * Mirrors the backend's `WarehouseResource.DashboardWarehouse`.
+ */
+export interface DashboardWarehouse {
+  whid: number;
+  /** The user-facing name, unique per user and free to change. */
+  name: string;
+  /** The Lakekeeper catalog name (`user-<uid>-<whid>`), stable for life (#7753). */
+  lakekeeperWarehouseName: string;
+  flavor: string;
+  createdAtMillis: number;
+  /**
+   * Owner display info, mirroring DashboardWorkflowComputingUnit: every
+   * warehouse belongs to the caller today, but binding to the entry keeps
+   * shared warehouses rendering the right person (#7743). Null when the owner
+   * has not set a name or avatar.
+   */
+  ownerName: string | null;
+  ownerAvatar: string | null;
+}
+
+/**
+ * Response of `GET /warehouse/status`. `enabled` reflects the deployment-wide
+ * feature flag; with it off the warehouse UI stays hidden entirely.
+ */
+export interface WarehouseStatus {
+  enabled: boolean;
+  warehouses: ReadonlyArray<DashboardWarehouse>;
+}

--- a/frontend/src/app/dashboard/component/dashboard.component.html
+++ b/frontend/src/app/dashboard/component/dashboard.component.html
@@ -110,6 +110,18 @@
             <span>Compute</span>
           </li>
           <li
+            *ngIf="warehouseEnabled"
+            nz-menu-item
+            nz-tooltip="Manage warehouses"
+            nzMatchRouter="true"
+            nzTooltipPlacement="right"
+            [routerLink]="USER_WAREHOUSE">
+            <span
+              nz-icon
+              nzType="cloud-server"></span>
+            <span>Warehouses</span>
+          </li>
+          <li
             nz-menu-item
             nz-tooltip="Manage saved Python virtual environments"
             nzMatchRouter="true"

--- a/frontend/src/app/dashboard/component/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/component/dashboard.component.spec.ts
@@ -42,6 +42,7 @@ import type { Mock } from "vitest";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { commonTestProviders } from "../../common/testing/test-utils";
 import { GuiConfigService } from "../../common/service/gui-config.service";
+import { WarehouseService } from "../../common/service/warehouse/warehouse.service";
 import {
   ABOUT,
   ADMIN_EXECUTION,
@@ -53,6 +54,7 @@ import {
   USER_DISCUSSION,
   USER_PROJECT,
   USER_QUOTA,
+  USER_WAREHOUSE,
   USER_WORKFLOW,
 } from "../../app-routing.constant";
 
@@ -265,6 +267,7 @@ describe("DashboardComponent", () => {
     expect(USER_WORKFLOW).toBe("/user/workflow");
     expect(USER_DATASET).toBe("/user/dataset");
     expect(USER_COMPUTING_UNIT).toBe("/user/compute");
+    expect(USER_WAREHOUSE).toBe("/user/warehouse");
     expect(USER_QUOTA).toBe("/user/quota");
     expect(USER_DISCUSSION).toBe("/user/discussion");
     expect(ADMIN_USER).toBe("/admin/user");
@@ -296,6 +299,48 @@ describe("DashboardComponent", () => {
 
     // 7 "Your Work" links (incl. Python Venvs) + 4 admin links + 1 about link + 1 feedback link = 13
     expect(fixture.debugElement.queryAll(By.directive(RouterLink)).length).toBe(13);
+  });
+
+  describe("warehouse tab gating (#6933)", () => {
+    const warehouseMenuItem = () =>
+      fixture.debugElement
+        .queryAll(By.css("li[nz-menu-item]"))
+        .find(de => (de.nativeElement.textContent || "").trim() === "Warehouses");
+
+    beforeEach(() => {
+      (userServiceMock.isLogin as Mock).mockReturnValue(true);
+      component.isLogin = true;
+      component.sidebarTabs = { ...component.sidebarTabs, your_work_enabled: true };
+    });
+
+    it("shows the Warehouses item only while the backend reports the feature enabled", () => {
+      component.warehouseEnabled = false;
+      fixture.detectChanges();
+      expect(warehouseMenuItem()).toBeUndefined();
+
+      component.warehouseEnabled = true;
+      fixture.detectChanges();
+      expect(warehouseMenuItem()).toBeTruthy();
+    });
+
+    it("loadWarehouseEnabled follows the status endpoint, and stays hidden when logged out or failing", () => {
+      const statusSpy = vi
+        .spyOn(TestBed.inject(WarehouseService), "getStatus")
+        .mockReturnValue(of({ enabled: true, warehouses: [] }));
+
+      component.isLogin = false;
+      component.loadWarehouseEnabled();
+      expect(statusSpy).not.toHaveBeenCalled();
+      expect(component.warehouseEnabled).toBe(false);
+
+      component.isLogin = true;
+      component.loadWarehouseEnabled();
+      expect(component.warehouseEnabled).toBe(true);
+
+      statusSpy.mockReturnValue(throwError(() => new Error("401")));
+      component.loadWarehouseEnabled();
+      expect(component.warehouseEnabled).toBe(false);
+    });
   });
 
   describe("sidebar active-route highlighting (#3490)", () => {

--- a/frontend/src/app/dashboard/component/dashboard.component.spec.ts
+++ b/frontend/src/app/dashboard/component/dashboard.component.spec.ts
@@ -323,6 +323,24 @@ describe("DashboardComponent", () => {
       expect(warehouseMenuItem()).toBeTruthy();
     });
 
+    it("asks the status endpoint exactly once per dashboard load", () => {
+      // userChanged() replays the current user synchronously (a ReplaySubject(1)
+      // primed in UserService's constructor), so that subscription already covers
+      // the initial load: a second explicit call in ngOnInit would double every
+      // dashboard load, and dropping both would leave the tab permanently hidden.
+      (userServiceMock.isLogin as Mock).mockReturnValue(true);
+      const statusSpy = vi
+        .spyOn(TestBed.inject(WarehouseService), "getStatus")
+        .mockReturnValue(of({ enabled: true, warehouses: [] }));
+
+      const freshFixture = TestBed.createComponent(DashboardComponent);
+      freshFixture.detectChanges();
+
+      expect(statusSpy).toHaveBeenCalledTimes(1);
+      expect(freshFixture.componentInstance.warehouseEnabled).toBe(true);
+      freshFixture.destroy();
+    });
+
     it("loadWarehouseEnabled follows the status endpoint, and stays hidden when logged out or failing", () => {
       const statusSpy = vi
         .spyOn(TestBed.inject(WarehouseService), "getStatus")

--- a/frontend/src/app/dashboard/component/dashboard.component.ts
+++ b/frontend/src/app/dashboard/component/dashboard.component.ts
@@ -25,6 +25,7 @@ import { HttpErrorResponse } from "@angular/common/http";
 import { ActivatedRoute, NavigationEnd, Router, RouterLink, RouterOutlet } from "@angular/router";
 import { HubComponent } from "../../hub/component/hub.component";
 import { AdminSettingsService } from "../service/admin/settings/admin-settings.service";
+import { WarehouseService } from "../../common/service/warehouse/warehouse.service";
 import { GuiConfigService } from "../../common/service/gui-config.service";
 
 import {
@@ -39,6 +40,7 @@ import {
   USER_PROJECT,
   USER_PYTHON_VENV,
   USER_QUOTA,
+  USER_WAREHOUSE,
   USER_WORKFLOW,
   USER_FEEDBACK,
   LOGIN,
@@ -112,11 +114,16 @@ export class DashboardComponent implements OnInit {
     about_enabled: false,
   };
 
+  // Unlike sidebarTabs (admin-configured), the Warehouses tab follows the
+  // backend's warehouse feature flag, reported by GET /warehouse/status (#6933).
+  warehouseEnabled = false;
+
   protected readonly LOGIN = LOGIN;
   protected readonly USER_PROJECT = USER_PROJECT;
   protected readonly USER_WORKFLOW = USER_WORKFLOW;
   protected readonly USER_DATASET = USER_DATASET;
   protected readonly USER_COMPUTING_UNIT = USER_COMPUTING_UNIT;
+  protected readonly USER_WAREHOUSE = USER_WAREHOUSE;
   protected readonly USER_PYTHON_VENV = USER_PYTHON_VENV;
   protected readonly USER_QUOTA = USER_QUOTA;
   protected readonly USER_DISCUSSION = USER_DISCUSSION;
@@ -135,7 +142,8 @@ export class DashboardComponent implements OnInit {
     private ngZone: NgZone,
     private route: ActivatedRoute,
     private adminSettingsService: AdminSettingsService,
-    protected config: GuiConfigService
+    protected config: GuiConfigService,
+    private warehouseService: WarehouseService
   ) {}
 
   ngOnInit(): void {
@@ -160,12 +168,35 @@ export class DashboardComponent implements OnInit {
           this.isLogin = this.userService.isLogin();
           this.isAdmin = this.userService.isAdmin();
           this.forumLogin();
+          this.loadWarehouseEnabled();
         });
       });
 
     this.loadLogos();
 
     this.loadTabs();
+
+    this.loadWarehouseEnabled();
+  }
+
+  // The status endpoint needs an authenticated user; logged out (or on any
+  // fetch failure) the tab simply stays hidden.
+  loadWarehouseEnabled(): void {
+    if (!this.isLogin) {
+      this.warehouseEnabled = false;
+      return;
+    }
+    this.warehouseService
+      .getStatus()
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: status => {
+          this.warehouseEnabled = status.enabled;
+        },
+        error: () => {
+          this.warehouseEnabled = false;
+        },
+      });
   }
 
   // A missing key or a failed settings fetch keeps the branding/tab defaults;

--- a/frontend/src/app/dashboard/component/dashboard.component.ts
+++ b/frontend/src/app/dashboard/component/dashboard.component.ts
@@ -175,8 +175,6 @@ export class DashboardComponent implements OnInit {
     this.loadLogos();
 
     this.loadTabs();
-
-    this.loadWarehouseEnabled();
   }
 
   // The status endpoint needs an authenticated user; logged out (or on any

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.html
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.html
@@ -50,8 +50,6 @@
       class="resource-name-group">
       <div
         class="resource-name truncate-single-line"
-        nz-tooltip
-        [nzTooltipTitle]="warehouse.name"
         (click)="openWarehouseMetadataModal()">
         {{ warehouse.name }}
       </div>

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.html
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.html
@@ -1,0 +1,88 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<nz-card
+  [nzBodyStyle]="{padding: '3px'}"
+  class="warehouse-list-item-card">
+  <div
+    nz-row
+    nzAlign="middle"
+    class="warehouse-item-row">
+    <div
+      nz-col
+      nzFlex="20px"></div>
+
+    <div
+      nz-col
+      nzFlex="0"
+      class="type-icon">
+      <i
+        nz-icon
+        nzType="cloud-server"></i>
+    </div>
+
+    <div
+      nz-col
+      nzFlex="0"
+      class="warehouse-id">
+      <i>#{{ warehouse.whid }}</i>
+    </div>
+
+    <div
+      nz-col
+      nzFlex="1"
+      class="resource-name-group">
+      <div
+        class="resource-name truncate-single-line"
+        nz-tooltip
+        [nzTooltipTitle]="warehouse.name"
+        (click)="openWarehouseMetadataModal()">
+        {{ warehouse.name }}
+      </div>
+    </div>
+
+    <div class="button-group">
+      <button
+        nz-button
+        nzType="text"
+        title="Delete"
+        (click)="deleted.emit()">
+        <i
+          nz-icon
+          nzType="delete"></i>
+      </button>
+    </div>
+
+    <div
+      nz-col
+      nzFlex="100px"
+      class="resource-info">
+      Created:<br />
+      {{ formatRelativeTime(warehouse.createdAtMillis) }}
+    </div>
+
+    <div
+      nz-col
+      nzFlex="90px"
+      class="resource-info">
+      Flavor:<br />
+      {{ warehouse.flavor }}
+    </div>
+  </div>
+</nz-card>

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.scss
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@use "../../../section-style" as *;
+@use "../../../dashboard.component.scss" as *;
+
+.warehouse-list-item-card {
+  padding: 3px;
+  width: 100%;
+  background-color: white;
+  position: relative;
+  min-height: 65px;
+  height: auto;
+
+  &:hover {
+    background-color: #f0f0f0;
+  }
+}
+
+// The computing-unit row is 64px of content: its two 32px metric bars drive
+// the height. A warehouse row has no metrics, so pin the same content height
+// here — card paddings and borders already match, so the rows line up exactly.
+.warehouse-item-row {
+  min-height: 64px;
+}
+
+.warehouse-list-item-card:hover .button-group {
+  display: flex;
+  background-color: transparent;
+}
+
+.type-icon {
+  font-size: 30px;
+}
+
+.warehouse-id {
+  padding: 6px;
+}
+
+.resource-name-group {
+  min-width: 0;
+}
+
+.resource-name {
+  font-size: 17px;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.resource-name:hover {
+  text-decoration: underline;
+}
+
+.resource-info {
+  font-size: 13px;
+  color: grey;
+}
+
+.truncate-single-line {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.button-group {
+  display: none;
+  position: absolute;
+  height: 70px;
+  min-width: 150px;
+  right: 0;
+  bottom: 0;
+  justify-content: right;
+  align-items: center;
+  transition: none;
+  z-index: 10;
+
+  button {
+    margin-right: 32px;
+    transition: none;
+    background-color: #e0e0e0;
+    border: 1px solid #d0d0d0;
+    border-radius: 8px;
+  }
+
+  button:hover {
+    background-color: #c7c7c7;
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.spec.ts
@@ -23,6 +23,7 @@ import { NzIconModule } from "ng-zorro-antd/icon";
 import { NzModalRef, NzModalService } from "ng-zorro-antd/modal";
 import { CloudServerOutline, DeleteOutline } from "@ant-design/icons-angular/icons";
 import { UserWarehouseListItemComponent } from "./user-warehouse-list-item.component";
+import { WarehouseMetadataComponent } from "../../../../../common/component/warehouse-metadata/warehouse-metadata.component";
 import { DashboardWarehouse } from "../../../../../common/type/warehouse";
 import { commonTestProviders } from "../../../../../common/testing/test-utils";
 
@@ -89,6 +90,8 @@ describe("UserWarehouseListItemComponent", () => {
     expect(createSpy).toHaveBeenCalledTimes(1);
     const config = createSpy.mock.calls[0][0];
     expect(config.nzTitle).toBe("Warehouse Information");
+    // The content component is what the dialog actually shows.
+    expect(config.nzContent).toBe(WarehouseMetadataComponent);
     expect(config.nzData).toEqual(warehouse);
     expect(config.nzFooter).toBeNull();
   });

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { NzIconModule } from "ng-zorro-antd/icon";
+import { NzModalRef, NzModalService } from "ng-zorro-antd/modal";
+import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
+import { CloudServerOutline, DeleteOutline } from "@ant-design/icons-angular/icons";
+import { UserWarehouseListItemComponent } from "./user-warehouse-list-item.component";
+import { DashboardWarehouse } from "../../../../../common/type/warehouse";
+import { commonTestProviders } from "../../../../../common/testing/test-utils";
+
+describe("UserWarehouseListItemComponent", () => {
+  let fixture: ComponentFixture<UserWarehouseListItemComponent>;
+
+  const warehouse: DashboardWarehouse = {
+    whid: 3,
+    name: "sales",
+    lakekeeperWarehouseName: "user-1-sales",
+    flavor: "local",
+    createdAtMillis: 0,
+    ownerName: "Alice",
+    ownerAvatar: "",
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [UserWarehouseListItemComponent, NzIconModule.forChild([CloudServerOutline, DeleteOutline])],
+      providers: [NzModalService, ...commonTestProviders],
+    }).compileComponents();
+  });
+
+  it("throws when rendered without a warehouse", () => {
+    const item = new UserWarehouseListItemComponent({} as NzModalService);
+
+    expect(() => item.warehouse).toThrowError("warehouse property must be provided to UserWarehouseListItemComponent.");
+  });
+
+  it("renders the id, the name with its full-name tooltip, and the metadata columns", () => {
+    fixture = TestBed.createComponent(UserWarehouseListItemComponent);
+    fixture.componentInstance.warehouse = warehouse;
+    fixture.detectChanges();
+
+    const element: HTMLElement = fixture.nativeElement;
+    expect(element.querySelector(".warehouse-id")?.textContent).toContain("#3");
+    expect(element.querySelector(".resource-name")?.textContent).toContain("sales");
+    const nameTooltip = fixture.debugElement.query(By.css(".resource-name")).injector.get(NzTooltipDirective);
+    expect(nameTooltip.title).toBe("sales");
+    // The relative "Created" value depends on the clock; assert the labels only.
+    expect(element.textContent).toContain("Created:");
+    expect(element.textContent).toContain("Flavor:");
+    expect(element.textContent).toContain("local");
+  });
+
+  it("emits deleted when the delete button is clicked", () => {
+    fixture = TestBed.createComponent(UserWarehouseListItemComponent);
+    fixture.componentInstance.warehouse = warehouse;
+    fixture.detectChanges();
+    const deletedSpy = vi.fn();
+    fixture.componentInstance.deleted.subscribe(deletedSpy);
+
+    fixture.debugElement.query(By.css(".button-group button")).triggerEventHandler("click", null);
+
+    expect(deletedSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the metadata modal when the name is clicked", () => {
+    fixture = TestBed.createComponent(UserWarehouseListItemComponent);
+    fixture.componentInstance.warehouse = warehouse;
+    fixture.detectChanges();
+    const createSpy = vi.spyOn(TestBed.inject(NzModalService), "create").mockReturnValue({} as NzModalRef);
+
+    fixture.debugElement.query(By.css(".resource-name")).triggerEventHandler("click", null);
+
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    const config = createSpy.mock.calls[0][0];
+    expect(config.nzTitle).toBe("Warehouse Information");
+    expect(config.nzData).toEqual(warehouse);
+    expect(config.nzFooter).toBeNull();
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.spec.ts
@@ -21,7 +21,6 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { NzIconModule } from "ng-zorro-antd/icon";
 import { NzModalRef, NzModalService } from "ng-zorro-antd/modal";
-import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { CloudServerOutline, DeleteOutline } from "@ant-design/icons-angular/icons";
 import { UserWarehouseListItemComponent } from "./user-warehouse-list-item.component";
 import { DashboardWarehouse } from "../../../../../common/type/warehouse";
@@ -53,7 +52,7 @@ describe("UserWarehouseListItemComponent", () => {
     expect(() => item.warehouse).toThrowError("warehouse property must be provided to UserWarehouseListItemComponent.");
   });
 
-  it("renders the id, the name with its full-name tooltip, and the metadata columns", () => {
+  it("renders the id, the name, and the metadata columns", () => {
     fixture = TestBed.createComponent(UserWarehouseListItemComponent);
     fixture.componentInstance.warehouse = warehouse;
     fixture.detectChanges();
@@ -61,8 +60,6 @@ describe("UserWarehouseListItemComponent", () => {
     const element: HTMLElement = fixture.nativeElement;
     expect(element.querySelector(".warehouse-id")?.textContent).toContain("#3");
     expect(element.querySelector(".resource-name")?.textContent).toContain("sales");
-    const nameTooltip = fixture.debugElement.query(By.css(".resource-name")).injector.get(NzTooltipDirective);
-    expect(nameTooltip.title).toBe("sales");
     // The relative "Created" value depends on the clock; assert the labels only.
     expect(element.textContent).toContain("Created:");
     expect(element.textContent).toContain("Flavor:");

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.ts
@@ -28,7 +28,6 @@ import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patc
 import { NzRowDirective, NzColDirective } from "ng-zorro-antd/grid";
 import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
-import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 
 /**
  * One warehouse row of the dashboard tab (#6933), mirroring
@@ -47,7 +46,6 @@ import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
     NzIconDirective,
     NzSpaceCompactItemDirective,
     NzButtonComponent,
-    NzTooltipDirective,
   ],
 })
 export class UserWarehouseListItemComponent {

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse-list-item/user-warehouse-list-item.component.ts
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, EventEmitter, Input, Output } from "@angular/core";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { WarehouseMetadataComponent } from "../../../../../common/component/warehouse-metadata/warehouse-metadata.component";
+import { DashboardWarehouse } from "../../../../../common/type/warehouse";
+import { formatRelativeTime } from "../../../../../common/util/format.util";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzCardComponent } from "ng-zorro-antd/card";
+import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
+import { NzRowDirective, NzColDirective } from "ng-zorro-antd/grid";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
+import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
+
+/**
+ * One warehouse row of the dashboard tab (#6933), mirroring
+ * UserComputingUnitListItemComponent: the row only emits `deleted`; the
+ * containing list owns the confirmation dialog.
+ */
+@Component({
+  selector: "texera-user-warehouse-list-item",
+  templateUrl: "./user-warehouse-list-item.component.html",
+  styleUrls: ["./user-warehouse-list-item.component.scss"],
+  imports: [
+    NzCardComponent,
+    NzRowDirective,
+    NzColDirective,
+    ɵNzTransitionPatchDirective,
+    NzIconDirective,
+    NzSpaceCompactItemDirective,
+    NzButtonComponent,
+    NzTooltipDirective,
+  ],
+})
+export class UserWarehouseListItemComponent {
+  private _warehouse?: DashboardWarehouse;
+  @Output() deleted = new EventEmitter<void>();
+
+  @Input()
+  get warehouse(): DashboardWarehouse {
+    if (!this._warehouse) {
+      throw new Error("warehouse property must be provided to UserWarehouseListItemComponent.");
+    }
+    return this._warehouse;
+  }
+
+  set warehouse(value: DashboardWarehouse) {
+    this._warehouse = value;
+  }
+
+  constructor(private modalService: NzModalService) {}
+
+  openWarehouseMetadataModal(): void {
+    this.modalService.create({
+      nzTitle: "Warehouse Information",
+      nzContent: WarehouseMetadataComponent,
+      nzData: this.warehouse,
+      nzFooter: null,
+      nzMaskClosable: true,
+      nzWidth: "600px",
+    });
+  }
+
+  formatRelativeTime = formatRelativeTime;
+}

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.html
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.html
@@ -40,6 +40,18 @@
     class="section-list-container"
     [nzBodyStyle]="{ height: '100%'}">
     <div
+      *ngIf="loadFailed"
+      class="warehouse-page-empty">
+      Could not load your warehouses.
+      <button
+        nz-button
+        nzType="link"
+        (click)="retry()">
+        Retry
+      </button>
+    </div>
+
+    <div
       *ngIf="warehouseEnabled === false"
       class="warehouse-page-empty">
       Per-user warehouses are disabled in this deployment.

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.html
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.html
@@ -1,0 +1,72 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="section-container subsection-grid-container">
+  <nz-card class="section-title">
+    <h2 class="page-title">Warehouses</h2>
+    <div class="button-group">
+      <button
+        nz-button
+        class="create-btn"
+        (click)="showAddWarehouseModalVisible()"
+        [disabled]="!warehouseEnabled"
+        title="Create Warehouse">
+        <i
+          nz-icon
+          nzType="file-add"
+          nzTheme="outline"></i>
+        <span>Create Warehouse</span>
+      </button>
+    </div>
+  </nz-card>
+
+  <nz-card
+    class="section-list-container"
+    [nzBodyStyle]="{ height: '100%'}">
+    <div
+      *ngIf="!warehouseEnabled"
+      class="warehouse-page-empty">
+      Per-user warehouses are disabled in this deployment.
+    </div>
+
+    <div
+      *ngIf="warehouseEnabled && warehouses.length === 0"
+      class="warehouse-page-empty">
+      No warehouses yet. Click <strong>Create Warehouse</strong> to create one.
+    </div>
+
+    <cdk-virtual-scroll-viewport
+      *ngIf="warehouseEnabled && warehouses.length > 0"
+      itemSize="70"
+      class="virtual-scroll-container">
+      <nz-list>
+        <ng-container *cdkVirtualFor="let warehouse of warehouses">
+          <texera-user-warehouse-list-item
+            (deleted)="deleteWarehouse(warehouse)"
+            [warehouse]="warehouse"></texera-user-warehouse-list-item>
+        </ng-container>
+      </nz-list>
+    </cdk-virtual-scroll-viewport>
+  </nz-card>
+</div>
+
+<!-- Panel for creating the warehouse -->
+<texera-warehouse-create-modal
+  [(visible)]="addWarehouseModalVisible"
+  (warehouseCreated)="onWarehouseCreated()"></texera-warehouse-create-modal>

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.html
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.html
@@ -40,7 +40,7 @@
     class="section-list-container"
     [nzBodyStyle]="{ height: '100%'}">
     <div
-      *ngIf="!warehouseEnabled"
+      *ngIf="warehouseEnabled === false"
       class="warehouse-page-empty">
       Per-user warehouses are disabled in this deployment.
     </div>
@@ -52,7 +52,6 @@
     </div>
 
     <cdk-virtual-scroll-viewport
-      *ngIf="warehouseEnabled && warehouses.length > 0"
       itemSize="70"
       class="virtual-scroll-container">
       <nz-list>

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.scss
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.scss
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+@use "../../dashboard.component.scss" as *;
+@use "../../section-style" as *;
+@use "../../button-style" as *;
+
+.subsection-grid-container {
+  min-width: 100%;
+  width: 100%;
+  min-height: 100%;
+  height: 100%;
+}
+
+.warehouse-page-empty {
+  padding: 24px;
+  color: rgba(0, 0, 0, 0.55);
+  text-align: center;
+  border: 1px dashed #d9d9d9;
+  border-radius: 4px;
+}

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
+import { CloudServerOutline, DeleteOutline, FileAddOutline } from "@ant-design/icons-angular/icons";
+import { NzIconModule } from "ng-zorro-antd/icon";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { of, throwError } from "rxjs";
+
+import { UserWarehouseComponent } from "./user-warehouse.component";
+import { WarehouseCreateModalComponent } from "../../../../common/component/warehouse-create-modal/warehouse-create-modal.component";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WarehouseActionsService } from "../../../../common/service/warehouse/warehouse-actions.service";
+import { WarehouseService } from "../../../../common/service/warehouse/warehouse.service";
+import { DashboardWarehouse } from "../../../../common/type/warehouse";
+import { commonTestProviders } from "../../../../common/testing/test-utils";
+
+describe("UserWarehouseComponent", () => {
+  let component: UserWarehouseComponent;
+  let fixture: ComponentFixture<UserWarehouseComponent>;
+
+  let warehouseServiceSpy: {
+    getStatus: ReturnType<typeof vi.fn>;
+    createWarehouse: ReturnType<typeof vi.fn>;
+    deleteWarehouse: ReturnType<typeof vi.fn>;
+  };
+  let notificationSpy: {
+    error: ReturnType<typeof vi.fn>;
+    success: ReturnType<typeof vi.fn>;
+    info: ReturnType<typeof vi.fn>;
+    warning: ReturnType<typeof vi.fn>;
+  };
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  const warehouse = (whid: number, name: string): DashboardWarehouse => ({
+    whid,
+    name,
+    lakekeeperWarehouseName: `user-1-${name}`,
+    flavor: "local",
+    createdAtMillis: 1723300000000,
+    ownerName: "Alice",
+    ownerAvatar: "",
+  });
+
+  beforeEach(async () => {
+    warehouseServiceSpy = {
+      getStatus: vi.fn().mockReturnValue(of({ enabled: true, warehouses: [] })),
+      createWarehouse: vi.fn().mockReturnValue(of(warehouse(1, "mybucket"))),
+      deleteWarehouse: vi.fn().mockReturnValue(of(undefined)),
+    };
+    notificationSpy = {
+      error: vi.fn(),
+      success: vi.fn(),
+      info: vi.fn(),
+      warning: vi.fn(),
+    };
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        UserWarehouseComponent,
+        NoopAnimationsModule,
+        NzIconModule.forChild([FileAddOutline, CloudServerOutline, DeleteOutline]),
+      ],
+      providers: [
+        NzModalService,
+        { provide: WarehouseService, useValue: warehouseServiceSpy as unknown as WarehouseService },
+        { provide: NotificationService, useValue: notificationSpy as unknown as NotificationService },
+        ...commonTestProviders,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserWarehouseComponent);
+    component = fixture.componentInstance;
+  });
+
+  afterEach(() => {
+    consoleErrorSpy?.mockRestore();
+    fixture?.destroy();
+  });
+
+  it("shows the disabled notice when the deployment reports the feature off", () => {
+    warehouseServiceSpy.getStatus.mockReturnValue(of({ enabled: false, warehouses: [] }));
+
+    fixture.detectChanges();
+
+    expect(component.warehouseEnabled).toBe(false);
+    const notice = fixture.nativeElement.querySelector(".warehouse-page-empty");
+    expect(notice?.textContent).toContain("disabled in this deployment");
+    expect(fixture.nativeElement.querySelector("cdk-virtual-scroll-viewport")).toBeNull();
+  });
+
+  it("shows the create hint while the user has no warehouses", () => {
+    fixture.detectChanges();
+
+    const notice = fixture.nativeElement.querySelector(".warehouse-page-empty");
+    expect(notice?.textContent).toContain("No warehouses yet");
+    expect(fixture.nativeElement.querySelector("cdk-virtual-scroll-viewport")).toBeNull();
+  });
+
+  it("lists the user's warehouses in the virtual-scroll list", () => {
+    warehouseServiceSpy.getStatus.mockReturnValue(
+      of({ enabled: true, warehouses: [warehouse(1, "first"), warehouse(2, "second")] })
+    );
+
+    fixture.detectChanges();
+
+    // The virtual-scroll viewport has no height in jsdom, so assert the mapped
+    // state rather than the virtualized rows (their markup is covered by the
+    // list-item's own spec).
+    expect(component.warehouses.map(w => w.whid)).toEqual([1, 2]);
+    expect(fixture.nativeElement.querySelector("cdk-virtual-scroll-viewport")).toBeTruthy();
+    expect(fixture.nativeElement.querySelector(".warehouse-page-empty")).toBeNull();
+  });
+
+  it("surfaces a failed status fetch as a notification", () => {
+    warehouseServiceSpy.getStatus.mockReturnValue(throwError(() => new Error("boom")));
+
+    fixture.detectChanges();
+
+    expect(notificationSpy.error).toHaveBeenCalledWith("Failed to fetch warehouses.");
+  });
+
+  it("hands the warehouse to the actions service, and refreshes once it reports the delete", () => {
+    const actionsService = TestBed.inject(WarehouseActionsService);
+    const confirmAndDeleteSpy = vi.spyOn(actionsService, "confirmAndDelete").mockImplementation(() => {});
+    fixture.detectChanges();
+    warehouseServiceSpy.getStatus.mockClear();
+    const doomed = warehouse(3, "doomed");
+
+    component.deleteWarehouse(doomed);
+
+    expect(confirmAndDeleteSpy).toHaveBeenCalledTimes(1);
+    expect(confirmAndDeleteSpy.mock.calls[0][0]).toEqual(doomed);
+    const onDeleted = confirmAndDeleteSpy.mock.calls[0][1] as () => void;
+    onDeleted();
+    expect(warehouseServiceSpy.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes the warehouse list when the modal emits warehouseCreated", () => {
+    fixture.detectChanges();
+    warehouseServiceSpy.getStatus.mockClear();
+
+    const modal = fixture.debugElement.query(By.directive(WarehouseCreateModalComponent)).componentInstance;
+    modal.warehouseCreated.emit(warehouse(1, "mybucket"));
+
+    expect(warehouseServiceSpy.getStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("syncs visibility when the embedded modal closes itself", () => {
+    fixture.detectChanges();
+    component.showAddWarehouseModalVisible();
+    expect(component.addWarehouseModalVisible).toBe(true);
+
+    const modal = fixture.debugElement.query(By.directive(WarehouseCreateModalComponent)).componentInstance;
+    modal.visibleChange.emit(false);
+
+    expect(component.addWarehouseModalVisible).toBe(false);
+  });
+});

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.spec.ts
@@ -23,7 +23,7 @@ import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { CloudServerOutline, DeleteOutline, FileAddOutline } from "@ant-design/icons-angular/icons";
 import { NzIconModule } from "ng-zorro-antd/icon";
 import { NzModalService } from "ng-zorro-antd/modal";
-import { of, throwError } from "rxjs";
+import { NEVER, of, throwError } from "rxjs";
 
 import { UserWarehouseComponent } from "./user-warehouse.component";
 import { WarehouseCreateModalComponent } from "../../../../common/component/warehouse-create-modal/warehouse-create-modal.component";
@@ -105,7 +105,18 @@ describe("UserWarehouseComponent", () => {
     expect(component.warehouseEnabled).toBe(false);
     const notice = fixture.nativeElement.querySelector(".warehouse-page-empty");
     expect(notice?.textContent).toContain("disabled in this deployment");
-    expect(fixture.nativeElement.querySelector("cdk-virtual-scroll-viewport")).toBeNull();
+    expect(fixture.nativeElement.querySelectorAll("texera-user-warehouse-list-item").length).toBe(0);
+  });
+
+  it("says nothing about the feature while the status request is still in flight", () => {
+    // A plain false would render the "disabled in this deployment" notice, naming
+    // the wrong cause while the request is pending or after it failed.
+    warehouseServiceSpy.getStatus.mockReturnValue(NEVER);
+
+    fixture.detectChanges();
+
+    expect(component.warehouseEnabled).toBeUndefined();
+    expect(fixture.nativeElement.querySelector(".warehouse-page-empty")).toBeNull();
   });
 
   it("shows the create hint while the user has no warehouses", () => {
@@ -113,7 +124,7 @@ describe("UserWarehouseComponent", () => {
 
     const notice = fixture.nativeElement.querySelector(".warehouse-page-empty");
     expect(notice?.textContent).toContain("No warehouses yet");
-    expect(fixture.nativeElement.querySelector("cdk-virtual-scroll-viewport")).toBeNull();
+    expect(fixture.nativeElement.querySelectorAll("texera-user-warehouse-list-item").length).toBe(0);
   });
 
   it("lists the user's warehouses in the virtual-scroll list", () => {
@@ -137,6 +148,9 @@ describe("UserWarehouseComponent", () => {
     fixture.detectChanges();
 
     expect(notificationSpy.error).toHaveBeenCalledWith("Failed to fetch warehouses.");
+    // Still undefined, so the page does not claim the feature is disabled.
+    expect(component.warehouseEnabled).toBeUndefined();
+    expect(fixture.nativeElement.querySelector(".warehouse-page-empty")).toBeNull();
   });
 
   it("hands the warehouse to the actions service, and refreshes once it reports the delete", () => {

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.spec.ts
@@ -137,9 +137,49 @@ describe("UserWarehouseComponent", () => {
     // The virtual-scroll viewport has no height in jsdom, so assert the mapped
     // state rather than the virtualized rows (their markup is covered by the
     // list-item's own spec).
+    // The virtual-scroll viewport has no height in jsdom, so no rows are laid
+    // out here; the row markup is covered by the list item's own spec. What this
+    // asserts is the state the template iterates and the absence of any notice.
     expect(component.warehouses.map(w => w.whid)).toEqual([1, 2]);
-    expect(fixture.nativeElement.querySelector("cdk-virtual-scroll-viewport")).toBeTruthy();
     expect(fixture.nativeElement.querySelector(".warehouse-page-empty")).toBeNull();
+  });
+
+  it("opens the create modal from the header button, which is disabled while the feature is off", () => {
+    warehouseServiceSpy.getStatus.mockReturnValue(of({ enabled: false, warehouses: [] }));
+    fixture.detectChanges();
+
+    const createButton = fixture.debugElement.query(By.css(".create-btn"));
+    expect(createButton.nativeElement.disabled).toBe(true);
+
+    warehouseServiceSpy.getStatus.mockReturnValue(of({ enabled: true, warehouses: [] }));
+    component.ngOnInit();
+    fixture.detectChanges();
+    expect(createButton.nativeElement.disabled).toBe(false);
+
+    createButton.triggerEventHandler("click", null);
+    fixture.detectChanges();
+
+    expect(component.addWarehouseModalVisible).toBe(true);
+    // The flag has to reach the embedded modal, not just the component field.
+    expect(fixture.debugElement.query(By.directive(WarehouseCreateModalComponent)).componentInstance.visible).toBe(
+      true
+    );
+  });
+
+  it("offers a retry when the status request fails, and recovers on success", () => {
+    warehouseServiceSpy.getStatus.mockReturnValue(throwError(() => new Error("boom")));
+    fixture.detectChanges();
+
+    expect(component.loadFailed).toBe(true);
+    const notice = fixture.nativeElement.querySelector(".warehouse-page-empty");
+    expect(notice?.textContent).toContain("Could not load your warehouses");
+
+    warehouseServiceSpy.getStatus.mockReturnValue(of({ enabled: true, warehouses: [warehouse(1, "first")] }));
+    fixture.debugElement.query(By.css(".warehouse-page-empty button")).triggerEventHandler("click", null);
+    fixture.detectChanges();
+
+    expect(component.loadFailed).toBe(false);
+    expect(component.warehouses.map(w => w.whid)).toEqual([1]);
   });
 
   it("surfaces a failed status fetch as a notification", () => {
@@ -148,9 +188,12 @@ describe("UserWarehouseComponent", () => {
     fixture.detectChanges();
 
     expect(notificationSpy.error).toHaveBeenCalledWith("Failed to fetch warehouses.");
-    // Still undefined, so the page does not claim the feature is disabled.
+    // Still undefined, so the page reports the failure rather than claiming the
+    // feature is disabled.
     expect(component.warehouseEnabled).toBeUndefined();
-    expect(fixture.nativeElement.querySelector(".warehouse-page-empty")).toBeNull();
+    expect(fixture.nativeElement.querySelector(".warehouse-page-empty")?.textContent).toContain(
+      "Could not load your warehouses"
+    );
   });
 
   it("hands the warehouse to the actions service, and refreshes once it reports the delete", () => {

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.ts
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit } from "@angular/core";
+import { NgIf } from "@angular/common";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+
+import { ɵɵCdkVirtualScrollViewport, ɵɵCdkFixedSizeVirtualScroll, ɵɵCdkVirtualForOf } from "@angular/cdk/overlay";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzCardComponent } from "ng-zorro-antd/card";
+import { ɵNzTransitionPatchDirective } from "ng-zorro-antd/core/transition-patch";
+import { NzWaveDirective } from "ng-zorro-antd/core/wave";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzListComponent } from "ng-zorro-antd/list";
+import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
+
+import { WarehouseCreateModalComponent } from "../../../../common/component/warehouse-create-modal/warehouse-create-modal.component";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WarehouseActionsService } from "../../../../common/service/warehouse/warehouse-actions.service";
+import { WarehouseService } from "../../../../common/service/warehouse/warehouse.service";
+import { DashboardWarehouse } from "../../../../common/type/warehouse";
+import { UserWarehouseListItemComponent } from "./user-warehouse-list-item/user-warehouse-list-item.component";
+
+/**
+ * Dashboard page for per-user warehouses (#6933), mirroring
+ * UserComputingUnitComponent: list the caller's warehouses, create one (Local
+ * flavor), delete one. Reachable only while the deployment reports the feature
+ * enabled; the page re-checks and says so otherwise.
+ */
+@UntilDestroy()
+@Component({
+  selector: "texera-user-warehouse",
+  templateUrl: "./user-warehouse.component.html",
+  styleUrls: ["./user-warehouse.component.scss"],
+  imports: [
+    NgIf,
+    NzCardComponent,
+    NzSpaceCompactItemDirective,
+    NzButtonComponent,
+    NzWaveDirective,
+    ɵNzTransitionPatchDirective,
+    NzIconDirective,
+    ɵɵCdkVirtualScrollViewport,
+    ɵɵCdkFixedSizeVirtualScroll,
+    NzListComponent,
+    ɵɵCdkVirtualForOf,
+    UserWarehouseListItemComponent,
+    WarehouseCreateModalComponent,
+  ],
+})
+export class UserWarehouseComponent implements OnInit {
+  warehouseEnabled = false;
+  warehouses: DashboardWarehouse[] = [];
+
+  // visibility of the shared create-warehouse modal
+  addWarehouseModalVisible = false;
+
+  constructor(
+    private warehouseService: WarehouseService,
+    private notificationService: NotificationService,
+    private warehouseActionsService: WarehouseActionsService
+  ) {}
+
+  ngOnInit(): void {
+    this.refresh();
+  }
+
+  private refresh(): void {
+    this.warehouseService
+      .getStatus()
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: status => {
+          this.warehouseEnabled = status.enabled;
+          this.warehouses = [...status.warehouses];
+        },
+        error: (err: unknown) => {
+          console.error("Failed to fetch warehouses", err);
+          this.notificationService.error("Failed to fetch warehouses.");
+        },
+      });
+  }
+
+  deleteWarehouse(warehouse: DashboardWarehouse): void {
+    this.warehouseActionsService.confirmAndDelete(warehouse, () => this.refresh());
+  }
+
+  showAddWarehouseModalVisible(): void {
+    this.addWarehouseModalVisible = true;
+  }
+
+  onWarehouseCreated(): void {
+    this.refresh();
+  }
+}

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.ts
@@ -70,6 +70,9 @@ export class UserWarehouseComponent implements OnInit {
   // the wrong cause.
   warehouseEnabled?: boolean;
   warehouses: DashboardWarehouse[] = [];
+  // The status request failed: without this the page renders neither the
+  // disabled notice nor the list, leaving a blank card and no way back.
+  loadFailed = false;
 
   // visibility of the shared create-warehouse modal
   addWarehouseModalVisible = false;
@@ -84,16 +87,22 @@ export class UserWarehouseComponent implements OnInit {
     this.refresh();
   }
 
+  retry(): void {
+    this.refresh();
+  }
+
   private refresh(): void {
     this.warehouseService
       .getStatus()
       .pipe(untilDestroyed(this))
       .subscribe({
         next: status => {
+          this.loadFailed = false;
           this.warehouseEnabled = status.enabled;
           this.warehouses = [...status.warehouses];
         },
         error: (err: unknown) => {
+          this.loadFailed = true;
           console.error("Failed to fetch warehouses", err);
           this.notificationService.error("Failed to fetch warehouses.");
         },

--- a/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-warehouse/user-warehouse.component.ts
@@ -65,7 +65,10 @@ import { UserWarehouseListItemComponent } from "./user-warehouse-list-item/user-
   ],
 })
 export class UserWarehouseComponent implements OnInit {
-  warehouseEnabled = false;
+  // Undefined until the status request settles: with a plain false, a pending or
+  // failed request renders the "disabled in this deployment" notice, which names
+  // the wrong cause.
+  warehouseEnabled?: boolean;
   warehouses: DashboardWarehouse[] = [];
 
   // visibility of the shared create-warehouse modal


### PR DESCRIPTION
### What changes were proposed in this PR?

The dashboard page for managing per-user warehouses. This is one half of #6933's original scope — the on-canvas per-execution picker is split out to #7817 so each surface lands as one reviewable change — and it is the half that has no dependency on the other: nothing here touches the workspace, the execution request, or any existing behaviour.

The page mirrors the computing-unit tab so the two read as one product rather than two:

- **`user-warehouse`** — the section container: title card, a `cloud-server` create button, and the same virtual-scroll list the computing-unit tab uses. It states its own empty cases (feature disabled, no warehouses yet, status request failed) and offers a retry on the last one.
- **`user-warehouse-list-item`** — the row card, matched to the computing-unit row down to its 64px content height, hover-revealed actions, id column and metadata columns. Clicking the name opens a read-only details dialog (name, owner, flavor, created).
- **`warehouse-create-modal`** — a shared dialog embedded through `[(visible)]`, the same contract as `ComputingUnitCreateModalComponent`. It keeps itself open on failure, disables Create on an empty name, guards against double submission, and abandons the attempt when the dialog closes so Cancel actually cancels.
- **`WarehouseService` / `WarehouseActionsService`** — the HTTP client and, mirroring `ComputingUnitActionsService`, one service behind which both create and delete sit, owning the delete confirmation and its wording. The delete dialog stays busy until the request settles: deleting a warehouse that holds data waits out Lakekeeper's asynchronous purge (#7742), which takes seconds.
- **Gating and routing** — the sidebar entry appears only when `GET /warehouse/status` reports the feature enabled. The route is registered unconditionally, as `/user/compute` is; with the flag off the page says the feature is disabled and every warehouse endpoint answers 403.

Warehouses have no status, metrics, rename or sharing, so the computing-unit row's badge, progress bars, inline rename and share control have no counterpart here — those are the only places the two rows differ.

With the flag off, which is every deployment today, none of this is reachable and the UI is unchanged.

### Any related issues, documentation, discussions?

Closes #6933. Part of #6870; the on-canvas picker follows in #7817. Builds on the merged backend: the warehouse endpoints (#6932), the owner fields the rows and dialog render (#7743), the id-derived catalog name (#7753) and the purge-aware delete (#7742).

### How was this PR tested?

- Vitest specs for every piece — tab container, list item, create modal, details dialog, HTTP service and actions service: 56 tests across 7 files.
  - Whole suite as CI runs it: `yarn test:ci`
  - Just this change: `ng test --watch=false --include "src/app/common/component/warehouse-*/**/*.spec.ts" --include "src/app/common/service/warehouse/*.spec.ts" --include "src/app/dashboard/component/user/user-warehouse/**/*.spec.ts" --include "src/app/dashboard/component/dashboard.component.spec.ts"`
- Failure paths verified rather than assumed: each behaviour these specs pin was broken on purpose — the create button's click and disabled binding, the modal wiring, the status call sites, the details dialog's content component, the tri-state flag, the cancel teardown — and the suite was confirmed to fail for the expected reason before being restored.
- Manually exercised against a local deployment with the flag on, backed by live Lakekeeper and MinIO: create, list, delete (including a warehouse holding execution data), the details dialog, and the disabled-deployment view with the flag off.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-5, claude-fable-5)
