### PR TITLE
test(auth, amber): cover the activity tracker upsert and the amber home path

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/common/WorkflowActorSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/common/WorkflowActorSpec.scala
@@ -59,8 +59,10 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 
 import java.net.URI
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import scala.concurrent.duration.DurationInt
+import scala.jdk.CollectionConverters._
 
 class WorkflowActorSpec
     extends TestKit(ActorSystem("WorkflowActorSpec"))
@@ -161,6 +163,40 @@ class WorkflowActorSpec
       extends TrivialControlTester(workerId) {
     override def handleInputMessage(messageId: Long, workflowMsg: WorkflowFIFOMessage): Unit =
       throw new IllegalStateException("handleInputMessage failed")
+  }
+
+  /** A *direct* `WorkflowActor` subclass, i.e. the smallest actor that actually
+    * runs the base class's own `preStart`. `TrivialControlTester` overrides
+    * `preStart` without calling `super`, so nothing derived from it ever enters
+    * `WorkflowActor.preStart`.
+    */
+  private class MinimalWorkflowActor(
+      workerId: ActorVirtualIdentity,
+      failInitState: Boolean
+  ) extends WorkflowActor(replayLogConfOpt = None, actorId = workerId) {
+
+    /** The preStart steps observed from inside `initState`, in the order they
+      * happened. `transferService.initialize()` is not called by this class, so it
+      * is recorded through its only observable effect: `initState` finding the two
+      * periodic handles already live. Permuting the two calls therefore drops the
+      * first element of this sequence.
+      */
+    private val events = new ConcurrentLinkedQueue[String]()
+    def preStartEvents: Seq[String] = events.asScala.toSeq
+
+    override def handleInputMessage(id: Long, workflowMsg: WorkflowFIFOMessage): Unit = {}
+
+    override def getQueuedCredit(channelId: ChannelIdentity): Long = 0L
+
+    override def handleBackpressure(isBackpressured: Boolean): Unit = {}
+
+    override def initState(): Unit = {
+      if (!transferService.resendHandle.isCancelled) events.add("transferService.initialize")
+      events.add("initState")
+      if (failInitState) throw new IllegalStateException("initState failed")
+    }
+
+    override def loadFromCheckpoint(chkpt: CheckpointState): Unit = {}
   }
 
   // ---------------------------------------------------------------------------
@@ -502,6 +538,79 @@ class WorkflowActorSpec
       actor.ap.inputGateway.getAllChannels.isEmpty,
       "the checkpoint branch must not replay the top-level log"
     )
+  }
+
+  // ---------------------------------------------------------------------------
+  // preStart (WorkflowActor lines 229-238)
+  // ---------------------------------------------------------------------------
+
+  it should "start its transfer service and register itself with its parent in preStart" in {
+    val parent = TestProbe()
+    // The identity and the actor path name are deliberately different strings: with
+    // one literal for both, a registration reporting `context.self.path.name` instead
+    // of `actorId` would be indistinguishable from the real thing.
+    val actorId = ActorVirtualIdentity("prestart-succeeds-id")
+    val ref = TestActorRef[MinimalWorkflowActor](
+      Props(new MinimalWorkflowActor(actorId, failInitState = false)),
+      parent.ref,
+      "prestart-succeeds"
+    )
+    val transferService = ref.underlyingActor.transferService
+
+    // PekkoMessageTransferService starts out holding `Cancellable.alreadyCancelled`
+    // for both periodic handles, so live handles can only come from
+    // transferService.initialize() having run.
+    assert(!transferService.resendHandle.isCancelled)
+    assert(!transferService.creditPollingHandle.isCancelled)
+
+    // Order, not merely occurrence: initState found the transfer service already
+    // running, so initialize() ran first. Swapping the two calls yields Seq("initState").
+    assert(ref.underlyingActor.preStartEvents == Seq("transferService.initialize", "initState"))
+
+    // The parent is the only party that can answer GetActorRef for this actor, so
+    // the registration has to travel upwards rather than to self.
+    val registered = parent.expectMsgType[RegisterActorRef]
+    assert(registered.id == actorId)
+    assert(registered.ref == ref)
+
+    // Stopping the actor is also the cleanup this case owes the shared ActorSystem:
+    // left running, its 30s resend timer and its 200ms credit-polling timer keep
+    // firing until afterAll. postStop is what cancels them.
+    system.stop(ref)
+    awaitAssert(
+      {
+        assert(transferService.resendHandle.isCancelled)
+        assert(transferService.creditPollingHandle.isCancelled)
+      },
+      5.seconds,
+      100.millis
+    )
+  }
+
+  it should "rethrow an initialization failure so supervision tears the actor down" in {
+    val parent = TestProbe()
+    val actorId = ActorVirtualIdentity("prestart-fails-id")
+    // Swallowing this would leave a half-initialized actor in the running state and
+    // its supervisor none the wiser. Re-throwing turns it into an
+    // ActorInitializationException, which the default decider maps to Stop.
+    //
+    // Scope of this case: it pins `throw t` *given the catch exists*. It cannot see
+    // the catch block itself -- with no try/catch at all the exception takes exactly
+    // the same route to the same outcome -- and it does not observe the `logger.warn`,
+    // which is line-hit only.
+    val ref = TestActorRef[MinimalWorkflowActor](
+      Props(new MinimalWorkflowActor(actorId, failInitState = true)),
+      parent.ref,
+      "prestart-fails"
+    )
+
+    watch(ref)
+    expectTerminated(ref, 10.seconds)
+
+    // Ordering, the other half of the pin in the success case: a doomed actor must
+    // never have advertised itself upwards. Hoisting the registration above
+    // initState() would have put a RegisterActorRef here before the throw.
+    parent.expectNoMessage(500.millis)
   }
 
 }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/common/UtilsSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/common/UtilsSpec.scala
@@ -23,10 +23,48 @@ import com.twitter.util.{Await, Future, Time}
 import org.apache.texera.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import org.scalatest.flatspec.AnyFlatSpec
 
+import java.nio.file.Paths
 import java.util.concurrent.locks.ReentrantLock
 import scala.collection.mutable
 
 class UtilsSpec extends AnyFlatSpec {
+
+  // -- amberHomePath --------------------------------------------------------
+
+  "Utils.AMBER_HOME_FOLDER_NAME" should "be the literal directory name `amber`" in {
+    // Pinned on its own so that the search result below can be compared against a
+    // literal rather than against the constant that selected it -- comparing the two
+    // would move both sides of the equality together and detect nothing.
+    assert(Utils.AMBER_HOME_FOLDER_NAME == "amber")
+  }
+
+  "Utils.amberHomePath" should "resolve to an `amber` directory beneath the working directory" in {
+    // The tests run from the repo root, which is not itself amber home, so this
+    // exercises the Files.walk search rather than the early return.
+    //
+    // Only the *file name* is asserted, never the whole path: `findAny` on a
+    // sequential walk returns the first pre-order directory whose name ends in
+    // "amber", and dot-prefixed sibling directories are visited before `amber/`
+    // itself -- so a local `.<tool>/amber` legitimately wins here (the same hazard
+    // ArrowFlightActorBench documents).
+    //
+    // NOT covered here: the `2` in `Files.walk(cwd, 2)`. `amberHomePath` is a lazy
+    // val reading the process working directory, and `amber/` is a direct child of
+    // the repo root, so depth 1 finds it just as well and any depth >= 1 passes every
+    // assertion below. Only depth 0 dies. Pinning the documented grandchild case
+    // would need an injectable start directory in production code.
+    val currentWorkingDirectory = Paths.get(".").toRealPath()
+    val amberHome = Utils.amberHomePath
+
+    // The literal, never `Utils.AMBER_HOME_FOLDER_NAME`: the constant is what decides
+    // which directory the walk accepts, so asserting against it is a tautology.
+    assert(amberHome.getFileName.toString == "amber")
+    // Pinning it as a strict descendant is what keeps the assertion above from
+    // passing vacuously: on the early-return branch the result IS the working
+    // directory, so a run that never reached the walk would fail here.
+    assert(amberHome.startsWith(currentWorkingDirectory))
+    assert(amberHome != currentWorkingDirectory)
+  }
 
   // -- aggregatedStateToString ----------------------------------------------
 

--- a/common/auth/src/test/scala/org/apache/texera/auth/UserActivityTrackerSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/UserActivityTrackerSpec.scala
@@ -19,23 +19,48 @@
 
 package org.apache.texera.auth
 
+import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.jooq.generated.Tables.USER_LAST_ACTIVE_TIME
+import org.apache.texera.dao.jooq.generated.tables.daos.UserDao
+import org.apache.texera.dao.jooq.generated.tables.pojos.User
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Millis, Seconds, Span}
 
-import java.time.{Duration, Instant}
+import java.time.{Duration, Instant, OffsetDateTime, ZoneOffset}
 import java.util.concurrent.{
   ConcurrentLinkedQueue,
   CountDownLatch,
   Executor,
   RejectedExecutionException
 }
-import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 
-class UserActivityTrackerSpec extends AnyFlatSpec with Matchers {
+class UserActivityTrackerSpec
+    extends AnyFlatSpec
+    with Matchers
+    with Eventually
+    with BeforeAndAfterAll
+    with MockTexeraDB {
 
   // Synchronous executor: runnable runs on the calling thread, so the
   // test can observe upsert invocations deterministically.
   private val sameThread: Executor = (cmd: Runnable) => cmd.run()
+
+  /** Same calling-thread semantics as [[sameThread]], but it keeps whatever escapes
+    * the submitted task. That is what tells "swallowed inside the task, by the
+    * wrapper around upsertFn" apart from "swallowed one level up by markActive's own
+    * catch" -- both look identical to the caller.
+    */
+  private class CapturingExecutor extends Executor {
+    val escaped = new AtomicReference[Throwable]()
+
+    override def execute(cmd: Runnable): Unit =
+      try cmd.run()
+      catch { case t: Throwable => escaped.set(t) }
+  }
 
   private class Recorder {
     val calls = new ConcurrentLinkedQueue[(Integer, Instant)]()
@@ -48,6 +73,79 @@ class UserActivityTrackerSpec extends AnyFlatSpec with Matchers {
       clock: AtomicReference[Instant]
   ) =
     new UserActivityTracker(writeInterval, recorder.upsert, sameThread, () => clock.get())
+
+  // -- singleton fixture ------------------------------------------------------
+  //
+  // The `UserActivityTracker` object writes through `defaultUpsert`, which needs a
+  // real DSLContext, so the singleton cases run against MockTexeraDB's embedded
+  // Postgres. Its cooldown is per-uid and per-JVM, so each singleton case owns a
+  // distinct uid: a second call for the same uid inside the production 5-minute
+  // window would be suppressed no matter what the case did.
+  //
+  // uid 8810 has no activity row -> plain INSERT.
+  // uid 8820 is pre-seeded -> ON CONFLICT ... DO UPDATE.
+  //
+  // The two are ten apart on purpose: an off-by-one on the uid written by production
+  // code then lands on a uid that exists in neither fixture, so it fails loudly on the
+  // foreign key instead of quietly redirecting one case's write onto the other case's
+  // row -- which would abort the sibling case on its own clobbered precondition and
+  // credit the kill to the wrong test.
+  //
+  // NOT verified anywhere in this spec: WRITE_INTERVAL's value, WRITER_QUEUE_CAPACITY,
+  // the DiscardOldest policy, and the periodic cleanup scheduler. Every line of the
+  // companion object runs during class initialisation, so a 100% line figure on this
+  // file must not be read as 100% verified.
+  private val insertUid: Integer = 8810
+  private val updateUid: Integer = 8820
+  // used by the queued-write case: 8830's insert is deliberately blocked so that
+  // 8840's write cannot start until the test lets go of a table lock.
+  private val blockerUid: Integer = 8830
+  private val delayedUid: Integer = 8840
+  private val seededInstant: Instant = Instant.parse("2001-02-03T04:05:06Z")
+
+  implicit override val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(20, Seconds), interval = Span(50, Millis))
+
+  override def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+    val userDao = new UserDao(getDSLContext.configuration())
+    // user_last_active_time.uid is a FK onto "user"(uid), so every fixture uid needs a
+    // parent row.
+    Seq(
+      insertUid -> "activity-insert",
+      updateUid -> "activity-update",
+      blockerUid -> "activity-blocker",
+      delayedUid -> "activity-delayed"
+    ).foreach {
+      case (uid, name) =>
+        val user = new User
+        user.setUid(uid)
+        user.setName(name)
+        userDao.insert(user)
+    }
+    getDSLContext
+      .insertInto(USER_LAST_ACTIVE_TIME)
+      .set(USER_LAST_ACTIVE_TIME.UID, updateUid)
+      .set(
+        USER_LAST_ACTIVE_TIME.LAST_ACTIVE_TIME,
+        OffsetDateTime.ofInstant(seededInstant, ZoneOffset.UTC)
+      )
+      .execute()
+  }
+
+  override def afterAll(): Unit = closeConnectionPool()
+
+  private def readLastActive(uid: Integer): Option[Instant] =
+    Option(
+      getDSLContext
+        .select(USER_LAST_ACTIVE_TIME.LAST_ACTIVE_TIME)
+        .from(USER_LAST_ACTIVE_TIME)
+        .where(USER_LAST_ACTIVE_TIME.UID.eq(uid))
+        .fetchOne()
+    ).flatMap(record => Option(record.value1())).map(_.toInstant)
+
+  private def activityRowCount(uid: Integer): Int =
+    getDSLContext.fetchCount(USER_LAST_ACTIVE_TIME, USER_LAST_ACTIVE_TIME.UID.eq(uid))
 
   "UserActivityTracker" should "trigger an upsert on the first call for a uid" in {
     val recorder = new Recorder
@@ -134,44 +232,68 @@ class UserActivityTrackerSpec extends AnyFlatSpec with Matchers {
     tracker.cooldownSize shouldBe 0
   }
 
-  it should "swallow upsertFn exceptions instead of propagating to the caller" in {
-    val t0 = Instant.parse("2026-01-01T00:00:00Z")
-    val clock = new AtomicReference[Instant](t0)
-    val throwing: (Integer, Instant) => Unit =
-      (_, _) => throw new RuntimeException("simulated DB outage")
-    val tracker =
-      new UserActivityTracker(Duration.ofMinutes(5), throwing, sameThread, () => clock.get())
+  // Both non-fatal shapes are exercised at every catch site: a RuntimeException and a
+  // *checked* IOException. The checked one is the shape that separates the actual
+  // predicate, `case NonFatal(e)`, from the narrower `case e: RuntimeException` -- Scala
+  // throws checked exceptions without declaring them, so the lambda shapes are unchanged.
+  private val nonFatalShapes: Seq[Throwable] = Seq(
+    new RuntimeException("simulated outage"),
+    new java.io.IOException("simulated checked outage")
+  )
 
-    // Must not throw — the wrapper catches NonFatal from upsertFn.
-    noException should be thrownBy tracker.markActive(42)
+  it should "swallow upsertFn exceptions instead of propagating to the caller" in {
+    nonFatalShapes.foreach { boom =>
+      withClue(s"upsertFn threw $boom: ") {
+        val t0 = Instant.parse("2026-01-01T00:00:00Z")
+        val clock = new AtomicReference[Instant](t0)
+        val executor = new CapturingExecutor
+        val throwing: (Integer, Instant) => Unit = (_, _) => throw boom
+        val tracker =
+          new UserActivityTracker(Duration.ofMinutes(5), throwing, executor, () => clock.get())
+
+        // Must not throw — the wrapper catches NonFatal from upsertFn.
+        noException should be thrownBy tracker.markActive(42)
+        // And it is that wrapper, inside the task, that catches it: nothing escapes the
+        // submitted runnable to be mopped up by markActive's own catch instead.
+        Option(executor.escaped.get()) shouldBe None
+      }
+    }
   }
 
   it should "swallow exceptions thrown before the write is dispatched" in {
-    val recorder = new Recorder
-    // a clock that throws forces the failure in markActive before executor.execute
-    val tracker =
-      new UserActivityTracker(
-        Duration.ofMinutes(5),
-        recorder.upsert,
-        sameThread,
-        () => throw new RuntimeException("clock boom")
-      )
+    nonFatalShapes.foreach { boom =>
+      withClue(s"clock threw $boom: ") {
+        val recorder = new Recorder
+        // a clock that throws forces the failure in markActive before executor.execute
+        val tracker =
+          new UserActivityTracker(
+            Duration.ofMinutes(5),
+            recorder.upsert,
+            sameThread,
+            () => throw boom
+          )
 
-    noException should be thrownBy tracker.markActive(7)
-    recorder.calls.size shouldBe 0 // the write was never dispatched
+        noException should be thrownBy tracker.markActive(7)
+        recorder.calls.size shouldBe 0 // the write was never dispatched
+      }
+    }
   }
 
   it should "swallow exceptions thrown by evictStale" in {
-    val recorder = new Recorder
-    val tracker =
-      new UserActivityTracker(
-        Duration.ofMinutes(5),
-        recorder.upsert,
-        sameThread,
-        () => throw new RuntimeException("clock boom")
-      )
+    nonFatalShapes.foreach { boom =>
+      withClue(s"clock threw $boom: ") {
+        val recorder = new Recorder
+        val tracker =
+          new UserActivityTracker(
+            Duration.ofMinutes(5),
+            recorder.upsert,
+            sameThread,
+            () => throw boom
+          )
 
-    noException should be thrownBy tracker.evictStale()
+        noException should be thrownBy tracker.evictStale()
+      }
+    }
   }
 
   it should "not create a cooldown entry for a null uid" in {
@@ -373,7 +495,171 @@ class UserActivityTrackerSpec extends AnyFlatSpec with Matchers {
     tracker.cooldownSize shouldBe 1
   }
 
+  it should "let a fatal error from the clock escape markActive" in {
+    val recorder = new Recorder
+    val t0 = Instant.parse("2026-01-01T00:00:00Z")
+    // The catch is `NonFatal`, not `Throwable`: a transient clock/DB hiccup is
+    // swallowed (cases above), but an InterruptedException or an OOM has to reach
+    // the caller instead of being logged and dropped as if it were transient.
+    //
+    // The first clock read succeeds on purpose. `clock()` is the first statement in
+    // markActive's try, so after a throw on the very first call every count is zero no
+    // matter what the rest of the method does; letting one call through first makes the
+    // trailing assertions observations about state the tracker really built.
+    val reads = new AtomicInteger()
+    val tracker =
+      new UserActivityTracker(
+        Duration.ofMinutes(5),
+        recorder.upsert,
+        sameThread,
+        () =>
+          if (reads.incrementAndGet() == 1) t0
+          else throw new InterruptedException("fatal clock")
+      )
+
+    tracker.markActive(5150)
+    recorder.calls.size shouldBe 1
+    tracker.cooldownSize shouldBe 1
+
+    an[InterruptedException] should be thrownBy tracker.markActive(5150)
+
+    // the escape left the first call's write and its cooldown claim exactly as they were
+    recorder.calls.size shouldBe 1
+    tracker.cooldownSize shouldBe 1
+  }
+
+  it should "let a fatal error from upsertFn escape markActive" in {
+    val t0 = Instant.parse("2026-01-01T00:00:00Z")
+    val clock = new AtomicReference[Instant](t0)
+    val fatal: (Integer, Instant) => Unit =
+      (_, _) => throw new InterruptedException("fatal upsert")
+    val tracker =
+      new UserActivityTracker(Duration.ofMinutes(5), fatal, sameThread, () => clock.get())
+
+    // The same NonFatal-not-Throwable contract at the third catch site, the wrapper
+    // around upsertFn: on this synchronous executor a fatal from the write passes
+    // through both catches and out to the caller.
+    an[InterruptedException] should be thrownBy tracker.markActive(4242)
+
+    // the slot was claimed before the write was dispatched
+    tracker.cooldownSize shouldBe 1
+  }
+
+  it should "let a fatal error from the clock escape evictStale" in {
+    val recorder = new Recorder
+    val tracker =
+      new UserActivityTracker(
+        Duration.ofMinutes(5),
+        recorder.upsert,
+        sameThread,
+        () => throw new InterruptedException("fatal clock")
+      )
+
+    an[InterruptedException] should be thrownBy tracker.evictStale()
+  }
+
   "UserActivityTracker singleton" should "treat a null uid as a no-op without touching the DB" in {
     noException should be thrownBy UserActivityTracker.markActive(null)
+  }
+
+  it should "insert a last-active row for a uid that has none" in {
+    // No row at all, which is what makes this the INSERT arm rather than the DO UPDATE
+    // arm. `readLastActive` alone would not establish that: last_active_time is
+    // nullable, so a row carrying a NULL also reads back as None.
+    activityRowCount(insertUid) shouldBe 0
+
+    val beforeCall = Instant.now()
+    UserActivityTracker.markActive(insertUid)
+    // Taken here, not after the `eventually` below: the accepted window is then the
+    // duration of the markActive call itself rather than however long the poll took,
+    // which is what binds the stored value to the instant handed to the writer.
+    val afterCall = Instant.now()
+
+    // The singleton dispatches the upsert onto its own writer thread, so the row
+    // appears asynchronously.
+    val stored = eventually {
+      readLastActive(insertUid).getOrElse(fail(s"no activity row was written for $insertUid"))
+    }
+
+    // The stamped instant is the claim time, taken synchronously inside markActive, so
+    // it lands in [beforeCall, afterCall]. The millisecond of slack absorbs Postgres'
+    // microsecond rounding, nothing more; a timestamp taken at write time instead
+    // lands after this window, because opening a DSLContext and round-tripping the
+    // insert is never a sub-millisecond affair.
+    withClue(s"stored=$stored window=[$beforeCall, $afterCall]: ") {
+      stored.isBefore(beforeCall.minusMillis(1)) shouldBe false
+      stored.isAfter(afterCall.plusMillis(1)) shouldBe false
+    }
+  }
+
+  it should "stamp a queued write with its claim time rather than the time it runs" in {
+    // A tight wall-clock window around markActive is not enough to separate claim time
+    // from write time: the writer thread normally picks the task up within a
+    // millisecond, so both land inside any window wide enough to be stable. The
+    // difference only becomes visible when the write is made to WAIT, which is also the
+    // case that matters -- under a DB stall, tasks sit in the bounded writer queue, and
+    // what has to be recorded is when the user was seen, not when the row finally
+    // landed.
+    //
+    // The stall is manufactured with an EXCLUSIVE table lock held on a raw connection
+    // (outside the pool the writer borrows from): it blocks blockerUid's insert, and the
+    // single-threaded writer therefore cannot even start delayedUid's task until the
+    // lock is released.
+    val lockConn = newRawConnection()
+    val beforeCall = Instant.now()
+    val afterCall =
+      try {
+        lockConn.setAutoCommit(false)
+        val stmt = lockConn.createStatement()
+        try stmt.execute("LOCK TABLE texera_db.user_last_active_time IN EXCLUSIVE MODE")
+        finally stmt.close()
+
+        UserActivityTracker.markActive(blockerUid)
+        // give the writer thread time to start the insert and block on the lock
+        Thread.sleep(500)
+        UserActivityTracker.markActive(delayedUid)
+        val callReturned = Instant.now()
+        // keep the writer parked well past the tolerance asserted below
+        Thread.sleep(1500)
+        callReturned
+      } finally {
+        lockConn.rollback()
+        lockConn.close()
+      }
+
+    val stored = eventually {
+      readLastActive(delayedUid).getOrElse(fail(s"no activity row was written for $delayedUid"))
+    }
+
+    // The write ran at least a second and a half after the call returned, so a stamp
+    // taken at write time lands far outside this window while the claim-time stamp the
+    // caller handed over is still inside it.
+    withClue(s"stored=$stored window=[$beforeCall, $afterCall]: ") {
+      stored.isBefore(beforeCall.minusMillis(1)) shouldBe false
+      stored.isAfter(afterCall.plusMillis(100)) shouldBe false
+    }
+  }
+
+  it should "overwrite the existing last-active row instead of failing on its primary key" in {
+    // uid is the primary key, so a write for a user that already has a row can only
+    // succeed through the ON CONFLICT ... DO UPDATE arm. The specific seeded value is
+    // what establishes that premise -- and what the new write has to replace.
+    readLastActive(updateUid) shouldBe Some(seededInstant)
+
+    val beforeCall = Instant.now()
+    UserActivityTracker.markActive(updateUid)
+    val afterCall = Instant.now()
+
+    val stored = eventually {
+      val current =
+        readLastActive(updateUid).getOrElse(fail(s"activity row for $updateUid disappeared"))
+      current should not be seededInstant
+      current
+    }
+
+    withClue(s"stored=$stored window=[$beforeCall, $afterCall]: ") {
+      stored.isBefore(beforeCall.minusMillis(1)) shouldBe false
+      stored.isAfter(afterCall.plusMillis(1)) shouldBe false
+    }
   }
 }

--- a/common/auth/src/test/scala/org/apache/texera/auth/UserActivityTrackerSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/UserActivityTrackerSpec.scala
@@ -615,8 +615,6 @@ class UserActivityTrackerSpec
         finally stmt.close()
 
         UserActivityTracker.markActive(blockerUid)
-        // give the writer thread time to start the insert and block on the lock
-        Thread.sleep(500)
         UserActivityTracker.markActive(delayedUid)
         val callReturned = Instant.now()
         // keep the writer parked well past the tolerance asserted below


### PR DESCRIPTION
### What changes were proposed in this PR?

Three small targets, bundled because each is a few lines with no coverage. 10 tests added (52 → 62 across the three specs).

All figures below were measured with `<Module>/jacoco` under a `Tests.Filter` naming only the spec(s) in question, the same filter for the before and after run, parsing `jacoco.xml` per `<sourcefile>`. Two numbers per file, because they differ: JaCoCo line-hit (any instruction covered) and the Codecov metric (fully-covered lines, so a line with any missed branch arm counts against you).

| File | JaCoCo line-hit | Codecov metric |
|---|---|---|
| `UserActivityTracker.scala` | 47/56 = 83.9% → **56/56 = 100%** | 42/56 = 75.0% → **49/56 = 87.5%** |
| `Utils.scala` | 58/69 = 84.1% → **66/69 = 95.7%** | 38/69 = 55.1% → **44/69 = 63.8%** |
| `WorkflowActor.scala` | 83/89 = 93.3% → **88/89 = 98.9%** | 48/89 = 53.9% → **52/89 = 58.4%** |

All 9 previously-missed lines of `UserActivityTracker` (151-157, 159, 160 — the whole of the private `defaultUpsert`) are covered, plus the two fatal-escapes-the-catch arms at 89 and 103.

**Two honest caveats on those numbers.** First, `WorkflowActor`'s apparent gain is inflated by the narrow filter: against a full CI amber run only lines 236 and 237 are new, because 231-233 are already covered there by real workers. Second, `UserActivityTracker`'s Codecov metric carries about ±2 lines of run-to-run noise, because the 16-thread CAS race at lines 77 and 79 does not always cover both arms — do not read a 2-line drop on this file as a regression.

### What adversarial review changed, because it caught a test that pinned nothing

The first draft of the `Utils` test asserted `amberHome.getFileName.toString == Utils.AMBER_HOME_FOLDER_NAME`. That is tautological: production selects the directory *using* that constant, so mutating it to `"common"` moves both sides of the equality together and the test stays green — `./common` also exists at depth 1, so the walk finds it and the two supporting legs (strict descendant, not equal to cwd) are satisfied by any descendant. It was the assertion the whole target rested on, and it constrained nothing.

It now asserts the literal `"amber"`, with the constant pinned separately by its own one-line test. Mutating the constant kills both.

### Verification

33 mutations, **28 killed, 5 survivors**, all 5 stated below. Each was applied one at a time from a scratch-dir snapshot with an applier that aborts unless the anchor occurs exactly once, reverted by copying the snapshot over the one exact file path, with the production diff and an md5 re-checked after every revert.

A selection — the full table is long, so these are the ones that pin something a reader would otherwise assume:

| Mutation | Killed by |
|---|---|
| `AMBER_HOME_FOLDER_NAME` `"amber"` → `"common"` | the constant test **and** the `getFileName` literal leg |
| negate the `isAmberHomePath(cwd)` early-return guard | resolves to an `amber` directory beneath the working directory |
| `.filter(isAmberHomePath)` → `.filter(_ => true)` | same test |
| walk root `Paths.get(".")` → `.getParent` | the strict-descendant leg (environment-sensitive — see below) |
| **reorder** `preStart` to initState / register / initialize | the recorded event sequence |
| **reorder** `preStart` to hoist register above `initState` | the failure case's `expectNoMessage` on the parent probe |
| `RegisterActorRef(actorId, …)` → `ActorVirtualIdentity(context.self.path.name)` | the identity assertion, after the fixture stopped reusing one literal for both |
| `context.parent !` → `context.self !` | parent probe times out |
| `postStop`'s `transferService.stop()` → `()` | the post-stop handle-cancellation assertion |
| `NonFatal` → `Throwable` at each of the three catch sites | three fatal-escape cases, one per site |
| `NonFatal` → `RuntimeException` at each of the three catch sites | three checked-`IOException` shapes, one per site |
| `OffsetDateTime.ofInstant(ts, UTC)` → `now(UTC)` (discard `ts`) | the queued-write case — **and nothing else**, see below |
| `.set(UID, uid)` → `uid + 1` | both singleton cases, each on its own assertion |
| VALUES arm and DO UPDATE arm timestamps, separately | insert case and overwrite case respectively — the arms are orthogonal |
| delete `.onConflict(UID).doUpdate()` | the overwrite case |
| cooldown comparison `< 0` → `<= 0`, eviction `×2` → `×3`, `isBefore` → `!isAfter` | the interval and eviction boundary cases |

Three of these are worth calling out because the obvious version of the test does not kill them:

- **Discarding the upsert's `ts` argument survived a tightened wall-clock window.** The single-threaded writer picks the task up inside the clock's own granularity — measured `beforeCall == afterCall` to the tick on this machine. Killing it needed the stall the property exists for: an exclusive lock on `texera_db.user_last_active_time` held on a raw connection *outside* the Hikari pool the writer borrows from, which blocks one insert so the writer cannot reach the next task for 1.5s. If that case is ever deleted, this mutation goes straight back to surviving.
- **The three `NonFatal` catch sites needed a checked non-fatal**, since a suite where every non-fatal thrower is a `RuntimeException` lets `case NonFatal(e)` → `case e: RuntimeException` survive everywhere. The third site (inside the executor task) also needed a capturing executor to be observable at all — an `IOException` from `upsertFn` on a same-thread executor is caught one level up by `markActive`, so the caller sees nothing either way.
- **The fixture uids moved to 8810/8820/8830/8840.** With adjacent uids, the off-by-one mutation redirected one case's write onto the other case's seed row, and the resulting "kill" was really a test aborting on its own clobbered precondition.

### The five survivors, and the equivalent mutants among them

- **`Files.walk(cwd, 2)` → `1` survives.** Unpinnable from a test: `amberHomePath` is a `lazy val` reading the process working directory, so one JVM takes one branch, and `isAmberHomePath` is private. `amber/` is a direct child of the repo root, so depth 1 still finds it. Only depth 0 dies, and it dies through production's own exception rather than any assertion about depth. Both suggested fixes needed a production visibility change, so neither was taken; a comment in the spec records this so the depth-0 kill is not mistaken for a depth pin.
- **Dropping `.toRealPath()` from `isAmberHomePath` survives** — every `Files.walk` result is already rooted at a real path. Pinning the symlink intent would need a temp symlink tree.
- **Deleting `preStart`'s entire try/catch survives, and is an equivalent mutant.** The `IllegalStateException` leaves `preStart` either way, Pekko wraps it in `ActorInitializationException` either way, the default decider Stops either way, `postStop` runs either way, and `Terminated` arrives either way. Asserting on the exception's cause does not discriminate it either — the cause is identical with and without the catch. So `throw t` is pinned *given the catch exists*, and nothing more than that is claimed.
- **Deleting the catch's `logger.warn` survives** — a strict subset of the above. Line 236 is line-hit only, never verified, and is stated as such in the spec.
- **Deleting `markActive`'s `if (uid == null) return` survives.** `ConcurrentHashMap.get(null)` throws an NPE, which is non-fatal, so the outer catch swallows it and the caller still observes a no-op with no write and no cooldown entry. Only the log noise differs. Reported rather than repaired for that reason; it was untried by the first pass and found while re-deriving the table.

One kill is environment-sensitive and says so: retargeting the walk root at `cwd.getParent` dies here only because sibling worktrees contain their own `amber/` directories. In a checkout whose parent has no sibling `amber`, the walk would return `<checkout>/amber`, which still starts with cwd, and the mutant would survive.

### Deliberately not included

`WRITE_INTERVAL` (5 minutes), `WRITER_QUEUE_CAPACITY` (256), the `DiscardOldest` policy and the periodic eviction scheduler are unverified — the singleton fixture is deliberately built *around* the throttle by giving each case its own uid. So `UserActivityTracker.scala` reaching 100% line-hit should not be read as 100% verified, and the fixture carries a comment saying so.

`WorkflowActor.scala:47` (the companion's module initializer) remains uncovered; nothing here can reach it.

One inherent fragility, recorded in the fixture: the singleton cases assume no other `Auth` suite calls `UserActivityTracker.markActive` for uids 8810/8820/8830/8840, since the cooldown is per-uid and per-JVM and a prior call would suppress the write. That is unavoidable when testing a JVM singleton with a 5-minute throttle.

No production file is touched.

### Any related issues, documentation, discussions?

Closes #7844

### How was this PR tested?

```
sbt "Auth/testOnly org.apache.texera.auth.UserActivityTrackerSpec"
```

```
[info] Tests: succeeded 28, failed 0, canceled 0, ignored 0, pending 0
```

```
sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.common.UtilsSpec org.apache.texera.amber.engine.architecture.common.WorkflowActorSpec"
```

```
[info] Tests: succeeded 34, failed 0, canceled 0, ignored 0, pending 0
```

The whole `Auth` module is green at 105 tests across 10 suites, which is the check that matters here — it confirms the new `MockTexeraDB` mixin does not disturb the sibling suites sharing the JVM and the `SqlServer` singleton. `Test/scalafmtCheck` and `Test/scalafix --check` pass for both modules.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
