### PR TITLE
ci: freeze setup-python interpreter

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -150,6 +150,15 @@
       groupName: 'pyamber minor updates',
     },
 
+    // The Python interpreter selects the wheels used by the frozen
+    // pandas/numpy/pyarrow data path below. Upgrade it manually with those
+    // packages so setup-python cannot move CI beyond their published wheels.
+    {
+      matchManagers: ['github-actions'],
+      matchDepNames: ['python'],
+      enabled: false,
+    },
+
     // GitHub Actions bumps in one group, scoped as chore(deps, ci).
     {
       matchManagers: ['github-actions'],


### PR DESCRIPTION
### What changes were proposed in this PR?

Prevent Renovate from independently raising the Python interpreter used by GitHub Actions while the CI data stack remains pinned to older pandas, NumPy, and PyArrow releases.

```text
Before: setup-python bump -> interpreter may outrun frozen package wheels -> CI install failure
After:  interpreter stays frozen -> interpreter and data packages are upgraded together manually
```

The rule is narrowly scoped to the `github-actions` manager and Renovate's `python` dependency name. Other GitHub Actions updates remain enabled and grouped as before.

### Any related issues, documentation, discussions?

Closes #7720.

### How was this PR tested?

The regression check was written before the config change and initially failed because no setup-python freeze rule existed. After the change:

```text
npx --yes --package renovate@44.46.4 renovate-config-validator .github/renovate.json5
git diff --check
```

Result: Renovate reported `Config validated successfully against 1 file(s)`, and the diff check passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex was used for implementation and verification assistance. I reviewed the final code and test output before submission.
