### PR TITLE
feat(amber): report malformed websocket messages

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/WorkflowWebsocketResource.scala
@@ -78,7 +78,6 @@ class WorkflowWebsocketResource extends LazyLogging {
 
   @OnMessage
   def myOnMsg(session: Session, message: String): Unit = {
-    val request = objectMapper.readValue(message, classOf[TexeraWebSocketRequest])
     val userOpt = session.getUserProperties.asScala
       .get(classOf[User].getName)
       .map(_.asInstanceOf[User])
@@ -88,6 +87,7 @@ class WorkflowWebsocketResource extends LazyLogging {
     val workflowStateOpt = sessionState.getCurrentWorkflowState
     val executionStateOpt = workflowStateOpt.flatMap(x => Option(x.executionService.getValue))
     try {
+      val request = objectMapper.readValue(message, classOf[TexeraWebSocketRequest])
       request match {
         case heartbeat: HeartBeatRequest =>
           sessionState.send(HeartBeatResponse())

--- a/amber/src/test/scala/org/apache/texera/web/resource/WorkflowWebsocketResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/WorkflowWebsocketResourceSpec.scala
@@ -82,10 +82,6 @@ import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsJava, SeqHasA
   *     then rethrows so the container sees it too. Both halves are asserted: dropping either the
   *     send or the rethrow would leave the other silently missing.
   *
-  * Worth knowing, and the reason there is no malformed-frame test here: `objectMapper.readValue`
-  * sits OUTSIDE the try, so an unparseable frame escapes un-mapped and the client is told nothing.
-  * That looks like an oversight, but pinning today's behaviour would cement it.
-  *
   * Everything here drives a mocked `javax.websocket.Session` (the pattern `CollaborationResourceSpec`
   * established) and registers a `SessionState` directly, so no real workflow is created.
   *
@@ -381,6 +377,18 @@ class WorkflowWebsocketResourceSpec
     resource.myOnMsg(session, frameOf(HeartBeatRequest()))
 
     sentTypes(sent) shouldBe Seq("HeartBeatResponse")
+  }
+
+  it should "report a malformed frame to the client" in {
+    val (session, sent) = mockSession()
+    registerState(session, PrivilegeEnum.WRITE)
+
+    intercept[Exception] {
+      resource.myOnMsg(session, "{")
+    }
+
+    sentTypes(sent) shouldBe Seq("WorkflowErrorEvent")
+    fatalErrorMessages(sent).head should include("Unexpected end-of-input")
   }
 
   // -- the write-access gate ----------------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this PR?

Workflow WebSocket request parsing now runs inside the endpoint's existing error handler. Malformed JSON is reported with the same `WorkflowErrorEvent` used for other request failures, while the parsing exception still reaches the WebSocket container.

A regression test sends incomplete JSON through the real handler and verifies the error event. The existing heartbeat test continues to cover valid input.

Before: Malformed JSON escaped without an error event.

After: Malformed JSON produces a `WorkflowErrorEvent`.

### Any related issues, documentation, discussions?

Closes #8091

### How was this PR tested?

The regression test failed before the production change because no message was sent. After the change, all 16 tests in the WebSocket resource suite passed.

```shell
sbt "set DAO / Compile / sourceGenerators := Seq.empty" "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.WorkflowWebsocketResourceSpec"
sbt "set DAO / Compile / sourceGenerators := Seq.empty" "scalafixAll --check"
sbt scalafmtCheckAll
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex