### PR TITLE
feat(frontend): add searchable property dropdowns

### DIFF
--- a/frontend/src/app/common/formly/formly-config.spec.ts
+++ b/frontend/src/app/common/formly/formly-config.spec.ts
@@ -29,7 +29,9 @@ import {
   minlengthValidationMessage,
   minValidationMessage,
   multipleOfValidationMessage,
+  TEXERA_FORMLY_CONFIG,
 } from "./formly-config";
+import { SearchableSelectTypeComponent } from "./searchable-select.type";
 
 // the `err` argument is unused by every message builder, so any value is fine
 const err = {} as any;
@@ -79,5 +81,17 @@ describe("formly validation messages", () => {
   it("renders the literal 'undefined' when the relevant prop is missing", () => {
     expect(minValidationMessage(err, field({}))).toBe("should be >= undefined");
     expect(constValidationMessage(err, field({}))).toBe('should be equal to constant "undefined"');
+  });
+});
+
+describe("formly enum type", () => {
+  it("uses the searchable select component for schema-backed dropdowns", () => {
+    const enumType = TEXERA_FORMLY_CONFIG.types.find(type => type.name === "enum");
+
+    expect(enumType).toEqual({
+      name: "enum",
+      extends: "select",
+      component: SearchableSelectTypeComponent,
+    });
   });
 });

--- a/frontend/src/app/common/formly/formly-config.ts
+++ b/frontend/src/app/common/formly/formly-config.ts
@@ -32,6 +32,7 @@ import { DatasetVersionSelectorComponent } from "../../workspace/component/datas
 import { HuggingFaceImageUploadComponent } from "../../workspace/component/hugging-face-image-upload/hugging-face-image-upload.component";
 import { HuggingFaceComponent } from "../../workspace/component/hugging-face/hugging-face.component";
 import { HuggingFaceAudioUploadComponent } from "../../workspace/component/hugging-face-audio-upload/hugging-face-audio-upload.component";
+import { SearchableSelectTypeComponent } from "./searchable-select.type";
 
 /**
  * Configuration for using Json Schema with Formly.
@@ -75,7 +76,7 @@ export const TEXERA_FORMLY_CONFIG = {
       },
     },
     { name: "boolean", extends: "checkbox" },
-    { name: "enum", extends: "select" },
+    { name: "enum", extends: "select", component: SearchableSelectTypeComponent },
     { name: "null", component: NullTypeComponent, wrappers: ["form-field"] },
     { name: "array", component: ArrayTypeComponent },
     { name: "object", component: ObjectTypeComponent },

--- a/frontend/src/app/common/formly/searchable-select.type.spec.ts
+++ b/frontend/src/app/common/formly/searchable-select.type.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
+import { FormlyModule } from "@ngx-formly/core";
+import { By } from "@angular/platform-browser";
+import { NzSelectComponent, NzSelectModule } from "ng-zorro-antd/select";
+import { SearchableSelectTypeComponent } from "./searchable-select.type";
+
+describe("SearchableSelectTypeComponent", () => {
+  let fixture: ComponentFixture<SearchableSelectTypeComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [SearchableSelectTypeComponent, ReactiveFormsModule, FormlyModule.forRoot(), NzSelectModule],
+    }).compileComponents();
+  });
+
+  function render(options: unknown[], multiple = false): NzSelectComponent {
+    fixture = TestBed.createComponent(SearchableSelectTypeComponent);
+    fixture.componentInstance.field = {
+      key: "attribute",
+      formControl: new FormControl(),
+      props: { options, multiple },
+      options: { showError: () => false },
+    };
+    fixture.detectChanges();
+    return fixture.debugElement.query(By.directive(NzSelectComponent)).componentInstance as NzSelectComponent;
+  }
+
+  it("searches option labels case-insensitively", () => {
+    const select = render(["customer_id", "order_total"]);
+
+    expect(select.nzShowSearch).toBe(true);
+    expect(select.nzFilterOption("TOTAL", { nzLabel: "order_total" } as any)).toBe(true);
+    expect(select.nzFilterOption("missing", { nzLabel: "order_total" } as any)).toBe(false);
+  });
+
+  it("preserves default and multiple selection modes", () => {
+    expect(render(["customer_id"]).nzMode).toBe("default");
+    fixture.destroy();
+    expect(render(["customer_id"], true).nzMode).toBe("multiple");
+  });
+
+  it("supports an empty option list", () => {
+    expect(render([]).nzShowSearch).toBe(true);
+  });
+});

--- a/frontend/src/app/common/formly/searchable-select.type.ts
+++ b/frontend/src/app/common/formly/searchable-select.type.ts
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CommonModule } from "@angular/common";
+import { Component } from "@angular/core";
+import { ReactiveFormsModule } from "@angular/forms";
+import { FieldType, FieldTypeConfig, FormlyModule } from "@ngx-formly/core";
+import { FormlyFieldSelectProps, FormlySelectModule } from "@ngx-formly/core/select";
+import { NzSelectModule } from "ng-zorro-antd/select";
+
+interface SearchableSelectProps extends FormlyFieldSelectProps {
+  multiple?: boolean;
+}
+
+@Component({
+  template: `
+    <nz-select
+      [class.ng-dirty]="showError"
+      [nzPlaceHolder]="props.placeholder ?? null"
+      [formControl]="formControl"
+      [formlyAttributes]="field"
+      [nzMode]="props.multiple ? 'multiple' : 'default'"
+      nzShowSearch
+      (ngModelChange)="props.change && props.change(field, $event)">
+      <ng-container *ngFor="let item of props.options | formlySelectOptions: field | async">
+        <nz-option-group
+          *ngIf="item.group"
+          [nzLabel]="item.label">
+          <nz-option
+            *ngFor="let child of item.group"
+            [nzValue]="child.value"
+            [nzDisabled]="child.disabled"
+            [nzLabel]="child.label">
+          </nz-option>
+        </nz-option-group>
+        <nz-option
+          *ngIf="!item.group"
+          [nzValue]="item.value"
+          [nzDisabled]="item.disabled"
+          [nzLabel]="item.label">
+        </nz-option>
+      </ng-container>
+    </nz-select>
+  `,
+  imports: [CommonModule, ReactiveFormsModule, FormlyModule, FormlySelectModule, NzSelectModule],
+})
+export class SearchableSelectTypeComponent extends FieldType<FieldTypeConfig<SearchableSelectProps>> {}


### PR DESCRIPTION
### What changes were proposed in this PR?

Use a searchable NG-ZORRO select for schema-backed enum fields in the operator property panel. Users can type to filter attribute and option labels while retaining grouped options, disabled states, multiple selection, placeholders, and change callbacks.

This keeps the integration scoped to the existing Formly `enum` type so dropdown definitions do not need individual changes.

The before state is shown in #8069. After this change, typing in the same dropdown filters its options case-insensitively while mouse and keyboard selection continue to work normally.

### Any related issues, documentation, discussions?

Closes #8069

### How was this PR tested?

```bash
cd frontend
yarn test --include="src/app/common/formly/formly-config.spec.ts" --include="src/app/common/formly/searchable-select.type.spec.ts"
yarn prettier --check src/app/common/formly/formly-config.ts src/app/common/formly/formly-config.spec.ts src/app/common/formly/searchable-select.type.ts src/app/common/formly/searchable-select.type.spec.ts
yarn eslint src/app/common/formly/formly-config.ts src/app/common/formly/formly-config.spec.ts src/app/common/formly/searchable-select.type.ts src/app/common/formly/searchable-select.type.spec.ts
yarn build
```

- 15 focused unit tests passed.
- Manually verified the local development UI with the repository stack.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex
