### PR TITLE
test(pybuilder): cover the encodable inspector's type classification

### DIFF
--- a/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/EncodableInspectorSpec.scala
+++ b/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/EncodableInspectorSpec.scala
@@ -327,15 +327,15 @@ class EncodableInspectorSpec extends AnyFunSuite {
   }
 
   test("a never-typechecked argument tree is classified non-Encodable by every predicate") {
-    // Pins the fail-safe default of the `tpe != null` / `argType != null` guards on lines 131,
-    // 136, 147 and 164: swapping either `&&` so the guard runs second turns this test into an NPE.
+    // Pins the fail-safe default of the `tpe != null` / `argType != null` guards used by
+    // `isPythonTemplateBuilderArg`, `isStringRendererArg`, `isDirectEncodableStringArg`, and `wrapArg`:
+    // swapping either `&&` so the null check runs second turns this test into an NPE.
     //
     // Honest scope note: `pyb` cannot deliver such a tree - a blackbox macro's argument trees are
     // typechecked by construction - so these guards are defensive-only, reachable in practice only
-    // through a probe like this one. And the *fifth* null guard, `tree.tpe != null` on line 126, is
-    // provably redundant rather than merely untested: `typeHasEncodableString`'s `loop` already
-    // answers false for null on line 79, so deleting it is an equivalent mutation. No test can (or
-    // should) pretend to pin it.
+    // through a probe like this one. And the extra `tree.tpe != null` check in `treeHasEncodableString`
+    // is provably redundant rather than merely untested: `typeHasEncodableString` already answers false
+    // for `null`, so deleting the guard is an equivalent mutation. No test can (or should) pretend to pin it.
     assert(evalProbe("classifyUntyped") == "ptb=false sr=false enc=false treeEnc=false")
   }
 

--- a/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/EncodableInspectorSpec.scala
+++ b/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/EncodableInspectorSpec.scala
@@ -21,8 +21,83 @@ package org.apache.texera.amber.pybuilder
 
 import org.scalatest.funsuite.AnyFunSuite
 
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
 import scala.reflect.runtime.currentMirror
 import scala.tools.reflect.{ToolBox, ToolBoxError}
+
+/**
+  * Test-only probe macro: reports what [[EncodableInspector]] answers for a spliced argument.
+  *
+  * `EncodableInspector` is context-bound, so no plain unit test can call it: every method takes
+  * `c.universe` types that only exist while a macro expands. The spec therefore drives real macro
+  * expansions through a runtime `ToolBox`, and this object is the macro it drives. Because the
+  * probe's expansion result is a plain `String` literal, `tb.eval` returns the inspector's actual
+  * answers instead of the compile-error text the `pyb"..."`-based tests have to settle for
+  * (`pyb` expands to the `private[amber]` `PythonTemplateBuilder.fromInterpolated`, which the
+  * ToolBox's synthetic wrapper package may not access).
+  *
+  * The macro definitions and their implementations may share this compilation unit: the "macro
+  * implementation not found" restriction applies at the *expansion* site, and every expansion here
+  * happens later, in the ToolBox's separate compilation run.
+  */
+object EncodableInspectorProbe {
+
+  /** `"ptb=<b> sr=<b> enc=<b> treeEnc=<b>"` for the spliced argument. */
+  def classify(arg: Any): String = macro classifyImpl
+
+  /** `showCode` of the tree `wrapArg` lowers the spliced argument to. */
+  def wrapCode(arg: Any): String = macro wrapCodeImpl
+
+  /** Same as [[classify]], but the inspector is handed a never-typechecked tree. */
+  def classifyUntyped: String = macro classifyUntypedImpl
+
+  /** Same as [[wrapCode]], but the inspector is handed a never-typechecked tree. */
+  def wrapCodeUntyped: String = macro wrapCodeUntypedImpl
+
+  def classifyImpl(c: blackbox.Context)(arg: c.Expr[Any]): c.Expr[String] =
+    literal(c)(flags(c)(arg.tree))
+
+  def wrapCodeImpl(c: blackbox.Context)(arg: c.Expr[Any]): c.Expr[String] =
+    literal(c)(wrapped(c)(arg.tree))
+
+  def classifyUntypedImpl(c: blackbox.Context): c.Expr[String] =
+    literal(c)(flags(c)(untypedTree(c)))
+
+  def wrapCodeUntypedImpl(c: blackbox.Context): c.Expr[String] =
+    literal(c)(wrapped(c)(untypedTree(c)))
+
+  /**
+    * A freshly built tree that has never been through the typer, so its `tpe` is `null`.
+    *
+    * This is the fail-safe input that every `tpe != null` / `tree.tpe != null` guard in the
+    * inspector exists for.
+    */
+  private def untypedTree(c: blackbox.Context): c.Tree = {
+    import c.universe._
+    Literal(Constant("x"))
+  }
+
+  private def literal(c: blackbox.Context)(value: String): c.Expr[String] = {
+    import c.universe._
+    c.Expr[String](Literal(Constant(value)))
+  }
+
+  private def flags(c: blackbox.Context)(tree: c.Tree): String = {
+    val inspector = new EncodableInspector[c.type](c)
+    val argExpr = c.Expr[Any](tree)
+    val ptb = inspector.isPythonTemplateBuilderArg(argExpr)
+    val sr = inspector.isStringRendererArg(argExpr)
+    val enc = inspector.isDirectEncodableStringArg(argExpr)
+    val treeEnc = inspector.treeHasEncodableString(tree)
+    s"ptb=$ptb sr=$sr enc=$enc treeEnc=$treeEnc"
+  }
+
+  private def wrapped(c: blackbox.Context)(tree: c.Tree): String = {
+    val inspector = new EncodableInspector[c.type](c)
+    c.universe.showCode(inspector.wrapArg(c.Expr[Any](tree)))
+  }
+}
 
 /**
   * Runtime coverage for `EncodableInspector`.
@@ -81,6 +156,15 @@ class EncodableInspectorSpec extends AnyFunSuite {
       s"expected the benign private-access failure after full expansion, got: $msg"
     )
   }
+
+  /** Snippet preamble for the probe-macro tests. */
+  private val probeHeader =
+    s"""$header
+       |import org.apache.texera.amber.pybuilder.EncodableInspectorProbe._""".stripMargin
+
+  /** Expand a probe snippet inside the ToolBox and return the macro's result string. */
+  private def evalProbe(body: String): String =
+    tb.eval(tb.parse(s"{\n$probeHeader\n$body\n}")).asInstanceOf[String]
 
   // ========================================================================
   // Classified Encodable (unsafe splice => BoundaryValidator aborts).
@@ -187,6 +271,276 @@ class EncodableInspectorSpec extends AnyFunSuite {
     assertNotClassifiedEncodable(
       """val ui: EncodableString = "x"
         |pyb"a $ui b"""".stripMargin
+    )
+  }
+
+  // ========================================================================
+  // Probe-macro tests: these read the classifier's *actual* answers rather than
+  // inferring them from compile-error text, and they can hand the inspector
+  // argument shapes `pyb"..."` cannot produce.
+  //
+  // `flags` is always "ptb=<b> sr=<b> enc=<b> treeEnc=<b>", i.e.
+  // isPythonTemplateBuilderArg / isStringRendererArg / isDirectEncodableStringArg /
+  // treeHasEncodableString, in that order.
+  // ========================================================================
+
+  // NOTE, so nobody over-reads the coverage these two tests buy: `isStringRendererArg` has no
+  // caller anywhere in the repo outside this spec (`wrapArg` inlines the same subtype check).
+  // Its body is therefore production code that only the test harness executes, which is exactly
+  // why its two lines were never covered before. The predicate is still worth pinning - `wrapArg`
+  // duplicates its logic - but the coverage it adds is not new *production* behaviour.
+  test("isStringRendererArg accepts a StringRenderer-typed argument") {
+    assert(
+      evalProbe("""classify(PyLiteralStringRenderer("x"))""") ==
+        "ptb=false sr=true enc=false treeEnc=false"
+    )
+  }
+
+  test("isStringRendererArg rejects a plain String argument") {
+    assert(evalProbe("""classify("x")""") == "ptb=false sr=false enc=false treeEnc=false")
+  }
+
+  test("isPythonTemplateBuilderArg accepts a PythonTemplateBuilder-typed argument") {
+    // A PythonTemplateBuilder cannot be *constructed* inside a ToolBox snippet (its factory is
+    // private[amber]), but a declaration of that type is enough: the probe macro only inspects
+    // the argument tree, it never evaluates it.
+    assert(
+      evalProbe(
+        """def nested: org.apache.texera.amber.pybuilder.PythonTemplateBuilder = ???
+          |classify(nested)""".stripMargin
+      ) == "ptb=true sr=false enc=false treeEnc=false"
+    )
+  }
+
+  test("wrapArg keeps an existing EncodableStringRenderer as a cast rather than re-wrapping it") {
+    // This fixture satisfies priority 1 only (`treeEnc=false`), so it pins the cast *branch* -
+    // swapping its body with the literal fallback fails here - but NOT the branch *order*.
+    // The order is pinned by "wrapArg prefers the StringRenderer cast ..." below.
+    assert(
+      evalProbe("""classify(EncodableStringRenderer("x"))""") ==
+        "ptb=false sr=true enc=true treeEnc=false"
+    )
+    val wrap = evalProbe("""wrapCode(EncodableStringRenderer("x"))""")
+    assert(wrap.contains(".asInstanceOf["), wrap)
+    assert(wrap.endsWith("PythonTemplateBuilder.StringRenderer]"), wrap)
+    assert(!wrap.contains(".toString"), wrap)
+  }
+
+  test("a never-typechecked argument tree is classified non-Encodable by every predicate") {
+    // Pins the fail-safe default of the `tpe != null` / `argType != null` guards on lines 131,
+    // 136, 147 and 164: swapping either `&&` so the guard runs second turns this test into an NPE.
+    //
+    // Honest scope note: `pyb` cannot deliver such a tree - a blackbox macro's argument trees are
+    // typechecked by construction - so these guards are defensive-only, reachable in practice only
+    // through a probe like this one. And the *fifth* null guard, `tree.tpe != null` on line 126, is
+    // provably redundant rather than merely untested: `typeHasEncodableString`'s `loop` already
+    // answers false for null on line 79, so deleting it is an equivalent mutation. No test can (or
+    // should) pretend to pin it.
+    assert(evalProbe("classifyUntyped") == "ptb=false sr=false enc=false treeEnc=false")
+  }
+
+  test("a never-typechecked argument tree is lowered to a PyLiteralStringRenderer") {
+    val wrap = evalProbe("wrapCodeUntyped")
+    assert(wrap.contains("PyLiteralStringRenderer("), wrap)
+    assert(!wrap.contains(".asInstanceOf["), wrap)
+  }
+
+  test("a type annotation other than @EncodableStringAnnotation leaves the argument a literal") {
+    // Pins that `annIsEncodableString` actually discriminates (flipping its `==` to `!=` fails
+    // here). It does NOT pin the `encodableStringAnnotationFqn` string itself: within one
+    // compilation run there is exactly one symbol per fully-qualified name, so the fullName test
+    // can only be true when line 68's `<:< typeOf[EncodableStringAnnotation]` is also true.
+    // Pointing the constant at a non-existent FQN is therefore an equivalent mutation (measured:
+    // it passes the whole module), and no test can pin it.
+    assert(
+      evalProbe(
+        """class ZzAnn extends scala.annotation.StaticAnnotation
+          |val d: String @ZzAnn = "x"
+          |classify(d)""".stripMargin
+      ) == "ptb=false sr=false enc=false treeEnc=false"
+    )
+  }
+
+  test("a compound type with an Encodable-marked parent is Encodable") {
+    assert(
+      evalProbe(
+        """type Marked = String @EncodableStringAnnotation
+          |val mr: Marked with java.io.Serializable =
+          |  "x".asInstanceOf[Marked with java.io.Serializable]
+          |classify(mr)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  test("a compound type with no Encodable-marked parent is not Encodable") {
+    assert(
+      evalProbe(
+        """val ur: String with java.io.Serializable =
+          |  "x".asInstanceOf[String with java.io.Serializable]
+          |classify(ur)""".stripMargin
+      ) == "ptb=false sr=false enc=false treeEnc=false"
+    )
+  }
+
+  test("an unmarked method-local val is classified from its type alone") {
+    // A val inside a `def` body is a plain TermSymbol, not the object accessor a ToolBox
+    // top-level val becomes, so `treeHasEncodableString` takes the non-MethodSymbol path.
+    assert(
+      evalProbe(
+        """def go: String = { val loc: String = "x"; classify(loc) }
+          |go""".stripMargin
+      ) == "ptb=false sr=false enc=false treeEnc=false"
+    )
+  }
+
+  test("a marked method-local val is Encodable via its annotated type") {
+    assert(
+      evalProbe(
+        """def go: String = { val loc: EncodableString = "x"; classify(loc) }
+          |go""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  test("a def whose result type carries the marker is Encodable") {
+    // End-to-end assertion: this shape must classify Encodable. It does NOT pin the
+    // `methodReturnHasAnn` clause (lines 117-123) that it happens to execute - `tree.tpe` carries
+    // the same annotation, so replacing the `MethodSymbol` arm with `false` passes every test in
+    // the module on a forced clean rebuild (measured, including the compile-time `pyb` expansions
+    // in PythonTemplateBuilderSpec). Isolating that arm would need a production seam, so it stays
+    // unpinned rather than falsely credited.
+    assert(
+      evalProbe(
+        """object H { def ui: EncodableString = "x" }
+          |classify(H.ui)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  test("an Encodable marker nested in a type argument is found") {
+    assert(
+      evalProbe(
+        """val xs: List[EncodableString] = List("x")
+          |classify(xs)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  // ========================================================================
+  // Repair pass: fixtures that make a *competing* guard, a non-first list
+  // element, or a nested wrapper decide the answer. Each one exists because a
+  // mutation of the production code survived the fixtures above.
+  // ========================================================================
+
+  test("wrapArg prefers the StringRenderer cast when an argument is BOTH a renderer and marked") {
+    // Priority 1 (already a StringRenderer) must win over priority 2 (Encodable-marked), or a
+    // pre-encoded payload would be re-encoded through `.toString`. The test above cannot show
+    // that: its fixture satisfies priority 1 only (treeEnc=false), so no ordering can matter.
+    // This fixture satisfies BOTH guards - `PyLiteralStringRenderer <:< StringRenderer` and the
+    // `@EncodableStringAnnotation` sits on the def's own symbol - so the order decides.
+    val bothMarked =
+      """object H { @EncodableStringAnnotation def r: PyLiteralStringRenderer = ??? }"""
+    val flags = evalProbe(s"""$bothMarked
+                             |classify(H.r)""".stripMargin)
+    assert(flags == "ptb=false sr=true enc=true treeEnc=true", flags)
+
+    val wrap = evalProbe(s"""$bothMarked
+                            |wrapCode(H.r)""".stripMargin)
+    assert(wrap.contains(".asInstanceOf["), wrap)
+    assert(wrap.endsWith("PythonTemplateBuilder.StringRenderer]"), wrap)
+    assert(!wrap.contains("EncodableStringRenderer("), wrap)
+    assert(!wrap.contains(".toString"), wrap)
+  }
+
+  test("a nested PythonTemplateBuilder is not a direct Encodable arg even when it is marked") {
+    // isDirectEncodableStringArg's `if (isPythonTemplateBuilderArg(argExpr)) false` short-circuit
+    // is what keeps a *marked* nested builder off the direct-Encodable path (and therefore out of
+    // BoundaryValidator.validateCompileTime, which only guards direct args; nested builders get
+    // runtime checks instead). The unmarked nested-builder test cannot show that: with no marker
+    // the else-branch answers false on its own.
+    assert(
+      evalProbe(
+        """object H {
+          |  @EncodableStringAnnotation
+          |  def nested: org.apache.texera.amber.pybuilder.PythonTemplateBuilder = ???
+          |}
+          |classify(H.nested)""".stripMargin
+      ) == "ptb=true sr=false enc=false treeEnc=true"
+    )
+  }
+
+  test("an Encodable marker under a second type annotation is found") {
+    // Forces the `loop(underlying)` disjunct of the AnnotatedType case: the outer annotation is
+    // not the marker, so the answer can only come from recursing into the annotated underlying
+    // type. Every other fixture in this spec finds the marker in the outer annotation list.
+    assert(
+      evalProbe(
+        """class ZzAnnUnder extends scala.annotation.StaticAnnotation
+          |type Inner = String @EncodableStringAnnotation
+          |val n: Inner @ZzAnnUnder = "x".asInstanceOf[Inner @ZzAnnUnder]
+          |classify(n)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  test("an Encodable marker that is not the first annotation on a type is found") {
+    // scalac's stored annotation order need not match source order, so both source orders are
+    // asserted: whichever way round it stores them, one of the two puts the marker off the head
+    // and pins the `exists` scan rather than just position 0.
+    val markerFirst = evalProbe(
+      """class ZzAnnT1 extends scala.annotation.StaticAnnotation
+        |val d: String @EncodableStringAnnotation @ZzAnnT1 = "x"
+        |classify(d)""".stripMargin
+    )
+    assert(markerFirst == "ptb=false sr=false enc=true treeEnc=true", markerFirst)
+
+    val markerSecond = evalProbe(
+      """class ZzAnnT2 extends scala.annotation.StaticAnnotation
+        |val d: String @ZzAnnT2 @EncodableStringAnnotation = "x"
+        |classify(d)""".stripMargin
+    )
+    assert(markerSecond == "ptb=false sr=false enc=true treeEnc=true", markerSecond)
+  }
+
+  test("an Encodable marker that is not the first annotation on a symbol is found") {
+    // Same idea for the symbol-annotation path (safeAccessed(...).annotations), which no other
+    // fixture in the module reaches with more than one annotation present.
+    val markerFirst = evalProbe(
+      """class ZzAnnS1 extends scala.annotation.StaticAnnotation
+        |def go: String = { @EncodableStringAnnotation @ZzAnnS1 val loc = "x"; classify(loc) }
+        |go""".stripMargin
+    )
+    assert(markerFirst == "ptb=false sr=false enc=true treeEnc=true", markerFirst)
+
+    val markerSecond = evalProbe(
+      """class ZzAnnS2 extends scala.annotation.StaticAnnotation
+        |def go: String = { @ZzAnnS2 @EncodableStringAnnotation val loc = "x"; classify(loc) }
+        |go""".stripMargin
+    )
+    assert(markerSecond == "ptb=false sr=false enc=true treeEnc=true", markerSecond)
+  }
+
+  test("an Encodable marker on a non-first parent of a compound type is found") {
+    // The marked-parent test above puts the marker in parents(0), so it cannot tell
+    // `parents.exists(loop)` apart from `parents.head`.
+    assert(
+      evalProbe(
+        """trait Ta; trait Tb
+          |type MarkedB = Tb @EncodableStringAnnotation
+          |val v: Ta with MarkedB = (new Ta with Tb {}).asInstanceOf[Ta with MarkedB]
+          |classify(v)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  test("an Encodable marker in a non-first type argument is found") {
+    // `List[EncodableString]` has a single type argument, so it cannot tell `args.exists(loop)`
+    // apart from `args.head`. A map of UI strings is the obvious real shape that can.
+    assert(
+      evalProbe(
+        """val m: Map[String, EncodableString] = Map("k" -> "v")
+          |classify(m)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
     )
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

`EncodableInspectorSpec` goes from 12 tests to 32. `EncodableInspector` was the largest free coverage gap in the repo at 50.0%.

Measured across the **whole `PyBuilder` module with no test filter** — which is what Codecov actually uploads — with one fresh sbt JVM per measurement and `PyBuilder/clean` first in every run, so the unforked in-JVM counters cannot accumulate. Production was gated pristine (sha256 plus an empty production diff) before every measurement.

| Metric | Before | After |
|---|---|---|
| Codecov (fully-covered lines) | 29/58 = 50.0% | **39/58 = 67.2%** |
| JaCoCo line-hit | 51/58 = 87.9% | **54/58 = 93.1%** |
| Branch arms | 67/140 | **83/140 (+16)** |

The arm ledger is re-derived per line and sums to exactly +16, not the +18 first estimated: lines 111 and 118 did not move.

### The ten lines, graded honestly

Ten lines moved to fully-covered, but they are not worth the same, and the PR should not imply otherwise:

- **84, 88, 122** — production-reachable *and* mutation-pinned. These are the real gain.
- **125** — production-reachable, but its new arm belongs to a surviving mutant, so it is unpinned.
- **135, 136** — a predicate with no production callers.
- **126** — a provably redundant guard (an equivalent mutant).
- **131, 147, 164** — moved only via a defensive `tpe == null` arm the `pyb` pipeline cannot produce. Pinned as guards, but that is all they are.

### Verification

25 mutations, **22 killed, 3 survivors.**

The interesting mechanical contribution is a **test-side probe macro**: `pyb"..."` can never be `tb.eval`'d, because it expands to the `private[amber] PythonTemplateBuilder.fromInterpolated` which the ToolBox's synthetic `__wrapper` package cannot access. That is why the pre-existing tests could only assert on compile-error *text*. The probe turns those string proxies into direct assertions on the classifier's output.

**The three survivors, stated plainly:**

- Replacing `case m: MethodSymbol => typeHasEncodableString(m.typeSignature.finalResultType)` with `case _: MethodSymbol => false` survives all 184 module tests on a forced clean rebuild. So the whole `methodReturnHasAnn` clause (lines 117-123) is unpinned by the module — including by the compile-time `pyb` expansions elsewhere. This is a real gap, not an equivalence, and it is why line 125's new arm is described above as unpinned.
- Changing the fully-qualified-name constant to a non-existent name survives — an equivalent mutant, which also makes the earlier "killed" verdict on that row one-sided.
- Deleting line 126's `tree.tpe != null &&` survives — equivalent, the guard is redundant.

### The seven repair tests add zero coverage

The 25-test and 32-test runs produce an identical fully-covered set, an identical `ci==0` set, identical 15 partials and identical 83/140 arms. Those seven tests buy mutation strength, not lines. Stated so nobody credits them with a number.

### Deliberately not included, with evidence

Most of the 29-line gap is structural, so an assessment counting the 21 partials as winnable would be off by roughly a factor of two:

- **Nine lines are permanently partial** because Scala's `!=` on references compiles to a three-branch null-safe equals and every such chain here sits behind an explicit `x != null` guard, making the lhs-null and rhs-null arms unreachable.
- **The `ExistentialType` arm is dead.** scalac never produces one here: `List[_]` and `List[T] forSome {type T}` both arrive as `TypeRef(List, [Any])`, and a hand-built `c.internal.existentialType` is stripped by the `dealias.widen` at the top of the loop — verified by building one and watching the counters not move.
- **`safeAccessed`'s second case can never fire**, since `MethodSymbol <: TermSymbol` means anything that is a `MethodSymbol` and an accessor already matched case 1.
- **Line 68's true arm is unreachable**: a Java `@interface` cannot be subclassed, and a Scala alias to it is dealiased before the comparison — tested with `type ZzAlias = EncodableStringAnnotation`, which classified via the fullName equality with the `<:<` never returning true.
- JaCoCo's `SyntheticFilter` drops all six `$anonfun$typeHasEncodableString$*` methods, so the eta-expanded bodies are worth exactly zero. The lifted local `def loop` survives as `loop$1` and *is* counted, which is the only reason lines 79-95 are trackable at all.

### Reported, not pinned

`@EncodableStringAnnotation` on a **trait** val is silently ignored. `safeAccessed` unconditionally hops accessor to `accessed`, which is `NoSymbol` for a trait getter — and the annotation lives on the getter, since the Java `@Target` includes `METHOD` and a trait has no backing field. Documented in the spec rather than asserted.

Also worth recording for whoever works here next: the pre-existing `pyb`-based tests must not be deleted or rewritten. A `PythonTemplateBuilder`-typed argument cannot be constructed inside a ToolBox snippet at all, so the existing nested-builder test is the only thing covering the `isPythonTemplateBuilderArg == true` arm.

No production file is touched.

### Any related issues, documentation, discussions?

Closes #7862

### How was this PR tested?

```
sbt "PyBuilder/clean" "PyBuilder/test"
```

```
[info] Suites: completed 5, aborted 0
[info] Tests: succeeded 184, failed 0, canceled 0, ignored 0, pending 0
```

The whole module is green at 184 tests across 5 suites (164 at HEAD). The other four specs are untouched. `Test/scalafmtCheck` and `Test/scalafix --check` both pass.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
