### PR TITLE
refactor(frontend): remove unused computing unit code

### DIFF
--- a/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.scss
+++ b/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.scss
@@ -164,10 +164,6 @@
   i {
     flex-shrink: 0;
   }
-
-  i.ant-dropdown-trigger {
-    margin-left: auto;
-  }
 }
 
 .unit-name-text,

--- a/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.spec.ts
+++ b/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.spec.ts
@@ -1112,13 +1112,6 @@ describe("PowerButtonComponent", () => {
   });
 
   describe("status helpers", () => {
-    it("getButtonText returns 'Connect' with no selection and the unit name otherwise", () => {
-      component.selectedComputingUnit = null;
-      expect(component.getButtonText()).toBe("Connect");
-      component.selectedComputingUnit = makeComputingUnit({ name: "My Unit" });
-      expect(component.getButtonText()).toBe("My Unit");
-    });
-
     it("computeStatus maps selection + status onto badge states", () => {
       component.selectedComputingUnit = null;
       expect(component.computeStatus()).toBe("processing");
@@ -1480,8 +1473,6 @@ describe("PowerButtonComponent", () => {
       expect(component.getSharedMemorySize()).toBe("64Mi");
       expect(component.getCpuLimitUnit()).toBe("CPU");
       expect(component.getMemoryLimitUnit()).toBe("Gi");
-      expect(component.getCpuUnit()).toBe("Cores");
-      expect(component.getMemoryUnit()).toBe("Gi");
     });
 
     it("returns zero usage values and percentages when metrics are unavailable", () => {

--- a/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.ts
+++ b/frontend/src/app/workspace/component/power-button/computing-unit-selection.component.ts
@@ -301,14 +301,6 @@ export class ComputingUnitSelectionComponent implements OnInit {
     return this.selectedComputingUnit != null && this.selectedComputingUnit.status === "Running";
   }
 
-  getButtonText(): string {
-    if (!this.selectedComputingUnit) {
-      return "Connect";
-    } else {
-      return this.selectedComputingUnit.computingUnit.name;
-    }
-  }
-
   computeStatus(): string {
     if (!this.selectedComputingUnit) {
       return "processing";
@@ -563,14 +555,6 @@ export class ComputingUnitSelectionComponent implements OnInit {
 
   getMemoryStatus(): "success" | "exception" | "active" | "normal" {
     return getComputingUnitMemoryStatus(this.getMemoryPercentage());
-  }
-
-  getCpuUnit(): string {
-    return this.getCpuLimitUnit() === "CPU" ? "Cores" : this.getCpuLimitUnit();
-  }
-
-  getMemoryUnit(): string {
-    return this.getMemoryLimitUnit() === "" ? "B" : this.getMemoryLimitUnit();
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove unreachable code from the computing-unit selection component without changing user-facing behavior:

- remove `getButtonText`; the template already renders the selected unit name or `Connect` directly;
- remove `getCpuUnit` and `getMemoryUnit`; the live metrics template uses `getCpuLimitUnit` and `getMemoryLimitUnit`;
- remove the test case and assertions that only preserved those unused helpers; and
- remove `.button-content i.ant-dropdown-trigger`, which cannot match because ng-zorro attaches `ant-dropdown-trigger` to the outer dropdown button, not the inner icon.

Existing DOM tests continue to cover both trigger-button states. No screenshots are included because the removed methods and selector were not part of the rendered behavior, so there is no visible UI change.

### Any related issues, documentation, discussions?

Closes #8119

### How was this PR tested?

The targeted component suite passed before the refactor (109 tests) and after it (108 tests). The removed test was the dedicated test for the unused `getButtonText` helper; live DOM coverage remains unchanged.

```shell
NODE_OPTIONS="--localstorage-file=/private/tmp/texera-vitest-localstorage-root" \
  yarn test --include \
  src/app/workspace/component/power-button/computing-unit-selection.component.spec.ts

yarn prettier --check \
  src/app/workspace/component/power-button/computing-unit-selection.component.ts \
  src/app/workspace/component/power-button/computing-unit-selection.component.spec.ts \
  src/app/workspace/component/power-button/computing-unit-selection.component.scss

yarn eslint \
  src/app/workspace/component/power-button/computing-unit-selection.component.ts \
  src/app/workspace/component/power-button/computing-unit-selection.component.spec.ts

git diff --check
```

Results:

- targeted component tests: 108/108 passed;
- Prettier check: passed;
- ESLint check: passed; and
- `git diff --check`: passed.

### Was this PR authored or co-authored using generative AI tooling?

Co-authored by: OpenAI Codex (GPT-5.6-Sol)