### PR TITLE
fix(pybuilder): recognize the Encodable marker on a trait member

### DIFF
--- a/common/pybuilder/src/main/scala/org/apache/texera/amber/pybuilder/EncodableInspector.scala
+++ b/common/pybuilder/src/main/scala/org/apache/texera/amber/pybuilder/EncodableInspector.scala
@@ -52,12 +52,22 @@ final class EncodableInspector[C <: blackbox.Context](val c: C) {
     * If we are pointing at a getter/accessor, hop to its accessed field symbol when possible.
     *
     * Why: Many annotations are placed on constructor params/fields, but call sites see the accessor.
+    *
+    * The hop is conditional because it is not always possible. A trait member has no backing field
+    * of its own, so its accessor's `accessed` is `NoSymbol`, and hopping there unconditionally
+    * would throw the annotation away: `@EncodableStringAnnotation` also targets `METHOD`, and for a
+    * trait `val`/`var` scalac leaves it on the accessor itself. Fall back to the accessor so those
+    * members are still recognised as Encodable.
+    *
+    * (Only `TermSymbol` is matched: `MethodSymbol` is a subtype of it, so a getter - which is both -
+    * is already covered here.)
     */
   private def safeAccessed(sym: Symbol): Symbol =
     sym match {
-      case termAccessor: TermSymbol if termAccessor.isAccessor       => termAccessor.accessed
-      case methodAccessor: MethodSymbol if methodAccessor.isAccessor => methodAccessor.accessed
-      case _                                                         => sym
+      case accessor: TermSymbol if accessor.isAccessor =>
+        val field = accessor.accessed
+        if (field == null || field == NoSymbol) accessor else field
+      case _ => sym
     }
 
   /** True if an annotation instance is @EncodableStringAnn. */

--- a/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/EncodableInspectorSpec.scala
+++ b/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/EncodableInspectorSpec.scala
@@ -404,11 +404,10 @@ class EncodableInspectorSpec extends AnyFunSuite {
 
   test("a def whose result type carries the marker is Encodable") {
     // End-to-end assertion: this shape must classify Encodable. It does NOT pin the
-    // `methodReturnHasAnn` clause (lines 117-123) that it happens to execute - `tree.tpe` carries
-    // the same annotation, so replacing the `MethodSymbol` arm with `false` passes every test in
-    // the module on a forced clean rebuild (measured, including the compile-time `pyb` expansions
-    // in PythonTemplateBuilderSpec). Isolating that arm would need a production seam, so it stays
-    // unpinned rather than falsely credited.
+    // `methodReturnHasAnn` clause that it happens to execute: `EncodableString` is a type *alias*,
+    // so `tree.tpe` dealiases to the same annotated type and the last disjunct answers true on its
+    // own (measured: replacing the `MethodSymbol` arm with `false` passes this test). The
+    // inline-annotation fixture in the last section is the one that pins the clause.
     assert(
       evalProbe(
         """object H { def ui: EncodableString = "x" }
@@ -540,6 +539,108 @@ class EncodableInspectorSpec extends AnyFunSuite {
       evalProbe(
         """val m: Map[String, EncodableString] = Map("k" -> "v")
           |classify(m)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  // ========================================================================
+  // Accessors with no backing field.
+  //
+  // `safeAccessed` hops from an accessor to the field it accesses, because a class
+  // `val` parks its annotations on that field. A trait member has no field of its
+  // own, so the hop lands on `NoSymbol`, and scalac leaves the marker on the
+  // accessor instead (`@EncodableStringAnnotation` targets `METHOD` as well as
+  // `FIELD`). Losing it fails *open* - the string is emitted raw rather than
+  // encoded, with no diagnostic - so the fallback is a safety property, not a
+  // convenience.
+  // ========================================================================
+
+  test("a trait's marked val is Encodable even though its accessor has no backing field") {
+    val abstractVal = evalProbe(
+      """trait TAbs { @EncodableStringAnnotation val s: String }
+        |def t: TAbs = ???
+        |classify(t.s)""".stripMargin
+    )
+    assert(abstractVal == "ptb=false sr=false enc=true treeEnc=true", abstractVal)
+
+    // A *concrete* trait val is the same shape as far as the macro is concerned: the field is
+    // created later, in whichever class mixes the trait in, so `accessed` is `NoSymbol` here too.
+    val concreteVal = evalProbe(
+      """trait TCon { @EncodableStringAnnotation val s: String = "x" }
+        |def t: TCon = ???
+        |classify(t.s)""".stripMargin
+    )
+    assert(concreteVal == "ptb=false sr=false enc=true treeEnc=true", concreteVal)
+
+    val varMember = evalProbe(
+      """trait TVar { @EncodableStringAnnotation var s: String = "x" }
+        |def t: TVar = ???
+        |classify(t.s)""".stripMargin
+    )
+    assert(varMember == "ptb=false sr=false enc=true treeEnc=true", varMember)
+  }
+
+  test("a marked trait val is lowered to an EncodableStringRenderer") {
+    // The classification only matters for what it lowers to: `wrapArg` has to reach priority 2 and
+    // encode, instead of falling through to the raw-literal default.
+    val wrap = evalProbe(
+      """trait TW { @EncodableStringAnnotation val s: String }
+        |def t: TW = ???
+        |wrapCode(t.s)""".stripMargin
+    )
+    assert(wrap.contains("EncodableStringRenderer("), wrap)
+    assert(!wrap.contains("PyLiteralStringRenderer("), wrap)
+  }
+
+  test("an unmarked trait val stays a plain literal") {
+    // The fallback must still read the accessor's *own* annotations: turning it into an
+    // unconditional "fieldless accessors are Encodable" fails here.
+    val bare = evalProbe(
+      """trait TPlain { val s: String }
+        |def t: TPlain = ???
+        |classify(t.s)""".stripMargin
+    )
+    assert(bare == "ptb=false sr=false enc=false treeEnc=false", bare)
+
+    // And it must read them *selectively*. The accessor is a newly reachable place to find symbol
+    // annotations, so this is the first fixture that puts a foreign one there: without it,
+    // weakening the symbol-annotation scan to `annotations.nonEmpty` survives the whole module.
+    val foreign = evalProbe(
+      """import scala.annotation.meta.getter
+        |class ZzAnnG extends scala.annotation.StaticAnnotation
+        |trait TForeign { @(ZzAnnG @getter) val s: String }
+        |def t: TForeign = ???
+        |classify(t.s)""".stripMargin
+    )
+    assert(foreign == "ptb=false sr=false enc=false treeEnc=false", foreign)
+  }
+
+  test("an abstract class's abstract val needs the marker in type position") {
+    // Recorded so the trait tests above are not read as covering every fieldless accessor. For
+    // `abstract class C { @EncodableStringAnnotation val s: String }` scalac keeps the marker on
+    // neither the accessor nor any field - measured: the accessor's `annotations` is empty once
+    // its info is forced, and its `accessed` is `NoSymbol` - so the macro never sees it and no
+    // `safeAccessed` fallback can recover it. Type position is the shape that works there, and it
+    // is what the `EncodableString` alias expands to anyway.
+    assert(
+      evalProbe(
+        """abstract class CAbs { val s: String @EncodableStringAnnotation }
+          |def c: CAbs = ???
+          |classify(c.s)""".stripMargin
+      ) == "ptb=false sr=false enc=true treeEnc=true"
+    )
+  }
+
+  test("a def whose inline-annotated result type is stripped at the call site is Encodable") {
+    // Pins `methodReturnHasAnn`. Unlike the `EncodableString`-*alias* fixture earlier, an inline
+    // `String @EncodableStringAnnotation` result type does not survive onto the call-site tree:
+    // `tree.tpe` there is a bare `String`, and the def's symbol carries no annotation either, so
+    // the method signature is the only place left to look. Replacing the `MethodSymbol` arm with
+    // `false` fails here.
+    assert(
+      evalProbe(
+        """object HInline { def ui: String @EncodableStringAnnotation = "x" }
+          |classify(HInline.ui)""".stripMargin
       ) == "ptb=false sr=false enc=true treeEnc=true"
     )
   }


### PR DESCRIPTION
### What changes were proposed in this PR?

`EncodableInspector.safeAccessed` hopped from an accessor symbol to `accessed` unconditionally. A trait member has no backing field of its own, so its accessor's `accessed` is `NoSymbol` — and that is exactly where scalac leaves the marker for a trait `val`/`var`, since `@EncodableStringAnnotation` targets `METHOD` as well as `FIELD`. The hop threw the annotation away, and the failure direction is the dangerous one:

```
Before:  trait T { @EncodableStringAnnotation val s: String }
         pyb"print(${t.s})"  ->  PyLiteralStringRenderer  ->  emitted raw, no diagnostic
After:                       ->  EncodableStringRenderer  ->  decode(...) at run time
```

Nothing warned about it at either end. `BoundaryValidator.validateCompileTime` runs only for arguments the inspector classified Encodable (`PythonTemplateBuilder.scala:358`), so a trait member spliced into an unsafe position skipped the compile-time boundary check as well.

The hop is now conditional — fall back to the accessor when there is no field to hop to:

```scala
case accessor: TermSymbol if accessor.isAccessor =>
  val field = accessor.accessed
  if (field == null || field == NoSymbol) accessor else field
case _ => sym
```

Measured one shape per row, with a throwaway probe macro that dumped the symbol and type state at expansion time (`@Enc` abbreviates `@EncodableStringAnnotation`):

| Declaration | `accessed` | Marker sits on | Before | After |
| --- | --- | --- | --- | --- |
| `trait T { @Enc val s: String }` | `NoSymbol` | the accessor | raw | **encoded** |
| `trait T { @Enc val s: String = "x" }` | `NoSymbol` | the accessor | raw | **encoded** |
| `trait T { @Enc var s: String = "x" }` | `NoSymbol` | the accessor | raw | **encoded** |
| `class C { @Enc val s: String = "x" }` | the field | the field | encoded | unchanged |
| `case class H(@Enc ui: String)` | the field | the ctor param | raw | unchanged |
| `abstract class C { @Enc val s: String }` | `NoSymbol` | — | raw | raw |

Two rows deliberately do not move. The case-class one is the documented meta-annotation rule: without a meta-annotation the marker stays on the constructor parameter, and `@(EncodableStringAnnotation @field)` is the shape that reaches the field. The abstract-class one is out of reach from here — scalac keeps the marker on neither the accessor (its `annotations` is empty once its info is forced) nor any field, so the macro never sees it. Type position works there, `val s: String @EncodableStringAnnotation`, which is what the `EncodableString` alias expands to anyway; the spec asserts that working shape rather than cementing the hole with a negative test.

`safeAccessed`'s second case, `case methodAccessor: MethodSymbol if methodAccessor.isAccessor`, goes at the same time. `MethodSymbol` is a subtype of `TermSymbol` in scala-reflect, so anything that reached it had already matched the first case: it could never fire, and it was not a trait path in disguise.

### Any related issues, documentation, discussions?

Follows #7864, which added the probe macro these tests use and deliberately left this path unpinned so that fixing it would not have to fight a test that had cemented it. That PR has since merged, and this branch is rebased onto it, so the diff here is the fix alone.

#7864 also recorded `methodReturnHasAnn` as unpinnable without a production seam. That turned out to be wrong for a reason worth writing down; it is pinned here, and the stale comment is corrected.

### How was this PR tested?

Five tests added to `EncodableInspectorSpec`, all driven through #7864's probe macro so they read the classifier's answers directly instead of inferring them from compile-error text:

| Test | Pins |
| --- | --- |
| `a trait's marked val is Encodable even though its accessor has no backing field` | the defect itself, over three fixtures: abstract `val`, concrete `val`, `var` |
| `a marked trait val is lowered to an EncodableStringRenderer` | what the classification is *for* — `wrapArg` must reach priority 2, not the raw-literal default |
| `an unmarked trait val stays a plain literal` | the fallback reads the accessor's own annotations, and reads them *selectively*: a second fixture puts a foreign `@(ZzAnnG @getter)` annotation there |
| `an abstract class's abstract val needs the marker in type position` | the working shape for the row the fallback cannot reach |
| `a def whose inline-annotated result type is stripped at the call site is Encodable` | `methodReturnHasAnn` |

Written before the fix. Mutation testing on the touched code — 4 mutants, 4 killed:

| Mutant | Killed by |
| --- | --- |
| revert `safeAccessed` to the unconditional hop (the defect) | the two trait-member tests |
| never hop to the field, `case accessor ... => accessor` | the pre-existing `@(EncodableStringAnnotation @field)` test |
| symbol scan `annotations.exists(annIsEncodableString)` -> `annotations.nonEmpty` | `an unmarked trait val stays a plain literal` |
| `case m: MethodSymbol => typeHasEncodableString(...)` -> `case _: MethodSymbol => false` | `an abstract class's abstract val ...` and `a def whose inline-annotated result type ...` |

The last row is the gap #7864 recorded. The trait-member fixture is not what closes it — a trait `val` is detected through the symbol path, not the signature path. A different measurement is: `EncodableString` is a type *alias*, so on `def ui: EncodableString` the call-site tree's own type dealiases back to the annotated type and the last disjunct answers true on its own, which is why the arm looked untestable. An *inline* `def ui: String @EncodableStringAnnotation` behaves differently — scalac strips the annotation off the call-site tree, leaving `m.typeSignature.finalResultType` the only place the marker survives.

```bash
sbt "PyBuilder/clean" "PyBuilder/test"
```

`Tests: succeeded 189, failed 0` across 5 suites, 184 before.

```bash
sbt "PyBuilder/scalafmtCheckAll" "PyBuilder/scalafixAll --check"
```

Clean.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)

