### PR TITLE
test(workflow-core): extend IcebergUtil test coverage

### DIFF
--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/util/IcebergUtilSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/util/IcebergUtilSpec.scala
@@ -22,10 +22,12 @@ package org.apache.texera.amber.util
 import org.apache.texera.amber.core.tuple.{AttributeType, LargeBinary, Schema, Tuple}
 import org.apache.texera.amber.util.IcebergUtil.toIcebergSchema
 import org.apache.hadoop.fs.FileSystem
+import org.apache.iceberg.catalog.{Catalog, TableIdentifier}
 import org.apache.iceberg.data.GenericRecord
-import org.apache.iceberg.exceptions.RESTException
+import org.apache.iceberg.exceptions.{AlreadyExistsException, RESTException}
 import org.apache.iceberg.types.Types
 import org.apache.iceberg.{Schema => IcebergSchema}
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.net.URI
@@ -35,7 +37,7 @@ import java.sql.Timestamp
 import java.time.{LocalDateTime, ZoneId}
 import scala.jdk.CollectionConverters._
 
-class IcebergUtilSpec extends AnyFlatSpec {
+class IcebergUtilSpec extends AnyFlatSpec with MockFactory {
 
   val texeraSchema: Schema = Schema()
     .add("test-1", AttributeType.INTEGER)
@@ -70,6 +72,14 @@ class IcebergUtilSpec extends AnyFlatSpec {
     assert(IcebergUtil.toIcebergType(AttributeType.BINARY) == Types.BinaryType.get())
   }
 
+  it should "reject ANY when converting to an Iceberg Type" in {
+    val exception = intercept[IllegalArgumentException] {
+      IcebergUtil.toIcebergType(AttributeType.ANY)
+    }
+
+    assert(exception.getMessage == "ANY type is not supported in Iceberg")
+  }
+
   it should "convert from Iceberg Type to AttributeType correctly" in {
     assert(IcebergUtil.fromIcebergType(Types.IntegerType.get()) == AttributeType.INTEGER)
     assert(IcebergUtil.fromIcebergType(Types.LongType.get()) == AttributeType.LONG)
@@ -80,6 +90,14 @@ class IcebergUtilSpec extends AnyFlatSpec {
     )
     assert(IcebergUtil.fromIcebergType(Types.StringType.get()) == AttributeType.STRING)
     assert(IcebergUtil.fromIcebergType(Types.BinaryType.get()) == AttributeType.BINARY)
+  }
+
+  it should "reject unsupported primitive Iceberg types" in {
+    val exception = intercept[IllegalArgumentException] {
+      IcebergUtil.fromIcebergType(Types.DateType.get())
+    }
+
+    assert(exception.getMessage == "Unsupported Iceberg type: date")
   }
 
   it should "convert from Texera Schema to Iceberg Schema correctly" in {
@@ -338,6 +356,97 @@ class IcebergUtilSpec extends AnyFlatSpec {
       "table metadata must be written through the local file system"
     )
     assert(IcebergUtil.loadTableMetadata(catalog, "test_namespace", "test_table").nonEmpty)
+    assert(IcebergUtil.loadTableMetadata(catalog, "test_namespace", "missing_table").isEmpty)
+  }
+
+  it should "reject catalogs that do not support namespaces" in {
+    val catalog = mock[Catalog]
+
+    val exception = intercept[IllegalArgumentException] {
+      IcebergUtil.createTable(
+        catalog,
+        "test_namespace",
+        "test_table",
+        icebergSchema,
+        overrideIfExists = true
+      )
+    }
+
+    assert(
+      exception.getMessage ==
+        s"Catalog ${catalog.getClass.getName} does not support namespaces"
+    )
+  }
+
+  it should "drop and recreate an existing table when override is enabled" in {
+    val warehouse = Files.createTempDirectory("iceberg-override-warehouse")
+    val catalog = IcebergUtil.createHadoopCatalog("override_test", warehouse)
+    val originalSchema = IcebergUtil.toIcebergSchema(Schema().add("id", AttributeType.INTEGER))
+    val replacementSchema = IcebergUtil.toIcebergSchema(Schema().add("value", AttributeType.STRING))
+
+    IcebergUtil.createTable(
+      catalog,
+      "test_namespace",
+      "test_table",
+      originalSchema,
+      overrideIfExists = false
+    )
+    val recreatedTable = IcebergUtil.createTable(
+      catalog,
+      "test_namespace",
+      "test_table",
+      replacementSchema,
+      overrideIfExists = true
+    )
+
+    assert(recreatedTable.schema().sameSchema(replacementSchema))
+    assert(
+      catalog
+        .loadTable(TableIdentifier.of("test_namespace", "test_table"))
+        .schema()
+        .sameSchema(replacementSchema)
+    )
+  }
+
+  it should "preserve an existing table when override is disabled" in {
+    val warehouse = Files.createTempDirectory("iceberg-preserve-warehouse")
+    val catalog = IcebergUtil.createHadoopCatalog("preserve_test", warehouse)
+    val originalSchema = IcebergUtil.toIcebergSchema(Schema().add("id", AttributeType.INTEGER))
+    val replacementSchema = IcebergUtil.toIcebergSchema(Schema().add("value", AttributeType.STRING))
+
+    IcebergUtil.createTable(
+      catalog,
+      "test_namespace",
+      "test_table",
+      originalSchema,
+      overrideIfExists = false
+    )
+
+    intercept[AlreadyExistsException] {
+      IcebergUtil.createTable(
+        catalog,
+        "test_namespace",
+        "test_table",
+        replacementSchema,
+        overrideIfExists = false
+      )
+    }
+    assert(
+      catalog
+        .loadTable(TableIdentifier.of("test_namespace", "test_table"))
+        .schema()
+        .sameSchema(originalSchema)
+    )
+  }
+
+  it should "return None when loading table metadata fails" in {
+    val catalog = mock[Catalog]
+    val identifier = TableIdentifier.of("test_namespace", "test_table")
+    (catalog.loadTable _)
+      .expects(identifier)
+      .throwing(new RuntimeException("catalog unavailable"))
+
+    assert(IcebergUtil.loadTableMetadata(catalog, "test_namespace", "test_table").isEmpty)
   }
 
   it should "surface RESTException when createRestCatalog cannot reach the REST endpoint" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR extends test coverage for `IcebergUtil` error and edge contracts without changing production behavior.

| Contract | Added coverage |
| --- | --- |
| Amber `ANY` type | Rejects it with the documented `IllegalArgumentException` |
| Unsupported Iceberg primitive | Rejects `DateType` with the unsupported-type error |
| Catalog without namespace support | Reports the concrete catalog class before attempting table operations |
| Existing table with override enabled | Recreates the table and persists the replacement schema |
| Existing table with override disabled | Raises `AlreadyExistsException` and preserves the original schema |
| Missing table metadata | Returns `None` through a real `HadoopCatalog` |
| Catalog load failure | Returns `None` when `loadTable` raises another runtime exception |

### Any related issues, documentation, discussions?

Closes #8120

### How was this PR tested?

The complete `IcebergUtilSpec` was run with JDK 17 while excluding an unrelated failing DAO test classpath:

```bash
JAVA_HOME=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home PATH=/Library/Java/JavaVirtualMachines/jdk-17.jdk/Contents/Home/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin sbt -Dsbt.log.noformat=true \
  'set WorkflowCore / Test / sources := Seq((WorkflowCore / baseDirectory).value / "src/test/scala/org/apache/texera/amber/util/IcebergUtilSpec.scala", (WorkflowCore / baseDirectory).value / "src/test/java/org/apache/texera/common/tags/NonParallelTest.java")' \
  'set WorkflowCore / Test / internalDependencyClasspath := (WorkflowCore / Compile / fullClasspath).value' \
  'WorkflowCore/testOnly org.apache.texera.amber.util.IcebergUtilSpec' \
  'WorkflowCore/Test/scalafmtCheck'
```

Result: 23 tests passed and the target test source passed the formatting check.

`git diff --check` also passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-5.6-sol)
