### PR TITLE
test(agent-service): cover the full logical-plan branch of buildLogicalPlan

### DIFF
--- a/agent-service/src/agent/tools/workflow-execution-tools.spec.ts
+++ b/agent-service/src/agent/tools/workflow-execution-tools.spec.ts
@@ -369,6 +369,55 @@ describe("executeOperatorAndFormat — request construction", () => {
       expect.objectContaining({ operatorID: "src", operatorType: "TestOp", limit: 3 })
     );
   });
+
+  test("sends the whole workflow, not an upstream slice, when the operator id is empty", async () => {
+    // The plan builder only takes the sub-DAG path for a *truthy* target id, so an empty
+    // operator id falls through to the "every operator" branch. `sink` and `orphan` are the
+    // tell: neither is upstream of `mid`, so a sub-DAG walk would have dropped them.
+    const src = makeOperator("src", [], {
+      operatorProperties: { limit: 3 },
+      outputPorts: [{ portID: "output-0" }, { portID: "output-1" }],
+    });
+    const mid = makeOperator("mid", [{ portID: "input-0" }], { outputPorts: [{ portID: "output-0" }] });
+    const sink = makeOperator("sink", [{ portID: "input-0" }, { portID: "input-1" }]);
+    const orphan = makeOperator("orphan");
+    const off = makeOperator("off", [], { isDisabled: true });
+    const state = stateWith(src, mid, sink, orphan, off);
+    state.addLink(makeLink("src", "output-1", "mid", "input-0"));
+    state.addLink(makeLink("mid", "output-0", "sink", "input-1"));
+    resolveFetch(fetchSpy, { success: true, state: "Completed", operators: {} });
+
+    await executeOperatorAndFormat(state, cfg(), "");
+
+    const body = requestBody(fetchSpy);
+    expect(body.logicalPlan.operators.map((op: { operatorID: string }) => op.operatorID).sort()).toEqual([
+      // getAllEnabledOperators() does not filter on isDisabled, so `off` is sent too.
+      "mid",
+      "off",
+      "orphan",
+      "sink",
+      "src",
+    ]);
+    expect(body.logicalPlan.operators).toContainEqual(
+      expect.objectContaining({ operatorID: "src", operatorType: "TestOp", limit: 3, outputPorts: src.outputPorts })
+    );
+    expect(body.logicalPlan.links).toEqual([
+      { fromOpId: "src", fromPortId: { id: 1, internal: false }, toOpId: "mid", toPortId: { id: 0, internal: false } },
+      { fromOpId: "mid", fromPortId: { id: 0, internal: false }, toOpId: "sink", toPortId: { id: 1, internal: false } },
+    ]);
+    // The empty id matches no operator, so nothing is requested back.
+    expect(body.logicalPlan.opsToViewResult).toEqual([]);
+
+    // Contrast: a real id takes the sub-DAG path and keeps only what feeds it.
+    fetchSpy.mockClear();
+    resolveFetch(fetchSpy, { success: true, state: "Completed", operators: {} });
+    await executeOperatorAndFormat(state, cfg(), "mid");
+    expect(
+      requestBody(fetchSpy)
+        .logicalPlan.operators.map((op: { operatorID: string }) => op.operatorID)
+        .sort()
+    ).toEqual(["mid", "src"]);
+  });
 });
 
 describe("executeOperatorAndFormat — result rendering", () => {


### PR DESCRIPTION
### What changes were proposed in this PR?

Extends `workflow-execution-tools.spec.ts` over the "every enabled operator" branch
of `buildLogicalPlan`, the second of the two gaps #7959 lists. Measured locally with
`bun test --coverage`:

| `workflow-execution-tools.ts` | Before | After |
| --- | --- | --- |
| lines | 95.16 % (uncovered 169-178, 221-226, 229-233) | **97.70 % (uncovered 169-178)** |
| functions | 85.71 % | **90.48 %** |

The branch is reachable, but not the way the issue assumed. `buildLogicalPlan`'s only
call site passes `[operatorId]` — always a one-element array — so `useSubDAG` is always
true and the sub-DAG path is chosen by `targetOperatorId` being *truthy*. What actually
falls through to the full-workflow branch is an **empty** operator id, which the tool's
`z.string()` schema accepts. The test drives that path through the public
`executeOperatorAndFormat` and asserts the request the backend receives:

- every operator is sent, including `sink` and `orphan` — neither is upstream of `mid`,
  so a sub-DAG walk would have dropped them; that is what distinguishes the two branches;
- both links resolve to the right port ordinals on both ends;
- `operatorProperties` are flattened onto the wire operator alongside its ports;
- `opsToViewResult` comes back empty, since the empty id matches no operator;
- the same state with a real id (`"mid"`) is asserted to send only `mid` and `src`, so the
  test fails if the sub-DAG path is taken instead.

Two things the test records rather than asserts as designed:

- **`getAllEnabledOperators()` does not filter on `isDisabled`** — `workflow-state.ts:122`
  is `return this.getAllOperators()`. The issue asked for a disabled operator to be
  excluded here; it is not, so a disabled operator is sent to the engine on this path.
  `getSubDAG` does honour `isDisabled`, so the two paths disagree.
- An empty `operatorId` silently turns "execute this operator's upstream slice" into
  "execute the whole workflow", and then reports that the operator has no result.

Both are noted for follow-up; this PR only characterises the current behaviour and
changes no production code.

### Any related issues, documentation, discussions?

Part of #7959. The other half of that issue, `formatWorkflowValidationErrors`
(169-178), has no call site anywhere in the repository and has had none since it was
introduced in #4540 — `executeOperatorAndFormat` inlines its own, differently indented
formatter instead. It is module-private, so covering it would mean exporting dead code
and freezing an output format nothing uses. Removing it is proposed separately.

### How was this PR tested?

`bun test src/agent/tools/workflow-execution-tools.spec.ts` — 24 pass (23 before, 1 new),
repeated 3× for stability; the whole agent-service suite stays green (300 pass across 19
files). `bun run typecheck` and `bun run format:check` clean. Failure path verified by
changing one port ordinal in the new test's link assertion: 1 fail / 23 pass, non-zero
exit, then restored to green.

Determinism: the workflow state is built from plain in-memory fixtures, `fetch` is a spy
that resolves a canned response, and the assertions read the captured request body rather
than comparing whole-plan JSON.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
