### PR TITLE
test(frontend, auth): pin the email validator, re-home the unauthorized spec

### DIFF
--- a/common/auth/src/test/scala/org/apache/texera/auth/UnauthorizedExceptionMapperSpec.scala
+++ b/common/auth/src/test/scala/org/apache/texera/auth/UnauthorizedExceptionMapperSpec.scala
@@ -36,6 +36,11 @@ class UnauthorizedExceptionMapperSpec extends AnyFlatSpec with Matchers {
   "UnauthorizedExceptionMapper" should "map any UnauthorizedException to HTTP 401" in {
     val response = mapper.toResponse(new UnauthorizedException("Bearer realm=\"texera\""))
     response.getStatus shouldBe 401
+    // Pin the whole status line, not just the code. The challenge is RFC 6750
+    // syntax full of commas and quotes; a mapper that passed it to the
+    // two-argument `status(int, String)` overload would stamp it into the HTTP
+    // reason phrase and still satisfy `getStatus shouldBe 401`.
+    response.getStatusInfo.getReasonPhrase shouldBe "Unauthorized"
   }
 
   it should "carry the exception's challenge string verbatim in the WWW-Authenticate header" in {

--- a/frontend/src/app/common/util/email.spec.ts
+++ b/frontend/src/app/common/util/email.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { validateEmailFormat } from "./email";
+
+describe("validateEmailFormat", () => {
+  it("rejects an empty address as empty rather than as malformed", () => {
+    // The two failure messages are what the caller shows the user
+    // (`notificationService.error(validation.message)` in AuthService), so the
+    // message — not just `result` — is the contract: "you left it blank" and
+    // "what you typed is not an address" are different instructions to the user.
+    expect(validateEmailFormat("")).toEqual({
+      result: false,
+      message: "Email should not be empty.",
+    });
+  });
+
+  it("treats a whitespace-only address as empty, not as a format error", () => {
+    // A user who types spaces into the field has effectively left it blank.
+    expect(validateEmailFormat("   ")).toEqual({
+      result: false,
+      message: "Email should not be empty.",
+    });
+  });
+
+  it("trims surrounding whitespace before validating, so a padded address is accepted", () => {
+    // The other half of the trim contract: copy-pasted addresses routinely
+    // carry leading/trailing spaces, and the regex's `[^\s@]+` would reject
+    // them outright if the value were not trimmed first.
+    expect(validateEmailFormat("  someone@example.com  ")).toEqual({
+      result: true,
+      message: "Email frontend validation success.",
+    });
+  });
+
+  it("treats a null or undefined address as empty rather than throwing", () => {
+    // No current caller can reach this: both of them coalesce one line earlier
+    // (`(this.email ?? "").trim()` in email-request-modal.component.ts, and
+    // `(this.form.get("email")?.value ?? "").trim()` in
+    // texera-login.component.ts), and the declared parameter type is `string`
+    // — hence the casts below. The `??` in the implementation is therefore
+    // belt-and-braces for a future caller that hands over a raw Angular form
+    // control value (`T | null` at runtime); this test pins that defensive
+    // contract so the guard is not "cleaned up" later, and it is deliberately
+    // NOT counted as coverage of a reachable arm.
+    expect(validateEmailFormat(null as unknown as string)).toEqual({
+      result: false,
+      message: "Email should not be empty.",
+    });
+    expect(validateEmailFormat(undefined as unknown as string)).toEqual({
+      result: false,
+      message: "Email should not be empty.",
+    });
+  });
+
+  // ─── the pattern itself ───────────────────────────────────────────────────
+  // The three cases below raise no coverage count: lines 36-38 are already hit
+  // indirectly (auth.service.spec.ts and texera-login.component.spec.ts both
+  // drive an address with no `@`, and the latter drives `alice@example.com`).
+  // What no existing test constrains is the *shape* the pattern accepts, in
+  // either direction — so each case below pins one boundary of the rule this
+  // function exists for.
+
+  it("rejects an address with no dot after the @, as a format error", () => {
+    // Pins the `\.` requirement: without it the rule degrades to "contains an
+    // @", which would wave through every internal-looking typo.
+    expect(validateEmailFormat("someone@example")).toEqual({
+      result: false,
+      message: "Email format is invalid.",
+    });
+  });
+
+  it("rejects trailing junk after an otherwise valid address", () => {
+    // Pins the `^`/`$` anchors. Unanchored, the pattern only has to match
+    // *somewhere* in the input, so a pasted "Name <a@b.com>" or a second
+    // address after a space would be accepted and sent to the backend.
+    expect(validateEmailFormat("someone@example.com extra")).toEqual({
+      result: false,
+      message: "Email format is invalid.",
+    });
+  });
+
+  it("accepts a non-.com top-level domain", () => {
+    // The other direction, and the one that matters most here: this validator
+    // gates registration (`UserService.validateEmail`) and the missing-address
+    // prompt, and this project's users are largely @uci.edu. A pattern that
+    // narrowed to `.com` would lock them out before any round trip, so the
+    // permissive `[^\s@]+` tail is pinned as deliberate.
+    expect(validateEmailFormat("student@uci.edu")).toEqual({
+      result: true,
+      message: "Email frontend validation success.",
+    });
+  });
+});


### PR DESCRIPTION
### What changes were proposed in this PR?

Two small, unrelated things that share one property: the behaviour is exercised today but asserted nowhere.

**1. `frontend/src/app/common/util/email.ts` had no spec.** It is the only un-spec'd file in its `util` directory, and it is on the sign-in path — `AuthService` reads `email` out of the email-request modal's `getValues()`. New `email.spec.ts`, 7 tests, taking the file to 100% lines and branches.

**2. `UnauthorizedExceptionMapperSpec` was in the wrong module.** It tests `common/auth`'s `UnauthorizedException`, but lived in `access-control-service`. JaCoCo reports per module, so it credited that file with nothing. Moved to `common/auth/src/test`, which takes `UnauthorizedException.scala` from 66.7% to 100%.

| File | Codecov | How |
|---|---|---|
| `email.ts` | 5/8 = 62.5% → **8/8 = 100%** | new spec |
| `UnauthorizedException.scala` | 6/9 = 66.7% → **9/9 = 100%** | spec relocation |

Both baselines reproduce Codecov's published figures digit-for-digit, measured whole-module with no filter on either side.

### The honest yield is smaller than those percentages suggest

**+5 fully-covered lines and +1 branch arm — of which +3 lines are re-attribution, not new testing.** The Scala half moves already-tested, already-CI-running behaviour into the module where it counts; it adds one new assertion and nothing else. And on the frontend half, one of the three lines is promoted only by an unreachable null-guard arm, so that half is +2 lines and +1 arm rather than +3 and +2.

So the genuinely new coverage here is **2 lines**. I would rather lead with that than with two 100%s.

### What actually earns the PR

The email validator could be gutted and nothing in the repository would notice. Five mutants survived the first draft, three of them on `email.ts`:

| Mutation | Now killed by |
|---|---|
| drop the trailing anchor from the regex | rejects an address with trailing text after the TLD |
| replace the whole regex with `/@/` | rejects strings that merely contain an at-sign |
| narrow the TLD to `\.com$` | accepts a non-`.com` TLD |
| `UnauthorizedException`'s reason-phrase overload | the 401 test's new reason-phrase assertion |
| `UnauthorizedException`'s status constant | existing status assertion |

That is the point of the frontend spec: the file's *coverage* was largely duplicated by indirect drivers, but its *behaviour* was duplicated nowhere. The indirect drivers are `auth.service.spec.ts` and `texera-login.component.spec.ts` — the latter reaching it through a static call, which the first draft got wrong when it inventoried them.

### Verification

16 mutations, **15 killed, 1 survivor.**

**The survivor, stated plainly and not dressed up as equivalent:** flipping `UnauthorizedException.scala:43`'s `enableSuppression = false` to `true` leaves the whole 108-test module green. It *is* observable in principle through `getSuppressed`, but nothing in the repository calls it, so there is no honest assertion to make. Recorded rather than papered over.

### Deliberately not included

`LargeBinaryManager` was the third file in scope and is dropped at **+0 lines**. Reaching it needs a `build.sbt` change with LICENSE-binary fallout, which the test-only constraint forbids.

Three tests added in the repair pass move zero counters — the lcov is byte-identical with and without them — and they are kept only for the mutants they kill.

No production file is touched. `access-control-service` was re-compiled after the move to confirm nothing there depended on the relocated spec.

### Any related issues, documentation, discussions?

Closes #7918

### How was this PR tested?

```
sbt "Auth/test"
```

```
[info] Total number of tests run: 108
[info] Tests: succeeded 108, failed 0, canceled 0, ignored 0, pending 0
```

```
npx ng test --watch=false --include="**/email.spec.ts"
```

```
 Test Files  1 passed (1)
```

`Auth/Test/scalafmtCheck` passes, `AccessControlService/Test/compile` succeeds after the move, and `yarn format:ci` passes. The new frontend spec carries the Apache licence header.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
