### PR TITLE
fix(frontend): disable repeat remove buttons

### DIFF
--- a/frontend/src/app/common/formly/repeat-dnd/repeat-dnd.component.html
+++ b/frontend/src/app/common/formly/repeat-dnd/repeat-dnd.component.html
@@ -21,7 +21,7 @@
   cdkDropList
   (cdkDropListDropped)="onDrop($event)">
   <div
-    *ngFor="let field of field.fieldGroup; let i = index"
+    *ngFor="let row of field.fieldGroup; let i = index"
     cdkDrag
     class="dnd-row">
     <div
@@ -35,7 +35,7 @@
 
     <div class="dnd-field-wrapper">
       <formly-field
-        *ngFor="let subField of field.fieldGroup"
+        *ngFor="let subField of row.fieldGroup"
         class="dnd-field"
         [field]="subField"></formly-field>
     </div>

--- a/frontend/src/app/common/formly/repeat-dnd/repeat-dnd.component.spec.ts
+++ b/frontend/src/app/common/formly/repeat-dnd/repeat-dnd.component.spec.ts
@@ -149,6 +149,20 @@ describe("FormlyRepeatDndComponent", () => {
       expect(spy).toHaveBeenCalledWith(1);
     });
 
+    it("locks every remove button for a disabled section", () => {
+      render({ disabled: true });
+
+      expect(removeButtons()).toHaveLength(3);
+      expect(removeButtons().every(button => button.getAttribute("disabled") !== null)).toBe(true);
+    });
+
+    it("leaves every remove button available otherwise", () => {
+      render({ disabled: false });
+
+      expect(removeButtons()).toHaveLength(3);
+      expect(removeButtons().every(button => button.getAttribute("disabled") === null)).toBe(true);
+    });
+
     it("appends a row from the add button", () => {
       const spy = vi.spyOn(component, "add").mockImplementation(() => {});
       render();


### PR DESCRIPTION
### What changes were proposed in this PR?

Rename the repeat row's <code>*ngFor</code> variable so it no longer shadows the component's <code>field</code>. The remove buttons now read the section-level <code>templateOptions.disabled</code>, matching the add button.

| Before | After |
| --- | --- |
| Remove buttons stay active while the section is disabled. | All remove buttons and the add button are disabled together. |
| ![Before: disabled repeat section with active remove buttons](https://github.com/user-attachments/assets/6051a9b4-9a80-4fc9-8dc4-5a86881dff14) | ![After: disabled repeat section with disabled remove buttons](https://github.com/user-attachments/assets/c954338a-0ebd-4726-987d-73b3b6e986c2) |

Permanent rendering tests cover both directions: every remove button is disabled for a disabled section, and every remove button remains available otherwise.

### Any related issues, documentation, discussions?

Closes #7431

### How was this PR tested?

~~~powershell
cd frontend
node node_modules\@angular\cli\bin\ng.js test --watch=false --include src/app/common/formly/repeat-dnd/repeat-dnd.component.spec.ts
node .yarn\releases\yarn-4.14.1.cjs run format:ci
git diff --check
~~~

Result: 14 tests passed; the frontend Prettier and ESLint CI check passed; <code>git diff --check</code> passed.

The before/after evidence above was captured from the actual Angular component in Playwright Chromium with <code>templateOptions.disabled = true</code>.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5)
