### PR TITLE
feat(treeplot): declare igraph so the Tree Plot operator can run

### DIFF
--- a/amber/operator-requirements.txt
+++ b/amber/operator-requirements.txt
@@ -19,6 +19,7 @@ wordcloud==1.9.6
 plotly==5.24.1
 praw==7.6.1
 pillow==12.3.0
+igraph==1.0.0
 
 # Pin torch to the CPU wheel on Linux x86_64 to avoid the NVIDIA CUDA deps.
 --extra-index-url https://download.pytorch.org/whl/cpu


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds `igraph==1.0.0` to `amber/operator-requirements.txt`. The Tree Plot operator's
generated Python template imports igraph, but the package was not declared in any of
the repository's Python dependency files, so an environment built from them could
never run the operator.

### Any related issues, documentation, discussions?

Closes #7969

### How was this PR tested?

Built a workflow of CSV File Scan into Tree Plot against a virtualenv created from the
repository requirements. It failed with `No module named 'igraph'`. Installing igraph
1.0.0 into that same environment made the identical workflow render the tree, with no
other change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
