### PR TITLE
fix(frontend): use singular relative time units

### DIFF
--- a/frontend/src/app/common/util/format.util.spec.ts
+++ b/frontend/src/app/common/util/format.util.spec.ts
@@ -96,6 +96,7 @@ describe("formatRelativeTime", () => {
   });
 
   it("formats sub-hour differences in minutes", () => {
+    expect(formatRelativeTime(NOW - 60 * 1000)).toBe("1 minute ago");
     expect(formatRelativeTime(NOW - 5 * 60 * 1000)).toBe("5 minutes ago");
     expect(formatRelativeTime(NOW - 59 * 60 * 1000)).toBe("59 minutes ago");
     // boundary: just-now floors to 0
@@ -103,17 +104,17 @@ describe("formatRelativeTime", () => {
   });
 
   it("formats sub-day differences in hours", () => {
-    expect(formatRelativeTime(NOW - 60 * 60 * 1000)).toBe("1 hours ago");
+    expect(formatRelativeTime(NOW - 60 * 60 * 1000)).toBe("1 hour ago");
     expect(formatRelativeTime(NOW - 23 * 60 * 60 * 1000)).toBe("23 hours ago");
   });
 
   it("formats sub-week differences in days", () => {
-    expect(formatRelativeTime(NOW - 24 * 60 * 60 * 1000)).toBe("1 days ago");
+    expect(formatRelativeTime(NOW - 24 * 60 * 60 * 1000)).toBe("1 day ago");
     expect(formatRelativeTime(NOW - 6 * 24 * 60 * 60 * 1000)).toBe("6 days ago");
   });
 
   it("formats sub-month differences in weeks", () => {
-    expect(formatRelativeTime(NOW - 7 * 24 * 60 * 60 * 1000)).toBe("1 weeks ago");
+    expect(formatRelativeTime(NOW - 7 * 24 * 60 * 60 * 1000)).toBe("1 week ago");
     expect(formatRelativeTime(NOW - 3 * 7 * 24 * 60 * 60 * 1000)).toBe("3 weeks ago");
   });
 

--- a/frontend/src/app/common/util/format.util.ts
+++ b/frontend/src/app/common/util/format.util.ts
@@ -70,13 +70,13 @@ export const formatRelativeTime = (timestamp: number | undefined): string => {
   const weeksAgo = Math.floor(daysAgo / 7);
 
   if (minutesAgo < 60) {
-    return `${minutesAgo} minutes ago`;
+    return `${minutesAgo} minute${minutesAgo === 1 ? "" : "s"} ago`;
   } else if (hoursAgo < 24) {
-    return `${hoursAgo} hours ago`;
+    return `${hoursAgo} hour${hoursAgo === 1 ? "" : "s"} ago`;
   } else if (daysAgo < 7) {
-    return `${daysAgo} days ago`;
+    return `${daysAgo} day${daysAgo === 1 ? "" : "s"} ago`;
   } else if (weeksAgo < 4) {
-    return `${weeksAgo} weeks ago`;
+    return `${weeksAgo} week${weeksAgo === 1 ? "" : "s"} ago`;
   }
   return new Date(timestamp).toLocaleDateString();
 };


### PR DESCRIPTION
### What changes were proposed in this PR?

Relative time labels now use singular units when the value is one while preserving plural units for every other value.

Before: `1 minutes ago`, `1 hours ago`, `1 days ago`, and `1 weeks ago`.
After: `1 minute ago`, `1 hour ago`, `1 day ago`, and `1 week ago`.

### Any related issues, documentation, discussions?

Closes #8108

### How was this PR tested?

`yarn test --include src/app/common/util/format.util.spec.ts`
`yarn format:ci`

Manual:
1. Start Texera locally from this worktree.
2. Set a local workflow creation and edit time to exactly one hour ago.
3. Open Your Work, then Workflows in Chrome.
4. Confirm both labels display `1 hour ago` while older cards retain plural units.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex