### PR TITLE
feat(config): add form-view-enabled feature flag, default off

### DIFF
--- a/common/config/src/main/resources/gui.conf
+++ b/common/config/src/main/resources/gui.conf
@@ -78,6 +78,10 @@ gui {
     timetravel-enabled = false
     timetravel-enabled = ${?GUI_WORKFLOW_WORKSPACE_TIMETRAVEL_ENABLED}
 
+    # whether the Form View (a second, form-based view of a workflow) is enabled
+    form-view-enabled = false
+    form-view-enabled = ${?GUI_WORKFLOW_WORKSPACE_FORM_VIEW_ENABLED}
+
     # Whether to connect to local or production shared editing server. Set to true if you have
     # reverse proxy set up for y-websocket.
     production-shared-editing-server = false

--- a/common/config/src/main/scala/org/apache/texera/common/config/GuiConfig.scala
+++ b/common/config/src/main/scala/org/apache/texera/common/config/GuiConfig.scala
@@ -55,6 +55,8 @@ object GuiConfig {
     conf.getBoolean("gui.workflow-workspace.async-rendering-enabled")
   val guiWorkflowWorkspaceTimetravelEnabled: Boolean =
     conf.getBoolean("gui.workflow-workspace.timetravel-enabled")
+  val guiWorkflowWorkspaceFormViewEnabled: Boolean =
+    conf.getBoolean("gui.workflow-workspace.form-view-enabled")
   val guiWorkflowWorkspaceProductionSharedEditingServer: Boolean =
     conf.getBoolean("gui.workflow-workspace.production-shared-editing-server")
   val guiWorkflowWorkspacePythonLanguageServerPort: String =

--- a/common/config/src/test/scala/org/apache/texera/common/config/GuiConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/GuiConfigSpec.scala
@@ -56,6 +56,10 @@ class GuiConfigSpec extends AnyFlatSpec with Matchers {
     ifUnset("GUI_WORKFLOW_WORKSPACE_TIMETRAVEL_ENABLED")(
       GuiConfig.guiWorkflowWorkspaceTimetravelEnabled shouldBe false
     )
+    // Form View ships disabled so merging the feature never turns it on; the final PR flips it.
+    ifUnset("GUI_WORKFLOW_WORKSPACE_FORM_VIEW_ENABLED")(
+      GuiConfig.guiWorkflowWorkspaceFormViewEnabled shouldBe false
+    )
     ifUnset("GUI_WORKFLOW_WORKSPACE_PRODUCTION_SHARED_EDITING_SERVER")(
       GuiConfig.guiWorkflowWorkspaceProductionSharedEditingServer shouldBe false
     )

--- a/config-service/src/main/scala/org/apache/texera/service/resource/ConfigResource.scala
+++ b/config-service/src/main/scala/org/apache/texera/service/resource/ConfigResource.scala
@@ -85,6 +85,7 @@ class ConfigResource {
       "linkBreakpointEnabled" -> GuiConfig.guiWorkflowWorkspaceLinkBreakpointEnabled,
       "asyncRenderingEnabled" -> GuiConfig.guiWorkflowWorkspaceAsyncRenderingEnabled,
       "timetravelEnabled" -> GuiConfig.guiWorkflowWorkspaceTimetravelEnabled,
+      "formViewEnabled" -> GuiConfig.guiWorkflowWorkspaceFormViewEnabled,
       "productionSharedEditingServer" -> GuiConfig.guiWorkflowWorkspaceProductionSharedEditingServer,
       "defaultExecutionMode" -> GuiConfig.guiWorkflowWorkspaceDefaultExecutionMode,
       "workflowEmailNotificationEnabled" -> GuiConfig.guiWorkflowWorkspaceWorkflowEmailNotificationEnabled,

--- a/frontend/src/app/common/service/gui-config.service.mock.ts
+++ b/frontend/src/app/common/service/gui-config.service.mock.ts
@@ -39,6 +39,7 @@ export class MockGuiConfigService {
     linkBreakpointEnabled: false,
     asyncRenderingEnabled: false,
     timetravelEnabled: false,
+    formViewEnabled: false,
     productionSharedEditingServer: false,
     pythonLanguageServerPort: "3000",
     defaultDataTransferBatchSize: 100,

--- a/frontend/src/app/common/type/gui-config.ts
+++ b/frontend/src/app/common/type/gui-config.ts
@@ -30,6 +30,7 @@ export interface GuiConfig {
   linkBreakpointEnabled: boolean;
   asyncRenderingEnabled: boolean;
   timetravelEnabled: boolean;
+  formViewEnabled: boolean;
   productionSharedEditingServer: boolean;
   pythonLanguageServerPort: string;
   defaultDataTransferBatchSize: number;


### PR DESCRIPTION
### What changes were proposed in this PR?
Adds a single feature flag `form-view-enabled` (default **off**) that will gate the entire Form View feature, so the rest of the stacked series can merge without exposing an unfinished feature to users.

- `common/config/.../gui.conf`: `gui.workflow-workspace.form-view-enabled = false` (env-overridable)
- `GuiConfig`: read it as `guiWorkflowWorkspaceFormViewEnabled`
- `ConfigResource`: expose via `/api/config/gui` as `formViewEnabled`
- frontend `gui-config.ts` + `gui-config.service.mock.ts`: add `formViewEnabled`

Nothing reads the flag yet; it is flipped on only by the final PR in the series.

### Any related issues, documentation, discussions?
Closes #8013.
Part of #8011  — first of a stacked series of 16 PRs (1/16)

### How was this PR tested?
`GuiConfigSpec` asserts the flag parses; `ng build` and the existing frontend test suite pass. No behavior change — nothing consumes the flag yet.

### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus)