### PR TITLE
chore(agent-service): remove the unreferenced workflow validation formatter

### DIFF
--- a/agent-service/src/agent/tools/workflow-execution-tools.ts
+++ b/agent-service/src/agent/tools/workflow-execution-tools.ts
@@ -166,19 +166,6 @@ function validateWorkflow(workflowState: WorkflowState): WorkflowValidationResul
   };
 }
 
-function formatWorkflowValidationErrors(validationResult: WorkflowValidationResult): string {
-  if (validationResult.isValid) return "";
-
-  const lines: string[] = ["Workflow validation failed:"];
-  for (const [operatorId, fieldErrors] of Object.entries(validationResult.errors)) {
-    lines.push(`  Operator ${operatorId}:`);
-    for (const [field, message] of Object.entries(fieldErrors)) {
-      lines.push(`    - ${field}: ${message}`);
-    }
-  }
-  return lines.join("\n");
-}
-
 function buildLogicalPlan(workflowState: WorkflowState, opsToViewResult?: string[]): LogicalPlan {
   const useSubDAG = opsToViewResult && opsToViewResult.length === 1;
   const targetOperatorId = useSubDAG ? opsToViewResult[0] : undefined;


### PR DESCRIPTION
### What changes were proposed in this PR?

Removes `formatWorkflowValidationErrors` from
`agent-service/src/agent/tools/workflow-execution-tools.ts` — 13 lines with no caller.

- `grep` over the whole repository finds exactly one occurrence: the declaration itself.
- `git log -S formatWorkflowValidationErrors` shows it arrived in #4540 and has never had
  a call site since.
- It is superseded in practice: `executeOperatorAndFormat` builds its own validation
  report inline, with different indentation (`Operator <id>:` / `  - <field>: <message>`
  against this function's `  Operator <id>:` / `    - <field>: <message>`) and without the
  `"Workflow validation failed:"` header. Keeping both invites the two from drifting
  further apart.
- `WorkflowValidationResult` stays in use by `validateWorkflow`, so nothing is orphaned by
  the removal.

These were also the last uncoverable lines in the file: with #7959's test PR in place, the
file goes from 97.70 % to **100 % line coverage** once this lands.

### Any related issues, documentation, discussions?

Closes #7959. The other half of that issue is covered by the companion test PR; this
removes the half that cannot be covered without exporting dead code.

### How was this PR tested?

`bun test` — the whole agent-service suite stays green (299 pass across 19 files),
`bun run typecheck` and `bun run format:check` clean. Coverage of
`workflow-execution-tools.ts` moves from 95.16 % to 97.40 % on this branch alone (the
remaining gap is the logical-plan branch the companion PR covers), and to 100 % with both.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 4.8 [1M context])
