### PR TITLE
feat(amber): guard logic changes before execution

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/WorkflowWebsocketResource.scala
@@ -96,8 +96,10 @@ class WorkflowWebsocketResource extends LazyLogging {
             sessionState.send(state.resultService.handleResultPagination(paginationRequest))
           )
         case modifyLogicRequest: ModifyLogicRequest =>
-          if (workflowStateOpt.isDefined) {
-            val executionService = workflowStateOpt.get.executionService.getValue
+          workflowStateOpt.foreach { workflowState =>
+            val executionService = Option(workflowState.executionService.getValue).getOrElse(
+              throw new IllegalStateException("workflow execution is not initialized")
+            )
             val modifyLogicResponse =
               executionService.executionReconfigurationService.modifyOperatorLogic(
                 modifyLogicRequest

--- a/amber/src/test/scala/org/apache/texera/web/resource/WorkflowWebsocketResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/WorkflowWebsocketResourceSpec.scala
@@ -93,11 +93,6 @@ import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsJava, SeqHasA
   *   - `myOnOpen`'s missing-`wid`/`cuid` and bogus-privilege paths, which fail with NPE /
   *     IndexOutOfBounds / IllegalArgumentException. A harmless improvement (a default, or a clear
   *     message) would break such a test.
-  *   - `ModifyLogicRequest` with a workflow but no execution: `executionService.getValue` is null,
-  *     so the handler NPEs instead of reporting "workflow execution is not initialized". Same guard
-  *     gap as `case other` below — reported, not pinned. It is also the only input that would tell
-  *     `if (workflowStateOpt.isDefined)` apart from `if (executionStateOpt.isDefined)`, so that
-  *     guard's exact condition is left unpinned on purpose; see the no-workflow case below.
   *   - `ResultPaginationRequest`'s real payload, which needs a DB; only the request/response
   *     pass-through is asserted here, against a stubbed result service.
   *   - the deserialization line, already owned by `TexeraWebSocketRequestSpec`.
@@ -523,17 +518,21 @@ class WorkflowWebsocketResourceSpec
     response.get("errorMessage").asText() shouldBe "7"
   }
 
+  it should "report a ModifyLogicRequest received before execution is initialized" in {
+    val (session, sent) = mockSession(uid = Some(42))
+    val workflow = new TestWorkflowService(9107L)
+    attach(session, PrivilegeEnum.WRITE, workflow)
+
+    val ex = intercept[IllegalStateException] {
+      resource.myOnMsg(session, modifyLogicFrame)
+    }
+
+    ex.getMessage should include("workflow execution is not initialized")
+    sentTypes(sent) shouldBe Seq("WorkflowErrorEvent")
+    fatalErrorMessages(sent).head should include("workflow execution is not initialized")
+  }
+
   it should "ignore a ModifyLogicRequest that arrives before any workflow is attached" in {
-    // The `if (workflowStateOpt.isDefined)` guard, observed false. Without this case the guard could
-    // be replaced by `if (true)` and nothing would notice: the `.get` on the empty Option would
-    // throw NoSuchElementException, the catch-all would turn it into a WorkflowErrorEvent, and the
-    // rethrow would escape — so both assertions here have teeth.
-    //
-    // NOT pinned, and it cannot be: rewriting the guard as `if (executionStateOpt.isDefined)` is
-    // indistinguishable from the current one to every test in this suite. The only input that
-    // separates them is a workflow with no execution, where today's guard NPEs on
-    // `executionService.getValue` and the rewrite quietly does nothing. Pinning either answer would
-    // cement one of them, and the rewrite is arguably the fix.
     val (session, sent) = mockSession(uid = Some(42))
     registerState(session, PrivilegeEnum.WRITE)
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Guard ModifyLogicRequest handling when a workflow exists but its execution has not been initialized.

Before: the handler dereferenced a null execution service and raised a NullPointerException.

After: the handler raises a clear IllegalStateException and sends a WorkflowErrorEvent.

### Any related issues, documentation, discussions?

Closes #8094

### How was this PR tested?

A regression test was added first. It reproduced the bug with 15 tests passing and 1 failing. After the fix, all 16 tests pass.

```
sbt "set DAO / Compile / sourceGenerators := Seq.empty" "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.WorkflowWebsocketResourceSpec"
sbt "set DAO / Compile / sourceGenerators := Seq.empty" "scalafixAll --check"
sbt scalafmtCheckAll
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex