### PR TITLE
ci: register the v1.3 release line with Meng Wang as its manager

### DIFF
--- a/.github/release-branches.yml
+++ b/.github/release-branches.yml
@@ -38,6 +38,9 @@
 # `manager` is a GitHub username. It may be omitted (leave the branch as a
 # backport target without an auto-requested reviewer), but is recommended.
 targets:
+  - branch: release/v1.3
+    manager: mengw15
+    actively-supporting: true
   - branch: release/v1.2
     manager: xuang7
     actively-supporting: true


### PR DESCRIPTION
### What changes were proposed in this PR?

Adds `release/v1.3` to the backport automation's active targets, with `mengw15` as its release manager, above the v1.2 entry. Once the branch is cut, `fix:` PRs on main get the `release/v1.3` label by default, Meng is auto-requested as reviewer, and the post-merge backport runs for that line. That is exactly the labelling and review the branch-cut notice asks contributors to do by hand. Until the branch exists the entry is inert: the per-branch existence check finds nothing on `release/v1.3` and skips it. Listing `refs/heads/release/v1.3` in the `.asf.yaml` merge-queue ruleset is a separate follow-up after the cut.

### Any related issues, documentation, discussions?

Closes #8109

- dev@ ANNOUNCEMENT — Meng Wang will serve as Release Manager for release line v1.3: https://lists.apache.org/thread/6yhfrdjtfs5frxls2p6hq0j8hb5mp5m3
- dev@ FYI — branch cut for v1.3 planned for September 1: https://lists.apache.org/thread/ovh5rggd6otwpp8ntm564v7lxd7jndxq

### How was this PR tested?

- Ran the release-branches parser on the edited file; it emits all three targets with v1.3 active and `mengw15` as its manager.
- Config-only change, no workflow logic touched.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
