### PR TITLE
test(amber): cover the DP thread's lifecycle edges

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DPThreadSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DPThreadSpec.scala
@@ -23,7 +23,11 @@ import org.apache.texera.amber.core.executor.OperatorExecutor
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema, Tuple, TupleLike}
 import org.apache.texera.amber.core.virtualidentity.{ActorVirtualIdentity, ChannelIdentity}
 import org.apache.texera.amber.core.workflow.PortIdentity
-import org.apache.texera.amber.engine.architecture.logreplay.{ReplayLogManager, ReplayLogRecord}
+import org.apache.texera.amber.engine.architecture.logreplay.{
+  ProcessingStep,
+  ReplayLogManager,
+  ReplayLogRecord
+}
 import org.apache.texera.amber.engine.architecture.messaginglayer.WorkerTimerService
 import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
   AsyncRPCContext,
@@ -34,6 +38,7 @@ import org.apache.texera.amber.engine.architecture.rpc.workerservice.WorkerServi
   METHOD_RESUME_WORKER
 }
 import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.{
+  ActorCommandElement,
   DPInputQueueElement,
   FIFOMessageElement,
   MainThreadDelegateMessage,
@@ -51,11 +56,19 @@ import org.apache.texera.amber.engine.common.virtualidentity.util.SELF
 import org.apache.texera.service.util.LargeBinaryManager
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import java.net.URI
-import java.util.concurrent.{CompletableFuture, LinkedBlockingQueue, TimeUnit}
+import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
+import java.util.concurrent.{
+  CompletableFuture,
+  ConcurrentLinkedQueue,
+  CountDownLatch,
+  LinkedBlockingQueue,
+  TimeUnit
+}
 
-class DPThreadSpec extends AnyFlatSpec with MockFactory {
+class DPThreadSpec extends AnyFlatSpec with Matchers with MockFactory {
 
   private val workerId: ActorVirtualIdentity = ActorVirtualIdentity("DP mock")
   private val senderWorkerId: ActorVirtualIdentity = ActorVirtualIdentity("mock sender")
@@ -71,6 +84,37 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
   private val logStorage = SequentialRecordStorage.getStorage[ReplayLogRecord](None)
   private val logManager: ReplayLogManager =
     ReplayLogManager.createLogManager(logStorage, "none", x => {})
+
+  /** Poll `cond` until it holds or the budget runs out. Returns the final value. */
+  private def awaitCond(cond: => Boolean, budgetMs: Int = 5000): Boolean = {
+    val deadline = System.currentTimeMillis() + budgetMs
+    while (!cond && System.currentTimeMillis() < deadline) {
+      Thread.sleep(20)
+    }
+    cond
+  }
+
+  /** A DataProcessor wired to one input port on `dataChannelId`, driven by `queue`.
+    * `outputHandler` defaults to swallowing everything; pass one in to observe what the
+    * DP thread hands back to the main thread.
+    */
+  private def newDataProcessor(
+      queue: LinkedBlockingQueue[DPInputQueueElement],
+      outputHandler: Either[MainThreadDelegateMessage, WorkflowFIFOMessage] => Unit = _ => {}
+  ): DataProcessor = {
+    val dp = new DataProcessor(workerId, outputHandler, inputMessageQueue = queue)
+    dp.inputManager.addPort(mockInputPortId, schema, List.empty, List.empty)
+    dp.inputGateway.getChannel(dataChannelId).setPortId(mockInputPortId)
+    dp.adaptiveBatchingMonitor = mock[WorkerTimerService]
+    (dp.adaptiveBatchingMonitor.resumeAdaptiveBatching _).expects().anyNumberOfTimes()
+    (dp.adaptiveBatchingMonitor.startAdaptiveBatching _).expects().anyNumberOfTimes()
+    dp
+  }
+
+  private def dataFrameOf(count: Int, seq: Long = 0): FIFOMessageElement =
+    FIFOMessageElement(
+      WorkflowFIFOMessage(dataChannelId, seq, DataFrame(tuples.slice(0, count)))
+    )
 
   "DP Thread" should "handle pause/resume during processing" in {
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
@@ -245,6 +289,14 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
     val logs = logStorage.getReader("tmpLog").mkRecordIterator().toArray
     logStorage.deleteStorage()
     assert(logs.length > 1)
+    // A determinant is only useful if it names the channel the step actually came
+    // from -- that is the channel replay resumes on. Only these two data channels
+    // were fed, so only these two ids may appear.
+    val loggedChannels = logs.collect { case ProcessingStep(cid, _) => cid }.toSet
+    assert(
+      loggedChannels == Set(dataChannelId, dataChannelId2),
+      s"determinants must name the channels actually processed, got $loggedChannels"
+    )
   }
 
   "DP Thread" should "seed the base URI so create() yields execution-scoped keys" in {
@@ -349,6 +401,345 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
           assert(thrown.getMessage == "boom")
         case other => fail(s"expected Left(MainThreadDelegateMessage), got $other")
       }
+    } finally {
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "treat stop() before start() as a no-op" in {
+    // stop() is also reached on the teardown path of a worker that never started
+    // (e.g. an actor that fails during initialization). Neither the executor
+    // service nor the thread future exists yet, so both guards must short-circuit
+    // rather than dereference a null.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = new DataProcessor(workerId, x => {}, inputMessageQueue = inputQueue)
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+
+    // The entire contract on this path is that the call does not blow up. Asserting
+    // that the two fields are null would assert nothing: stop() only ever reads them,
+    // so `dpThread == null` is the field initializer talking, not production code, and
+    // it would hold even if stop()'s body were deleted. Flipping either guard to
+    // `== null` makes this call NPE, and that is what this test detects.
+    noException should be thrownBy dpThread.stop()
+  }
+
+  "DP Thread" should "not return from stop() until the DP thread has left the main loop" in {
+    // stop() must be a synchronous join: WorkflowWorker tears down the output gateway
+    // and the statistics manager right after it returns, so the DP thread must already
+    // be out of run() by then. The join is `endFuture.get()`, and nothing else in the
+    // suite constrains it. We park the DP thread in a NON-interruptible spin (an
+    // interruptible wait would be swallowed by DataProcessor.handleExecutorException
+    // and let stop() legitimately return early) and check that stop() blocks.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = newDataProcessor(inputQueue)
+    val release = new AtomicBoolean(false)
+    val inSpin = new CountDownLatch(1)
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        inSpin.countDown()
+        while (!release.get()) {}
+        Iterator.empty
+      }
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    val stopReturned = new CountDownLatch(1)
+    try {
+      dpThread.start()
+      inputQueue.put(dataFrameOf(4))
+      assert(inSpin.await(5, TimeUnit.SECONDS), "the DP thread must be inside the executor")
+      val stopper = new Thread(() => {
+        try {
+          dpThread.stop()
+        } finally {
+          stopReturned.countDown()
+        }
+      })
+      stopper.setDaemon(true)
+      stopper.start()
+      assert(
+        !stopReturned.await(500, TimeUnit.MILLISECONDS),
+        "stop() must not return while the DP thread is still inside run()"
+      )
+      release.set(true)
+      assert(
+        stopReturned.await(10, TimeUnit.SECONDS),
+        "stop() must return once the DP thread exits"
+      )
+    } finally {
+      release.set(true)
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "park when idle and exit quietly when stop() interrupts it there" in {
+    // Two properties of the same moment. (1) An idle DP thread must PARK on
+    // internalQueue.take rather than spin: input selection sets `waitingForInput = true`
+    // when no channel can be picked, and that flag is the only thing that sends the loop
+    // back into the blocking take. Thread.State is the only way to tell parking from
+    // spinning from outside. (2) stop() then interrupts the DP thread out of that take,
+    // and run() must treat the InterruptedException as an ordinary teardown -- log it and
+    // nothing more. The other catch arm delegates the error back to the worker actor, and
+    // with the usual swallowing output handler the two are indistinguishable, so record
+    // what the handler receives instead of dropping it.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val delegates = new ConcurrentLinkedQueue[MainThreadDelegateMessage]()
+    val dp = newDataProcessor(
+      inputQueue,
+      {
+        case Left(m) => delegates.add(m)
+        case _       => ()
+      }
+    )
+    // processTuple runs ON the DP thread, so this is how we get hold of that exact
+    // thread. Every DPThread names its thread "DP-thread" and earlier tests in this
+    // suite leave theirs alive, so matching by name would be ambiguous.
+    val dpWorkerThread = new AtomicReference[Thread]()
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        dpWorkerThread.set(Thread.currentThread())
+        Iterator.empty
+      }
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    val idleState = () => Option(dpWorkerThread.get()).map(_.getState)
+    try {
+      dpThread.start()
+      inputQueue.put(dataFrameOf(1))
+      assert(
+        awaitCond(idleState().contains(Thread.State.WAITING)),
+        s"an idle DP thread must park on take, was ${idleState()}"
+      )
+      // stop() joins the DP thread, so run() has returned by the time this returns.
+      dpThread.stop()
+      assert(
+        delegates.isEmpty,
+        s"an interrupted teardown must not delegate an error, got ${delegates.peek()}"
+      )
+    } finally {
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "hold back data intake while a queued Backpressure command is in effect" in {
+    // Backpressure delivered through the internal queue as an ActorCommandElement,
+    // which is how the worker actor actually sends it. While it is on, the DP
+    // thread must stop taking data, so a data frame that arrives afterwards stays
+    // queued in its channel and no tuple is processed until backpressure is lifted.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = newDataProcessor(inputQueue)
+    val processed = new AtomicInteger(0)
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        processed.incrementAndGet()
+        Iterator.empty
+      }
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    try {
+      dpThread.start()
+      inputQueue.put(ActorCommandElement(Backpressure(enableBackpressure = true)))
+      // `backpressureStatus` is a plain (non-volatile) var written by the DP thread, so
+      // reading it from here needs a happens-before edge. CreditUpdate is inert -- it
+      // falls through handleActorCommand's `case _ => // no op` arm -- and observing the
+      // queue drained is a read of LinkedBlockingQueue's AtomicInteger count, which the
+      // DP thread decremented after it had already handled the Backpressure element.
+      inputQueue.put(ActorCommandElement(CreditUpdate()))
+      assert(awaitCond(inputQueue.isEmpty), "the queued commands must be consumed")
+      assert(dpThread.backpressureStatus, "backpressure must be picked up")
+
+      inputQueue.put(dataFrameOf(200))
+      Thread.sleep(500)
+      assert(processed.get() == 0, "no data may be taken while backpressured")
+      // Deliberately no assertion about control messages in this state: the
+      // input-selection expression reads
+      //   if (backpressureStatus) { tryPickControlChannel } else { tryPickChannel } match {...}
+      // and Scala binds `match` to the else branch alone, so while backpressure is
+      // on the picked channel is discarded. Asserting either outcome here would
+      // freeze that behaviour in place, so this test only pins the data hold-back.
+
+      inputQueue.put(ActorCommandElement(Backpressure(enableBackpressure = false)))
+      assert(awaitCond(processed.get() == 200), s"drained ${processed.get()} of 200")
+    } finally {
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "stall the remainder of a batch when backpressure arrives mid-batch" in {
+    // Same switch, but flipped while a batch is half-consumed. Here the input
+    // selection takes the "unfinished input" path, so it is the pause/backpressure
+    // guard inside that path that has to hold the batch back.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = newDataProcessor(inputQueue)
+    val processed = new AtomicInteger(0)
+    val firstTuple = new CountDownLatch(1)
+    val gate = new CountDownLatch(1)
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        if (processed.getAndIncrement() == 0) {
+          firstTuple.countDown()
+          gate.await()
+        }
+        Iterator.empty
+      }
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    try {
+      dpThread.start()
+      inputQueue.put(dataFrameOf(2000))
+      assert(firstTuple.await(5, TimeUnit.SECONDS), "batch must start")
+      // Queue the switch while the DP thread is parked inside the executor, so it
+      // is consumed on the very next loop iteration, mid-batch.
+      inputQueue.put(ActorCommandElement(Backpressure(enableBackpressure = true)))
+      // Inert trailing command, as above: draining it gives the happens-before edge
+      // that makes the non-volatile `backpressureStatus` read below well-defined.
+      inputQueue.put(ActorCommandElement(CreditUpdate()))
+      gate.countDown()
+      assert(awaitCond(inputQueue.isEmpty), "the queued commands must be consumed")
+      assert(dpThread.backpressureStatus, "backpressure must be picked up")
+
+      Thread.sleep(400)
+      assert(dp.inputManager.hasUnfinishedInput, "the batch must still be unfinished")
+      val stalledAt = processed.get()
+      Thread.sleep(400)
+      assert(
+        processed.get() == stalledAt,
+        s"no further tuple may be taken while backpressured, went $stalledAt -> ${processed.get()}"
+      )
+
+      inputQueue.put(ActorCommandElement(Backpressure(enableBackpressure = false)))
+      assert(awaitCond(processed.get() == 2000), s"drained ${processed.get()} of 2000")
+    } finally {
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "stall the remainder of a batch when a pause arrives mid-batch" in {
+    // The sibling of the backpressure case above, on the OTHER operand of the same
+    // guard: `if (!dp.pauseManager.isPaused && !backpressureStatus)`. Nothing below the
+    // DP thread re-checks the pause -- InputManager.getNextTuple, hasUnfinishedInput and
+    // DataProcessor.continueDataProcessing have no pause check, and PauseManager.pause
+    // only disables the data channels, which stops NEW frames, not the current one --
+    // so this guard is the entire mid-batch pause contract.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = newDataProcessor(inputQueue)
+    val processed = new AtomicInteger(0)
+    val firstTuple = new CountDownLatch(1)
+    val gate = new CountDownLatch(1)
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        if (processed.getAndIncrement() == 0) {
+          firstTuple.countDown()
+          gate.await()
+        }
+        Iterator.empty
+      }
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    try {
+      dpThread.start()
+      inputQueue.put(dataFrameOf(2000))
+      assert(firstTuple.await(5, TimeUnit.SECONDS), "batch must start")
+      // Queued while the DP thread is parked inside the executor, so it is picked up on
+      // the very next loop iteration -- with 1999 tuples of the batch still to go.
+      inputQueue.put(
+        TimerBasedControlElement(
+          ControlInvocation(METHOD_PAUSE_WORKER, EmptyRequest(), AsyncRPCContext(SELF, SELF), 0)
+        )
+      )
+      gate.countDown()
+      assert(awaitCond(dp.pauseManager.isPaused), "pause must be picked up")
+
+      Thread.sleep(400)
+      assert(
+        dp.inputManager.hasUnfinishedInput,
+        s"a paused worker must not finish its batch, processed ${processed.get()} of 2000"
+      )
+      val stalledAt = processed.get()
+      Thread.sleep(400)
+      assert(
+        processed.get() == stalledAt,
+        s"no further tuple may be taken while paused, went $stalledAt -> ${processed.get()}"
+      )
+
+      inputQueue.put(
+        TimerBasedControlElement(
+          ControlInvocation(METHOD_RESUME_WORKER, EmptyRequest(), AsyncRPCContext(SELF, SELF), 1)
+        )
+      )
+      assert(awaitCond(processed.get() == 2000), s"drained ${processed.get()} of 2000")
+    } finally {
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "leave the main loop on the stopped flag without draining the batch" in {
+    // The graceful exit: stop() sets `stopped` and interrupts, but the DP thread is
+    // busy in the executor rather than blocked on the queue, so it never sees an
+    // InterruptedException and has to fall out of the main loop on the flag alone,
+    // abandoning the rest of the batch.
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = newDataProcessor(inputQueue)
+    val processed = new AtomicInteger(0)
+    val firstTuple = new CountDownLatch(1)
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        processed.incrementAndGet()
+        firstTuple.countDown()
+        // A non-interruptible spin: ~0.5ms of work per tuple, so 2000 tuples take
+        // about a second while stop() lands after ~100ms.
+        val until = System.nanoTime() + 500000L
+        while (System.nanoTime() < until) {}
+        Iterator.empty
+      }
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    try {
+      dpThread.start()
+      inputQueue.put(dataFrameOf(2000))
+      assert(firstTuple.await(5, TimeUnit.SECONDS), "batch must start")
+      Thread.sleep(100)
+      dpThread.stop()
+      val done = processed.get()
+      assert(done < 2000, s"stop() must abandon the rest of the batch, processed $done of 2000")
+      assert(dp.inputManager.hasUnfinishedInput, "the abandoned batch is left unfinished")
+    } finally {
+      dpThread.stop()
+    }
+  }
+
+  "DP Thread" should "keep draining a pending output backlog after the input batch is exhausted" in {
+    // One input tuple fanning out to 50 output tuples: after the single tuple is
+    // consumed there is no unfinished input and no pause, so only the pending
+    // output backlog can keep the loop calling continueDataProcessing().
+    val fanOut = 50
+    val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
+    val dp = newDataProcessor(inputQueue)
+    dp.outputManager.addPort(PortIdentity(1), schema, None)
+    dp.executor = new OperatorExecutor {
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] =
+        (0 until fanOut).iterator.map(i => TupleLike(i))
+    }
+    val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
+    try {
+      dpThread.start()
+      inputQueue.put(dataFrameOf(1))
+      // Fixture guard, sampled DURING the drain: processDataPayload consumes the whole
+      // one-tuple frame in the same step that sets up the output iterator, so input is
+      // already exhausted when the first output tuple appears. Checked here rather than
+      // at the end because at the end it holds for any frame size -- it would not
+      // notice the frame growing and the output clause silently going untested.
+      assert(
+        awaitCond(dp.statisticsManager.getOutputTupleCount >= 1L),
+        "the first output tuple must be emitted"
+      )
+      assert(
+        !dp.inputManager.hasUnfinishedInput,
+        "input must already be exhausted while output tuples are still pending"
+      )
+      assert(
+        awaitCond(dp.statisticsManager.getOutputTupleCount == fanOut.toLong),
+        s"emitted ${dp.statisticsManager.getOutputTupleCount} of $fanOut output tuples"
+      )
     } finally {
       dpThread.stop()
     }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DPThreadSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DPThreadSpec.scala
@@ -435,11 +435,10 @@ class DPThreadSpec extends AnyFlatSpec with Matchers with MockFactory {
     val release = new AtomicBoolean(false)
     val inSpin = new CountDownLatch(1)
     dp.executor = new OperatorExecutor {
-override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
-  inSpin.countDown()
-  while (!release.get()) { Thread.onSpinWait() }
-  Iterator.empty
-}
+      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+        inSpin.countDown()
+        while (!release.get()) { Thread.onSpinWait() }
+        Iterator.empty
       }
     }
     val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
@@ -548,11 +547,11 @@ override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
       assert(awaitCond(inputQueue.isEmpty), "the queued commands must be consumed")
       assert(dpThread.backpressureStatus, "backpressure must be picked up")
 
-inputQueue.put(dataFrameOf(200))
-assert(
-  !awaitCond(processed.get() != 0, budgetMs = 1000),
-  "no data may be taken while backpressured"
-)
+      inputQueue.put(dataFrameOf(200))
+      assert(
+        !awaitCond(processed.get() != 0, budgetMs = 1000),
+        "no data may be taken while backpressured"
+      )
       // Deliberately no assertion about control messages in this state: the
       // input-selection expression reads
       //   if (backpressureStatus) { tryPickControlChannel } else { tryPickChannel } match {...}

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DPThreadSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/DPThreadSpec.scala
@@ -435,10 +435,11 @@ class DPThreadSpec extends AnyFlatSpec with Matchers with MockFactory {
     val release = new AtomicBoolean(false)
     val inSpin = new CountDownLatch(1)
     dp.executor = new OperatorExecutor {
-      override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
-        inSpin.countDown()
-        while (!release.get()) {}
-        Iterator.empty
+override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = {
+  inSpin.countDown()
+  while (!release.get()) { Thread.onSpinWait() }
+  Iterator.empty
+}
       }
     }
     val dpThread = new DPThread(workerId, dp, logManager, inputQueue)
@@ -547,9 +548,11 @@ class DPThreadSpec extends AnyFlatSpec with Matchers with MockFactory {
       assert(awaitCond(inputQueue.isEmpty), "the queued commands must be consumed")
       assert(dpThread.backpressureStatus, "backpressure must be picked up")
 
-      inputQueue.put(dataFrameOf(200))
-      Thread.sleep(500)
-      assert(processed.get() == 0, "no data may be taken while backpressured")
+inputQueue.put(dataFrameOf(200))
+assert(
+  !awaitCond(processed.get() != 0, budgetMs = 1000),
+  "no data may be taken while backpressured"
+)
       // Deliberately no assertion about control messages in this state: the
       // input-selection expression reads
       //   if (backpressureStatus) { tryPickControlChannel } else { tryPickChannel } match {...}


### PR DESCRIPTION
### What changes were proposed in this PR?

`DPThreadSpec` goes from 8 tests to 16, covering the DP thread's lifecycle edges: stopping before it ever starts, returning from `stop()` only after the thread has left the main loop, parking when idle and exiting quietly when interrupted there, and a pause arriving mid-batch.

Measured with one fresh sbt JVM per run, `rm -rf` on the jacoco dir between them, and an identical suite-name filter before and after.

| Metric | Before | After |
|---|---|---|
| Codecov (fully-covered lines) | 65/87 = 74.7% | **74/87 = 85.1%** |
| Missed lines | 3 (157, 158, 185) | **0** |
| Branch arms | 50 covered / 26 missed | **58 covered / 18 missed** |

Adding `WorkerSpec` — the only other in-repo spec that constructs a `DPThread` — gives an identical 74/87, so this is the whole picture from unit tests.

Worth naming the classification rule, since it changes the number: Codecov treats a line as covered only when `ci>0 && mb==0`, so partial-arm lines count against you. A stricter rule that also demands `mi==0` gives a different figure for this file, because four lines have missed *instructions* but no missed *branches*. All figures above use Codecov's rule.

### A production defect, found by a mutation that cannot be killed

Replacing `dp.inputGateway.tryPickControlChannel` with `None` at line 185 **survives all 16 tests**, and no test can kill it: the value is dead. This is a `match`-precedence defect at lines 182-193 — re-verified independently in bytecode rather than taken on trust. It is therefore an *equivalent* mutant, meaning unkillable by any test whatsoever, not merely unkilled by these.

That is reported rather than pinned, and it is the one survivor in the table.

### Verification

13 production mutations, **12 killed, 1 equivalent survivor.** Eleven of the twelve kills are attributable to exactly one named test. Every mutant was applied from and reverted to a pristine snapshot, with an exactly-once anchor assertion, a "replacement count grew by exactly one" assertion, and a pristine-hash plus empty-production-diff check immediately *before* each compile and again after each revert — the harness aborts on any of those, so no mutant was ever live during another's run.

### Corrections made during review, including to the reviewers

The first draft reported no survivors on a narrow table. Adversarial review produced 8 findings; several were right, and three were wrong in ways worth recording:

- **A reviewer's suggested fix would not have killed that reviewer's own mutant.** Their finding proposed adding `assert(delegates.isEmpty)` to the stop-flag test. It was implemented verbatim and measured: the mutant left that test green, because of where its execution actually diverges. Replaced with a gate that does discriminate.
- **A reviewer's suggested mechanism was unsound here** — locating the DP thread by the name `"DP-thread"`. Five tests in this spec never stop their thread, so several live threads share that name and a lookup over an unordered key set could sample the wrong one.
- **A reviewer overstated one relocation** as establishing "the causal claim". It remains unfalsifiable by any production mutation, because with a one-tuple frame the relevant predicate is false throughout the drain.

Corrections to my own first draft: one mutation's kill was credited to a single test but actually fails two, both legitimately; another's kill was credited to an *unsynchronized* read of a plain `var` written by the DP thread, and is now credited to a properly synchronized gate; a third's failure mode moved to an earlier gate after a relocation. The diff is also larger than first stated — +394/-3 on one file, not +188/-1.

One projection was downgraded rather than restated: the first draft called a CI figure "provably" bounded. It rests on assumptions about which arms the e2e specs reach, and those specs need an Iceberg REST catalog that is not running here, so "argued" is the honest word.

### Deliberately not included

74/87 is the hard ceiling without a production change. The 13 remaining partial lines are the lazy-val bitmap, four scala-logging `isXEnabled` guards, `$outer == null` guards, a `MatchError` arm of a sealed trait with three final case classes, `MatchError` arms of exhaustive `Option` matches, and the null-equals-null leg of a state comparison whose operand is never null.

Lines 204-223 — the `withFaultTolerant` payload-dispatch block — and line 201's filter lambda are outside the 87-line denominator entirely: they compile to `ACC_SYNTHETIC` `$anonfun` methods that JaCoCo drops, verified in the tracked line list jumping 203 → 224. Tests aimed there earn behaviour but no lines.

Scope: `DPThreadSpec` and `WorkerSpec` were run, not the whole module, so the module's overall baseline was not re-established. `DPThreadSpec` is untagged and runs in the CI amber job.

No production file is touched — sha256 of `DPThread.scala` is byte-identical to the pre-mutation snapshot.

### Any related issues, documentation, discussions?

Closes #7867

### How was this PR tested?

```
sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.architecture.worker.DPThreadSpec"
```

```
[info] Total number of tests run: 16
[info] Tests: succeeded 16, failed 0, canceled 0, ignored 0, pending 0
```

The four new tests add roughly 4-5s of wall clock. `Test/scalafmtCheck` passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
