### PR TITLE
test(frontend): cover the admin-execution and user-dataset templates

### DIFF
--- a/frontend/src/app/dashboard/component/admin/execution/admin-execution.component.spec.ts
+++ b/frontend/src/app/dashboard/component/admin/execution/admin-execution.component.spec.ts
@@ -26,7 +26,7 @@ import { NzDropDownModule } from "ng-zorro-antd/dropdown";
 import { NzModalModule } from "ng-zorro-antd/modal";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
 import { Execution } from "../../../../common/type/execution";
-import { NzTableQueryParams } from "ng-zorro-antd/table";
+import { NzTableComponent, NzTableQueryParams, NzThAddOnComponent } from "ng-zorro-antd/table";
 import { NzModalService } from "ng-zorro-antd/modal";
 import { WorkflowWebsocketService } from "../../../../workspace/service/workflow-websocket/workflow-websocket.service";
 import { NO_SORT } from "./admin-execution.component";
@@ -594,37 +594,238 @@ describe("AdminExecutionComponent template rendering", () => {
       [rowIndex].queryAll(By.css("td"))
       .map(td => (td.nativeElement.textContent ?? "").trim());
 
+  // The four action buttons carry no text and no distinguishing attribute: nz-tooltip is a
+  // directive input and never reaches the DOM. nz-icon does render [nzType] as an
+  // `anticon-<type>` class, so the icon is the only way to tell them apart.
+  const actionButton = (icon: string) =>
+    fixture.debugElement
+      .queryAll(By.css("tbody tr button"))
+      .find(btn => (btn.nativeElement as HTMLElement).querySelector(`i.anticon-${icon}`));
+
+  // Whether the control is greyed out. Read in both directions on every row that is rendered:
+  // asserting only that the one relevant control is enabled leaves every widening of a
+  // [disabled] predicate (and every exchange between two of them) invisible.
+  const isDisabled = (icon: string): boolean => {
+    const button = actionButton(icon);
+    expect(button, `no action button with the ${icon} icon`).toBeTruthy();
+    return (button!.nativeElement as HTMLButtonElement).disabled;
+  };
+
   it("renders one row per execution with the truncated name and formatted duration", () => {
-    const execution = makeExecution();
-    renderRows([execution]);
+    renderRows([makeExecution()]);
 
     expect(dataRows()).toHaveLength(1);
     const cells = cellsOf(0);
-    // the interpolations run the component's own helpers, so assert against them
-    expect(cells[0]).toContain(component.maxStringLength(execution.workflowName, 16));
-    expect(cells[0]).toContain(String(execution.workflowId));
-    expect(cells.join(" ")).toContain(component.convertSecondsToTime(execution.executionTime));
+    // Hard literals rather than the component helpers the template itself calls, so the
+    // expectations cannot collapse into the production code they are meant to pin. Every column
+    // is read: without that, two <td>s can be exchanged without a test noticing.
+    expect(cells[0]).toContain("a-very-long-work . . . "); // 37-char name cut to 16
+    expect(cells[0]).not.toContain("truncate"); // the tail is really gone
+    expect(cells[0]).toContain("(11)");
+    expect(cells[1]).toBe("run-1 (21)");
+    expect(cells[2]).toBe("alice");
+    expect(cells[3]).toBe("COMPLETED");
+    // startTime/endTime are 100 s apart, and a finished execution's duration is that fixed span.
+    expect(cells[4]).toBe("00:01:40");
   });
 
   it("renders the Not Available arm when the execution time is negative", () => {
     renderRows([makeExecution({ executionTime: -1, endTime: 0 })]);
 
-    expect(cellsOf(0).join(" ")).toContain("Not Available");
+    // Per cell rather than on the row's joined text: with both fallbacks firing at once, joined
+    // text cannot tell which of the two cells produced the string.
+    const cells = cellsOf(0);
+    expect(cells[4]).toBe("Not Available");
+    expect(cells[5]).toBe("Not Available");
   });
 
   it("kills the execution with its workflow id when the kill control is clicked", () => {
     const killSpy = vi.spyOn(component, "killExecution").mockImplementation(() => {});
     renderRows([makeExecution({ executionStatus: "RUNNING", workflowId: 42 })]);
 
-    // nz-icon renders [nzType] as an `anticon-<type>` class; the kill button is the one
-    // carrying the "stop" icon (nz-tooltip is a directive input and never reaches the DOM).
-    const killButton = fixture.debugElement
-      .queryAll(By.css("tbody tr button"))
-      .find(btn => btn.nativeElement.querySelector("i.anticon-stop"));
+    const killButton = actionButton("stop");
     expect(killButton).toBeTruthy();
 
     killButton!.triggerEventHandler("click", null);
 
     expect(killSpy).toHaveBeenCalledWith(42);
+  });
+
+  it("renders the workflow name as plain text when the admin has no access", () => {
+    // Without access the admin must not be handed a link into the workflow editor, but the
+    // name and id still have to be readable so the row can be identified. The name is
+    // deliberately longer than the 16-character limit: this branch has to truncate too, and a
+    // short name would make an untruncated render indistinguishable from a truncated one.
+    renderRows([makeExecution({ access: false, workflowId: 77, workflowName: "secret-workflow-name-too-long" })]);
+
+    expect(fixture.debugElement.query(By.css('a[href="/user/workflow/77"]'))).toBeNull();
+    expect(cellsOf(0)[0]).toContain("secret-workflow- . . . ");
+    expect(cellsOf(0)[0]).not.toContain("name-too-long");
+    expect(cellsOf(0)[0]).toContain("(77)");
+  });
+
+  it("pauses the execution when the pause control is clicked on a running row", () => {
+    const pauseSpy = vi.spyOn(component, "pauseExecution").mockImplementation(() => {});
+    renderRows([makeExecution({ executionStatus: "RUNNING", workflowId: 42 })]);
+
+    const pauseButton = actionButton("pause");
+    expect(pauseButton).toBeTruthy();
+    // A native click (rather than triggerEventHandler) so the [disabled] predicate is part of
+    // what is being asserted: a running execution is exactly the case that must be pausable.
+    const nativePause = pauseButton!.nativeElement as HTMLButtonElement;
+    expect(nativePause.disabled).toBe(false);
+    // The other two controls in the same row, in their opposite state: a running execution
+    // cannot be resumed, and can still be killed.
+    expect(isDisabled("redo")).toBe(true);
+    expect(isDisabled("stop")).toBe(false);
+
+    nativePause.click();
+
+    expect(pauseSpy).toHaveBeenCalledWith(42);
+  });
+
+  it("resumes the execution when the resume control is clicked on a paused row", () => {
+    const resumeSpy = vi.spyOn(component, "resumeExecution").mockImplementation(() => {});
+    renderRows([makeExecution({ executionStatus: "PAUSED", workflowId: 43 })]);
+
+    const resumeButton = actionButton("redo");
+    expect(resumeButton).toBeTruthy();
+    const nativeResume = resumeButton!.nativeElement as HTMLButtonElement;
+    expect(nativeResume.disabled).toBe(false);
+    // A paused execution cannot be paused again, and is still killable.
+    expect(isDisabled("pause")).toBe(true);
+    expect(isDisabled("stop")).toBe(false);
+
+    nativeResume.click();
+
+    expect(resumeSpy).toHaveBeenCalledWith(43);
+  });
+
+  it("greys out kill, pause and resume once the execution has finished", () => {
+    // The kill control fires a WorkflowKillRequest at a live execution; on a run that has
+    // already ended there is nothing to kill, pause or resume, so all three must be dead. Only
+    // the history control stays live.
+    renderRows([makeExecution({ executionStatus: "KILLED", workflowId: 45 })]);
+
+    expect(isDisabled("stop")).toBe(true);
+    expect(isDisabled("pause")).toBe(true);
+    expect(isDisabled("redo")).toBe(true);
+    expect(isDisabled("history")).toBe(false);
+  });
+
+  it("paints each row's status cell with that status's colour", () => {
+    // The colour is the only cue for a row's state, and getStatusColor's own unit tests say
+    // nothing about which value the template feeds it. Two rows with different statuses, so a
+    // binding that ignores the status cannot pass by rendering one right colour.
+    renderRows([
+      makeExecution({ executionStatus: "RUNNING", workflowId: 51 }),
+      makeExecution({ executionStatus: "KILLED", workflowId: 52 }),
+    ]);
+
+    const statusColour = (rowIndex: number): string =>
+      (dataRows()[rowIndex].queryAll(By.css("td"))[3].nativeElement as HTMLElement).style.color;
+
+    expect(statusColour(0)).toBe("orange");
+    expect(statusColour(1)).toBe("red");
+  });
+
+  it("sorts each column by that column's own server-side key", () => {
+    // onSortChange is unit-tested with a key the test supplies, so the key each *header* passes
+    // is observed nowhere: four adjacent columns are freely interchangeable without it.
+    const sortSpy = vi.spyOn(component, "onSortChange").mockImplementation(() => {});
+    renderRows([makeExecution()]);
+
+    // Five headers carry the add-on directive; the Status one filters instead of sorting and so
+    // contributes no call.
+    fixture.debugElement
+      .queryAll(By.directive(NzThAddOnComponent))
+      .forEach(header => header.componentInstance.nzSortOrderChange.emit("ascend"));
+
+    expect(sortSpy.mock.calls.map(call => call[0])).toEqual([
+      "workflow_name",
+      "execution_name",
+      "initiator",
+      "end_time",
+    ]);
+  });
+
+  it("hands the page bar the 1-indexed page, the page size and the server-side total", () => {
+    // The component tracks the page 0-indexed and the page bar is 1-indexed, and the rows arrive
+    // already paged by the server. The pagination suite drives onQueryParamsChange and asserts
+    // component fields, so this is the other half of that contract.
+    vi.mocked(service.getTotalWorkflows).mockReturnValue(of(65));
+    component.pageSize = 5;
+    component.currentPageIndex = 4; // 0-indexed page 5
+    renderRows([makeExecution()]);
+
+    const table = fixture.debugElement.query(By.directive(NzTableComponent)).componentInstance;
+    expect(table.nzPageIndex).toBe(5);
+    expect(table.nzPageSize).toBe(5);
+    expect(table.nzTotal).toBe(65);
+    // Re-paginating server-paged rows would hide all but the first pageSize of each fetch.
+    expect(table.nzFrontPagination).toBe(false);
+  });
+
+  it("labels each status filter with the status it actually filters for", () => {
+    renderRows([makeExecution()]);
+
+    const statusHeader = fixture.debugElement.queryAll(By.directive(NzThAddOnComponent))[3];
+    const filters = statusHeader.componentInstance.nzFilters as { text: string; value: string }[];
+
+    // A label that does not match its value filters for a status other than the one clicked.
+    expect(filters.map(entry => entry.text)).toEqual(filters.map(entry => entry.value));
+    // Every status the table can colour has to be filterable; "UNKNOWN" is offered as well.
+    for (const status of ["READY", "RUNNING", "PAUSED", "COMPLETED", "FAILED", "KILLED", "JUST COMPLETED"]) {
+      expect(filters.map(entry => entry.value)).toContain(status);
+    }
+    expect(filters).toHaveLength(8);
+  });
+
+  it("opens the execution history for the row's workflow", () => {
+    const historySpy = vi.spyOn(component, "clickToViewHistory").mockImplementation(() => {});
+    renderRows([makeExecution({ workflowId: 44, workflowName: "wf-44" })]);
+
+    const historyButton = actionButton("history");
+    expect(historyButton).toBeTruthy();
+
+    (historyButton!.nativeElement as HTMLButtonElement).click();
+
+    // Both arguments matter: the id selects the workflow, the name only titles the dialog.
+    expect(historySpy).toHaveBeenCalledWith(44, "wf-44");
+  });
+
+  it("reads Not Available in the end-time cell while the execution is still running", () => {
+    // The duration and end-time cells have independent fallbacks, so assert them separately: a
+    // still-running execution has a real elapsed time but no end time yet. The test below
+    // renders the mirror of this configuration, which is what actually pins the two conditions
+    // to their own cells. The clock is fixed because the rendered duration is computed from
+    // Date.now() for a RUNNING row.
+    const now = 1_700_000_000_000;
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+    try {
+      renderRows([makeExecution({ executionStatus: "RUNNING", startTime: now - 5_000, endTime: 0 })]);
+
+      const cells = cellsOf(0);
+      expect(cells[4]).toBe("00:00:05");
+      expect(cells[5]).toBe("Not Available");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reads Not Available in the duration cell while still showing a negative-duration run's end time", () => {
+    // The mirror of the test above, and the reason the two cells need separate assertions: here
+    // the duration falls back and the end time does not. A negative duration is what the
+    // duration cell's fallback exists for (the recorded start can be later than the recorded
+    // end when the two timestamps come from clocks that disagree).
+    const end = 1_700_000_000_000;
+    renderRows([makeExecution({ executionStatus: "COMPLETED", startTime: end + 100_000, endTime: end })]);
+
+    const cells = cellsOf(0);
+    expect(cells[4]).toBe("Not Available");
+    // A real timestamp, not the fallback. Built from the Date API rather than from the
+    // component's own converter so the expectation is not the production code under test.
+    expect(cells[5]).toBe(new Date(end).toLocaleString("en-US", { timeZoneName: "short" }));
   });
 });

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset.component.spec.ts
@@ -20,16 +20,19 @@
 import { of, Subject } from "rxjs";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
+import { NgModel } from "@angular/forms";
 import { provideRouter } from "@angular/router";
 import { NzModalService } from "ng-zorro-antd/modal";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { en_US, NZ_I18N } from "ng-zorro-antd/i18n";
 import { UserService } from "../../../../common/service/user/user.service";
-import { StubUserService } from "../../../../common/service/user/stub-user.service";
+import { MOCK_USER_ID, StubUserService } from "../../../../common/service/user/stub-user.service";
 import { SearchService } from "../../../service/user/search.service";
 import { DatasetService } from "../../../service/user/dataset/dataset.service";
 import { SearchResultsComponent } from "../search-results/search-results.component";
 import { SortButtonComponent } from "../sort-button/sort-button.component";
+import { CardItemComponent } from "../list-item/card-item/card-item.component";
+import { DashboardEntry } from "../../../type/dashboard-entry";
 import { commonTestImports, commonTestProviders } from "../../../../common/testing/test-utils";
 
 import { UserDatasetComponent } from "./user-dataset.component";
@@ -575,17 +578,22 @@ describe("UserDatasetComponent rendering", () => {
     expect(fixture.debugElement.query(By.directive(SearchResultsComponent)).componentInstance.viewMode).toBe("list");
   });
 
-  it("marks the results list as editable and private", () => {
-    // This is the user's own dataset page, so entries are editable and the search is scoped to them.
+  it("marks the results list as editable and private and hands it the viewer's own id", () => {
+    // This is the user's own dataset page, so entries are editable and the search is scoped to
+    // them. The viewer's id is what lets the list tell the user's own datasets from ones merely
+    // shared with them, so it belongs in the same enumeration.
     const results = fixture.debugElement.query(By.directive(SearchResultsComponent)).componentInstance;
 
     expect(results.editable).toBe(true);
     expect(results.isPrivateSearch).toBe(true);
+    expect(results.currentUid).toBe(MOCK_USER_ID);
   });
 
   it("re-runs the search when the sort method changes", () => {
-    // The template statement does two things — assign then search — and dropping either leaves the
-    // list showing results in the previous order.
+    // The template statement does two things — assign then search — and running them the other
+    // way round issues the request with the *previous* sort key, leaving the list in the old
+    // order until some unrelated search comes along. So assert the order too, by reading the
+    // sort key the request actually carried.
     const sortButton = fixture.debugElement.query(By.directive(SortButtonComponent));
     searchSpy.mockClear();
 
@@ -594,6 +602,8 @@ describe("UserDatasetComponent rendering", () => {
 
     expect(component.sortMethod).toBe(SortMethod.NameAsc);
     expect(searchSpy).toHaveBeenCalled();
+    // executeSearch(keywords, params, start, count, resourceType, sortMethod, ...)
+    expect(searchSpy.mock.calls[0][5]).toBe(SortMethod.NameAsc);
   });
 
   it("opens the create-dataset flow from the toolbar button", () => {
@@ -613,5 +623,162 @@ describe("UserDatasetComponent rendering", () => {
 
     expect(sortButton.showEditTime).toBe(false);
     expect(sortButton.showExecutionTime).toBe(false);
+  });
+
+  it("writes the tags typed into the search box back to the filter list", () => {
+    // The search box is bound two-way; with a one-way binding the tags the user types would
+    // render but never reach the filter list, and the search would silently stay unfiltered.
+    // nz-select's rendered value comes through its ControlValueAccessor, so the edit has to be
+    // driven at the NgModel rather than by mutating the bound property.
+    const select = fixture.debugElement.query(By.css("nz-select"));
+    expect(select, "no nz-select in the search bar").not.toBeNull();
+    // Free-text keywords only exist in tag mode; "multiple" would restrict the box to preset
+    // options while leaving the two-way binding below working perfectly.
+    expect(select.componentInstance.nzMode).toBe("tags");
+
+    select.injector.get(NgModel).viewToModelUpdate(["alpha", "beta"]);
+
+    expect(component.filters.masterFilterList).toEqual(["alpha", "beta"]);
+  });
+});
+
+/**
+ * The rendering suite above keeps the result list empty, so the card template the page hands to
+ * texera-search-results is never instantiated. This suite returns real datasets so the cards
+ * themselves render, which is the only way the bindings and outputs on them are exercised. It
+ * gets its own TestBed rather than seeding the suite above: several tests there assert on what
+ * renders under an empty result list.
+ */
+describe("UserDatasetComponent card view", () => {
+  let fixture: ComponentFixture<UserDatasetComponent>;
+  let component: UserDatasetComponent;
+  let deleteDatasetsSpy: ReturnType<typeof vi.fn>;
+
+  /** Someone else's uid, so an owner id can never stand in for the signed-in viewer's. */
+  const OTHER_USER_ID = MOCK_USER_ID + 98;
+
+  /**
+   * A dataset entry shaped the way SearchService returns one. A private dataset search returns
+   * both the viewer's own datasets and ones shared with them, so `ownerUid` varies.
+   */
+  const datasetEntry = (did: number, ownerUid: number) =>
+    new DashboardEntry({
+      isOwner: ownerUid === MOCK_USER_ID,
+      ownerEmail: "owner@texera.test",
+      accessPrivilege: "WRITE",
+      size: 1024,
+      dataset: {
+        did,
+        ownerUid,
+        name: `ds-${did}`,
+        isPublic: false,
+        isDownloadable: false,
+        storagePath: undefined,
+        description: "a dataset",
+        creationTime: 0,
+        // Left unset so the card keeps its placeholder preview and never asks
+        // DatasetService for a cover URL.
+        coverImage: undefined,
+      },
+    });
+
+  beforeEach(async () => {
+    // viewType is seeded from localStorage at construction and the card template only renders
+    // in card view, so a "list" left behind by another suite would empty this one out.
+    localStorage.removeItem(VIEW_MODE_STORAGE_KEY);
+    deleteDatasetsSpy = vi.fn(() => of({} as Response));
+    await TestBed.configureTestingModule({
+      imports: [UserDatasetComponent, ...commonTestImports],
+      providers: [
+        { provide: NzModalService, useValue: { create: vi.fn() } },
+        { provide: UserService, useClass: StubUserService },
+        {
+          provide: SearchService,
+          useValue: {
+            executeSearch: vi.fn(() =>
+              of({
+                // One of the viewer's own datasets and one shared with them.
+                entries: [datasetEntry(7, MOCK_USER_ID), datasetEntry(8, OTHER_USER_ID)],
+                more: false,
+                hasMismatch: false,
+              })
+            ),
+          },
+        },
+        { provide: DatasetService, useValue: { deleteDatasets: deleteDatasetsSpy } },
+        { provide: NzMessageService, useValue: { warning: vi.fn() } },
+        { provide: NZ_I18N, useValue: en_US },
+        provideRouter([]),
+        ...commonTestProviders,
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UserDatasetComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await component.search(true);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    localStorage.removeItem(VIEW_MODE_STORAGE_KEY);
+    vi.restoreAllMocks();
+  });
+
+  const cards = () => fixture.debugElement.queryAll(By.directive(CardItemComponent));
+
+  it("renders one card per dataset, each holding its own entry", () => {
+    // One card per result, and each card gets the entry from its own iteration of the template
+    // rather than a single shared one.
+    expect(cards().map(card => (card.componentInstance as CardItemComponent).entry.name)).toEqual(["ds-7", "ds-8"]);
+  });
+
+  it("hands every card the page's own view settings", () => {
+    // This is the signed-in user's own dataset page: the cards are editable and the search is
+    // private. Every card gets the *viewer's* id — including the dataset owned by someone else,
+    // which is the only card that can tell the viewer's id apart from the entry's owner.
+    expect(component.currentUid).toBe(MOCK_USER_ID);
+
+    for (const card of cards().map(c => c.componentInstance as CardItemComponent)) {
+      expect(card.currentUid).toBe(MOCK_USER_ID);
+      expect(card.editable).toBe(true);
+      expect(card.isPrivateSearch).toBe(true);
+    }
+  });
+
+  it("deletes the card's own dataset when the card reports a delete", () => {
+    // The second card, so a handler wired to a fixed entry rather than the row's own would
+    // delete the wrong dataset.
+    const secondCard = cards()[1].componentInstance as CardItemComponent;
+
+    secondCard.deleted.emit();
+
+    expect(deleteDatasetsSpy).toHaveBeenCalledWith(8);
+    expect(deleteDatasetsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("deletes the dataset the results list itself reports as deleted", () => {
+    // The list view's own delete path: texera-search-results raises (deleted) with the entry,
+    // and only this suite has a non-empty result list to raise it from. Distinct from the card
+    // output above, which goes through the page's card template instead.
+    const results = fixture.debugElement.query(By.directive(SearchResultsComponent))
+      .componentInstance as SearchResultsComponent;
+    const secondEntry = (cards()[1].componentInstance as CardItemComponent).entry;
+
+    results.deleted.emit(secondEntry);
+
+    expect(deleteDatasetsSpy).toHaveBeenCalledWith(8);
+    expect(deleteDatasetsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("forces a fresh search when a card asks for a refresh", () => {
+    const card = cards()[0].componentInstance as CardItemComponent;
+    const searchSpy = vi.spyOn(component, "search").mockResolvedValue(undefined);
+
+    card.refresh.emit();
+
+    // Forced: an unforced search would be dropped by the de-duplication check, since neither
+    // the filters nor the sort changed.
+    expect(searchSpy).toHaveBeenCalledWith(true);
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Two dashboard templates. 77 tests → 94.

Measured from `frontend/` with `ng test --coverage --coverage-reporters=lcovonly`, the same spec-file filter on both sides, `rm -rf coverage` between runs, and the "before" run taken from HEAD's specs rather than inherited from a report.

| Template | Before | After |
|---|---|---|
| `admin-execution.component.html` | 77/82 = 93.9% (5 missed) | **81/82 = 98.8%** (1 missed) |
| `user-dataset.component.html` | 32/37 = 86.5% (5 missed) | **37/37 = 100%**, branches **6/6** |

+9 fully-covered lines, +2 branch arms. Both "before" figures reproduce Codecov's published numbers exactly.

New tests cover the duration and end-time fallbacks, the filter and pagination wiring, and the dataset list's empty and populated states.

### Verification

29 mutations, **28 killed, 1 equivalent mutant.** Every mutant was run twice — once against the pre-review tree and once against the repaired tree — so the "now dies" claims are differences I observed rather than inferred.

The first draft reported `"survivors": []`. That was false: **17 distinct mutants survived at 87/87 on its own tree.** Its *numbers* were right — I reproduced 93.90%/5-missed, 86.49%/5-missed, +9 lines and +2 arms — but its closing claim that "the assessment was accurate on every number I checked" papered over the fact that the assertions behind those numbers did not constrain much.

Three of its test comments described separations the tests did not achieve:

- "The duration and end-time cells have independent fallbacks, so assert them separately" — each `ngIf` guard was in fact pinned in only one direction.
- An `EXCHANGE` of the pause and resume `[disabled]` predicates was framed as pinning the pair; it pins only pause-on-RUNNING and resume-on-PAUSED, not the converse.
- A comment claimed a template statement's assign-then-search ordering was observable; the test could not see it.

### This repair pass added zero coverage

The 7 new tests and 7 strengthenings buy **mutation strength, not lines** — the Codecov delta is identical before and after this pass. Said plainly so the diff size is not read as coverage.

### Deliberately not included, and honestly bounded

**This is not a claim that these templates are mutation-complete.** It is a claim about 29 specific mutants. Five wirings remain unpinned and are listed rather than hidden:

- `(nzQueryParams)` on line 43 and `(nzFilterChange)` on line 83 of `admin-execution.component.html` are both still `FNDA:0`. Deleting either would silently break every page click or filter change and nothing in the 53 tests would notice, because the pagination and filter suites call the handlers directly. Worth 0 Codecov lines either way.
- `(click)="setViewType('card')"` on `user-dataset.component.html:53` is still `FNDA:0` — the page starts in card view, so the existing toggle test only ever clicks the list button.
- `(refresh)="ngAfterViewInit()"` on line 100 is left unpinned **deliberately**: pinning it would cement a duplicate-subscription defect.
- Line 90's `(refresh)` has no `DA` record in the lcov at all, so it can never count toward the Codecov metric in either direction.

**`admin-execution.component.html:128` is the one remaining miss and it is dead markup**: `#endTimeNotAvailable` is declared twice, at lines 118 and 127, so lines 127-129 are unreachable. Re-verified from my own after-run lcov rather than inherited.

No production file is touched.

### Any related issues, documentation, discussions?

Closes #7892

### How was this PR tested?

```
npx ng test --watch=false --include="**/admin-execution.component.spec.ts" --include="**/user-dataset.component.spec.ts"
```

```
 Test Files  2 passed (2)
      Tests  94 passed (94)
```

`frontend/junit.xml` and `frontend/coverage/` are regenerated by every run and are not committed. `yarn format:ci` passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
