### PR TITLE
test(amber): cover the worker timer service and dataset statistics helpers

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/WorkerTimerServiceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/WorkerTimerServiceSpec.scala
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.architecture.messaginglayer
+
+import org.apache.pekko.actor.{ActorContext, ActorSystem, Props}
+import org.apache.pekko.testkit.{TestActorRef, TestKit}
+import org.apache.texera.amber.core.virtualidentity.ActorVirtualIdentity
+import org.apache.texera.amber.engine.architecture.coordinator.{
+  CapturingSelfSchedulerService,
+  TimerCtxHolder
+}
+import org.apache.texera.amber.engine.architecture.rpc.controlcommands.{
+  AsyncRPCContext,
+  ControlInvocation,
+  EmptyRequest
+}
+import org.apache.texera.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc.METHOD_FLUSH_NETWORK_BUFFER
+import org.apache.texera.amber.engine.common.rpc.AsyncRPCClient
+import org.apache.texera.amber.engine.common.virtualidentity.util.SELF
+import org.apache.texera.common.config.ApplicationConfig
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+
+import scala.concurrent.duration.{DurationInt, FiniteDuration, MILLISECONDS}
+
+/**
+  * Unit tests for [[WorkerTimerService]].
+  *
+  * The seam under test is [[org.apache.texera.amber.engine.architecture.common.PekkoActorService]],
+  * not Pekko's scheduler: `CapturingSelfSchedulerService` (shared with
+  * `CoordinatorTimerServiceSpec`, which is the coordinator-side analogue of this
+  * class) overrides `sendToSelfWithFixedDelay` to record the (initialDelay, delay,
+  * message) triple and hand back a `RecordingCancellable` instead of arming a real
+  * repeating timer. Consequently there is no wall-clock waiting anywhere in this
+  * suite - no sleeps, no `awaitCond`, no real scheduling.
+  *
+  * `PekkoActorService` eagerly dereferences `actorContext.self` and
+  * `actorContext.dispatcher` in its constructor, so a live `ActorContext` is
+  * required; it comes from a minimal `TimerCtxHolder` actor spawned per service.
+  */
+class WorkerTimerServiceSpec
+    extends TestKit(ActorSystem("WorkerTimerServiceSpec"))
+    with AnyFlatSpecLike
+    with BeforeAndAfterAll {
+
+  override def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  private val actorId: ActorVirtualIdentity = ActorVirtualIdentity("timer-test-worker")
+
+  private val ctxCounter = new java.util.concurrent.atomic.AtomicInteger(0)
+  private def freshContext(): ActorContext = {
+    val holder = TestActorRef[TimerCtxHolder](
+      Props(new TimerCtxHolder),
+      s"worker-timer-ctx-holder-${ctxCounter.incrementAndGet()}"
+    )
+    holder.underlyingActor.context
+  }
+
+  /**
+    * @param cancelResult what the fake timer handles report from `cancel()`. Pekko
+    *                     returns false when the task was already cancelled or the
+    *                     scheduler is shut down, and `stopAdaptiveBatching`
+    *                     discards that Boolean on purpose.
+    */
+  private def newTimerService(
+      cancelResult: Boolean = true
+  ): (WorkerTimerService, CapturingSelfSchedulerService) = {
+    val actorService = new CapturingSelfSchedulerService(actorId, freshContext(), cancelResult)
+    (new WorkerTimerService(actorService), actorService)
+  }
+
+  /**
+    * A service whose constructor-captured adaptive-batching flag has been forced
+    * to `false`.
+    *
+    * `ApplicationConfig.enableAdaptiveNetworkBuffering` is an object `val` bound to
+    * `enable-adaptive-buffering = true` in application.conf and is therefore fixed
+    * for the whole (shared, unforked) amber test JVM; the only test-only way to
+    * reach the disabled path is to overwrite the private field the constructor
+    * copied it into. The write is asserted below so that a JVM which silently
+    * refuses it fails loudly instead of turning the test vacuous.
+    */
+  private def newDisabledTimerService(): (WorkerTimerService, CapturingSelfSchedulerService) = {
+    val (service, actorService) = newTimerService()
+    val field = classOf[WorkerTimerService].getDeclaredField("enabledAdaptiveBatching")
+    field.setAccessible(true)
+    field.setBoolean(service, false)
+    (service, actorService)
+  }
+
+  private def expectedFlushInvocation: ControlInvocation =
+    AsyncRPCClient.ControlInvocation(
+      METHOD_FLUSH_NETWORK_BUFFER,
+      EmptyRequest(),
+      AsyncRPCContext(SELF, SELF),
+      AsyncRPCClient.IgnoreReplyAndDoNotLog
+    )
+
+  // ---------------------------------------------------------------------------
+  // startAdaptiveBatching: the scheduling payload (lines 51-62)
+  // ---------------------------------------------------------------------------
+
+  "startAdaptiveBatching" should
+    "arm one immediate FLUSH_NETWORK_BUFFER self-send repeating at the configured interval" in {
+    val (service, actorService) = newTimerService()
+
+    service.startAdaptiveBatching()
+
+    assert(actorService.captured.size == 1)
+    val capture = actorService.captured.head
+    // Immediate first flush, then one every `adaptiveBufferingTimeoutMs`. This
+    // assertion reads the same accessor the class under test reads, so by itself it
+    // pins the argument ORDER and the unit rather than the value: swapping the
+    // initializer for a config key that happens to hold 500 too (there is exactly
+    // one, `constants.status-update-interval`) would slip past it. The next test
+    // closes that gap from the other side.
+    assert(capture.initialDelay == 0.milliseconds)
+    assert(
+      capture.delay == FiniteDuration(ApplicationConfig.adaptiveBufferingTimeoutMs, MILLISECONDS)
+    )
+    // Field-by-field first for readable failures, then whole-message equality so a
+    // newly added field would still be pinned.
+    val invocation = capture.msg.asInstanceOf[ControlInvocation]
+    assert(invocation.methodName == METHOD_FLUSH_NETWORK_BUFFER.getBareMethodName)
+    assert(invocation.command == EmptyRequest())
+    assert(invocation.context == AsyncRPCContext(SELF, SELF))
+    assert(invocation.commandId == AsyncRPCClient.IgnoreReplyAndDoNotLog)
+    assert(invocation == expectedFlushInvocation)
+    assert(service.adaptiveBatchingHandle.contains(capture.handle))
+    assert(!capture.handle.isCancelled)
+    assert(!service.isPaused)
+  }
+
+  it should "repeat at the interval held by the field its constructor captured" in {
+    // Two things no assertion phrased in terms of `ApplicationConfig` can see,
+    // because the real interval is 500 and so is `constants.status-update-interval`:
+    // that the delay flows from the captured field at all (rather than from a
+    // hard-coded `500.milliseconds`), and that the field is an Int read from the
+    // adaptive-buffering key (a Long-typed sibling key makes `getInt` below throw).
+    // Forcing the field to a value no key holds pins the first; the equality
+    // guarding the write pins the second. Same reflective technique as
+    // `newDisabledTimerService`; the write is read back so a JVM that silently
+    // refuses it fails loudly instead of turning the test vacuous.
+    val (service, actorService) = newTimerService()
+    val field = classOf[WorkerTimerService].getDeclaredField("adaptiveBatchInterval")
+    field.setAccessible(true)
+    assert(field.getInt(service) == ApplicationConfig.adaptiveBufferingTimeoutMs)
+    field.setInt(service, 137)
+    assert(field.getInt(service) == 137)
+
+    service.startAdaptiveBatching()
+
+    assert(actorService.captured.size == 1)
+    assert(actorService.captured.head.delay == 137.milliseconds)
+    assert(actorService.captured.head.initialDelay == 0.milliseconds)
+  }
+
+  it should "be idempotent while its timer is already armed" in {
+    // DataProcessor.outputOneTuple() calls this on every output tuple, so the
+    // already-armed guard is on the hot path.
+    val (service, actorService) = newTimerService()
+
+    service.startAdaptiveBatching()
+    val handle = service.adaptiveBatchingHandle.get
+    service.startAdaptiveBatching()
+    service.startAdaptiveBatching()
+
+    assert(actorService.captured.size == 1)
+    assert(service.adaptiveBatchingHandle.get eq handle)
+  }
+
+  it should "arm nothing when adaptive network buffering is disabled" in {
+    // Guard the reflective write itself: if it stopped taking effect this test
+    // would otherwise pass for the wrong reason.
+    assert(ApplicationConfig.enableAdaptiveNetworkBuffering)
+    val (service, actorService) = newDisabledTimerService()
+    val field = classOf[WorkerTimerService].getDeclaredField("enabledAdaptiveBatching")
+    field.setAccessible(true)
+    assert(!field.getBoolean(service))
+
+    service.startAdaptiveBatching()
+
+    assert(actorService.captured.isEmpty)
+    assert(service.adaptiveBatchingHandle.isEmpty)
+  }
+
+  // ---------------------------------------------------------------------------
+  // stopAdaptiveBatching (lines 66-69)
+  // ---------------------------------------------------------------------------
+
+  "stopAdaptiveBatching" should "cancel the armed timer exactly once" in {
+    val (service, actorService) = newTimerService()
+
+    service.startAdaptiveBatching()
+    service.stopAdaptiveBatching()
+
+    assert(actorService.captured.head.handle.cancelCount == 1)
+    assert(!service.isPaused)
+  }
+
+  it should "be a no-op when no timer was ever armed" in {
+    // WorkflowWorker.postStop() stops the timer unconditionally, so this path is
+    // reached whenever a worker dies before producing its first output tuple.
+    val (service, actorService) = newTimerService()
+
+    service.stopAdaptiveBatching()
+
+    assert(actorService.captured.isEmpty)
+    assert(service.adaptiveBatchingHandle.isEmpty)
+    assert(!service.isPaused)
+  }
+
+  it should "lower the paused latch even when cancel() reports false" in {
+    // `stopAdaptiveBatching` discards the Boolean `cancel()` returns, and Pekko
+    // returns false for an already-cancelled task or a shut-down scheduler - which
+    // is exactly the shape of WorkflowWorker.postStop() stopping the timer after a
+    // pause already cancelled it. The bookkeeping must not depend on that Boolean.
+    val (service, actorService) = newTimerService(cancelResult = false)
+
+    service.startAdaptiveBatching()
+    service.pauseAdaptiveBatching()
+    service.stopAdaptiveBatching()
+
+    assert(actorService.captured.head.handle.cancelCount == 2)
+    assert(!service.isPaused)
+  }
+
+  // ---------------------------------------------------------------------------
+  // pauseAdaptiveBatching (lines 73-74)
+  // ---------------------------------------------------------------------------
+
+  "pauseAdaptiveBatching" should "cancel the armed timer and raise the paused latch" in {
+    val (service, actorService) = newTimerService()
+
+    service.startAdaptiveBatching()
+    service.pauseAdaptiveBatching()
+
+    assert(actorService.captured.head.handle.cancelCount == 1)
+    assert(service.isPaused)
+  }
+
+  // ---------------------------------------------------------------------------
+  // resumeAdaptiveBatching (lines 78-79)
+  // ---------------------------------------------------------------------------
+
+  "resumeAdaptiveBatching" should "arm nothing when the paused latch is down" in {
+    val (service, actorService) = newTimerService()
+
+    service.resumeAdaptiveBatching()
+
+    assert(actorService.captured.isEmpty)
+    assert(service.adaptiveBatchingHandle.isEmpty)
+  }
+
+  it should "re-arm the flush timer while the paused latch is up" in {
+    // The precondition (latch up, no live handle) is reached through the production
+    // API alone: a worker paused before it ever emitted an output tuple has never
+    // armed a timer, so `pauseAdaptiveBatching` raises the latch over an empty
+    // handle. Note that start -> pause -> resume is deliberately NOT tested here:
+    // `stopAdaptiveBatching` cancels the handle without clearing it, so after a
+    // real start+pause resume cannot re-arm at all; pinning either that no-op or
+    // its fix is out of scope for a test-only change (see the PR body).
+    val (service, actorService) = newTimerService()
+
+    service.pauseAdaptiveBatching()
+    assert(service.isPaused)
+    assert(service.adaptiveBatchingHandle.isEmpty)
+
+    service.resumeAdaptiveBatching()
+
+    assert(actorService.captured.size == 1)
+    val resumed = actorService.captured.head
+    assert(service.adaptiveBatchingHandle.contains(resumed.handle))
+    assert(!resumed.handle.isCancelled)
+    // The re-armed timer carries the same schedule and payload a start would.
+    assert(resumed.initialDelay == 0.milliseconds)
+    assert(
+      resumed.delay == FiniteDuration(ApplicationConfig.adaptiveBufferingTimeoutMs, MILLISECONDS)
+    )
+    assert(resumed.msg == expectedFlushInvocation)
+    // Characterization, not a specified contract: nothing in production reads
+    // `isPaused`, and as the class stands `stopAdaptiveBatching` is its only
+    // lowerer - resuming re-arms the timer and leaves the latch as it found it. If
+    // the latch semantics are ever deliberately changed so that resume lowers it,
+    // update this assertion.
+    assert(service.isPaused)
+  }
+
+  it should "arm nothing after a stop has lowered the paused latch" in {
+    val (service, actorService) = newTimerService()
+
+    service.pauseAdaptiveBatching()
+    service.stopAdaptiveBatching()
+
+    service.resumeAdaptiveBatching()
+
+    assert(!service.isPaused)
+    assert(actorService.captured.isEmpty)
+    assert(service.adaptiveBatchingHandle.isEmpty)
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/dataset/utils/DatasetStatisticsUtilsSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/dataset/utils/DatasetStatisticsUtilsSpec.scala
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.web.resource.dashboard.user.dataset.utils
+
+import org.apache.texera.dao.MockTexeraDB
+import org.apache.texera.dao.jooq.generated.Tables.{DATASET, USER}
+import org.apache.texera.dao.jooq.generated.tables.daos.{DatasetDao, UserDao}
+import org.apache.texera.dao.jooq.generated.tables.pojos.{Dataset, User}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+
+import java.sql.Timestamp
+import java.util.UUID
+
+/**
+  * Unit tests for [[DatasetStatisticsUtils]].
+  *
+  * `DatasetStatisticsUtils.context` resolves through `SqlServer.getInstance()`, and
+  * `MockTexeraDB.initializeDBAndReplaceDSLContext()` is exactly what re-points that
+  * singleton at this suite's isolated embedded-Postgres database, so no seam is
+  * needed - the object is exercised as production calls it.
+  *
+  * Every test seeds two distinct owners, because a fixture with a single owner
+  * cannot tell an owner-filtered query apart from an unfiltered one, and the
+  * owner's own datasets differ in every visibility flag, because a fixture whose
+  * rows are uniformly private (or uniformly downloadable) cannot tell the owner
+  * filter apart from an owner filter plus a spurious visibility predicate.
+  */
+class DatasetStatisticsUtilsSpec extends AnyFlatSpec with BeforeAndAfterAll with MockTexeraDB {
+
+  private val ownerUid = 7000 + scala.util.Random.nextInt(1000)
+  private val otherUid = ownerUid + 1
+  private val strangerUid = ownerUid + 2
+
+  private var userDao: UserDao = _
+  private var datasetDao: DatasetDao = _
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+    userDao = new UserDao(getDSLContext.configuration())
+    datasetDao = new DatasetDao(getDSLContext.configuration())
+  }
+
+  override protected def afterAll(): Unit = shutdownDB()
+
+  private def resetFixtures(): Unit = {
+    Seq(ownerUid, otherUid, strangerUid).foreach { uid =>
+      getDSLContext.deleteFrom(DATASET).where(DATASET.OWNER_UID.eq(uid)).execute()
+      getDSLContext.deleteFrom(USER).where(USER.UID.eq(uid)).execute()
+    }
+    Seq(ownerUid, otherUid, strangerUid).foreach(insertUser)
+  }
+
+  private def insertUser(uid: Int): Unit = {
+    val user = new User
+    user.setUid(uid)
+    user.setName(s"stats_user_$uid")
+    user.setEmail(s"stats_user_$uid@example.com")
+    userDao.insert(user)
+  }
+
+  private def insertDataset(
+      uid: Int,
+      creationTime: Timestamp,
+      isPublic: Boolean = false,
+      isDownloadable: Boolean = true
+  ): Dataset = {
+    val dataset = new Dataset
+    dataset.setOwnerUid(uid)
+    dataset.setName("stats_ds_" + UUID.randomUUID().toString.substring(0, 8))
+    dataset.setRepositoryName("repo-" + UUID.randomUUID().toString.substring(0, 8))
+    dataset.setIsPublic(isPublic)
+    dataset.setIsDownloadable(isDownloadable)
+    dataset.setDescription("")
+    dataset.setCreationTime(creationTime)
+    datasetDao.insert(dataset)
+    dataset
+  }
+
+  private def now(): Timestamp = new Timestamp(System.currentTimeMillis())
+
+  private def didOf(dataset: Dataset): Integer =
+    datasetDao.fetchByName(dataset.getName).get(0).getDid
+
+  /**
+    * Two datasets for `ownerUid` whose visibility flags disagree on both axes, one
+    * for `otherUid`, none for `strangerUid`. Both queries under test filter on
+    * OWNER_UID only, so any visibility predicate added to either of them would drop
+    * one of the owner's two rows.
+    */
+  private def seedTwoOwners(): Unit = {
+    resetFixtures()
+    insertDataset(ownerUid, now(), isPublic = true, isDownloadable = false)
+    insertDataset(ownerUid, now(), isPublic = false, isDownloadable = true)
+    insertDataset(otherUid, now())
+  }
+
+  // ---------------------------------------------------------------------------
+  // getUserCreatedDatasetCount
+  // ---------------------------------------------------------------------------
+
+  "getUserCreatedDatasetCount" should
+    "aggregate only the datasets owned by the given uid, and report 0 for a uid that owns none" in {
+    seedTwoOwners()
+
+    // The zero case shares this fixture on purpose: on its own it cannot
+    // distinguish a count from a null projection, and on its own the two-dataset
+    // case cannot distinguish an owner-filtered count from an unfiltered one.
+    assert(DatasetStatisticsUtils.getUserCreatedDatasetCount(ownerUid) == 2)
+    assert(DatasetStatisticsUtils.getUserCreatedDatasetCount(otherUid) == 1)
+    assert(DatasetStatisticsUtils.getUserCreatedDatasetCount(strangerUid) == 0)
+  }
+
+  it should "agree with the length of the list getUserCreatedDatasets returns" in {
+    seedTwoOwners()
+
+    Seq(ownerUid, otherUid, strangerUid).foreach { uid =>
+      assert(
+        DatasetStatisticsUtils.getUserCreatedDatasetCount(uid) ==
+          DatasetStatisticsUtils.getUserCreatedDatasets(uid).size
+      )
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // getUserCreatedDatasets
+  // ---------------------------------------------------------------------------
+
+  "getUserCreatedDatasets" should "return an empty list for a uid that owns no datasets" in {
+    resetFixtures()
+    insertDataset(otherUid, now())
+
+    assert(DatasetStatisticsUtils.getUserCreatedDatasets(strangerUid).isEmpty)
+  }
+
+  it should "project did, name and creation time of the owner's datasets, with size forced to 0" in {
+    resetFixtures()
+    // Two owned rows with distinct names AND distinct creation times, so a mapping
+    // that reads any field off one fixed record instead of the record it is
+    // projecting (the classic row-collapse regression) cannot pass. They also
+    // disagree on both visibility flags, so neither query may filter on those.
+    val firstTime = new Timestamp(1_700_000_000_000L)
+    val secondTime = new Timestamp(1_500_000_000_000L)
+    val owned = insertDataset(ownerUid, firstTime, isPublic = true, isDownloadable = false)
+    val alsoOwned = insertDataset(ownerUid, secondTime)
+    insertDataset(otherUid, now())
+
+    val quotas = DatasetStatisticsUtils.getUserCreatedDatasets(ownerUid)
+
+    assert(quotas.size == 2)
+    // Size reporting is deliberately disabled; a non-zero value would mean the
+    // dataset-size computation was silently re-enabled.
+    assert(
+      quotas.map(q => (q.did, q.name, q.creationTime, q.size)).toSet ==
+        Set(
+          (didOf(owned), owned.getName, firstTime.getTime, 0L),
+          (didOf(alsoOwned), alsoOwned.getName, secondTime.getTime, 0L)
+        )
+    )
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Two new specs for two files that had none. 15 tests.

Measured with a per-suite `Tests.Filter`, one fresh sbt JVM per run, identical filters apart from the suite set.

| File | Codecov | JaCoCo line-hit | Branch arms |
|---|---|---|---|
| `WorkerTimerService.scala` | 18/25 = 72.0% → **25/25 = 100%** | 20/25 → **25/25** | 4 covered / 4 missed → **8 / 0** |
| `DatasetStatisticsUtils.scala` | 12/17 = 70.6% → **17/17 = 100%** | 12/17 → **17/17** | no branch instructions |

Against Codecov's CI baseline that is **+10 fully-covered lines and +2 branch arms.** The first draft claimed +12 lines and +4 arms; the line figure was qualified against CI and the arm figure was not, and +4 does not hold there.

`ConfigParserUtil` was in the original scope and is absent: it already has a spec on main and needed nothing.

### Verification

23 mutations, **20 killed, 3 survivors.**

Four repairs are worth naming because the original tests pinned less than they appeared to:

- A test credited with pinning the scheduler interval did not: both sides read `ApplicationConfig.adaptiveBatchingInterval`, so it was self-referential. It now asserts against the value the constructor captured, reachable only by reflection on a private final field.
- Two resume tests **manufactured their precondition by writing production state** (`service.adaptiveBatchingHandle = None`) and then asserted that same value. Both writes are deleted; the tests now reach the precondition through the production API.
- `Cancellable.cancel()`'s Boolean was never false anywhere in the suite, hiding a whole mutant class. The spec's own helper is now parameterised so the false path runs.
- Every seeded dataset row was `isPublic=false` / `isDownloadable=true`, so two spurious-visibility mutants survived. Rows now vary both flags, with two owners, distinct names and distinct creation times.

**Two reviewer suggestions were refused, both because they discriminate nothing** — and this was checked by running them, not argued. One proposed replacing a config accessor with a path read: under the very mutant the reviewer demonstrated, that read returns the same value and the observation is unchanged. The other proposed a start-then-pause sequence: under the mutant it targets, that sequence still ends with `isPaused = true`.

**The survivors:**

- Setting a `size` field to a constant inside a private mapping survives — the value is overwritten by its only caller's `copy(size = …)`. Equivalent, not a gap.
- The wrong-config-key class is empty in the current configuration but **not closed in principle**: an `Int`-typed accessor holding exactly the same value would survive substitution.
- Exchanging the two `SELF` arguments in `AsyncRPCContext(SELF, SELF)` is unkillable by construction, since both operands are the same value. Stated so it is not mistaken for a kill.

### A production defect, left unpinned on purpose

`stopAdaptiveBatching` cancels the adaptive-batching handle without clearing it, so after a real start-then-pause, **`resumeAdaptiveBatching` cannot re-arm at all**. Adding the clear — the behaviour `CoordinatorTimerService.disableTimer` already has — is a production change and out of scope here.

The consequence for reading this PR: line coverage on the resume path does **not** constrain pause/resume behaviour. The defect is left unpinned in both directions rather than asserted, so a fix will not have to fight a test that cemented it.

Related: nothing in production reads `isPaused` — only the service itself — so the `isPaused` contract this spec pins is characterization, not specification. Said plainly rather than dressed up as a requirement.

Both new spec files carry the Apache license header. No production file is touched.

### Any related issues, documentation, discussions?

Closes #7902

### How was this PR tested?

```
sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.architecture.messaginglayer.WorkerTimerServiceSpec org.apache.texera.web.resource.dashboard.user.dataset.utils.DatasetStatisticsUtilsSpec"
```

```
[info] Total number of tests run: 15
[info] Tests: succeeded 15, failed 0, canceled 0, ignored 0, pending 0
```

`Test/scalafmtCheck` and `Test/scalafix --check` both pass.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
