### PR TITLE
fix(frontend): read autofill required-ness from the property's own schema level

### DIFF
--- a/frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.spec.ts
+++ b/frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.spec.ts
@@ -471,6 +471,100 @@ describe("WorkflowCompilingService.setOperatorInputAttrs / restoreOperatorInputA
       ).toEqual(["col_a", "col_b"]);
     });
 
+    /**
+     * Required-ness has to be read off the schema level the property actually belongs to.
+     * `mutateProperty` recurses into nested `properties` / `items` / `definitions`, so a property nested
+     * inside a list element carries its own `required` array, unrelated to the root's.
+     *
+     * The shape below mirrors SortOpDesc: root requires `attributes`, and each element of that list
+     * strictly requires its autofilled `attribute`. An empty option there would let the user pick a
+     * blank sort key, which the operator rejects at code-generation time instead of at form validation.
+     */
+    it("does not append an empty option for a property required inside a nested list element", () => {
+      const schema = makeOperatorSchema({
+        type: "object",
+        required: ["attributes"],
+        properties: {
+          attributes: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["attribute", "sortPreference"],
+              properties: {
+                attribute: { type: "string", autofill: "attributeName", autofillAttributeOnPort: 0 },
+                sortPreference: { type: "string", enum: ["ASC", "DESC"] },
+              },
+            },
+          },
+        },
+      });
+
+      const items = (
+        WorkflowCompilingService.setOperatorInputAttrs(schema, inputPortSchemaMap).jsonSchema.properties as any
+      ).attributes.items;
+      expect(items.properties.attribute.enum).toEqual(["col_a", "col_b"]);
+    });
+
+    /**
+     * The same lookup, in the opposite direction: a nested *optional* property whose name happens to
+     * collide with a root-level required name must keep its empty escape hatch.
+     */
+    it("appends the empty option for a nested optional property that shares a root-level required name", () => {
+      const schema = makeOperatorSchema({
+        type: "object",
+        // a root-level property that happens to share the nested property's name, and is required here
+        required: ["attribute", "aggregations"],
+        properties: {
+          attribute: { type: "string" },
+          aggregations: {
+            type: "array",
+            items: {
+              type: "object",
+              // `attribute` is optional at this level (COUNT(*) needs no column)
+              required: ["aggFunction"],
+              properties: {
+                attribute: { type: "string", autofill: "attributeName", autofillAttributeOnPort: 0 },
+                aggFunction: { type: "string", enum: ["sum", "count"] },
+              },
+            },
+          },
+        },
+      });
+
+      const items = (
+        WorkflowCompilingService.setOperatorInputAttrs(schema, inputPortSchemaMap).jsonSchema.properties as any
+      ).aggregations.items;
+      expect(items.properties.attribute.enum).toEqual(["col_a", "col_b", ""]);
+    });
+
+    /**
+     * The metadata generator emits nested object types as `$ref` + a root-level `definitions` entry, so the
+     * owning schema is reached through `definitions` rather than through `items`. Same rule applies.
+     */
+    it("reads required-ness from the owning definition when the nested type lives in definitions", () => {
+      const schema = makeOperatorSchema({
+        type: "object",
+        required: ["attributes"],
+        properties: {
+          attributes: { type: "array", items: { $ref: "#/definitions/SortCriteriaUnit" } },
+        },
+        definitions: {
+          SortCriteriaUnit: {
+            type: "object",
+            required: ["attribute"],
+            properties: {
+              attribute: { type: "string", autofill: "attributeName", autofillAttributeOnPort: 0 },
+            },
+          },
+        },
+      });
+
+      const definition = (
+        WorkflowCompilingService.setOperatorInputAttrs(schema, inputPortSchemaMap).jsonSchema.definitions as any
+      ).SortCriteriaUnit;
+      expect(definition.properties.attribute.enum).toEqual(["col_a", "col_b"]);
+    });
+
     it("includes additionalEnumValue before the optional empty option", () => {
       const schema = makeOperatorSchema({
         type: "object",

--- a/frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.ts
+++ b/frontend/src/app/workspace/service/compile-workflow/workflow-compiling.service.ts
@@ -338,7 +338,11 @@ export class WorkflowCompilingService {
 
     let newJsonSchema = operatorSchema.jsonSchema;
 
-    const getAttrNames = (attrName: string, v: CustomJSONSchema7): string[] | undefined => {
+    const getAttrNames = (
+      attrName: string,
+      v: CustomJSONSchema7,
+      owningSchema: CustomJSONSchema7
+    ): string[] | undefined => {
       const i = v.autofillAttributeOnPort;
       if (i === undefined || i === null || !Number.isInteger(i)) {
         return undefined;
@@ -359,7 +363,10 @@ export class WorkflowCompilingService {
       // https://github.com/ajv-validator/ajv/issues/1471
       // the null -> "" change is done by Ajv.validate() with useDefault set to true.
       // It is converted during the property editor form initialization and workflow validation, instead of during schema propagation.
-      if (!operatorSchema.jsonSchema.required?.includes(attrName)) {
+      // `required` is a keyword of the object schema that owns the property, so it has to be read off
+      // `owningSchema` rather than the root: mutateProperty also reaches properties nested inside
+      // `properties`/`items`/`definitions`, whose required-ness is declared on their own level.
+      if (!owningSchema.required?.includes(attrName)) {
         if (v.default) {
           if (typeof v.default !== "string") {
             throw new Error("default value must be a string");
@@ -377,10 +384,10 @@ export class WorkflowCompilingService {
     newJsonSchema = DynamicSchemaService.mutateProperty(
       newJsonSchema,
       (k, v) => v.autofill === "attributeName",
-      (attrName, old) => ({
+      (attrName, old, owningSchema) => ({
         ...old,
         type: "string",
-        enum: getAttrNames(attrName, old),
+        enum: getAttrNames(attrName, old, owningSchema),
         uniqueItems: true,
       })
     );
@@ -388,14 +395,14 @@ export class WorkflowCompilingService {
     newJsonSchema = DynamicSchemaService.mutateProperty(
       newJsonSchema,
       (k, v) => v.autofill === "attributeNameList",
-      (attrName, old) => ({
+      (attrName, old, owningSchema) => ({
         ...old,
         type: "array",
         uniqueItems: true,
         items: {
           ...(old.items as CustomJSONSchema7),
           type: "string",
-          enum: getAttrNames(attrName, old),
+          enum: getAttrNames(attrName, old, owningSchema),
         },
       })
     );

--- a/frontend/src/app/workspace/service/dynamic-schema/dynamic-schema.service.ts
+++ b/frontend/src/app/workspace/service/dynamic-schema/dynamic-schema.service.ts
@@ -155,13 +155,19 @@ export class DynamicSchemaService {
    * It recursively walks through the property field of a JSON schema, and tries to find the property name.
    * Once it finds the property name, it invokes the mutationFunction to get the new property and replaces the old property.
    * The mutationFunction optionally takes a input with current property of the propertyName and outputs the new mutated property.
+   * It also receives the schema that owns the property (the one holding the `properties`/`definitions` map it was
+   * found in), because keywords such as `required` live on that owning level rather than on the property itself.
    *
    * Returns a new object containing the new json schema property.
    */
   public static mutateProperty(
     jsonSchemaToChange: CustomJSONSchema7,
     matchFunc: (propertyName: string, propertyValue: CustomJSONSchema7) => boolean,
-    mutationFunc: (propertyName: string, propertyValue: CustomJSONSchema7) => CustomJSONSchema7
+    mutationFunc: (
+      propertyName: string,
+      propertyValue: CustomJSONSchema7,
+      owningSchema: CustomJSONSchema7
+    ) => CustomJSONSchema7
   ): CustomJSONSchema7 {
     // recursively walks the JSON schema property tree to find the property name
     const mutatePropertyRecurse = (jsonSchema: JSONSchema7) => {
@@ -176,7 +182,11 @@ export class DynamicSchemaService {
             return;
           }
           if (matchFunc(propertyName, propertyValue as CustomJSONSchema7)) {
-            objectProperty[propertyName] = mutationFunc(propertyName, propertyValue as CustomJSONSchema7);
+            objectProperty[propertyName] = mutationFunc(
+              propertyName,
+              propertyValue as CustomJSONSchema7,
+              jsonSchema as CustomJSONSchema7
+            );
           } else {
             mutatePropertyRecurse(propertyValue);
           }


### PR DESCRIPTION
### What changes were proposed in this PR?

`getAttrNames` decided whether an autofilled property was required by consulting the **root** schema, while `DynamicSchemaService.mutateProperty` recurses into nested `properties` / `items` / `definitions`. Its callbacks only received `(propertyName, propertyValue)`, so the owning object schema was never available — and a property nested inside a list element was tested against a `required` array that does not describe it.

**This has a real production consequence, not just a synthetic one.** `SortOpDesc` + `SortCriteriaUnit`: the root requires `attributes`, and each element declares `@JsonProperty(value = "attribute", required = true)` with `@AutofillAttributeName`. Root `required` is `["attributes"]`, so `"attribute"` was not found there and an empty option was appended — offering a blank sort key that `SortOpDesc.generatePythonCode` then rejects at code-generation time (`require(attributes.forall(c => c.attributeName != null && c.attributeName.trim.nonEmpty))`) instead of at form validation.

The mirror case is the `aggregations[].attribute` shape, where `attribute` is legitimately optional per element (COUNT(*) needs no column): a root-level required property sharing that name would silently strip its empty option.

### The fix

Two files, minimally:

- `dynamic-schema.service.ts` — `mutationFunc` gains a third parameter: the schema owning the `properties`/`definitions` map the property was found in. Inside `mutateObjectProperty` that is just the enclosing `jsonSchema`, already in scope. `matchFunc` is untouched, since it only inspects `autofill`.
- `workflow-compiling.service.ts` — `getAttrNames(attrName, v, owningSchema)` now tests `owningSchema.required?.includes(attrName)`; both `setOperatorInputAttrs` call sites forward it.

**On the signature change:** this does widen `mutateProperty`'s public callback type, but additively — TypeScript permits callbacks that declare fewer parameters, so both `restoreOperatorInputAttrs` call sites and all six spec call sites compile untouched. The alternative, pre-collecting required-ness in a second walk inside `setOperatorInputAttrs`, cannot work: required-ness would still be keyed by name, and the collision case is precisely where name-based lookup is ambiguous. Plumbing the owner is the only correct fix. `mutateProperty` is not otherwise refactored.

### Failing before, passing after — both directions

| | production reverted | with fix |
|---|---|---|
| `workflow-compiling.service.spec.ts` | **3 failed, 47 passed** | **50 passed** |
| with `dynamic-schema.service.spec.ts` | — | **62 passed** |

The three before-state failures are the three cases that matter:

| case | actual | expected |
|---|---|---|
| nested required via `items` | `['col_a','col_b','']` | `['col_a','col_b']` |
| nested optional colliding with a root-level required name | `['col_a','col_b']` | `['col_a','col_b','']` |
| nested required via `$ref` + `definitions` | `['col_a','col_b','']` | `['col_a','col_b']` |

The third is worth calling out: `definitions` is the shape the metadata generator actually emits (`OperatorMetadataGenerator.texeraSchemaGeneratorConfig` on mbknor-jackson-jsonSchema places nested types there), so it would have regressed independently of the `items` path.

### Root-level behaviour is unchanged

#7727's root-level tests are the regression net here and all pass: `injects the input attribute names as an enum on an optional attributeName property`, `does not append an empty option for required properties`, `appends the property's string default instead of "" for optional properties`, and `includes additionalEnumValue before the optional empty option`.

### Verification

- `workflow-compiling.service.spec.ts` 50/50; `dynamic-schema.service.spec.ts` 12/12 (direct `mutateProperty` coverage, including the `definitions` recursion).
- Combined with `operator-property-edit-frame.component.spec.ts`, the only other autofill consumer: **258 passed | 1 skipped**.
- Because the builder typechecks every spec on each run, those green runs also confirm no typecheck drift from the signature change.
- `yarn format:ci` exits 0; the spec diff is 94 insertions / 0 deletions, so no untouched lines were reformatted. No `junit.xml` left behind.

### Any related issues, documentation, discussions?

Closes #7826

### How was this PR tested?

```
npx ng test --watch=false --include="**/workflow-compiling.service.spec.ts" --include="**/dynamic-schema.service.spec.ts"
```

```
 Test Files  2 passed (2)
      Tests  62 passed (62)
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
