### PR TITLE
test(frontend): cover the code editor's worker wiring and disposal ordering

### DIFF
--- a/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.spec.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.spec.ts
@@ -977,10 +977,13 @@ describe("CodeEditorComponent", () => {
   // tests wait on the observable effect instead of on a fixed number of ticks.
   const settle = () => new Promise(resolve => setTimeout(resolve, 0));
 
+  const WAIT_FOR_INTERVAL_MS = 10;
+  const WAIT_FOR_MAX_ATTEMPTS = 400;
+
   async function waitFor(condition: () => boolean, what: string): Promise<void> {
-    for (let attempt = 0; attempt < 400; attempt++) {
+    for (let attempt = 0; attempt < WAIT_FOR_MAX_ATTEMPTS; attempt++) {
       if (condition()) return;
-      await new Promise(resolve => setTimeout(resolve, 10));
+      await new Promise(resolve => setTimeout(resolve, WAIT_FOR_INTERVAL_MS));
     }
     throw new Error(`timed out waiting for ${what}`);
   }

--- a/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.spec.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/code-editor.component.spec.ts
@@ -18,7 +18,7 @@
  */
 
 import { ComponentFixture, TestBed } from "@angular/core/testing";
-import { CodeEditorComponent } from "./code-editor.component";
+import { CodeEditorComponent, LANGUAGE_SERVER_CONNECTION_TIMEOUT_MS } from "./code-editor.component";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { mockJavaUDFPredicate, mockPoint } from "../../service/workflow-graph/model/mock-workflow-data";
@@ -40,6 +40,12 @@ import { NotificationService } from "../../../common/service/notification/notifi
 import { ComponentRef, SecurityContext } from "@angular/core";
 import { DomSanitizer, SafeHtml } from "@angular/platform-browser";
 import { Coeditor } from "../../../common/type/user";
+import { FormControl } from "@angular/forms";
+import { MonacoBinding } from "y-monaco";
+import { getEnhancedMonacoEnvironment } from "monaco-languageclient/vscodeApiWrapper";
+import { WorkflowVersionService } from "../../../dashboard/service/user/workflow-version/workflow-version.service";
+import { CodeDebuggerComponent } from "./code-debugger.component";
+import { Workflow } from "../../../common/type/workflow";
 
 // Operator types that the constructor's language-detection branch must map
 // to a specific language. `RUDFSource` / `RUDF` -> `r`; the three V2 Python
@@ -86,6 +92,16 @@ class AugmentedStubMetadataService extends StubOperatorMetadataService {
     return augmentedSchemas.some(op => op.operatorType === operatorType);
   }
 }
+
+// A `code` property on the predicate becomes a `Y.Text` on the shared
+// operator-properties map (`createYTypeFromObject` turns every string into
+// one), and that `Y.Text` is exactly what the editor binds to. Predicates
+// built without it leave `this.code` undefined, which is a different — and
+// separately tested — path through the editor bring-up.
+const buildPredicateWithCode = (operatorID: string, operatorType: string, code: string): OperatorPredicate => ({
+  ...buildPredicate(operatorID, operatorType),
+  operatorProperties: { code },
+});
 
 const buildPredicate = (operatorID: string, operatorType: string): OperatorPredicate => ({
   operatorID,
@@ -179,6 +195,7 @@ describe("CodeEditorComponent", () => {
   let aiEnabled$: BehaviorSubject<string>;
   let getTypeAnnotationsSpy: ReturnType<typeof vi.fn>;
   let locateUnannotatedSpy: ReturnType<typeof vi.fn>;
+  let attachToYCodeSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
     // The component persists the dialog geometry per operator id in
@@ -191,6 +208,7 @@ describe("CodeEditorComponent", () => {
     aiEnabled$ = new BehaviorSubject<string>("OpenAI");
     getTypeAnnotationsSpy = vi.fn().mockReturnValue(of({ choices: [{ message: { content: ": int" } }] }));
     locateUnannotatedSpy = vi.fn().mockReturnValue(of([]));
+    attachToYCodeSpy = vi.fn(() => () => undefined);
     await TestBed.configureTestingModule({
       providers: [
         WorkflowActionService,
@@ -198,7 +216,7 @@ describe("CodeEditorComponent", () => {
         {
           provide: UiUdfParametersSyncService,
           useValue: {
-            attachToYCode: vi.fn(() => () => undefined),
+            attachToYCode: attachToYCodeSpy,
             uiParametersParseError$: uiParametersParseErrors.asObservable(),
           },
         },
@@ -949,6 +967,490 @@ describe("CodeEditorComponent", () => {
 
       expect(() => withViewport(800, 600, () => fixture.componentInstance.onWindowResize())).not.toThrow();
       expect(container.style.width).toBe("790px");
+    });
+  });
+
+  // The editor really does come up under jsdom: `ensureVscodeApiStarted()`
+  // resolves, `EditorApp.start()` mounts a live monaco editor over a real text
+  // model, and the component's subscribe callback then binds that model to the
+  // yjs text. Nothing here is mocked out — the bring-up is asynchronous, so the
+  // tests wait on the observable effect instead of on a fixed number of ticks.
+  const settle = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  async function waitFor(condition: () => boolean, what: string): Promise<void> {
+    for (let attempt = 0; attempt < 400; attempt++) {
+      if (condition()) return;
+      await new Promise(resolve => setTimeout(resolve, 10));
+    }
+    throw new Error(`timed out waiting for ${what}`);
+  }
+
+  describe("monaco worker wiring", () => {
+    // `monacoWorkerFactory` installs the component's worker factory onto the
+    // process-wide `MonacoEnvironment`, so once the vscode API has been started
+    // the factory can be called straight off that global — no seam needed.
+    // jsdom ships no `Worker` at all, so one is staged for the duration of the
+    // call and torn down again.
+    function recordWorkers(run: () => void): string[] {
+      const constructed: string[] = [];
+      const previous = Object.getOwnPropertyDescriptor(globalThis, "Worker");
+      Object.defineProperty(globalThis, "Worker", {
+        configurable: true,
+        writable: true,
+        value: class {
+          constructor(url: string | URL) {
+            // Only the chunk's file name is comparable across callers: the
+            // rewritten worker URL is resolved against the *importing module's*
+            // `import.meta.url`, and a whole-project run serves the component
+            // from a hoisted chunk at the server root while this spec is served
+            // from its own directory. The content hash in the file name is the
+            // part that identifies the entry point, and it is stable either way.
+            const { pathname, search } = new URL(String(url), "http://chunk.invalid/");
+            constructed.push(`${pathname.slice(pathname.lastIndexOf("/") + 1)}${search}`);
+          }
+        },
+      });
+      try {
+        run();
+      } finally {
+        if (previous) {
+          Object.defineProperty(globalThis, "Worker", previous);
+        } else {
+          delete (globalThis as unknown as Record<string, unknown>).Worker;
+        }
+      }
+      return constructed;
+    }
+
+    // The bundler rewrites `new Worker(new URL("./workers/...", import.meta.url))`
+    // into a content-hashed chunk, so the chunk names themselves say nothing
+    // about which worker they hold. Referencing the same three entry points from
+    // this spec — which sits in the same directory — resolves them to the same
+    // chunks, which is what makes the label -> entry-point mapping assertable.
+    const referenceEntryPoints = () => {
+      new Worker(new URL("./workers/editor.worker", import.meta.url), { type: "module" });
+      new Worker(new URL("./workers/extension-host.worker", import.meta.url), { type: "module" });
+      new Worker(new URL("./workers/textmate.worker", import.meta.url), { type: "module" });
+    };
+
+    async function workerFactory(): Promise<(moduleId: string, label: string) => unknown> {
+      await (CodeEditorComponent as any).ensureVscodeApiStarted();
+      const factory = getEnhancedMonacoEnvironment().getWorker;
+      expect(typeof factory).toBe("function");
+      return factory as (moduleId: string, label: string) => unknown;
+    }
+
+    it("points each monaco worker label at its own worker entry point", async () => {
+      const factory = await workerFactory();
+      const [editorEntry, extensionHostEntry, textMateEntry] = recordWorkers(referenceEntryPoints);
+      // Three distinct chunks, so two labels sharing one entry point is visible.
+      expect(new Set([editorEntry, extensionHostEntry, textMateEntry]).size).toBe(3);
+
+      const produced = recordWorkers(() => {
+        factory("module-1", "editorWorkerService");
+        factory("module-2", "extensionHostWorkerMain");
+        factory("module-3", "TextMateWorker");
+      });
+
+      // Order matters here: each label has to land on its own entry point. Note
+      // that the worker's `{ type: "module" }` is *not* pinned by this — the
+      // bundler's worker transform supplies it itself (the rewritten URL even
+      // carries `?worker_file&type=module`), so dropping the literal from the
+      // component source is invisible here. Only the entry point is pinned.
+      expect(produced).toEqual([editorEntry, extensionHostEntry, textMateEntry]);
+    });
+
+    it("refuses a worker label it has no entry point for", async () => {
+      const factory = await workerFactory();
+      expect(() => recordWorkers(() => factory("module-9", "SomeUnwiredWorker"))).toThrow(
+        "No worker configured for label: SomeUnwiredWorker"
+      );
+    });
+  });
+
+  describe("vscode API bring-up", () => {
+    it("drops the cached start promise when the vscode API fails so a later open retries", async () => {
+      // The start is memoised for the whole process, so a *failed* start has to
+      // clear the memo — otherwise every later editor open would be handed the
+      // same rejected promise forever. The failure is forced by making the
+      // global `MonacoEnvironment` that the worker factory reads unreadable;
+      // the component itself is untouched.
+      await (CodeEditorComponent as any).ensureVscodeApiStarted();
+      const memoised = (CodeEditorComponent as any).apiWrapperStartPromise;
+      expect(memoised).toBeDefined();
+      const environment = Object.getOwnPropertyDescriptor(globalThis, "MonacoEnvironment")!;
+
+      (CodeEditorComponent as any).apiWrapperStartPromise = undefined;
+      Object.defineProperty(globalThis, "MonacoEnvironment", {
+        configurable: true,
+        get() {
+          throw new Error("vscode API services unavailable");
+        },
+      });
+      try {
+        await expect((CodeEditorComponent as any).ensureVscodeApiStarted()).rejects.toThrow(
+          "vscode API services unavailable"
+        );
+        expect((CodeEditorComponent as any).apiWrapperStartPromise).toBeUndefined();
+      } finally {
+        Object.defineProperty(globalThis, "MonacoEnvironment", environment);
+        (CodeEditorComponent as any).apiWrapperStartPromise = memoised;
+      }
+    });
+  });
+
+  describe("monaco editor bring-up", () => {
+    // The one thing the subscribe callback needs that no other test supplies is
+    // `formControl` — the host dialog assigns it, and without it the very first
+    // line of the callback throws and nothing below it ever runs.
+    const editorOf = (component: CodeEditorComponent) => (component as any).editorApp?.getEditor?.();
+    const bindingOf = (component: CodeEditorComponent) => (component as any).monacoBinding;
+
+    function mount(predicate: OperatorPredicate, formControl: FormControl): CodeEditorComponent {
+      const fixture = makeFixture(predicate);
+      // Assigned synchronously, before any await in the bring-up can resolve.
+      fixture.componentInstance.formControl = formControl;
+      return fixture.componentInstance;
+    }
+
+    it("binds the shared yjs text to the mounted editor and hands that editor to the debugger", async () => {
+      const component = mount(
+        buildPredicateWithCode("bring-up-bind", "PythonUDFV2", "alpha = 1\nbeta = 2\n"),
+        new FormControl("")
+      );
+      await waitFor(() => Boolean(bindingOf(component)), "the yjs binding");
+
+      expect(bindingOf(component)).toBeInstanceOf(MonacoBinding);
+      const model = editorOf(component).getModel();
+      // The model opens on the shared code, under a uri built from the operator
+      // id and the language's file suffix.
+      expect(model.getValue()).toBe("alpha = 1\nbeta = 2\n");
+      expect(model.uri.toString().endsWith("/in-memory-bring-up-bind.py")).toBe(true);
+      // The debugger is handed the very editor that was mounted.
+      expect(component.codeDebuggerComponent).toBe(CodeDebuggerComponent);
+      expect(component.editorToPass).toBe(editorOf(component));
+      // ...and the UI-parameter sync is attached to the same operator + text.
+      expect(attachToYCodeSpy).toHaveBeenCalledTimes(1);
+      expect(attachToYCodeSpy.mock.calls[0][0]).toBe("bring-up-bind");
+      expect(String(attachToYCodeSpy.mock.calls[0][1])).toBe("alpha = 1\nbeta = 2\n");
+    });
+
+    it("opens the editor read-only when the operator's form control is disabled", async () => {
+      const component = mount(
+        buildPredicateWithCode("bring-up-readonly", "PythonUDFV2", "locked = 1"),
+        new FormControl({ value: "locked = 1", disabled: true })
+      );
+      await waitFor(() => Boolean(bindingOf(component)), "the yjs binding");
+
+      expect(editorOf(component).getRawOptions().readOnly).toBe(true);
+    });
+
+    it("opens the editor writable when the operator's form control is enabled", async () => {
+      const component = mount(
+        buildPredicateWithCode("bring-up-writable", "PythonUDFV2", "open = 2"),
+        new FormControl({ value: "open = 2", disabled: false })
+      );
+      await waitFor(() => Boolean(bindingOf(component)), "the yjs binding");
+
+      expect(editorOf(component).getRawOptions().readOnly).toBe(false);
+    });
+
+    it("re-tokenizes every line of the model once the editor is mounted", async () => {
+      // The TextMate grammar registers asynchronously, so the component walks
+      // the whole model and forces a re-tokenize to get the syntax colours onto
+      // the first paint. Wrapping the model's own `forceTokenization` as the
+      // model is created is the only seam that exists before the component's
+      // callback runs.
+      const forcedLines: number[] = [];
+      const subscription = monaco.editor.onDidCreateModel(model => {
+        if (!model.uri.toString().includes("bring-up-tokenize")) return;
+        const tokenization = (model as any).tokenization;
+        const forceTokenization = tokenization.forceTokenization.bind(tokenization);
+        tokenization.forceTokenization = (line: number) => {
+          forcedLines.push(line);
+          return forceTokenization(line);
+        };
+      });
+      try {
+        const component = mount(
+          buildPredicateWithCode("bring-up-tokenize", "PythonUDFV2", "a = 1\nb = 2\nc = 3"),
+          new FormControl("")
+        );
+        await waitFor(() => Boolean(bindingOf(component)), "the yjs binding");
+
+        expect(editorOf(component).getModel().getLineCount()).toBe(3);
+        // First line through last line, each exactly once.
+        expect(forcedLines).toEqual([1, 2, 3]);
+      } finally {
+        subscription.dispose();
+      }
+    });
+
+    it("mounts the editor but binds nothing when the operator holds no shared code", async () => {
+      const reported: unknown[] = [];
+      const previousHandler = rxjsConfig.onUnhandledError;
+      rxjsConfig.onUnhandledError = error => reported.push(error);
+      try {
+        const component = mount(
+          buildPredicate("bring-up-no-code", "PythonUDFV2"),
+          new FormControl({ value: "", disabled: true })
+        );
+        // `readOnly` flipping is what proves the subscribe callback actually ran:
+        // it is applied on the statement immediately before the no-code bail-out,
+        // so without this gate the assertions below would also hold trivially
+        // while the bring-up was still in flight.
+        await waitFor(
+          () => editorOf(component)?.getRawOptions?.().readOnly === true,
+          "the editor options to be applied"
+        );
+        await settle();
+        await settle();
+
+        // The editor is up and configured, but there is no yjs text to bind to,
+        // so the binding, the debugger hand-off and the parameter sync are all
+        // skipped — and skipped by returning cleanly, not by failing.
+        expect(editorOf(component).getModel().getValue()).toBe("");
+        expect(bindingOf(component)).toBeUndefined();
+        expect(component.codeDebuggerComponent).toBeUndefined();
+        expect(component.editorToPass).toBeUndefined();
+        expect(attachToYCodeSpy).not.toHaveBeenCalled();
+        expect(reported).toEqual([]);
+      } finally {
+        rxjsConfig.onUnhandledError = previousHandler;
+      }
+    });
+
+    it("destroys the previous binding and detaches the previous listener on a second bring-up", async () => {
+      // Each `attachToYCode` hands back its own detach function so the test can
+      // tell which of the two was called.
+      const detachers: Array<ReturnType<typeof vi.fn>> = [];
+      attachToYCodeSpy.mockImplementation(() => {
+        const detach = vi.fn();
+        detachers.push(detach);
+        return detach;
+      });
+      const component = mount(
+        buildPredicateWithCode("bring-up-twice", "PythonUDFV2", "again = 3"),
+        new FormControl("")
+      );
+      await waitFor(() => Boolean(bindingOf(component)), "the first yjs binding");
+      const firstBinding = bindingOf(component);
+      const firstBindingDestroyed = vi.spyOn(firstBinding, "destroy");
+
+      // The version stream re-announcing "not viewing a version" brings the
+      // editor up again over the same operator.
+      TestBed.inject(WorkflowVersionService).setDisplayParticularVersion(false);
+      await waitFor(() => bindingOf(component) !== firstBinding, "the second yjs binding");
+
+      expect(firstBindingDestroyed).toHaveBeenCalledOnce();
+      expect(detachers).toHaveLength(2);
+      expect(detachers[0]).toHaveBeenCalledOnce();
+      expect(detachers[1]).not.toHaveBeenCalled();
+    });
+
+    it("keeps the editor usable when the python language server never answers", async () => {
+      // The language client is a best-effort step: it races against
+      // LANGUAGE_SERVER_CONNECTION_TIMEOUT_MS and anything that goes wrong is
+      // swallowed so the editor still mounts. There is no language server in
+      // this environment, so this is the real failure path.
+      const reported: unknown[] = [];
+      const previousHandler = rxjsConfig.onUnhandledError;
+      rxjsConfig.onUnhandledError = error => reported.push(error);
+      try {
+        const component = mount(
+          buildPredicateWithCode("bring-up-no-lsp", "PythonUDFV2", "lsp = 4"),
+          new FormControl("")
+        );
+        await waitFor(() => Boolean(bindingOf(component)), "the yjs binding");
+        // Wait past the timeout window so the timeout leg of the race fires.
+        await new Promise(resolve => setTimeout(resolve, LANGUAGE_SERVER_CONNECTION_TIMEOUT_MS + 250));
+
+        expect(bindingOf(component)).toBeInstanceOf(MonacoBinding);
+        expect(editorOf(component).getModel().getValue()).toBe("lsp = 4");
+        expect(reported).toEqual([]);
+      } finally {
+        rxjsConfig.onUnhandledError = previousHandler;
+      }
+    });
+  });
+
+  describe("version-diff editor", () => {
+    // While the workspace is showing a particular workflow version the dialog
+    // opens a read-only diff instead of an editable editor: the version being
+    // viewed on the left (the operator's own yjs text) against the latest
+    // editing version on the right (out of the temp workflow the version viewer
+    // parked on WorkflowActionService).
+    const diffModelOf = (component: CodeEditorComponent) =>
+      (component as any).editorApp?.getDiffEditor?.()?.getModel?.();
+
+    function stageTempWorkflow(operators: ReadonlyArray<{ operatorID: string; code?: string }>): void {
+      workflowActionService.setTempWorkflow({
+        content: {
+          operators: operators.map(({ operatorID, code }) => ({
+            operatorID,
+            operatorProperties: code === undefined ? {} : { code },
+          })),
+          operatorPositions: {},
+          links: [],
+          commentBoxes: [],
+          settings: { dataTransferBatchSize: 400 },
+        },
+      } as unknown as Workflow);
+    }
+
+    // The temp workflow and the version flag both have to be in place before the
+    // component is created, since `initializeDiffEditor` reads them the moment
+    // the version stream replays, so this cannot go through `makeFixture`.
+    async function openDiff(
+      predicate: OperatorPredicate,
+      tempOperators: ReadonlyArray<{ operatorID: string; code?: string }> | undefined
+    ): Promise<CodeEditorComponent> {
+      workflowActionService.addOperator(predicate, mockPoint);
+      workflowActionService.getJointGraphWrapper().highlightOperators(predicate.operatorID);
+      if (tempOperators) stageTempWorkflow(tempOperators);
+      TestBed.inject(WorkflowVersionService).setDisplayParticularVersion(true);
+      const fixture = TestBed.createComponent(CodeEditorComponent);
+      fixture.detectChanges();
+      await waitFor(() => Boolean(diffModelOf(fixture.componentInstance)), "the mounted diff editor");
+      return fixture.componentInstance;
+    }
+
+    it("diffs the version being viewed against the latest editing version", async () => {
+      const predicate = buildPredicateWithCode("diff-both", "PythonUDFV2", "VIEWED VERSION");
+      const component = await openDiff(predicate, [{ operatorID: predicate.operatorID, code: "LATEST EDITS" }]);
+
+      const model = diffModelOf(component)!;
+      // Two different texts, so the two sides cannot be transposed unnoticed.
+      expect(model.original.getValue()).toBe("VIEWED VERSION");
+      expect(model.modified.getValue()).toBe("LATEST EDITS");
+      // ...and they get separate uris, or monaco would collapse them onto one model.
+      expect(model.original.uri.toString().endsWith("/in-memory-diff-both-version.py")).toBe(true);
+      expect(model.modified.uri.toString().endsWith("/in-memory-diff-both.py")).toBe(true);
+      // A diff editor replaces the plain editor outright, so nothing is bound
+      // to yjs and no debugger is wired up.
+      expect((component as any).editorApp.getEditor()).toBeUndefined();
+      expect((component as any).monacoBinding).toBeUndefined();
+      expect(component.codeDebuggerComponent).toBeUndefined();
+    });
+
+    it("shows an empty latest version when the temp workflow has no entry for this operator", async () => {
+      const predicate = buildPredicateWithCode("diff-missing-latest", "PythonUDFV2", "ONLY VIEWED");
+      // A temp workflow holding some *other* operator: the lookup runs and finds
+      // nothing.
+      const component = await openDiff(predicate, [{ operatorID: "a-different-operator", code: "NOT THIS ONE" }]);
+
+      const model = diffModelOf(component)!;
+      expect(model.original.getValue()).toBe("ONLY VIEWED");
+      expect(model.modified.getValue()).toBe("");
+    });
+
+    it("shows an empty viewed version when the operator holds no shared code", async () => {
+      const predicate = buildPredicate("diff-missing-viewed", "PythonUDFV2");
+      const component = await openDiff(predicate, [{ operatorID: predicate.operatorID, code: "ONLY LATEST" }]);
+
+      const model = diffModelOf(component)!;
+      expect(model.original.getValue()).toBe("");
+      expect(model.modified.getValue()).toBe("ONLY LATEST");
+    });
+  });
+
+  describe("teardown", () => {
+    // A failing `dispose()` that records both the call order and whether the
+    // caller attached a rejection handler to what it returned. The component's
+    // `.catch(() => {})` is otherwise unobservable: dropping it only leaves an
+    // unhandled rejection, which this runner does not fail on, so the
+    // "swallowed" half of the contract would go untested.
+    function rejectingDisposal(label: string, order: string[]) {
+      const record = {
+        catchAttached: false,
+        dispose: vi.fn(() => {
+          order.push(label);
+          const rejected = Promise.reject(new Error(`${label} teardown failed`));
+          return {
+            catch(onRejected: (reason: unknown) => void) {
+              record.catchAttached = true;
+              return rejected.catch(onRejected);
+            },
+          };
+        }),
+      };
+      return record;
+    }
+
+    it("detaches the yjs code listener it attached", () => {
+      const fixture = makeFixture(mockJavaUDFPredicate);
+      const detach = vi.fn();
+      (fixture.componentInstance as any).detachYCodeListener = detach;
+
+      fixture.destroy();
+
+      expect(detach).toHaveBeenCalledOnce();
+    });
+
+    it("shuts the language client down before the editor and swallows both failures", async () => {
+      // Disposal order matters: the language client is attached to the editor's
+      // model, so it has to go first. Both handles are also cleared, so closing
+      // a dialog twice cannot dispose the same objects twice. Both disposals are
+      // staged as rejections, which is what drives the `.catch` on each call.
+      const fixture = makeFixture(mockJavaUDFPredicate);
+      const component = fixture.componentInstance;
+      const disposals: string[] = [];
+      const languageClient = rejectingDisposal("language-client", disposals);
+      const editorApp = rejectingDisposal("editor-app", disposals);
+      (component as any).languageClientWrapper = { dispose: languageClient.dispose };
+      (component as any).editorApp = { dispose: editorApp.dispose, getEditor: () => undefined };
+
+      expect(() => fixture.destroy()).not.toThrow();
+
+      expect(disposals).toEqual(["language-client", "editor-app"]);
+      // Each rejection is handed a handler, so a failing teardown cannot escape
+      // the component as an unhandled rejection.
+      expect(languageClient.catchAttached).toBe(true);
+      expect(editorApp.catchAttached).toBe(true);
+      // Asserted before yielding: this dialog's own editor bring-up is still in
+      // flight and reassigns `editorApp` when it lands.
+      expect((component as any).languageClientWrapper).toBeUndefined();
+      expect((component as any).editorApp).toBeUndefined();
+      await settle();
+    });
+  });
+
+  describe("window resize", () => {
+    it("clamps the dialog through the window resize host listener", () => {
+      // Driven through a real window event rather than by calling
+      // `onWindowResize` directly, so the @HostListener wiring is exercised too.
+      const fixture = makeFixture(mockJavaUDFPredicate);
+      const container = (fixture.componentInstance as any).containerElement.nativeElement as HTMLElement;
+      container.getBoundingClientRect = () => stubRect(15, 25, 4000, 4000);
+
+      withViewport(900, 700, () => window.dispatchEvent(new Event("resize")));
+
+      // 900 - 15 and 700 - 25: all four inputs differ, so no pair can be swapped.
+      expect(container.style.width).toBe("885px");
+      expect(container.style.height).toBe("675px");
+    });
+  });
+
+  describe("insertTypeAnnotations", () => {
+    it("inserts at the start of the document when there is no model to measure against", () => {
+      const fixture = makeFixture(mockJavaUDFPredicate);
+      const component = fixture.componentInstance;
+      const insert = vi.fn();
+      (component as any).editorApp = {
+        getEditor: () => ({ getModel: () => undefined }),
+        dispose: vi.fn().mockResolvedValue(undefined),
+      };
+      (component as any).code = { insert };
+
+      component.showAnnotationSuggestion = true;
+      component.currentRange = new monaco.Range(4, 2, 4, 9);
+      component.currentSuggestion = ": float";
+
+      component.acceptCurrentAnnotation();
+
+      // No model to turn the range end into an offset, so the annotation lands
+      // at offset 0 rather than being dropped.
+      expect(insert).toHaveBeenCalledWith(0, ": float");
     });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

17 tests for `code-editor.component.ts`, covering the four things PR #7735 declared unreachable.

**#7735's count was right and its explanation was wrong.** It named the `monacoWorkerFactory` label switch, the dynamic codingame extension imports, the retry-clearing `catch` and the LSP timeout reject — exactly 10 union-uncovered lines, and exactly the right ten (279, 281, 283, 285, 287, 302-303, 310-311, 377). But its stated reason, *"All sit behind `ensureVscodeApiStarted()`, a process-wide singleton both suites stub; reaching them means booting the real codingame stack"*, is false on both halves:

- The jsdom spec stubs **nothing**. A search for `vi.mock` / `vi.doMock` over it returns zero hits, and there is no `ensureVscodeApiStarted` stub — the only mentions are the new tests calling it.
- `ensureVscodeApiStarted()` genuinely resolves under jsdom; a real monaco editor mounts over a real text model.

Nor is `getEnhancedMonacoEnvironment()` a barrier: it assigns `globalThis.MonacoEnvironment = {}` when that global is undefined and returns that same global, and `configureMonacoWorkers()` runs at the top of `start()` before any dynamic import, so the factory installs `MonacoEnvironment.getWorker` on the way in regardless of what fails later. Three of the four items are now covered by plain jsdom tests. **If that paragraph of #7735 is ever quoted, treat it as retracted.**

### The number Codecov will show is inflated, so here are both

| Measurement | Before | After |
|---|---|---|
| Codecov-visible (jsdom lcov — the only one `build.yml` uploads) | 192/229 = 83.8% | **217/217 = 100%** |
| True union (jsdom + browser) | 237/247 = 95.9% | **245/247 = 99.2%** |

**The honest gain is 8 lines.** 29 of the 37 lines this bundle newly covers in jsdom were already exercised by browser-mode tests whose lcov is never uploaded — `build.yml` runs the browser target with no `--coverage`. Branches 80.7% → 98.2% and functions 76.7% → 100% on the jsdom target.

The durable value is less the 8 lines than the 17 tests now pinning behaviour that had no assertions at all: diff-editor side assignment, disposal ordering, the re-tokenize loop bound, and the retry-memo clearing.

Tests 51 → 68 `it` blocks (65 → 82 cases; the new blocks are partly table-driven).

### Verification

18 mutations, **17 killed, 1 unkillable survivor**, each applied one at a time from a scratch-dir snapshot with a uniqueness assertion on every anchor, and the production md5 verified against the HEAD copy after every revert.

| Mutation | Killed by |
|---|---|
| **exchange** the `editorWorkerService` and `TextMateWorker` case bodies | points each monaco worker label at its own worker entry point |
| `default:` returns the editor worker instead of throwing | refuses a worker label it has no entry point for |
| delete the cached-start-promise reset from the catch | drops the cached start promise when the vscode API fails so a later open retries |
| **exchange** the diff editor's modified and original sides | diffs the version being viewed against the latest editing version |
| **exchange** the two interpolations in the editor model uri | binds the shared yjs text to the mounted editor and hands that editor to the debugger |
| negate the `readOnly` flag | opens the editor read-only when disabled, and writable when enabled — both directions |
| off-by-one on the re-tokenize loop bound | re-tokenizes every line of the model once the editor is mounted |
| delete the no-shared-code bail-out in the bring-up subscribe | mounts the editor but binds nothing when the operator holds no shared code |
| **exchange** detach-after-reattach instead of before | destroys the previous binding and detaches the previous listener on a second bring-up |
| delete the monaco binding destroy | same test, distinct assertion |
| rethrow instead of swallowing the language-server race failure | keeps the editor usable when the python language server never answers |
| delete the destroy-time yjs listener detach | detaches the yjs code listener it attached |
| **exchange** the editor-app and language-client disposal order | shuts the language client down before the editor |
| drop both no-op rejection handlers from the disposals | same test, after strengthening — see below |
| retarget the host listener at `window:scroll` | clamps the dialog through the window resize host listener |
| no-model offset fallback 0 → 1 | inserts at the start of the document when there is no model to measure against |
| **exchange** the debugger init above the bail-out | proves the three undefined-assertions are not just reading field defaults |

One mutation failed only to **compile**, which proves nothing; it was discarded and replaced with a semantic version.

**The survivor, stated plainly:** dropping the module-type option from the worker construction survives and is unkillable from a spec. The bundler's worker plugin rewrites the whole expression and supplies the options itself — the recorded options carry the module type whether or not the source literal is present. The label to entry-point mapping *is* pinned.

### Two claims inherited from #7735's tests were wrong, and the tests changed

- The worker-wiring test asserted the module-type option, with a comment claiming every worker has to be a module worker. That is unassertable per the survivor above, so the comment was replaced with the real explanation rather than left as a lie in the file.
- The teardown test was named "…and swallows both failures", but deleting both no-op rejection handlers **survived** — this runner does not fail on those unhandled rejections. The plain rejected-promise stand-ins were replaced with a thenable that records whether the caller attached a rejection handler, which makes that mutation die on an assertion.

### Deliberately not included

Lines 302-303, the codingame python and java default-extension imports, remain the only uncovered lines in the union. They look like a v8 attribution artifact rather than dead code: the enclosing `Promise.all([` and the following `whenReady` sweep are both covered in all three runs, so the imports demonstrably resolved. Chasing a v8 range quirk is not a coverage win.

Uploading browser-target coverage belongs to #7586, not here. The coverage-provider `optimizeDeps` entry was applied only to take the union measurement above, then reverted from a pristine copy; the diff against `frontend/vitest.browser.config.ts` is empty.

No production file is touched.

### Any related issues, documentation, discussions?

Closes #7842

### How was this PR tested?

```
npx ng test --watch=false --include="**/code-editor.component.spec.ts"
```

```
 Test Files  1 passed (1)
      Tests  82 passed (82)
```

A full-project run is **required**, not optional, for anything touching a bundler-rewritten `new Worker(new URL(...))`: `--include` runs one file, but the suite-wide run changes how the component is chunked, which changes `import.meta.url`, which changes every rewritten worker URL. One of these tests passed alone and failed in the full run for exactly that reason — the component resolved from a hoisted chunk at the server root while the spec's reference resolved under its own directory, same content hash, different prefix. Fixed by comparing only the content-hashed chunk name plus query, then re-verified that the label-mapping mutation still dies.

```
npx ng test --watch=false
```

```
 Test Files  201 passed (201)
      Tests  4832 passed | 1 skipped (4833)
```

The `code-editor-dialog` directory is green at 130 tests across 4 spec files, and no later spec shows change-detection fallout. `yarn format:ci` passes with no files listed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
