### PR TITLE
feat(frontend): preview xlsx dataset files

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
@@ -209,6 +209,7 @@ describe("UserDatasetFileRendererComponent", () => {
       expect(getMimeType("data.csv")).toBe(MIME_TYPES.CSV);
       expect(getMimeType("clip.mp4")).toBe(MIME_TYPES.MP4);
       expect(getMimeType("notes.json")).toBe(MIME_TYPES.JSON);
+      expect(getMimeType("report.xlsx")).toBe(MIME_TYPES.MSEXCEL);
     });
 
     it("resolves the extension case-insensitively", () => {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.ts
@@ -54,6 +54,7 @@ export const MIME_TYPES = {
   PDF: "application/pdf",
   MSWORD: "application/msword",
   MSEXCEL: "application/vnd.ms-excel",
+  XLSX: "application/vnd.ms-excel",
   MSPOWERPOINT: "application/vnd.ms-powerpoint",
   MP4: "video/mp4",
   MP3: "audio/mpeg",


### PR DESCRIPTION
### What changes were proposed in this PR?

Map the `.xlsx` extension to the existing Excel preview MIME type. This lets the existing workbook parser render dataset spreadsheets instead of rejecting them as generic binary files.

### Any related issues, documentation, discussions?

Closes #8112

### How was this PR tested?

Regression test before the fix:

`yarn test --include src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts`

The new assertion failed because `.xlsx` resolved to `application/octet-stream`. The other 54 tests passed.

Verification after the fix:

`yarn test --include src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts`

All 55 tests passed.

`yarn format:ci`

Formatting passed.

Live verification in Chrome:

1. Started Texera locally from this worktree.
2. Created a dataset and uploaded a valid `.xlsx` workbook.
3. Confirmed current main showed the unsupported preview message.
4. Confirmed this branch rendered the same workbook as a table.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex