### PR TITLE
fix(frontend): enable operator reuse toolbar

### DIFF
--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -302,7 +302,7 @@
           </button>
           <button
             *ngIf="(operatorMenu.isMarkForReuse || ! operatorMenu.isReuseResultClickable)"
-            [disabled]="true || ! operatorMenu.isReuseResultClickable"
+            [disabled]="! operatorMenu.isReuseResultClickable"
             (click)="operatorMenu.reuseResultHighlightedOperator()"
             nz-button
             title="reuse result if possible">

--- a/frontend/src/app/workspace/component/menu/menu.component.spec.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.spec.ts
@@ -1288,10 +1288,8 @@ describe("MenuComponent", () => {
         expect(utility("disable operators").nativeElement.disabled).toBe(false);
         utility("disable operators").triggerEventHandler("click", null);
         utility("view result").triggerEventHandler("click", null);
-        // The "reuse result if possible" button is hard-disabled in the template
-        // (`[disabled]="true || …"`), so it is asserted, not clicked — firing its handler
-        // would claim an interaction the UI cannot perform.
-        expect(utility("reuse result if possible").nativeElement.disabled).toBe(true);
+        expect(utility("reuse result if possible").nativeElement.disabled).toBe(false);
+        utility("reuse result if possible").triggerEventHandler("click", null);
 
         menu.isDisableOperator = false;
         menu.isToViewResult = false;
@@ -1303,7 +1301,7 @@ describe("MenuComponent", () => {
 
         expect(disable).toHaveBeenCalledTimes(2);
         expect(view).toHaveBeenCalledTimes(2);
-        expect(reuse).toHaveBeenCalledTimes(1);
+        expect(reuse).toHaveBeenCalledTimes(2);
       });
 
       it("wires the export-result button", () => {


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove the hardcoded disable from the operator reuse toolbar button. The existing clickability guard still disables the action when no eligible operator is selected.

### Any related issues, documentation, discussions?

Closes #8116

### How was this PR tested?

Regression test before the fix:

`yarn test --include src/app/workspace/component/menu/menu.component.spec.ts`

The reuse button assertion failed because it remained disabled. The other 97 tests passed.

Verification after the fix:

`yarn test --include src/app/workspace/component/menu/menu.component.spec.ts`

All 98 tests passed.

`yarn format:ci`

Formatting passed.

Live verification in Chrome:

1. Started Texera locally from this worktree.
2. Selected a CSV File Scan operator.
3. Confirmed current main disabled the toolbar reuse action while the context menu action worked.
4. Confirmed this branch marked and unmarked the operator directly from the toolbar.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex