### PR TITLE
fix(frontend): protect selected dataset paths

### DIFF
--- a/frontend/src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.html
+++ b/frontend/src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.html
@@ -20,7 +20,7 @@
   *ngIf="formControl.value || !isFileSelectionEnabled"
   nz-input
   required
-  [readOnly]="isFileSelectionEnabled"
+  [readonly]="isFileSelectionEnabled"
   [formControl]="formControl" />
 <button
   *ngIf="isFileSelectionEnabled"

--- a/frontend/src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.spec.ts
+++ b/frontend/src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.spec.ts
@@ -122,17 +122,10 @@ describe("DatasetFileSelectorComponent", () => {
       expect(selectFileButton().nativeElement.textContent.trim()).toBe("Select File");
     });
 
-    it("leaves the path input editable even with file selection enabled", () => {
+    it("keeps the path input read-only when file selection is enabled", () => {
       render("/dataset/data.csv");
 
-      // Characterizing a defect rather than asserting the intent: the template's
-      // `[readOnly]` is camelCase, so it misses NzInputDirective's `readonly` input and
-      // lands on the DOM property; the directive then host-binds
-      // `[attr.readonly]="readonly() || null"`, which clears the attribute and resets the
-      // property. So the path the picker is meant to own can still be typed over.
-      // Spelling the binding `[readonly]` makes it take effect — a production change, out
-      // of scope here. Flip this expectation to `true` when that lands.
-      expect(input().nativeElement.readOnly).toBe(false);
+      expect(input().nativeElement.readOnly).toBe(true);
     });
 
     it("shows only the Select File button until a path has been chosen", () => {


### PR DESCRIPTION
### What changes were proposed in this PR?

Use the input directive's `readonly` binding for picker-generated dataset paths. This keeps the selected path visible while preventing keyboard edits. Manual path entry remains available when dataset file selection is disabled.

### Any related issues, documentation, discussions?

Closes #8114

### How was this PR tested?

Regression test before the fix:

`yarn test --include src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.spec.ts`

The read-only assertion failed. The other 10 tests passed.

Verification after the fix:

`yarn test --include src/app/workspace/component/dataset-file-selector/dataset-file-selector.component.spec.ts`

All 11 tests passed.

`yarn format:ci`

Formatting passed.

Live verification in Chrome:

1. Started Texera locally from this worktree.
2. Added CSV File Scan to a workflow.
3. Selected a dataset version file.
4. Confirmed current main accepted a keyboard overwrite.
5. Confirmed this branch rejected the same typing action and preserved the selected path.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex