### PR TITLE
test(frontend): cover the search-instructions and agent settings panels

### DIFF
--- a/frontend/src/app/dashboard/component/user/filters-instructions/filters-instructions.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/filters-instructions/filters-instructions.component.spec.ts
@@ -18,17 +18,26 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { By } from "@angular/platform-browser";
+import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 
 import { FiltersInstructionsComponent } from "./filters-instructions.component";
-import { NzPopoverModule } from "ng-zorro-antd/popover";
+import { NzPopoverDirective, NzPopoverModule } from "ng-zorro-antd/popover";
 
 describe("FiltersInstructionsComponent", () => {
   let component: FiltersInstructionsComponent;
   let fixture: ComponentFixture<FiltersInstructionsComponent>;
 
+  /** Collapses the template's indentation so each item can be compared as one line. */
+  function listItems(list: Element): string[] {
+    return Array.from(list.querySelectorAll("li")).map(li => (li.textContent ?? "").replace(/\s+/g, " ").trim());
+  }
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [FiltersInstructionsComponent, NzPopoverModule],
+      // NoopAnimationsModule keeps the popover's zoom transition out of the test, so
+      // the panel is in the DOM as soon as it opens and gone as soon as it closes.
+      imports: [FiltersInstructionsComponent, NzPopoverModule, NoopAnimationsModule],
     }).compileComponents();
   });
 
@@ -38,7 +47,67 @@ describe("FiltersInstructionsComponent", () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    // Destroying the fixture disposes the CDK overlay too, so nothing this spec
+    // rendered into document.body survives into the next test.
+    fixture.destroy();
+  });
+
   it("should create", () => {
     expect(component).toBeTruthy();
+  });
+
+  describe("instructions popover", () => {
+    // The help text lives in an <ng-template> that ng-zorro only stamps out once the
+    // popover opens, and it lands in the CDK overlay under document.body rather than
+    // in the fixture's own host element. Opening it through the directive keeps the
+    // test off the hover trigger's mouse-enter/leave delay timers.
+    function openPopover(): HTMLElement {
+      const trigger = fixture.debugElement.query(By.directive(NzPopoverDirective));
+      trigger.injector.get(NzPopoverDirective).show();
+      fixture.detectChanges();
+      const panel = document.querySelector(".ant-popover");
+      expect(panel, "expected the popover panel to be rendered").toBeTruthy();
+      return panel as HTMLElement;
+    }
+
+    it("renders only the trigger icon while the popover is closed", () => {
+      expect(fixture.nativeElement.querySelector("i.search-info-box")).toBeTruthy();
+      expect(document.querySelector(".ant-popover")).toBeNull();
+    });
+
+    it("lists every supported search criterion once opened", () => {
+      const panel = openPopover();
+
+      expect(panel.textContent).toContain("Filter Instructions");
+      expect(panel.textContent).toContain("We support the following search criteria:");
+
+      expect(listItems(panel.querySelectorAll("ul")[0])).toEqual([
+        "Search by Workflow Name: workflowName",
+        "Search by Workflow Creation Time: ctime: yyyy-MM-dd",
+        "Search by Workflow Modification Time: mtime: yyyy-MM-dd",
+        "Search by Workflow Owner: owner: John",
+        "Search by Workflow Id: id: workflowId",
+        "Search by Workflows' Operators: operator: operatorName",
+        "Search by User Projects: project: projectName",
+      ]);
+    });
+
+    it("explains how to change the search parameters and shows a worked example", () => {
+      const panel = openPopover();
+
+      expect(panel.textContent).toContain("You can change search parameters by:");
+
+      expect(listItems(panel.querySelectorAll("ul")[1])).toEqual([
+        "selecting/unselecting dropdown menu options",
+        "manually typing parameters into search bar",
+        "clicking the X on a tag or the search bar, to clear one or all tags",
+      ]);
+
+      expect(panel.textContent).toContain('Example: "Untitled Workflow" id:1 owner:John');
+      expect(panel.textContent).toContain(
+        "Meaning: Search for the workflow with name Untitled Workflow, id 1, and the owner called John."
+      );
+    });
   });
 });

--- a/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.spec.ts
+++ b/frontend/src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.spec.ts
@@ -20,11 +20,13 @@
 import { ApplicationRef } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { By } from "@angular/platform-browser";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
-import { NzModalService } from "ng-zorro-antd/modal";
+import { NzModalComponent, NzModalService } from "ng-zorro-antd/modal";
 import { MarkdownModule } from "ngx-markdown";
 import { BehaviorSubject, Observable, Subject, of, throwError } from "rxjs";
 import { AgentChatComponent } from "./agent-chat.component";
+import { ReActStepDetailModalComponent } from "../react-step-detail-modal/react-step-detail-modal.component";
 import { AgentInfo, AgentService, AgentSettingsApi } from "../../../../service/agent/agent.service";
 import { AgentState, ReActStep, ToolOperatorAccess } from "../../../../service/agent/agent-types";
 import { WorkflowActionService } from "../../../../service/workflow-graph/model/workflow-action.service";
@@ -782,6 +784,63 @@ describe("AgentChatComponent", () => {
       expect(messages[1].querySelector("button")).toBeTruthy();
     });
 
+    it("pluralises the tool-call summary and opens the details modal from the hover button", () => {
+      createComponent();
+      // A pure tool-call step carries no text, so nothing here waits on <markdown>.
+      const step = makeStep({
+        content: "",
+        isBegin: true,
+        toolCalls: [{ toolName: "addOperator" }, { toolName: "runWorkflow" }],
+      });
+      agentService.stepsSubject.next([step]);
+      fixture.detectChanges();
+
+      const message = fixture.nativeElement.querySelector(".messages-container .message") as HTMLElement;
+      expect(message.textContent).toContain("Execute 2 tools");
+
+      // The newest step is auto-hovered, so its details button is the one rendered.
+      (message.querySelector("button") as HTMLButtonElement).click();
+      fixture.detectChanges();
+
+      expect(component.selectedResponse).toBe(step);
+      expect(component.isDetailsModalVisible).toBe(true);
+    });
+
+    it("closing the step-detail modal clears the flag through its two-way binding", () => {
+      createComponent();
+      component.showResponseDetails(makeStep());
+      fixture.detectChanges();
+      expect(component.isDetailsModalVisible).toBe(true);
+
+      // The child owns the close control; its visibleChange output is what drives
+      // the parent's [(visible)] binding back to false.
+      const detailModal = fixture.debugElement.query(By.directive(ReActStepDetailModalComponent));
+      expect(detailModal, "expected the step-detail modal to be in the template").toBeTruthy();
+
+      detailModal.componentInstance.closeModal();
+      fixture.detectChanges();
+
+      expect(component.isDetailsModalVisible).toBe(false);
+    });
+
+    it("mirrors typed text into currentMessage through the textarea's ngModel binding", () => {
+      createComponent();
+      const textarea = fixture.nativeElement.querySelector("textarea") as HTMLTextAreaElement;
+      const sendButton = fixture.nativeElement.querySelector(".input-area button") as HTMLButtonElement;
+      expect(sendButton.disabled).toBe(true);
+
+      textarea.value = "summarise the results";
+      textarea.dispatchEvent(new Event("input"));
+      fixture.detectChanges();
+
+      expect(component.currentMessage).toBe("summarise the results");
+      expect(sendButton.disabled).toBe(false);
+
+      sendButton.click();
+      expect(agentService.sendMessage).toHaveBeenCalledWith(AGENT_ID, "summarise the results");
+      expect(component.currentMessage).toBe("");
+    });
+
     it("shows the thinking spinner and stop button while generating", async () => {
       createComponent();
       agentService.stateSubject.next(AgentState.GENERATING);
@@ -875,6 +934,14 @@ describe("AgentChatComponent", () => {
         flushOverlay();
       };
 
+      const buttonWithText = (label: string): HTMLButtonElement => {
+        const button = Array.from(document.querySelectorAll<HTMLButtonElement>("button")).find(
+          candidate => (candidate.textContent ?? "").trim() === label
+        );
+        expect(button, `expected a button labelled "${label}"`).toBeTruthy();
+        return button!;
+      };
+
       beforeEach(() => {
         createComponent();
         agentService.getSystemInfo.mockReturnValue(
@@ -939,6 +1006,108 @@ describe("AgentChatComponent", () => {
         flushOverlay();
         expect(document.querySelectorAll("nz-switch").length).toBe(0);
         expect(document.body.textContent).toContain('No operators match "nomatch-xyz"');
+      });
+
+      it("edits and saves every parameter from the Parameters tab", async () => {
+        component.showSystemInfo();
+        fixture.detectChanges();
+        await flushAsyncRendering();
+        flushOverlay();
+        clickTab("Parameters");
+
+        const items = Array.from(document.querySelectorAll<HTMLElement>(".settings-param-item"));
+        expect(items.length).toBe(5);
+
+        // Each row is typed into and then saved, so both the [(ngModel)] write-back and
+        // the row's own save handler run. Every value stays inside its nz-input-number
+        // range, so nothing is clamped on the way in.
+        const edits = [
+          { typed: "35000", payload: { maxOperatorResultCharLimit: 35000 }, toast: "Max character limit saved" },
+          { typed: "5000", payload: { maxOperatorResultCellCharLimit: 5000 }, toast: "Max cell character limit saved" },
+          { typed: "300", payload: { toolTimeoutSeconds: 300 }, toast: "Tool timeout saved" },
+          { typed: "25", payload: { executionTimeoutMinutes: 25 }, toast: "Execution timeout saved" },
+          { typed: "7", payload: { maxSteps: 7 }, toast: "Max steps saved" },
+        ];
+
+        edits.forEach(({ typed, payload, toast }, index) => {
+          const input = items[index].querySelector("input") as HTMLInputElement;
+          input.value = typed;
+          input.dispatchEvent(new Event("input"));
+          flushOverlay();
+
+          (items[index].querySelector(".settings-param-input > button") as HTMLButtonElement).click();
+
+          expect(agentService.updateAgentSettings).toHaveBeenCalledWith(AGENT_ID, payload);
+          expect(notification.success).toHaveBeenCalledWith(toast);
+        });
+
+        expect(component.settingsMaxCharLimit).toBe(35000);
+        expect(component.settingsMaxCellCharLimit).toBe(5000);
+        expect(component.settingsToolTimeoutSeconds).toBe(300);
+        expect(component.settingsExecutionTimeoutMinutes).toBe(25);
+        expect(component.settingsMaxSteps).toBe(7);
+      });
+
+      it("toggles, bulk-selects and searches operator types from the Operators tab", async () => {
+        component.showSystemInfo();
+        fixture.detectChanges();
+        await flushAsyncRendering();
+        flushOverlay();
+        clickTab("Operators");
+
+        // Nothing is allowed yet, so every switch starts off and the first click turns
+        // its row on. Doing this before the bulk buttons keeps the assertion independent
+        // of when ngModel pushes the new checked state back into nz-switch.
+        const switches = Array.from(document.querySelectorAll<HTMLElement>("nz-switch"));
+        expect(switches.length).toBe(2);
+        switches[0].click(); // rows are sorted, so this is CSVScan
+        flushOverlay();
+        expect(component.settingsAllowedOperatorTypes).toEqual(["CSVScan"]);
+        expect(agentService.updateAgentSettings).toHaveBeenCalledWith(AGENT_ID, { allowedOperatorTypes: ["CSVScan"] });
+        expect(notification.success).toHaveBeenCalledWith("1 operators enabled");
+
+        await flushAsyncRendering();
+        flushOverlay();
+
+        buttonWithText("Select All").click();
+        flushOverlay();
+        expect(component.settingsAllowedOperatorTypes).toEqual(["CSVScan", "PythonUDF"]);
+        expect(notification.success).toHaveBeenCalledWith("2 operators enabled");
+
+        buttonWithText("Deselect All").click();
+        flushOverlay();
+        expect(component.settingsAllowedOperatorTypes).toEqual([]);
+        expect(agentService.updateAgentSettings).toHaveBeenCalledWith(AGENT_ID, { allowedOperatorTypes: [] });
+        expect(notification.success).toHaveBeenCalledWith("All operators enabled");
+
+        const search = document.querySelector("input[placeholder='Search operators...']") as HTMLInputElement;
+        search.value = "python";
+        search.dispatchEvent(new Event("input"));
+        flushOverlay();
+
+        expect(component.operatorTypeSearchQuery).toBe("python");
+        expect(document.querySelectorAll("nz-switch").length).toBe(1);
+        expect(document.body.textContent).toContain("PythonUDF");
+      });
+
+      // nz-modal emits nzVisibleChange when it closes on its own (NzModalService.closeAll,
+      // for instance) rather than through the toolbar, and [(nzVisible)] has to carry
+      // that back into the component.
+      it("clears the modal flag when nz-modal reports that it closed", () => {
+        component.showSystemInfo();
+        flushOverlay();
+        expect(component.isSystemInfoModalVisible).toBe(true);
+
+        // The step-detail child renders an <nz-modal> of its own, so pick this one by title.
+        const systemInfoModal = fixture.debugElement
+          .queryAll(By.directive(NzModalComponent))
+          .find(modal => modal.componentInstance.nzTitle === "Agent System Information");
+        expect(systemInfoModal, "expected the system-info nz-modal to be in the template").toBeTruthy();
+
+        systemInfoModal!.triggerEventHandler("nzVisibleChange", false);
+        fixture.detectChanges();
+
+        expect(component.isSystemInfoModalVisible).toBe(false);
       });
     });
   });


### PR DESCRIPTION
### What changes were proposed in this PR?

Renders the two panels no test ever opened, so their markup executes (9 new tests):

| Template | Before | After |
| --- | --- | --- |
| `filters-instructions.component.html` | 3/20 lines | **20/20** |
| `agent-chat.component.html` | 183/192 lines, 16/35 branches | **192/192, 35/35** |

- **FiltersInstructionsComponent** — the entire help block lives in an
  `<ng-template>` that ng-zorro only stamps out once the popover opens, which is
  why the class sat at 100 % while the template sat at 15 %. The spec now opens
  the panel through the `NzPopoverDirective` rather than the hover trigger — the
  hover path runs on mouse-enter/leave delay timers — and asserts both lists item
  by item plus the worked example. The panel renders into the CDK overlay under
  `document.body`, so the assertions query it there and `fixture.destroy()` in
  `afterEach` disposes it again.
- **AgentChatComponent** — every remaining red line was a control inside a modal
  or panel that stayed closed. Added: the five parameter rows (typed into and
  saved, so both the `[(ngModel)]` write-back and each `save…()` handler run),
  the operator-type search box, select-all/deselect-all and a per-row
  `nz-switch`, the message textarea's `[(ngModel)]`, the `Execute N tools`
  plural arm, the details button's `showResponseDetails(...)`, and the
  `[(visible)]` / `[(nzVisible)]` write-backs of the two modals.

The operator-type test toggles the single switch before the bulk buttons: nothing
is allowed at that point, so the assertion does not depend on when `ngModel`
pushes a new checked state back into `nz-switch`. No production code was changed.

### Any related issues, documentation, discussions?

Closes #7838.

### How was this PR tested?

```
ng test --watch=false \
  --include src/app/dashboard/component/user/filters-instructions/filters-instructions.component.spec.ts \
  --include src/app/workspace/component/agent/agent-panel/agent-chat/agent-chat.component.spec.ts
```

62 passed; the line/branch numbers above come from the same run with
`--coverage --coverage-reporters=lcovonly`. Repeated 5× for stability, and the
surrounding folders (`workspace/component/agent/**`, `dashboard/component/user/**`,
42 spec files / 1193 tests) stay green. `yarn format:ci` clean. Failure path
verified by breaking one assertion in each of the 9 new tests: every one turned
red with a non-zero exit, then all were restored to green.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
