### PR TITLE
test(frontend): cover five small service and component gaps

### DIFF
--- a/frontend/src/app/common/service/user/config/user-config.service.spec.ts
+++ b/frontend/src/app/common/service/user/config/user-config.service.spec.ts
@@ -23,6 +23,8 @@ import { AppSettings } from "src/app/common/app-setting";
 import { UserConfigService, UserConfig } from "./user-config.service";
 import { UserService } from "../user.service";
 import { StubUserService, MOCK_USER } from "../stub-user.service";
+import { Subject } from "rxjs";
+import { User } from "../../../type/user";
 
 describe("UserConfigService", () => {
   let service: UserConfigService;
@@ -217,5 +219,41 @@ describe("UserConfigService", () => {
       expect(service.getDict()).toEqual({});
       httpMock.expectNone(endpoint);
     });
+  });
+});
+
+// StubUserService hard-codes `this.user = MOCK_USER` in its constructor, so the
+// suite above can only ever bring the service up while logged in, and the
+// constructor's `if (this.userService.isLogin())` guard is only ever seen from
+// its true side. This second TestBed constructs the service logged out instead.
+describe("UserConfigService (constructed while logged out)", () => {
+  let httpMock: HttpTestingController;
+  const endpoint = `${AppSettings.getApiEndpoint()}/${UserConfigService.USER_DICTIONARY_ENDPOINT}`;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        { provide: UserService, useValue: { isLogin: () => false, userChanged: () => new Subject<User>() } },
+        UserConfigService,
+      ],
+    });
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it("does not fetch the dictionary on construction when nobody is logged in", () => {
+    // The load-bearing assertion is that construction does not THROW. fetchAll()
+    // re-checks the login state and raises Error("user not logged in") before it
+    // issues any request, so a constructor that skipped the guard takes the whole
+    // service down at injection time; it never reaches a point where a request
+    // could be observed. (getDict() is deliberately not asserted here: it is
+    // fixed at {} by its field initialiser and would hold either way.)
+    expect(() => TestBed.inject(UserConfigService)).not.toThrow();
+
+    httpMock.expectNone(endpoint);
   });
 });

--- a/frontend/src/app/dashboard/service/user/workflow-version/workflow-version.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/workflow-version/workflow-version.service.spec.ts
@@ -374,6 +374,29 @@ describe("WorkflowVersionService", () => {
       expect(service.operatorPropertyDiff).toEqual({});
     });
 
+    it("leaves an operator that is identical in both versions out of the modified list", () => {
+      // The two contents differ overall (so the diff loop runs at all), but one
+      // of the two operators is untouched: it must be reported neither as
+      // modified nor given a property diff. The untouched pair is deliberately
+      // two *distinct* objects with equal contents, so a shallow `!==` in place
+      // of the deep compare would wrongly report it as modified.
+      const untouchedA = buildOperator({ operatorID: "same", operatorProperties: { a: 1 } });
+      const untouchedB = buildOperator({ operatorID: "same", operatorProperties: { a: 1 } });
+      const before = buildOperator({ operatorID: "moved", operatorProperties: { a: 1 } });
+      const after = buildOperator({ operatorID: "moved", operatorProperties: { a: 2 } });
+
+      const diff = service.getWorkflowsDifference(
+        buildContent({ operators: [untouchedA, before] }),
+        buildContent({ operators: [untouchedB, after] })
+      );
+
+      expect(diff.modified).toEqual(["moved"]);
+      expect(diff.added).toEqual([]);
+      expect(diff.deleted).toEqual([]);
+      expect(service.operatorPropertyDiff["same"]).toBeUndefined();
+      expect(service.operatorPropertyDiff["moved"]).toBeDefined();
+    });
+
     it("records per-property and version-bump diffs in operatorPropertyDiff", () => {
       const live = buildOperator({
         operatorID: "x",
@@ -449,6 +472,23 @@ describe("WorkflowVersionService", () => {
       actionSpy.disableWorkflowModification.mockClear();
       service.closeReadonlyWorkflowDisplay();
       expect(actionSpy.disableWorkflowModification).not.toHaveBeenCalled();
+    });
+
+    it("restoreModificationState leaves modification enabled when the snapshot was true", () => {
+      // The mirror of the test above: entering readonly display from an editable
+      // workflow must leave it editable on the way back out, not re-disable it.
+      actionSpy.checkWorkflowModificationEnabled.mockReturnValue(true);
+      service.displayReadonlyWorkflow(buildWorkflow());
+      actionSpy.disableWorkflowModification.mockClear();
+
+      service.closeReadonlyWorkflowDisplay();
+
+      // Only these two are about restoreModificationState. (An assertion on
+      // enableWorkflowModification would say nothing: closeReadonlyWorkflowDisplay
+      // calls it unconditionally, eleven lines before it restores the state.)
+      expect(actionSpy.disableWorkflowModification).not.toHaveBeenCalled();
+      // The snapshot is consumed, so the state is no longer restorable.
+      expect(service.canRestoreVersion).toBe(false);
     });
   });
 

--- a/frontend/src/app/workspace/component/code-editor-dialog/breakpoint-condition-input/breakpoint-condition-input.component.spec.ts
+++ b/frontend/src/app/workspace/component/code-editor-dialog/breakpoint-condition-input/breakpoint-condition-input.component.spec.ts
@@ -130,6 +130,52 @@ describe("BreakpointConditionInputComponent", () => {
       expect(component.topPosition).toBe("55px");
       expect(component.leftPosition).toBe("-120px");
     });
+
+    it("substitutes zero offsets when the editor has no dom node and no glyph margin", () => {
+      // Monaco reports no DOM node until the editor is attached, and a hidden
+      // glyph margin reports 0. The remaining terms stay non-zero (line bottom
+      // 40, scrollTop 5), so a stub that simply returned 0 everywhere would not
+      // produce the numbers asserted below.
+      mockUdfDebugService.getCondition.mockReturnValue("x > 1");
+      component.monacoEditor = {
+        getLayoutInfo: () => ({ glyphMarginLeft: 0 }),
+        getDomNode: () => undefined,
+        getBottomForLineNumber: () => 40,
+        getScrollTop: () => 5,
+        getScrollLeft: () => 0,
+        dispose: vi.fn(),
+      } as unknown as editor.IStandaloneCodeEditor;
+      component.lineNum = 3;
+      const changes: SimpleChanges = {
+        lineNum: { currentValue: 3, previousValue: 1, firstChange: false, isFirstChange: () => false },
+      };
+
+      component.ngOnChanges(changes);
+
+      // top: 0 (no rect) + 40 (line bottom) - 5 (scrollTop)
+      expect(component.topPosition).toBe("35px");
+      // left: 0 (no rect) + 0 (glyph margin) - 160 (popup width)
+      expect(component.leftPosition).toBe("-160px");
+      // top() reaches the same missing rect through its own fallback.
+      expect(component.top()).toBe(35);
+    });
+
+    it("defaults the condition to empty when the debugger holds none for that line", () => {
+      mockUdfDebugService.getCondition.mockReturnValue(undefined as unknown as string);
+      component.lineNum = 4;
+      const changes: SimpleChanges = {
+        lineNum: { currentValue: 4, previousValue: 1, firstChange: false, isFirstChange: () => false },
+      };
+      // Seed a stale value first. `condition` initialises to "" on the class, so
+      // without this the assertion below would also hold if ngOnChanges never
+      // assigned anything at all -- it has to observe an overwrite.
+      component.condition = "stale from the previous line";
+
+      component.ngOnChanges(changes);
+
+      // An unset breakpoint yields an empty box, not "undefined" in the input.
+      expect(component.condition).toBe("");
+    });
   });
 
   describe("visibility", () => {
@@ -201,6 +247,46 @@ describe("BreakpointConditionInputComponent", () => {
 
     component.handleEvent(); // Simulate focusout
 
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it("saves the condition when Enter is pressed anywhere in the window", () => {
+    // Every other test in this file calls handleEvent() directly, which leaves
+    // the @HostListener("window:keydown") wiring itself unexercised: deleting
+    // that decorator keeps the whole suite green. Drive a real window event.
+    const emitSpy = vi.spyOn(component.closeEmitter, "emit");
+    component.condition = " x > 1 ";
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", cancelable: true }));
+
+    expect(mockUdfDebugService.doUpdateBreakpointCondition).toHaveBeenCalledWith("test-operator", 1, "x > 1");
+    expect(emitSpy).toHaveBeenCalled();
+  });
+
+  it("ignores an ordinary keystroke arriving at the window", () => {
+    // The negative half of the same host binding, and the only test that pins
+    // its ["$event"] argument list: without the argument, Angular calls
+    // handleEvent() with no event, the key filter reads as focus-out, and every
+    // keystroke anywhere in the window saves the condition and closes the popup.
+    const emitSpy = vi.spyOn(component.closeEmitter, "emit");
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "a", cancelable: true }));
+
+    expect(mockUdfDebugService.doUpdateBreakpointCondition).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
+  });
+
+  it("saves and closes when the host element emits focusout", () => {
+    // The twin of the keydown binding, and it has the same gap: the pre-existing
+    // focusout test calls handleEvent() directly, so removing
+    // @HostListener("focusout") leaves the whole suite green while the popup
+    // silently stops saving on blur.
+    const emitSpy = vi.spyOn(component.closeEmitter, "emit");
+    component.condition = " y > 2 ";
+
+    fixture.nativeElement.dispatchEvent(new Event("focusout"));
+
+    expect(mockUdfDebugService.doUpdateBreakpointCondition).toHaveBeenCalledWith("test-operator", 1, "y > 2");
     expect(emitSpy).toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/workspace/component/workflow-editor/comment-box-modal/nz-modal-comment-box.component.spec.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/comment-box-modal/nz-modal-comment-box.component.spec.ts
@@ -283,4 +283,221 @@ describe("NzModalCommentBoxComponent", () => {
     expect(addComment.mock.calls[0][0]).toMatchObject({ content: "via host listener" });
     expect(event.defaultPrevented).toBe(true);
   });
+
+  // ─── template wiring ──────────────────────────────────────────────────────
+  // Every test above reaches the component's methods directly, so none of the
+  // template's own event bindings ever run. These drive the rendered DOM.
+  describe("template wiring", () => {
+    // The comment's author is deliberately NOT the signed-in user (makeUser is
+    // uid 1 / "Alice"). If the two shared their id and name, a binding that
+    // handed a handler `user.uid` where the template must hand it
+    // `item['creatorID']` — the classic "whose comment is this" wiring bug —
+    // would be indistinguishable from the correct one.
+    const COMMENT = { content: "original", creatorName: "Bob", creatorID: 7, creationTime: CREATION_TIME };
+
+    async function renderWithOneComment(): Promise<ComponentFixture<NzModalCommentBoxComponent>> {
+      const fixture = await createFixture({ user: makeUser(), comments: [COMMENT] });
+      fixture.detectChanges();
+      return fixture;
+    }
+
+    function actionLinks(fixture: ComponentFixture<NzModalCommentBoxComponent>): HTMLAnchorElement[] {
+      return Array.from(fixture.nativeElement.querySelectorAll("[nz-list-item-actions] a")) as HTMLAnchorElement[];
+    }
+
+    function footerTextarea(fixture: ComponentFixture<NzModalCommentBoxComponent>): HTMLTextAreaElement {
+      return fixture.nativeElement.querySelector(".modal-footer textarea") as HTMLTextAreaElement;
+    }
+
+    function footerButton(fixture: ComponentFixture<NzModalCommentBoxComponent>): HTMLButtonElement {
+      return fixture.nativeElement.querySelector(".modal-footer button") as HTMLButtonElement;
+    }
+
+    // The per-comment ids embed an ISO timestamp, whose colons and dots are not
+    // legal in a CSS `#id` selector, so match on the attribute instead.
+    function byId<T extends HTMLElement>(fixture: ComponentFixture<NzModalCommentBoxComponent>, id: string): T {
+      return fixture.nativeElement.querySelector(`[id="${id}"]`) as T;
+    }
+
+    it("posts the typed comment when the footer send button is pressed", async () => {
+      const fixture = await renderWithOneComment();
+      const component = fixture.componentInstance;
+      component.inputValue = "from the button";
+      // The button carries [disabled]="!user || !inputValue"; jsdom swallows a
+      // click on a disabled button, so the model has to be flushed first.
+      fixture.detectChanges();
+
+      const button = footerButton(fixture);
+      expect(button.disabled).toBe(false);
+      button.click();
+
+      expect(addComment).toHaveBeenCalledTimes(1);
+      expect(addComment.mock.calls[0][0]).toMatchObject({ content: "from the button" });
+      // onClickAddComment (not addComment) is what clears the box.
+      expect(component.inputValue).toBe("");
+    });
+
+    it("keeps the footer send button disabled while the box is empty", async () => {
+      const fixture = await renderWithOneComment();
+
+      expect(footerButton(fixture).disabled).toBe(true);
+    });
+
+    it("keeps both send buttons disabled while nobody is signed in", async () => {
+      // Everything else in this describe renders with a signed-in user, so the
+      // `!user` operand of both [disabled] expressions is otherwise never seen
+      // from its true side. Without it a signed-out viewer gets an enabled Send
+      // whose click is silently dropped by addComment/editComment's own guard.
+      const fixture = await createFixture({ user: undefined, comments: [COMMENT] });
+      const component = fixture.componentInstance;
+      component.inputValue = "typed while signed out";
+      component.editValue = "edited while signed out";
+      fixture.detectChanges();
+
+      expect(footerButton(fixture).disabled).toBe(true);
+      expect(byId<HTMLButtonElement>(fixture, `editbtn${COMMENT.creatorName}${CREATION_TIME}`).disabled).toBe(true);
+    });
+
+    it("writes the footer textarea back into inputValue through ngModel", async () => {
+      const fixture = await renderWithOneComment();
+      const textarea = footerTextarea(fixture);
+
+      textarea.value = "typed into the box";
+      textarea.dispatchEvent(new Event("input"));
+
+      expect(fixture.componentInstance.inputValue).toBe("typed into the box");
+      expect(fixture.componentInstance.editValue).toBe("");
+    });
+
+    it("submits the footer comment on Enter", async () => {
+      const fixture = await renderWithOneComment();
+      const component = fixture.componentInstance;
+      component.inputValue = "sent with the enter key";
+      fixture.detectChanges();
+
+      const event = new KeyboardEvent("keydown", { key: "Enter", cancelable: true, bubbles: true });
+      footerTextarea(fixture).dispatchEvent(event);
+
+      expect(addComment).toHaveBeenCalledTimes(1);
+      expect(addComment.mock.calls[0][0]).toMatchObject({ content: "sent with the enter key" });
+      // Enter goes through onClickAddComment, so the box is emptied too.
+      expect(component.inputValue).toBe("");
+      // Otherwise Enter would also insert a newline in the box it just cleared.
+      expect(event.defaultPrevented).toBe(true);
+    });
+
+    it("does not submit the footer comment on an ordinary keystroke", async () => {
+      // The binding is (keydown.enter); with the key filter dropped, every
+      // character typed would post the comment and preventDefault the keystroke,
+      // making the box impossible to type in.
+      const fixture = await renderWithOneComment();
+      const component = fixture.componentInstance;
+      component.inputValue = "half typed";
+      fixture.detectChanges();
+
+      const event = new KeyboardEvent("keydown", { key: "a", cancelable: true, bubbles: true });
+      footerTextarea(fixture).dispatchEvent(event);
+
+      expect(addComment).not.toHaveBeenCalled();
+      expect(component.inputValue).toBe("half typed");
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("saves the edited body when the per-comment send button is pressed", async () => {
+      const fixture = await renderWithOneComment();
+      const component = fixture.componentInstance;
+      const button = byId<HTMLButtonElement>(fixture, `editbtn${COMMENT.creatorName}${CREATION_TIME}`);
+      const textarea = byId<HTMLTextAreaElement>(fixture, `txarea${COMMENT.creatorName}${CREATION_TIME}`);
+      // [disabled]="!user || !editValue": an empty edit box cannot be sent.
+      expect(button.disabled).toBe(true);
+
+      // Open the editor the way the UI does rather than assigning editValue, so
+      // the textarea and button are really revealed and the body is loaded.
+      actionLinks(fixture)[1].click();
+      fixture.detectChanges();
+      expect(textarea.hasAttribute("hidden")).toBe(false);
+      expect(button.hasAttribute("hidden")).toBe(false);
+      expect(component.editValue).toBe("original");
+      expect(button.disabled).toBe(false);
+
+      button.click();
+
+      expect(editComment).toHaveBeenCalledWith(COMMENT.creatorID, CREATION_TIME, BOX_ID, "original");
+      expect(deleteComment).not.toHaveBeenCalled();
+      // editComment's DOM tail closes the editor again, and it can only find
+      // those two nodes through the creatorName the template hands it.
+      expect(textarea.hasAttribute("hidden")).toBe(true);
+      expect(button.hasAttribute("hidden")).toBe(true);
+    });
+
+    it("writes the per-comment textarea back into editValue through ngModel", async () => {
+      const fixture = await renderWithOneComment();
+      const textarea = byId<HTMLTextAreaElement>(fixture, `txarea${COMMENT.creatorName}${CREATION_TIME}`);
+
+      textarea.value = "an edit in progress";
+      textarea.dispatchEvent(new Event("input"));
+
+      expect(fixture.componentInstance.editValue).toBe("an edit in progress");
+      expect(fixture.componentInstance.inputValue).toBe("");
+    });
+
+    it("saves the edited body on Enter in the per-comment textarea", async () => {
+      const fixture = await renderWithOneComment();
+      const textarea = byId<HTMLTextAreaElement>(fixture, `txarea${COMMENT.creatorName}${CREATION_TIME}`);
+      const button = byId<HTMLButtonElement>(fixture, `editbtn${COMMENT.creatorName}${CREATION_TIME}`);
+      // Open the editor through the real link, so editComment's DOM tail has an
+      // editor to close -- that tail is the only thing the creatorName argument
+      // this binding passes can be observed through.
+      actionLinks(fixture)[1].click();
+      fixture.componentInstance.editValue = "edited with the enter key";
+      fixture.detectChanges();
+      expect(textarea.hasAttribute("hidden")).toBe(false);
+
+      const event = new KeyboardEvent("keydown", { key: "Enter", cancelable: true, bubbles: true });
+      textarea.dispatchEvent(event);
+
+      expect(editComment).toHaveBeenCalledWith(COMMENT.creatorID, CREATION_TIME, BOX_ID, "edited with the enter key");
+      expect(event.defaultPrevented).toBe(true);
+      expect(textarea.hasAttribute("hidden")).toBe(true);
+      expect(button.hasAttribute("hidden")).toBe(true);
+    });
+
+    it("does not save the edit on an ordinary keystroke in the per-comment textarea", async () => {
+      // Same key filter, same failure mode: without (keydown.enter) every
+      // character typed into the edit box would commit the edit.
+      const fixture = await renderWithOneComment();
+      fixture.componentInstance.editValue = "half edited";
+      fixture.detectChanges();
+
+      const textarea = byId<HTMLTextAreaElement>(fixture, `txarea${COMMENT.creatorName}${CREATION_TIME}`);
+      const event = new KeyboardEvent("keydown", { key: "a", cancelable: true, bubbles: true });
+      textarea.dispatchEvent(event);
+
+      expect(editComment).not.toHaveBeenCalled();
+      expect(fixture.componentInstance.editValue).toBe("half edited");
+      expect(event.defaultPrevented).toBe(false);
+    });
+
+    it("wires the delete, edit and reply action links to their own handlers", async () => {
+      const fixture = await renderWithOneComment();
+      const component = fixture.componentInstance;
+      const [deleteLink, editLink, replyLink] = actionLinks(fixture);
+      expect([deleteLink.textContent, editLink.textContent, replyLink.textContent]).toEqual([
+        "delete",
+        "edit",
+        "reply",
+      ]);
+
+      replyLink.click();
+      // The author, not the viewer: a reply quotes "Bob", never "Alice".
+      expect(component.inputValue).toBe('@Bob:"original"\n');
+
+      // toggleEditInput needs the ids the template itself renders.
+      editLink.click();
+      expect(component.editValue).toBe("original");
+
+      deleteLink.click();
+      expect(deleteComment).toHaveBeenCalledWith(COMMENT.creatorID, CREATION_TIME, BOX_ID);
+    });
+  });
 });

--- a/frontend/src/app/workspace/service/workflow-graph/util/workflow-util.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/util/workflow-util.service.spec.ts
@@ -22,10 +22,16 @@ import { OperatorMetadataService } from "./../../operator-metadata/operator-meta
 import { inject, TestBed } from "@angular/core/testing";
 
 import { WorkflowUtilService } from "./workflow-util.service";
-import { mockMultiInputOutputSchema, mockScanSourceSchema } from "../../operator-metadata/mock-operator-metadata.data";
+import {
+  mockMultiInputOutputSchema,
+  mockOperatorSchemaList,
+  mockScanSourceSchema,
+} from "../../operator-metadata/mock-operator-metadata.data";
 import { commonTestProviders } from "../../../../common/testing/test-utils";
 import { OperatorPredicate } from "../../../types/workflow-common.interface";
 import { ExecutionMode, Workflow, WorkflowContent } from "../../../../common/type/workflow";
+import { OperatorMetadata } from "../../../types/operator-schema.interface";
+import { Subject } from "rxjs";
 
 describe("WorkflowUtilService", () => {
   let workflowUtilService: WorkflowUtilService;
@@ -226,5 +232,54 @@ describe("WorkflowUtilService", () => {
     const second = workflowUtilService.getNewCommentBox();
 
     expect(first.commentBoxID).not.toEqual(second.commentBoxID);
+  });
+
+  it("should list every operator type carried by the loaded metadata", () => {
+    const types = workflowUtilService.getOperatorTypeList();
+
+    // The list is the operator *types*, not any other schema field: naming a few
+    // concrete ones pins the projection rather than just its length.
+    expect(types).toContain(mockScanSourceSchema.operatorType);
+    expect(types).toContain(mockMultiInputOutputSchema.operatorType);
+    expect(types.length).toEqual(mockOperatorSchemaList.length);
+  });
+
+  it("should prefix group and breakpoint uuids distinctly", () => {
+    const groupID = workflowUtilService.getGroupRandomUUID();
+    const breakpointID = workflowUtilService.getBreakpointRandomUUID();
+
+    // The prefix is what callers key on, so assert it rather than "is a string".
+    expect(groupID).toMatch(/^group-/);
+    expect(breakpointID).toMatch(/^breakpoint-/);
+    expect(workflowUtilService.getGroupRandomUUID()).not.toEqual(groupID);
+  });
+
+  it("should announce on the schema-list-created stream once the metadata arrives", () => {
+    // The service subscribes to the metadata in its constructor, and the stub
+    // metadata service emits synchronously, so a TestBed-injected instance has
+    // already fired by the time a test could subscribe. Drive the emission by
+    // hand instead so the subscription is in place first.
+    const metadata = new Subject<OperatorMetadata>();
+    const service = new WorkflowUtilService({
+      getOperatorMetadata: () => metadata.asObservable(),
+    } as unknown as OperatorMetadataService);
+
+    const seen: boolean[] = [];
+    let typesAtNotification: string[] | undefined;
+    service.getOperatorSchemaListCreatedStream().subscribe(value => {
+      seen.push(value);
+      // Read the list from INSIDE the notification. Asserting it afterwards
+      // would pass even if the subject fired before the list was assigned,
+      // which is precisely the ordering the notification exists to guarantee.
+      typesAtNotification = service.getOperatorTypeList();
+    });
+
+    // Nothing is published before the metadata resolves.
+    expect(seen).toEqual([]);
+
+    metadata.next({ operators: [mockScanSourceSchema], groups: [] } as unknown as OperatorMetadata);
+
+    expect(seen).toEqual([true]);
+    expect(typesAtNotification).toEqual([mockScanSourceSchema.operatorType]);
   });
 });


### PR DESCRIPTION
### What changes were proposed in this PR?

Five small frontend gaps, bundled because each is only 3-4 lines alone.

Measured with the **whole** frontend suite on both sides — no `--include` and no name filter, so there is no false attribution — reading `frontend/coverage/gui/lcov.info`. The before state was the five specs restored to HEAD via `git show HEAD:<exact single path>`, hash-verified against scratch copies.

| File | Codecov-missed | lcov detail |
|---|---|---|
| `workflow-util.service.ts` | 4 → **0** | lines 66/70 → 70/70; **functions 13/18 → 18/18** |
| `breakpoint-condition-input.component.ts` | 4 → **0** | branches 28/33 → **33/33**; functions 7/8 → 8/8 |
| `workflow-version.service.ts` | 4 → **2** | branches 55/59 → 57/59 |
| `user-config.service.ts` | 4 → **3** | branches 30/33 → 31/33 |
| `nz-modal-comment-box.component.html` | — | branch arms closed |

**+15 fully-covered lines and +12 branch arms.**

The one worth pointing at is `workflow-util.service.ts`: **five of its eighteen functions had zero calls** — four zero-caller methods plus a map lambda — behind a 94.6% line figure. That is the fourth time in this campaign the function counter found a gap the line counter hid.

### Verification

38 mutations, **all 38 killed**, every one dying on behaviour rather than a compile error (a `junit.xml` was produced on all 38 runs, so the bundle compiled every time).

The first draft claimed "all 22 mutants killed, every one of the 17 new tests individually mutation-proven". **At least ten semantic mutants were alive against it.**

**One survivor appeared during this pass and was fixed rather than dropped:** the Enter-key twin of a `creatorName`-argument hole survived 26/26 after the first repair, because only the button path had been hardened. Both paths are now pinned.

Three of the first draft's claims were corrected:

- A branch-count improvement on the comment-box template was presented as covering the `[disabled]` guards. Reading the raw records shows it did not.
- One kill was mis-credited: under that mutant the test dies at `TestBed.inject`, before any assertion runs.
- One reported failure message belonged to a different test than the row it was attached to.

### Deliberately not included

Three regions are dead, and no mutant was attempted in them because one would survive vacuously: `workflow-version.service.ts`'s else-arms at lines 174 and 198, and `user-config.service.ts`'s private `updateEntry` guards.

One measurement subtlety is worth recording because it makes two honest counts disagree by one: for a multi-line statement in `breakpoint-condition-input.component.ts`, lcov emits `BRDA:59,...` with **no `DA:59`** — that statement's line record is `DA:58`. A DA-restricted count reads 3 → 0 and a union count reads 4 → 0. Both reach zero, so the conclusion is unaffected, but the rule needs stating.

No production file is touched. The worktree used a **real yarn install**, not a `node_modules` junction — a junction is what emptied the main checkout's dependencies twice earlier in this campaign, since a recursive delete follows it and also reaches through yarn's portal link into `frontend/tools/jschardet-stub`.

### Any related issues, documentation, discussions?

Closes #7986

### How was this PR tested?

```
npx ng test --watch=false --include="**/workflow-util.service.spec.ts" --include="**/user-config.service.spec.ts" --include="**/workflow-version.service.spec.ts" --include="**/breakpoint-condition-input.component.spec.ts" --include="**/nz-modal-comment-box.component.spec.ts"
```

```
 Test Files  5 passed (5)
```

`yarn format:ci` passes. `frontend/junit.xml` and `frontend/coverage/` are regenerated by every run and are not committed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
