### PR TITLE
test(frontend): cover the workspace menu's run-button behavior and metadata handlers

### DIFF
--- a/frontend/src/app/workspace/component/menu/menu.component.spec.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.spec.ts
@@ -54,6 +54,7 @@ import { USER_WORKFLOW } from "../../../app-routing.constant";
 import { GuiConfigService } from "../../../common/service/gui-config.service";
 import { MockGuiConfigService } from "../../../common/service/gui-config.service.mock";
 import { JupyterPanelService } from "../../service/jupyter-panel/jupyter-panel.service";
+import { UserProjectService } from "../../../dashboard/service/user/project/user-project.service";
 import type { Mocked } from "vitest";
 
 vi.mock("file-saver", () => ({ saveAs: vi.fn() }));
@@ -212,6 +213,94 @@ describe("MenuComponent", () => {
       expect(behavior.text).toBe("Connecting");
       expect(behavior.disable).toBe(true);
     });
+
+    /** Puts the component into the valid, connected state the state switch needs. */
+    function connected(): void {
+      component.isWorkflowValid = true;
+      component.isWorkflowEmpty = false;
+      component.computingUnitStatus = ComputingUnitState.Running;
+      Object.defineProperty(component.workflowWebsocketService, "isConnected", { get: () => true, configurable: true });
+    }
+
+    it("wires both the 'Connect' and the 'Run' descriptor to runWorkflow", () => {
+      const runSpy = vi.spyOn(component, "runWorkflow").mockImplementation(() => {});
+
+      component.isWorkflowValid = true;
+      component.isWorkflowEmpty = false;
+      component.computingUnitStatus = ComputingUnitState.NoComputingUnit;
+      component.getRunButtonBehavior().onClick();
+      expect(runSpy).toHaveBeenCalledTimes(1);
+
+      connected();
+      component.executionState = ExecutionState.Completed;
+      const run = component.getRunButtonBehavior();
+      run.onClick();
+
+      expect(run.text).toBe("Run");
+      expect(runSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives the invalid, empty and connecting descriptors an inert click handler", () => {
+      const runSpy = vi.spyOn(component, "runWorkflow").mockImplementation(() => {});
+      const pauseSpy = vi.spyOn(executeWorkflowService, "pauseWorkflow").mockImplementation(() => {});
+      const resumeSpy = vi.spyOn(executeWorkflowService, "resumeWorkflow").mockImplementation(() => {});
+
+      component.isWorkflowValid = false;
+      component.getRunButtonBehavior().onClick();
+
+      component.isWorkflowValid = true;
+      component.isWorkflowEmpty = true;
+      component.getRunButtonBehavior().onClick();
+
+      component.isWorkflowEmpty = false;
+      component.computingUnitStatus = ComputingUnitState.Running;
+      Object.defineProperty(component.workflowWebsocketService, "isConnected", {
+        get: () => false,
+        configurable: true,
+      });
+      component.getRunButtonBehavior().onClick();
+
+      expect(runSpy).not.toHaveBeenCalled();
+      expect(pauseSpy).not.toHaveBeenCalled();
+      expect(resumeSpy).not.toHaveBeenCalled();
+    });
+
+    it("reports every transient execution state as a disabled spinner", () => {
+      connected();
+      const runSpy = vi.spyOn(component, "runWorkflow").mockImplementation(() => {});
+      const cases: [ExecutionState, string][] = [
+        [ExecutionState.Initializing, "Submitting"],
+        [ExecutionState.Pausing, "Pausing"],
+        [ExecutionState.Resuming, "Resuming"],
+        [ExecutionState.Recovering, "Recovering"],
+      ];
+
+      const seen = cases.map(([state]) => {
+        component.executionState = state;
+        const behavior = component.getRunButtonBehavior();
+        behavior.onClick();
+        return [behavior.text, behavior.icon, behavior.disable];
+      });
+
+      expect(seen).toEqual(cases.map(([, text]) => [text, "loading", true]));
+      expect(runSpy).not.toHaveBeenCalled();
+    });
+
+    it("falls back to 'Run' for a state the switch does not list", () => {
+      connected();
+      const runSpy = vi.spyOn(component, "runWorkflow").mockImplementation(() => {});
+      // Defensive default: every ExecutionState member has its own case, so this
+      // arm is only reachable with a value from outside the enum.
+      component.executionState = "Unrecognized" as ExecutionState;
+
+      const behavior = component.getRunButtonBehavior();
+      behavior.onClick();
+
+      expect(behavior.text).toBe("Run");
+      expect(behavior.icon).toBe("play-circle");
+      expect(behavior.disable).toBe(false);
+      expect(runSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   it("applyRunButtonBehavior copies the behavior onto the bound fields", () => {
@@ -366,6 +455,33 @@ describe("MenuComponent", () => {
 
       expect(executeSpy).toHaveBeenCalledWith("exec-1", expect.any(Boolean));
     });
+
+    it("names a new computing unit generically when the workflow has no name", () => {
+      component.isWorkflowValid = true;
+      component.isWorkflowEmpty = false;
+      component.computingUnitStatus = ComputingUnitState.NoComputingUnit;
+      component.currentWorkflowName = "";
+
+      component.runWorkflow();
+
+      expect(component.computingUnitSelectionComponent.showAddComputeUnitModalVisible).toHaveBeenCalledWith(
+        "New Computing Unit"
+      );
+    });
+
+    it("submits under 'Untitled Execution' when no execution name has been chosen", () => {
+      component.isWorkflowValid = true;
+      component.isWorkflowEmpty = false;
+      component.computingUnitStatus = ComputingUnitState.Running;
+      component.currentExecutionName = "";
+      const executeSpy = vi
+        .spyOn(executeWorkflowService, "executeWorkflowWithEmailNotification")
+        .mockImplementation(() => {});
+
+      component.runWorkflow();
+
+      expect(executeSpy).toHaveBeenCalledWith("Untitled Execution", false);
+    });
   });
 
   it("onWorkflowNameChange forwards the new name to the workflow action service", () => {
@@ -375,6 +491,19 @@ describe("MenuComponent", () => {
     component.onWorkflowNameChange();
 
     expect(setNameSpy).toHaveBeenCalledWith("renamed");
+  });
+
+  it("onWorkflowNameChange persists the rename only while logged in", () => {
+    vi.spyOn(workflowActionService, "setWorkflowName").mockImplementation(() => {});
+    const persistSpy = vi.spyOn(component, "persistWorkflow").mockImplementation(() => {});
+    const isLogin = vi.spyOn(component.userService, "isLogin").mockReturnValue(true);
+
+    component.onWorkflowNameChange();
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+
+    isLogin.mockReturnValue(false);
+    component.onWorkflowNameChange();
+    expect(persistSpy).toHaveBeenCalledTimes(1);
   });
 
   // Regression coverage for #6846 (resolved by discussion #6873): the toolbar's
@@ -864,6 +993,20 @@ describe("MenuComponent", () => {
 
       expect(input.style.width).toMatch(/^\d+px$/);
     });
+
+    it("adjustWorkflowNameWidth measures the placeholder when the input is empty", () => {
+      const input = document.createElement("input");
+      input.value = "";
+      input.placeholder = "Untitled Workflow";
+      component.workflowNameInput = { nativeElement: input } as typeof component.workflowNameInput;
+
+      component.adjustWorkflowNameWidth();
+
+      // jsdom reports every element as zero-width, so only the measured text is
+      // asserted here: the method still sizes the input and cleans up its probe.
+      expect(input.style.width).toMatch(/^\d+px$/);
+      expect(document.body.querySelector("span[style*='visibility: hidden']")).toBeNull();
+    });
   });
 
   describe("expand jupyter notebook panel", () => {
@@ -1214,6 +1357,296 @@ describe("MenuComponent", () => {
         q("#checkpoint-button").triggerEventHandler("click", null);
         expect(checkpoint).toHaveBeenCalled();
       });
+    });
+  });
+
+  describe("ngOnInit subscriptions", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("re-applies the run button behavior on every execution state event", () => {
+      const stateEvents$ = new Subject<{ current: { state: ExecutionState } }>();
+      vi.spyOn(executeWorkflowService, "getExecutionStateStream").mockReturnValue(
+        stateEvents$.asObservable() as ReturnType<typeof executeWorkflowService.getExecutionStateStream>
+      );
+      const stateFixture = TestBed.createComponent(MenuComponent);
+      const stateComponent = stateFixture.componentInstance;
+      stateFixture.detectChanges();
+      stateComponent.isWorkflowValid = true;
+      stateComponent.isWorkflowEmpty = false;
+      stateComponent.computingUnitStatus = ComputingUnitState.Running;
+      Object.defineProperty(stateComponent.workflowWebsocketService, "isConnected", {
+        get: () => true,
+        configurable: true,
+      });
+
+      try {
+        stateEvents$.next({ current: { state: ExecutionState.Running } });
+        expect(stateComponent.executionState).toBe(ExecutionState.Running);
+        expect(stateComponent.runButtonText).toBe("Pause");
+
+        stateEvents$.next({ current: { state: ExecutionState.Paused } });
+        expect(stateComponent.runButtonText).toBe("Resume");
+      } finally {
+        stateFixture.destroy();
+      }
+    });
+
+    it("deactivates the export button unless the feature is on and results exist", () => {
+      const guiConfig = TestBed.inject(GuiConfigService);
+      const results$ = component.workflowResultExportService.hasResultToExportOnAllOperators;
+
+      // Feature off: deactivated whatever the results say.
+      guiConfig.env.exportExecutionResultEnabled = false;
+      results$.next(true);
+      expect(component.isExportDeactivate).toBe(true);
+
+      // Feature on, but nothing to export.
+      guiConfig.env.exportExecutionResultEnabled = true;
+      results$.next(false);
+      expect(component.isExportDeactivate).toBe(true);
+
+      results$.next(true);
+      expect(component.isExportDeactivate).toBe(false);
+    });
+  });
+
+  describe("onClickGenerateReport", () => {
+    let reportService: ReportGenerationService;
+
+    beforeEach(() => {
+      reportService = TestBed.inject(ReportGenerationService);
+      vi.spyOn(notificationService, "blank");
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("orders the operator results by operator id and blanks the ones the backend omitted", () => {
+      vi.spyOn(workflowActionService, "getWorkflowContent").mockReturnValue({
+        operators: [{ operatorID: "op-1" }, { operatorID: "op-2" }],
+        links: [],
+        commentBoxes: [],
+        settings: {},
+      } as unknown as WorkflowContent);
+      vi.spyOn(reportService, "generateWorkflowSnapshot").mockReturnValue(of("snap-url"));
+      vi.spyOn(reportService, "getAllOperatorResults").mockReturnValue(of([{ operatorId: "op-1", html: "<b>x</b>" }]));
+      const htmlSpy = vi.spyOn(reportService, "generateReportAsHtml").mockImplementation(() => {});
+      const successSpy = vi.spyOn(notificationService, "success").mockImplementation(() => {});
+      const removeSpy = vi.spyOn(notificationService, "remove").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+      component.currentWorkflowName = "wf";
+
+      component.onClickGenerateReport();
+
+      expect(htmlSpy).toHaveBeenCalledWith("snap-url", ["<b>x</b>", ""], "wf");
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(successSpy).toHaveBeenCalledWith("Report successfully generated.");
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+
+    it("reports a failure to retrieve the operator results and closes the notification", () => {
+      vi.spyOn(reportService, "generateWorkflowSnapshot").mockReturnValue(of("snap-url"));
+      vi.spyOn(reportService, "getAllOperatorResults").mockReturnValue(throwError(() => new Error("no results")));
+      const htmlSpy = vi.spyOn(reportService, "generateReportAsHtml").mockImplementation(() => {});
+      const removeSpy = vi.spyOn(notificationService, "remove").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+
+      component.onClickGenerateReport();
+
+      expect(errorSpy).toHaveBeenCalledWith("Error in retrieving operator results: no results");
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(htmlSpy).not.toHaveBeenCalled();
+    });
+
+    it("reports a failure to take the workflow snapshot without asking for results", () => {
+      vi.spyOn(reportService, "generateWorkflowSnapshot").mockReturnValue(
+        throwError(() => new Error("snapshot failed"))
+      );
+      const resultsSpy = vi.spyOn(reportService, "getAllOperatorResults");
+      const removeSpy = vi.spyOn(notificationService, "remove").mockImplementation(() => {});
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+
+      component.onClickGenerateReport();
+
+      expect(errorSpy).toHaveBeenCalledWith("snapshot failed");
+      expect(removeSpy).toHaveBeenCalledTimes(1);
+      expect(resultsSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("onClickEditDescription", () => {
+    /** Opens the modal over a workflow with `description`, with the editor emitting `edited`. */
+    function open(description: string | undefined, edited: string) {
+      vi.spyOn(workflowActionService, "getWorkflow").mockReturnValue({
+        content: { operators: [], links: [], commentBoxes: [], settings: {} } as unknown as WorkflowContent,
+        name: "wf",
+        description,
+        wid: 1,
+        creationTime: undefined,
+        lastModifiedTime: undefined,
+        readonly: false,
+        isPublished: 0,
+      });
+      const close = vi.fn();
+      const createSpy = vi.spyOn(modalService, "create").mockReturnValue({
+        afterClose: of(undefined),
+        getContentComponent: () => ({ descriptionChange: of(edited) }),
+        close,
+      } as unknown as NzModalRef);
+      return { close, createSpy };
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("seeds the editor with an empty string when the workflow has no description", () => {
+      const { createSpy } = open(undefined, "ignored");
+
+      component.onClickEditDescription();
+
+      expect((createSpy.mock.calls[0][0] as ModalOptions).nzData).toEqual({ description: "" });
+    });
+
+    it("stores the edited description, persists it while logged in, and closes the modal", () => {
+      const { close } = open("old", "new description");
+      const metadataSpy = vi.spyOn(workflowActionService, "setWorkflowMetadata").mockImplementation(() => {});
+      const persistSpy = vi.spyOn(component, "persistWorkflow").mockImplementation(() => {});
+      vi.spyOn(component.userService, "isLogin").mockReturnValue(true);
+
+      component.onClickEditDescription();
+
+      expect(metadataSpy).toHaveBeenCalledWith(expect.objectContaining({ wid: 1, description: "new description" }));
+      expect(persistSpy).toHaveBeenCalledTimes(1);
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+
+    it("closes the modal without persisting when logged out", () => {
+      const { close } = open("old", "new description");
+      vi.spyOn(workflowActionService, "setWorkflowMetadata").mockImplementation(() => {});
+      const persistSpy = vi.spyOn(component, "persistWorkflow").mockImplementation(() => {});
+      vi.spyOn(component.userService, "isLogin").mockReturnValue(false);
+
+      component.onClickEditDescription();
+
+      expect(persistSpy).not.toHaveBeenCalled();
+      expect(close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("persistWorkflow", () => {
+    const saved = (wid?: number) => ({
+      content: { operators: [], links: [], commentBoxes: [], settings: {} } as unknown as WorkflowContent,
+      name: "wf",
+      description: undefined,
+      wid,
+      creationTime: undefined,
+      lastModifiedTime: undefined,
+      readonly: false,
+      isPublished: 0,
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("files the saved workflow under the open project when both ids are known", () => {
+      const userProjectService = TestBed.inject(UserProjectService);
+      vi.spyOn(workflowPersistService, "persistWorkflow").mockReturnValue(of(saved(9)));
+      const metadataSpy = vi.spyOn(workflowActionService, "setWorkflowMetadata").mockImplementation(() => {});
+      const addSpy = vi.spyOn(userProjectService, "addWorkflowToProject").mockReturnValue(of({} as Response));
+      component.pid = 3;
+
+      component.persistWorkflow();
+
+      expect(metadataSpy).toHaveBeenCalledWith(expect.objectContaining({ wid: 9 }));
+      expect(addSpy).toHaveBeenCalledWith(3, 9);
+      expect(component.isSaving).toBe(false);
+    });
+
+    it("leaves the project alone when the saved workflow has no id", () => {
+      const userProjectService = TestBed.inject(UserProjectService);
+      vi.spyOn(workflowPersistService, "persistWorkflow").mockReturnValue(of(saved(undefined)));
+      vi.spyOn(workflowActionService, "setWorkflowMetadata").mockImplementation(() => {});
+      const addSpy = vi.spyOn(userProjectService, "addWorkflowToProject");
+      component.pid = 3;
+
+      component.persistWorkflow();
+
+      expect(addSpy).not.toHaveBeenCalled();
+      expect(component.isSaving).toBe(false);
+    });
+
+    it("surfaces a save failure as a notification and stops the saving indicator", () => {
+      vi.spyOn(workflowPersistService, "persistWorkflow").mockReturnValue(throwError(() => new Error("save failed")));
+      const errorSpy = vi.spyOn(notificationService, "error").mockImplementation(() => {});
+
+      component.persistWorkflow();
+
+      expect(errorSpy).toHaveBeenCalledWith("save failed");
+      expect(component.isSaving).toBe(false);
+    });
+  });
+
+  describe("workflow metadata display", () => {
+    const metadata = (overrides: Record<string, unknown>) => ({
+      name: "wf",
+      description: undefined,
+      wid: 4,
+      creationTime: undefined,
+      lastModifiedTime: undefined,
+      isPublished: 0,
+      readonly: false,
+      ...overrides,
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.restoreAllMocks();
+    });
+
+    /** The refresh subscription is debounced by 100ms; the width fix-up is a 0ms macrotask. */
+    function refreshWith(overrides: Record<string, unknown>): void {
+      workflowActionService.setWorkflowMetadata(
+        metadata(overrides) as Parameters<typeof workflowActionService.setWorkflowMetadata>[0]
+      );
+      vi.advanceTimersByTime(101);
+    }
+
+    it("stamps the last save time for a workflow that has been persisted", () => {
+      vi.useFakeTimers();
+      const widthSpy = vi.spyOn(component, "adjustWorkflowNameWidth").mockImplementation(() => {});
+
+      refreshWith({ name: "saved wf", lastModifiedTime: 1_700_000_000_000 });
+
+      expect(component.currentWorkflowName).toBe("saved wf");
+      // The rendered instant depends on the runner's zone, so only the shape is asserted.
+      expect(component.autoSaveState).toMatch(/^Saved at \d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}$/);
+      expect(widthSpy).toHaveBeenCalled();
+    });
+
+    it("leaves the stamp empty for a workflow that has never been saved", () => {
+      vi.useFakeTimers();
+      vi.spyOn(component, "adjustWorkflowNameWidth").mockImplementation(() => {});
+
+      refreshWith({ name: "fresh wf", lastModifiedTime: undefined });
+
+      expect(component.currentWorkflowName).toBe("fresh wf");
+      expect(component.autoSaveState).toBe("");
+    });
+
+    it("stamps the version date when the displayed workflow has a creation time", () => {
+      workflowActionService.setWorkflowMetadata(
+        metadata({ creationTime: 1_700_000_000_000 }) as Parameters<typeof workflowActionService.setWorkflowMetadata>[0]
+      );
+
+      workflowVersionService.setDisplayParticularVersion(true, 1, 2);
+
+      expect(component.displayParticularWorkflowVersion).toBe(true);
+      expect(component.particularVersionDate).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}$/);
     });
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends `menu.component.spec.ts` over the class-file gaps the issue lists — the
run-button descriptor switch, the `ngOnInit` subscriptions, the report failure
paths, and the metadata/persist handlers — with 22 tests. This takes
`menu.component.ts` to full coverage. Measured locally with `--coverage`:

| `menu.component.ts` | Before | After |
| --- | --- | --- |
| lines | 248/274 (90.51 %) | **274/274 (100 %)** |
| statements | 253/281 | **281/281** |
| branches | 55/74 (74.32 %) | **74/74 (100 %)** |
| functions | 65/86 | **86/86** |

**`getRunButtonBehavior`** — the existing tests assert the descriptors but never
invoke them, so every `onClick` was an uncalled function. The new tests call the
returned handler and assert its effect: `Connect` and `Run` both reach
`runWorkflow`; the invalid, empty and connecting descriptors are inert; the four
transient states (`Initializing`, `Pausing`, `Resuming`, `Recovering`) each return
a disabled `loading` descriptor whose click does nothing; and the `default` arm
falls back to `Run`. That last case is only reachable with a value from outside
`ExecutionState` — every member has its own case — so the test casts one in and
says so in a comment.

**`ngOnInit`** — an execution-state event now drives the subscription that sets
`executionState` and re-applies the button (`Running` → `Pause`, `Paused` →
`Resume`), through a stubbed state stream on a second fixture. The export-button
flag is exercised on both sides of its `||`: with the feature off it stays
deactivated whatever the results say, and with it on the result flag decides.

**`onClickGenerateReport`** — the success path now runs with two operators and a
backend that returns only one result, which covers both sides of the
`find(...)?.html || ""` ordering and the operator-id `map`. Both failure paths are
covered too: a retrieval error reports
`"Error in retrieving operator results: …"` and closes the blocking notification,
and a snapshot error reports its own message without ever asking for results.

**`onClickEditDescription`** — a workflow with no description seeds the editor
with `""`; an edit stores the updated metadata, persists it while logged in and
closes the modal; logged out it closes without persisting.

**`persistWorkflow`** — with a project id and a saved `wid` the workflow is filed
under the project; with no `wid` the project is left alone; a failed save is
reported and clears `isSaving`. `onWorkflowNameChange` gets the same login guard
on both sides.

**Metadata display** — the debounced refresh subscription is driven by
`setWorkflowMetadata`: a persisted workflow gets a `Saved at …` stamp and the
deferred width fix-up runs, an unsaved one leaves the stamp empty, and the
version-display handler stamps `particularVersionDate` when the metadata carries a
creation time.

No production code was changed.

### Any related issues, documentation, discussions?

Closes #7912.

### How was this PR tested?

`ng test --watch=false --include src/app/workspace/component/menu/menu.component.spec.ts`
— 98 passed (76 before, 22 new), repeated 3× for stability; the whole
`workspace/component/menu/**` folder stays green (104). `yarn format:ci` clean.
Failure path verified by breaking one assertion in each of the 22 new tests: 22
failed / 76 passed, non-zero exit, and no pre-existing test was disturbed; then
restored to green.

Determinism: every stream is stubbed with `of(...)` / `throwError(...)` or a
`Subject` the test pushes, so nothing waits on a backend. The two metadata tests
install fake timers only for the 100 ms `debounceTime` the subscription itself
uses, and `afterEach` restores real timers; the deferred
`setTimeout(adjustWorkflowNameWidth, 0)` is spied rather than measured, since jsdom
reports every element as zero-width. Dates are asserted by shape, not by rendered
value, so the runner's time zone cannot change the outcome. Extra fixtures are
destroyed in a `finally`, and `vi.restoreAllMocks()` runs in each new block's
`afterEach`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
