### PR TITLE
fix(frontend): don't count dropped folders as failures

### DIFF
--- a/frontend/src/app/dashboard/component/user/files-uploader/files-uploader.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/files-uploader/files-uploader.component.spec.ts
@@ -61,6 +61,15 @@ const droppedFile = (relativePath: string, file: File): NgxFileDropEntry =>
     },
   }) as unknown as NgxFileDropEntry;
 
+// A dropped folder: ngx-file-drop reports it as an entry whose fileEntry is not a file.
+const droppedDirectory = (relativePath: string): NgxFileDropEntry =>
+  ({
+    relativePath,
+    fileEntry: {
+      isFile: false,
+    },
+  }) as unknown as NgxFileDropEntry;
+
 describe("FilesUploaderComponent", () => {
   let component: FilesUploaderComponent;
   let modals: CapturedModal[];
@@ -296,6 +305,78 @@ describe("FilesUploaderComponent", () => {
     expect((await emitted).map(item => item.name)).toEqual(["one.csv", "two.csv"]);
     expect(modals).toHaveLength(1);
     expect(component.fileUploadBannerType).toBe("success");
+  });
+
+  describe("dropped folders are not failures", () => {
+    // A folder resolves to null rather than rejecting, so it must not be counted as a
+    // file that failed to be selected.
+    beforeEach(() => {
+      datasetService.listMultipartUploads.mockReturnValue(of([]));
+      datasetService.findExistingUploadFiles.mockReturnValue(of([]));
+    });
+
+    const rejectEveryFile = () => (component.singleFileUploadMaxSizeMiB = 0);
+
+    it("shows no banner at all when only a folder is dropped", async () => {
+      const emitted = new Promise<FileUploadItem[]>(resolve => component.uploadedFiles.subscribe(resolve));
+
+      component.fileDropped([droppedDirectory("some-folder")]);
+
+      expect(await emitted).toEqual([]);
+      expect(component.fileUploadingFinished).toBe(false);
+      expect(component.fileUploadBannerMessage).toBe("");
+    });
+
+    it("reports only the valid file when a folder is dropped alongside it", async () => {
+      const emitted = new Promise<FileUploadItem[]>(resolve => component.uploadedFiles.subscribe(resolve));
+
+      component.fileDropped([
+        droppedDirectory("some-folder"),
+        droppedFile("clean.csv", new File(["clean"], "clean.csv")),
+      ]);
+
+      expect((await emitted).map(item => item.name)).toEqual(["clean.csv"]);
+      expect(component.fileUploadBannerType).toBe("success");
+      expect(component.fileUploadBannerMessage).toContain("1 file selected successfully!");
+    });
+
+    it("still reports a file that genuinely failed to be selected", async () => {
+      rejectEveryFile();
+      const emitted = new Promise<FileUploadItem[]>(resolve => component.uploadedFiles.subscribe(resolve));
+
+      component.fileDropped([droppedFile("huge.csv", new File(["too big"], "huge.csv"))]);
+
+      expect(await emitted).toEqual([]);
+      expect(component.fileUploadBannerType).toBe("error");
+      expect(component.fileUploadBannerMessage).toBe("1 file failed to be selected.");
+    });
+
+    it("counts only the rejected file when a folder is dropped with it", async () => {
+      rejectEveryFile();
+      const emitted = new Promise<FileUploadItem[]>(resolve => component.uploadedFiles.subscribe(resolve));
+
+      component.fileDropped([
+        droppedDirectory("some-folder"),
+        droppedFile("huge.csv", new File(["too big"], "huge.csv")),
+      ]);
+
+      expect(await emitted).toEqual([]);
+      expect(component.fileUploadBannerMessage).toBe("1 file failed to be selected.");
+    });
+
+    it("keeps the plural wording when several files are rejected", async () => {
+      rejectEveryFile();
+      const emitted = new Promise<FileUploadItem[]>(resolve => component.uploadedFiles.subscribe(resolve));
+
+      component.fileDropped([
+        droppedDirectory("some-folder"),
+        droppedFile("huge1.csv", new File(["too big"], "huge1.csv")),
+        droppedFile("huge2.csv", new File(["too big"], "huge2.csv")),
+      ]);
+
+      expect(await emitted).toEqual([]);
+      expect(component.fileUploadBannerMessage).toBe("2 files failed to be selected.");
+    });
   });
 
   it("showFileUploadBanner marks uploading finished and stores the given type and message", () => {

--- a/frontend/src/app/dashboard/component/user/files-uploader/files-uploader.component.ts
+++ b/frontend/src/app/dashboard/component/user/files-uploader/files-uploader.component.ts
@@ -350,7 +350,9 @@ export class FilesUploaderComponent {
           }
           this.showFileUploadBanner(skippedCount > 0 ? "info" : "success", messages.join(" "));
         }
-        const failedCount = results.length - successfulUploads.length;
+        // Only rejected entries actually failed. A dropped directory resolves to null, so
+        // deriving this from the length difference would report it as a failed file.
+        const failedCount = results.filter(result => result.status === "rejected").length;
         if (failedCount > 0) {
           const errorMessage = `${failedCount} file${failedCount > 1 ? "s" : ""} failed to be selected.`;
           this.showFileUploadBanner("error", errorMessage);


### PR DESCRIPTION
Dropping a folder onto the dataset file uploader reported "1 file failed to be selected." even though nothing failed and nothing was meant to be uploaded.

fileDropped settles one promise per dropped entry, and there are three outcomes: a valid file resolves to an item, a directory deliberately resolves to null, and an oversized or unreadable file rejects. The failure count was derived from the difference between the total settled results and the non-null successes, so a directory -- fulfilled, but filtered out as null -- was indistinguishable from a genuine rejection.

Count the rejected results directly instead. Directories are ignored silently, while files that really did fail are still reported, with the existing singular/plural wording.

Closes #7457

### What changes were proposed in this PR?

Dropping a folder onto the dataset file uploader showed a red banner reading *"1 file failed to be selected."* — even though nothing failed and nothing was meant to be uploaded. Valid files dropped alongside it were still selected correctly; only the banner was wrong.

`fileDropped` settles one promise per dropped entry (`files-uploader.component.ts:283-312`), with three possible outcomes:

| Outcome | How it settles | In `successfulUploads`? | In `results`? |
|---|---|---|---|
| valid file | `resolve({...})` | yes | yes |
| **directory** | `resolve(null)` (`:310`) | no — filtered out as `null` | yes |
| oversized / unreadable | `reject(...)` (`:295`, `:306`) | no | yes |

`successfulUploads` keeps only fulfilled **non-null** values (`:319-322`), but the failure count was derived from the raw length:

    const failedCount = results.length - successfulUploads.length;

That difference equals *rejections + directories*. A directory is fulfilled-with-`null`, never a rejection, so it was indistinguishable from a genuine failure and inflated the count.

The fix counts rejections directly, as the issue proposes:

    const failedCount = results.filter(result => result.status === "rejected").length;

`resolve(null)` occurs only in the non-file branch, so fulfilled-`null` corresponds exactly to a directory, and both `reject` sites are real failures. Directories are now ignored silently; files that genuinely failed are still reported, with the singular/plural wording untouched.

The behaviour change is limited to that banner — selection, conflict resolution, and emission are unaffected.

### Any related issues, documentation, discussions?

Closes #7457

### How was this PR tested?

Added five tests under `describe("dropped folders are not failures")` in `files-uploader.component.spec.ts`, plus a `droppedDirectory()` helper building an entry with `isFile: false` (the existing `droppedFile()` helper always sets `isFile: true`):

- a folder on its own produces **no banner at all** — asserts `fileUploadingFinished === false` and an empty message
- a folder alongside a valid file yields the success banner only, and emits just that file
- an oversized file on its own still reports `1 file failed to be selected.` — green before and after, guarding the real-failure path
- a folder plus an oversized file counts exactly **1**, not 2
- a folder plus two oversized files keeps the plural `2 files failed to be selected.`

Command:

    corepack yarn ng test --watch=false \
      --include="**/files-uploader.component.spec.ts"

- Against **unmodified** source: **4 failed, 31 passed (35)**. The plural case reported `3 files failed to be selected.` where `2 files failed to be selected.` was expected — the dropped folder inflating the count.
- After the fix: **35/35 passing**.

Regression sweep including `dataset-detail.component.spec.ts`, the only component embedding the uploader:

    corepack yarn ng test --watch=false \
      --include="**/files-uploader.component.spec.ts" \
      --include="**/dataset-detail.component.spec.ts"

Result: **2 files, 230/230 passing**. `yarn prettier-eslint` reports both touched files unchanged.

Before / after: dropping a folder previously raised a red *"1 file failed to be selected."* banner; it now completes silently.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Yes, Alongside Claude Code