### PR TITLE
test(amber): cover the auth resource's bootstrap and validation guards

### DIFF
--- a/amber/src/test/scala/org/apache/texera/web/resource/auth/AuthResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/auth/AuthResourceSpec.scala
@@ -19,6 +19,9 @@
 
 package org.apache.texera.web.resource.auth
 
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.classic.{Level, Logger => LogbackLogger}
+import ch.qos.logback.core.read.ListAppender
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.dropwizard.jersey.errors.LoggingExceptionMapper
 import org.apache.texera.auth.{JwtAuth, SessionUser}
@@ -33,10 +36,12 @@ import org.jasypt.util.password.StrongPasswordEncryptor
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import org.slf4j.LoggerFactory
 
 import java.time.OffsetDateTime
 import java.util.UUID
 import javax.ws.rs.{NotAcceptableException, NotAuthorizedException, WebApplicationException}
+import scala.jdk.CollectionConverters._
 
 class AuthResourceSpec
     extends AnyFlatSpec
@@ -126,6 +131,30 @@ class AuthResourceSpec
   private def subjectOf(token: String): String =
     JwtAuth.jwtConsumer.processToClaims(token).getSubject
 
+  private def googleIdClaimOf(token: String): AnyRef =
+    JwtAuth.jwtConsumer.processToClaims(token).getClaimValue("googleId")
+
+  /**
+    * Runs `body` with a capturing appender on the logger `AuthResource`'s companion writes to, and
+    * returns the WARN messages it emitted. The level is forced because the root logger governs
+    * this module (there is no logback-test.xml) and CI lowers it.
+    */
+  private def warningsDuring(body: => Unit): Seq[String] = {
+    val logger = LoggerFactory.getLogger(classOf[AuthResource]).asInstanceOf[LogbackLogger]
+    val appender = new ListAppender[ILoggingEvent]
+    appender.start()
+    val previousLevel = logger.getLevel
+    logger.setLevel(Level.WARN)
+    logger.addAppender(appender)
+    try body
+    finally {
+      logger.detachAppender(appender)
+      appender.stop()
+      logger.setLevel(previousLevel)
+    }
+    appender.list.asScala.toSeq.filter(_.getLevel == Level.WARN).map(_.getFormattedMessage)
+  }
+
   // ─── retrieveUserByUsernameAndPassword ──────────────────────────────────────
 
   "retrieveUserByUsernameAndPassword" should "return the user for correct credentials" in {
@@ -162,6 +191,29 @@ class AuthResourceSpec
   it should "reject invalid credentials with NotAuthorizedException" in {
     seedUser(uname("bad"), "pw")
     assertThrows[NotAuthorizedException](resource.login(UserLoginRequest(uname("bad"), "nope")))
+  }
+
+  // An account can hold a LOCAL and a GOOGLE credential at once, and the frontend reads `googleId`
+  // off the token whichever one was used to sign in. It has to be the GOOGLE provider id and not
+  // the login handle: `flarum.service.ts` passes the claim on as an account password, so a token
+  // that carried the handle under that name would be handing the handle out.
+  it should "carry the account's Google identity in the token of a local sign-in" in {
+    val user = seedUser(uname("dual"), "pw")
+    seedExternalProvider(user.getUid, ProviderTypeEnum.GOOGLE, s"google-dual-$runId")
+
+    val response = resource.login(UserLoginRequest(uname("dual"), "pw"))
+
+    googleIdClaimOf(response.accessToken) shouldBe s"google-dual-$runId"
+  }
+
+  // The claim is omitted rather than sent as null for an account that has no Google identity —
+  // `common/type/user.ts` declares it optional, and a null would reach Flarum as a password.
+  it should "omit googleId from the token of an account with no Google identity" in {
+    seedUser(uname("localonly"), "pw")
+
+    val response = resource.login(UserLoginRequest(uname("localonly"), "pw"))
+
+    googleIdClaimOf(response.accessToken) shouldBe null
   }
 
   // ─── register ─────────────────────────────────────────────────────────────
@@ -211,6 +263,32 @@ class AuthResourceSpec
     ex.getMessage should include("Password")
   }
 
+  // All three fields of the request are plain Strings, so a body that omits any of them arrives
+  // null, and each has to be read null-safely before anything asks it a question. Otherwise a
+  // half-filled body gets a 500 out of a NullPointerException instead of the 406 naming the field.
+  // The intercept is the whole assertion: every guard runs before every write in `register`, so
+  // "nothing was persisted" cannot fail once the exception escaped.
+  it should "reject a missing username" in {
+    val ex = intercept[NotAcceptableException](
+      resource.register(UserRegistrationRequest(null, uemail("mu"), "pw"))
+    )
+    ex.getMessage should include("Username cannot be empty")
+  }
+
+  it should "reject a missing email" in {
+    val ex = intercept[NotAcceptableException](
+      resource.register(UserRegistrationRequest(uname("me"), null, "pw"))
+    )
+    ex.getMessage should include("Email cannot be empty")
+  }
+
+  it should "reject a missing password" in {
+    val ex = intercept[NotAcceptableException](
+      resource.register(UserRegistrationRequest(uname("mp"), uemail("mp"), null))
+    )
+    ex.getMessage should include("Password cannot be empty")
+  }
+
   it should "reject a duplicate username" in {
     seedUser(uname("dupu"), "pw")
     val ex = intercept[NotAcceptableException](
@@ -253,6 +331,19 @@ class AuthResourceSpec
     auth.setUid(uid)
     auth.setProviderType(providerType)
     auth.setProviderId(providerId)
+    authDao.insert(auth)
+  }
+
+  /**
+    * Seed a LOCAL credential for an existing user. Unlike [[seedExternalProvider]] this must carry
+    * a password: ck_provider_credential requires one for LOCAL and only for LOCAL.
+    */
+  private def seedLocalProvider(uid: Integer, handle: String): Unit = {
+    val auth = new AuthProvider
+    auth.setUid(uid)
+    auth.setProviderType(ProviderTypeEnum.LOCAL)
+    auth.setProviderId(handle)
+    auth.setPassword(encryptor.encryptPassword("pw"))
     authDao.insert(auth)
   }
 
@@ -309,6 +400,28 @@ class AuthResourceSpec
     // no LOCAL credential was grafted on, and the Google identity is intact
     hasProvider(untouched.getUid, ProviderTypeEnum.LOCAL) shouldBe false
     providerIdOf(untouched.getUid, ProviderTypeEnum.GOOGLE) shouldEqual s"google-$runId"
+  }
+
+  // What makes an account claimable is the `is_placeholder` flag, and that flag is not a synonym
+  // for "holds no credential": `AdminUserResource.addUser` creates a row that is deliberately not
+  // a placeholder and has no credential either, and an admin fills its address in afterwards. So
+  // a takeover gated on "holds no credential" would hand every pre-provisioned account to the
+  // first stranger who registers its address.
+  it should "reject an address owned by a credential-less account that is not a placeholder" in {
+    val provisioned = new User
+    provisioned.setName(uname("provisioned"))
+    provisioned.setEmail(uemail("provisioned"))
+    provisioned.setRole(UserRoleEnum.INACTIVE)
+    userDao.insert(provisioned)
+
+    val ex = intercept[NotAcceptableException](
+      resource.register(UserRegistrationRequest(uname("takeover"), uemail("provisioned"), "pw"))
+    )
+    ex.getMessage should include("Email exists")
+
+    // Nothing was grafted onto it: still no way to sign in, and still under its own name.
+    hasProvider(provisioned.getUid, ProviderTypeEnum.LOCAL) shouldBe false
+    userDao.fetchOneByUid(provisioned.getUid).getName shouldBe uname("provisioned")
   }
 
   it should "reject claiming with an already-taken username" in {
@@ -370,6 +483,9 @@ class AuthResourceSpec
     val admins = userDao.fetchByName(UserSystemConfig.adminUsername)
     admins.size() shouldBe 1
     admins.get(0).getRole shouldBe UserRoleEnum.ADMIN
+    // The handle doubles as the address, which is what the clash guard below has to find on every
+    // later boot — and what keeps the first sign-in from prompting the admin for one.
+    admins.get(0).getEmail shouldBe UserSystemConfig.adminUsername
     encryptor.checkPassword(
       UserSystemConfig.adminPassword,
       storedPasswordOf(UserSystemConfig.adminUsername)
@@ -378,8 +494,94 @@ class AuthResourceSpec
 
   it should "not create a second admin when one already exists" in {
     AuthResource.createAdminUser()
-    AuthResource.createAdminUser()
+    // Silently, too. The admin's own address is the handle it was created from, so a bootstrap that
+    // asked about the address before asking about the handle would match the admin's own row on
+    // every restart and warn about a clash with itself — telling the operator to hand-grant a role
+    // that is already granted.
+    val warnings = warningsDuring(AuthResource.createAdminUser())
+
     userDao.fetchByName(UserSystemConfig.adminUsername).size() shouldBe 1
+    warnings shouldBe empty
+  }
+
+  // The taken-handle check has to ask auth_provider, exactly as `register`'s does. Both the display
+  // name and the address on that row are rewritten by `ExternalAuthProvisioner.refresh` when the
+  // admin signs in externally and their provider profile has moved on, so neither can answer
+  // "is this handle already mine?". A guard that read either would stop recognising the account it
+  // created and the next restart would die on uq_provider_identity, inside application bootstrap.
+  it should "not create a second admin when the existing one's name and address have drifted" in {
+    val handle = uname("boothandle")
+    AuthResource.createAdminUser(handle, "bootstrap-pw")
+    val admin = userDao.fetchByName(handle).get(0)
+    admin.setName(uname("boothandle_renamed_by_google"))
+    admin.setEmail(uemail("boothandle_real"))
+    userDao.update(admin)
+
+    AuthResource.createAdminUser(handle, "bootstrap-pw")
+
+    // Still exactly the one credential, and no second account inserted under the handle.
+    getDSLContext.fetchCount(
+      AUTH_PROVIDER,
+      AUTH_PROVIDER.PROVIDER_TYPE
+        .eq(ProviderTypeEnum.LOCAL)
+        .and(AUTH_PROVIDER.PROVIDER_ID.eq(handle))
+    ) shouldBe 1
+    userDao.fetchByName(handle).size() shouldBe 0
+  }
+
+  // A deployment that configures neither credential must come up with no admin at all rather than
+  // one anybody can guess. `createAdminUser()` reads two object vals resolved once per JVM, so the
+  // unconfigured case is only reachable through the parameterised overload.
+  //
+  // That overload takes the values already normalised, which leaves half of the guard unpinned:
+  // whitespace is turned into "unconfigured" by the no-arg overload's `.trim`, and no test can
+  // reach it — the values come from `user-system.conf` / the environment, resolved once per JVM
+  // before any test runs, and the checked-in config has no whitespace to trim. Dropping those two
+  // `.trim` calls therefore leaves this suite green while `USER_SYS_ADMIN_PASSWORD=" "` starts
+  // bootstrapping an admin whose password is a space. Closing that needs the normalisation moved
+  // into the overload, which is a production change.
+  it should "create nothing when the configured admin username is blank" in {
+    AuthResource.createAdminUser("", "bootstrap-pw")
+
+    // The username is what the account is named and what it logs in with, so a bootstrap that ran
+    // anyway would leave a blank-handled account holding the configured password.
+    getDSLContext.fetchCount(USER, USER.NAME.eq("")) shouldBe 0
+    storedPasswordOf("") shouldBe null
+  }
+
+  it should "create nothing when the configured admin password is blank" in {
+    AuthResource.createAdminUser(uname("blankpw"), "")
+
+    userDao.fetchByName(uname("blankpw")).size() shouldBe 0
+    storedPasswordOf(uname("blankpw")) shouldBe null
+  }
+
+  // The admin username doubles as the account's email address. `"user".email` is a case-sensitive
+  // UNIQUE, so inserting a second account holding the same address in different casing violates
+  // nothing — the original account would simply stop being the one that address resolves to, and
+  // its data would be stranded. Hence the bootstrap looks the address up case-insensitively and
+  // stands down.
+  it should "not create an admin whose username is already someone's email address" in {
+    val adminHandle = s"authspec_adminhandle_$runId@example.com"
+    val owner = new User
+    owner.setName(uname("addressowner"))
+    // Registration stores an address as the user typed it, so the casings provably differ.
+    owner.setEmail(s"AuthSpec_AdminHandle_$runId@Example.com")
+    owner.setRole(UserRoleEnum.REGULAR)
+    userDao.insert(owner)
+
+    val warnings = warningsDuring(AuthResource.createAdminUser(adminHandle, "bootstrap-pw"))
+
+    userDao.fetchByName(adminHandle).size() shouldBe 0
+    storedPasswordOf(adminHandle) shouldBe null
+    // Standing down is the whole of the behaviour, so the warning is the whole of the payload: the
+    // deployment comes up with no admin account, and this line is the only place an operator learns
+    // why and what to do instead. (Promoting the account it found is deliberately not done —
+    // holding the address is not consent to be an admin — but nothing in `createAdminUser` writes
+    // a role onto an existing row, so there is nothing there to assert.)
+    warnings should have size 1
+    warnings.head should include(adminHandle)
+    warnings.head should include("Grant that account the ADMIN role instead")
   }
 
   // ─── setEmail ───────────────────────────────────────────────────────────────
@@ -431,9 +633,26 @@ class AuthResourceSpec
   it should "reject a blank address" in {
     val user = seedEmaillessUser("blank")
 
-    assertThrows[NotAcceptableException] {
+    val ex = intercept[NotAcceptableException] {
       resource.setEmail(SetEmailRequest("   "), new SessionUser(user))
     }
+    // As the empty-address refusal, not the malformed-address one: EmailUtil's pattern rejects
+    // whitespace too, so both arms throw the same type here and only the message says which
+    // ran — i.e. whether the address was normalised before being validated.
+    ex.getMessage should include("Email cannot be empty")
+  }
+
+  // Addresses arrive padded from paste and autofill. Normalising before storing is not cosmetic:
+  // `"user".email` is UNIQUE and the lookup is on the trimmed form, so a padded address stored as
+  // typed would be a second row for an address someone already holds.
+  it should "store a padded address without its surrounding whitespace" in {
+    val user = seedEmaillessUser("pad")
+
+    val response =
+      resource.setEmail(SetEmailRequest(s"  ${uemail("pad")}  "), new SessionUser(user))
+
+    userDao.fetchOneByUid(user.getUid).getEmail shouldBe uemail("pad")
+    emailClaimOf(response.accessToken) shouldBe uemail("pad")
   }
 
   // Filling a blank only — replacing an address that is already set is a different operation with
@@ -523,6 +742,38 @@ class AuthResourceSpec
     userDao.fetchOneByUid(caller.getUid) shouldBe null
     userDao.fetchOneByUid(placeholder.getUid).getIsPlaceholder shouldBe false
     providerIdOf(placeholder.getUid, ProviderTypeEnum.LOCAL) shouldBe uname("active")
+  }
+
+  // What makes an account safe to hand over is that nobody can sign into it, and that is decided
+  // by whether it holds a credential — not by the `is_placeholder` flag, which is only a note about
+  // where the row came from. The two are kept in step by every path that writes a credential
+  // (`claimPlaceholder` runs in the same transaction), so this pairing is not one the application
+  // produces; nothing in the schema forbids it either, and the check that would catch it if it ever
+  // showed up is the difference between a 409 and handing someone else's sign-in away.
+  it should "not adopt a placeholder that already holds a credential" in {
+    val placeholder = seedPlaceholder(uname("credited"), uemail("credited"))
+    // A LOCAL credential specifically, so that the refusal has to come *before* the move rather
+    // than merely instead of it: the caller holds a LOCAL credential too and auth_provider is keyed
+    // (uid, provider_type), so re-pointing the caller's row at this uid first would break the
+    // primary key and surface as a 500 in place of this 409.
+    seedLocalProvider(placeholder.getUid, uname("credited_signin"))
+    val caller = seedEmaillessUser("wouldadopt")
+
+    val thrown = intercept[WebApplicationException] {
+      resource.setEmail(SetEmailRequest(uemail("credited")), new SessionUser(caller))
+    }
+
+    statusOf(thrown) shouldBe 409
+    // Both accounts hold a credential here, so this fixture cannot say *whose* the check reads —
+    // that is pinned by the two adoption tests above, which fail if it reads the caller's. What it
+    // pins is that holding one at all is what stops the adoption. The post-state below is likewise
+    // documentation rather than a second pin: `setEmail` runs in one transaction, so a caught
+    // exception already implies an unchanged database.
+    providerIdOf(placeholder.getUid, ProviderTypeEnum.LOCAL) shouldBe uname("credited_signin")
+    providerIdOf(caller.getUid, ProviderTypeEnum.LOCAL) shouldBe uname("wouldadopt")
+    val untouched = userDao.fetchOneByUid(placeholder.getUid)
+    untouched.getIsPlaceholder shouldBe true
+    untouched.getName shouldBe uname("credited")
   }
 
   // Past INACTIVE the caller may own content, so its row cannot be discarded and the placeholder

--- a/amber/src/test/scala/org/apache/texera/web/resource/auth/AuthResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/auth/AuthResourceSpec.scala
@@ -213,7 +213,7 @@ class AuthResourceSpec
 
     val response = resource.login(UserLoginRequest(uname("localonly"), "pw"))
 
-    googleIdClaimOf(response.accessToken) shouldBe null
+    JwtAuth.jwtConsumer.processToClaims(response.accessToken).hasClaim("googleId") shouldBe false
   }
 
   // ─── register ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
### What changes were proposed in this PR?

Test-only. **No production file changes.**

`AuthResource`, measured with `WorkflowExecutionService/jacoco` under an identical filter for the before and after runs:

| Metric | Before | After |
|---|---|---|
| Codecov metric (fully-covered lines) | 85.1% — 80/94, 4 missed + 10 partial | **90.4% — 85/94, 0 missed + 9 partial** |
| JaCoCo line-hit | 95.7% (90/94) | **100% (94/94)** |
| Branches | 55.0% (44/80) | **62.5% (50/80)** — 6 arms closed |

Tests **36 → 43**. Zero missed lines remain.

Covered: the whole `logger.warn` + early-return block in `createAdminUser` (lines 137-141), both blank-credential legs of its guard, the already-an-email branch, the placeholder-email adoption guard, and the registration password validation.

A useful confirmation for anyone measuring this module: the filtered baseline reproduced the reported percentages **exactly**, which pins down that the metric Codecov shows is fully-covered-lines / total-lines — partials count against you. That is why the JaCoCo line-hit figure (100%) and the Codecov figure (90.4%) differ so much here.

### 5 mutations, 5 killed, no survivors

Each applied alone, reverted with the production diff verified empty, and the failing test named:

| Mutation | Killed by |
|---|---|
| drop the admin-username leg of the guard at :132 | `createAdminUser should create nothing…` |
| drop the admin-password leg of the same guard | same test |
| warn about the address clash at :141 but bootstrap anyway | `createAdminUser should not create an…` |
| drop the credential leg of the adoption guard at :222 | `setEmail should not adopt a placeholder…` |
| drop the null leg of the registration password guard at :274 | `register should reject a missing pass…` |

### The companion target was dropped, at an honest zero

`FinalizeCheckpointHandler` was bundled into this work at an assessed 5 closable lines. **The real count is 0**, and it was proved rather than guessed: a throwaway probe spec ran the exact production sequence and got

```
java.io.NotSerializableException: No configured serialization-bindings for class
[org.apache.texera.amber.engine.common.CheckpointState]
```

from `Serialization.serializerFor` inside `SequentialRecordWriter.writeRecord`. `CheckpointState` extends nothing, `cluster.conf` binds only `java.io.Serializable` → kryo with `allow-java-serialization = off`, and `AmberRuntime.serde` is a JVM-global with no setter. Every available seam is a production one.

Notably the #7770 harness was **not** the blocker: `FinalizeCheckpointHandlerSpec` already drives a real `WorkflowWorker` through `TestActorRef` and already reaches lines 66-68 — the wall is one line further in. Adding `amber/src/test/resources/application.conf` would merge a test-only binding in, but it would change the Pekko config of every spec in the shared JVM *and* make a green test out of a path production cannot execute. Rejected on both counts.

So this PR is one file rather than two, and smaller than the bundle it was scoped as. I would rather say that than pad it.

### Also deliberately not covered

`AuthResource.scala:49` (`case class SetEmailRequest`) carries 20 missed branch arms — the largest single chunk left — but they are compiler-synthesized `equals`/`hashCode`/`copy`/`toString`/`canEqual`/`product*` members. A Jackson round-trip test would pin the wire field name `email` and incidentally clip a few `equals` arms; that is padding, not pinning, so it is left out.

### Any related issues, documentation, discussions?

Closes #7834

### How was this PR tested?

```
STORAGE_ICEBERG_CATALOG_TYPE=postgres sbt "WorkflowExecutionService/testOnly org.apache.texera.web.resource.auth.AuthResourceSpec"
```

```
[info] Tests: succeeded 43, failed 0, canceled 0, ignored 0, pending 0
```

`Test/scalafmtCheck` passes; `git diff -- '*/src/main/*'` is empty.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
