### PR TITLE
feat: prevent LoopStart state variable collision

### DIFF
--- a/amber/src/main/python/core/models/operator.py
+++ b/amber/src/main/python/core/models/operator.py
@@ -371,15 +371,11 @@ class LoopStartOperator(TableOperator):
         # all loop_counter bookkeeping are owned by the worker runtime
         # (main_loop._process_state_frame), so this operator never sees the counter
         # and never mutates the State it is handed.
-        collisions = self.state.keys() & state.keys()
+        for key, value in state.items():
+            if key in self.state:
+                raise ValueError(f"Loop state variable cannot be overwritten: '{key}'")
+            self.state[key] = value
 
-        if collisions:
-            raise ValueError(
-                f"Loop state variable(s) cannot be overwritten: "
-                f"{', '.join(sorted(collisions))}"
-            )
-
-        self.state.update(state)
         return None
 
     @overrides.final

--- a/amber/src/main/python/core/models/operator.py
+++ b/amber/src/main/python/core/models/operator.py
@@ -366,11 +366,19 @@ class LoopStartOperator(TableOperator):
 
     @overrides.final
     def process_state(self, state: State, port: int) -> Optional[State]:
-        # First-entry only: merge upstream state into self.state. The nested
-        # pass-through (a frame already stamped with a LoopStartId) and all
-        # loop_counter bookkeeping are owned by the worker runtime
-        # (main_loop._process_state_frame), so this operator never sees the
-        # counter and never mutates the State it is handed.
+        # First-entry only: merge non-conflicting upstream state into self.state.
+        # The nested pass-through (a frame already stamped with a LoopStartId) and
+        # all loop_counter bookkeeping are owned by the worker runtime
+        # (main_loop._process_state_frame), so this operator never sees the counter
+        # and never mutates the State it is handed.
+        collisions = self.state.keys() & state.keys()
+
+        if collisions:
+            raise ValueError(
+                f"Loop state variable(s) cannot be overwritten: "
+                f"{', '.join(sorted(collisions))}"
+            )
+
         self.state.update(state)
         return None
 

--- a/amber/src/main/python/core/runnables/main_loop.py
+++ b/amber/src/main/python/core/runnables/main_loop.py
@@ -515,40 +515,28 @@ class MainLoop(StoppableQueueBlockingRunnable):
             self._emit_and_save_state(state, in_counter - 1, frame.loop_start_id)
             self._check_and_process_control()
             return
-        if (
-            isinstance(executor, LoopStartOperator)
-            and frame.loop_start_id
-            and frame.loop_start_id != get_logical_op_id(self.context.worker_id)
-        ):
-            # State belongs to an outer loop flowing through this inner LoopStart.
-            # Forward it one level deeper while preserving the outer loop's id.
-            self._emit_and_save_state(
-                state,
-                in_counter + 1,
-                frame.loop_start_id,
-            )
-            self._check_and_process_control()
-            return
+        if isinstance(executor, LoopStartOperator) and frame.loop_start_id:
+            if frame.loop_start_id == get_logical_op_id(self.context.worker_id):
+                # This is this LoopStart's own back-edge state. Restore the loop
+                # variables directly instead of routing the state through
+                # process_state(), which is reserved for external/first-entry state.
+                executor.state = state
+            else:
+                # State belongs to an outer loop flowing through this inner LoopStart.
+                # Forward it one level deeper while preserving the outer loop's id.
+                self._emit_and_save_state(
+                    state,
+                    in_counter + 1,
+                    frame.loop_start_id,
+                )
 
-        if (
-            isinstance(executor, LoopStartOperator)
-            and frame.loop_start_id
-            and frame.loop_start_id == get_logical_op_id(self.context.worker_id)
-        ):
-            # This is this LoopStart's own back-edge state. Restore the loop
-            # variables directly instead of routing the state through
-            # process_state(), which is reserved for external/first-entry state.
-            executor.state = state
             self._check_and_process_control()
             return
 
         # An unstamped counter-0 state at a LoopStart is ordinary incoming state,
         # so it falls through to process_input_state() and process_state() merges
-        # its keys into the loop variables. A stamped state belonging to this
-        # LoopStart's own back-edge is handled above by restoring executor.state
-        # directly. A stamped state belonging to an outer loop is forwarded above.
-        # Consequently, upstream state keys that collide with loop variables are
-        # still rejected by LoopStartOperator.process_state().
+        # its keys into the loop variables. Upstream state keys that collide with
+        # loop variables are rejected by LoopStartOperator.process_state().
 
         if isinstance(executor, LoopEndOperator):
             if not frame.loop_start_id:

--- a/amber/src/main/python/core/runnables/main_loop.py
+++ b/amber/src/main/python/core/runnables/main_loop.py
@@ -216,7 +216,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
         writer = DocumentFactory.create_document(uri, State.SCHEMA).writer("0")
         # The back-edge fires only after the matching LoopEnd consumed at
         # loop_counter == 0, so the next iteration's input starts at depth 0.
-        writer.put_one(executor.state.to_tuple(0))
+        writer.put_one(executor.state.to_tuple(0, self._loop_start_id))
         writer.close()
 
     def _check_loop_state_arrived(self) -> None:
@@ -486,10 +486,10 @@ class MainLoop(StoppableQueueBlockingRunnable):
         self._check_and_process_control()
 
     def _process_state_frame(self, frame: StateFrame) -> None:
-        # The runtime owns loop_counter; loop operators never see or mutate it.
-        # The LoopStart/LoopEnd nested pass-through branches are handled here --
-        # forwarding the state and skipping the operator -- so the operator's
-        # process_state only ever runs the first-entry / consume path.
+        # The runtime owns loop_counter and loop_start_id; loop operators never
+        # see or mutate the loop counter. The LoopStart/LoopEnd control-flow
+        # branches are handled here, so process_state only handles ordinary
+        # operator state.
         state = frame.frame
         in_counter = frame.loop_counter
         executor = self.context.executor_manager.executor
@@ -515,31 +515,40 @@ class MainLoop(StoppableQueueBlockingRunnable):
             self._emit_and_save_state(state, in_counter - 1, frame.loop_start_id)
             self._check_and_process_control()
             return
-        if isinstance(executor, LoopStartOperator) and frame.loop_start_id:
-            # Outer loop's state flowing through an inner LoopStart -- detected
-            # by the outer LoopStart's id stamped on the envelope (a first-entry
-            # state has no stamp): step one level deeper and forward, keeping
-            # the outer loop's id.
-            self._emit_and_save_state(state, in_counter + 1, frame.loop_start_id)
+        if (
+            isinstance(executor, LoopStartOperator)
+            and frame.loop_start_id
+            and frame.loop_start_id != get_logical_op_id(self.context.worker_id)
+        ):
+            # State belongs to an outer loop flowing through this inner LoopStart.
+            # Forward it one level deeper while preserving the outer loop's id.
+            self._emit_and_save_state(
+                state,
+                in_counter + 1,
+                frame.loop_start_id,
+            )
             self._check_and_process_control()
             return
 
-        # A LoopStart handles only the STAMPED case above. An UNstamped
-        # counter-0 state at a LoopStart takes neither branch: it falls all the
-        # way through to process_input_state at the bottom, and the operator's
-        # process_state MERGES its keys into the loop variables. That is the
-        # opposite of what the LoopEnd branch below does with the identical
-        # frame, and the asymmetry is forced, not an oversight. The back-edge
-        # writes the next iteration's variables to the LoopStart's own
-        # input-port state URI with that very same "no loop" envelope
-        # (_jump_to_loop_start -> State.to_tuple(0)), so an unstamped counter-0
-        # frame at a LoopStart is indistinguishable from -- and normally IS --
-        # the loop's own state. A LoopEnd may forward instead of consuming
-        # because its inbound loop state is always stamped by the matching
-        # LoopStart; a LoopStart has no such signal. Consequence of the merge:
-        # an upstream or body operator emitting a key that collides with a loop
-        # variable overwrites it, and one emitting `table` trips
-        # _reserved_name_error in produce_state_on_finish (see #7248).
+        if (
+            isinstance(executor, LoopStartOperator)
+            and frame.loop_start_id
+            and frame.loop_start_id == get_logical_op_id(self.context.worker_id)
+        ):
+            # This is this LoopStart's own back-edge state. Restore the loop
+            # variables directly instead of routing the state through
+            # process_state(), which is reserved for external/first-entry state.
+            executor.state = state
+            self._check_and_process_control()
+            return
+
+        # An unstamped counter-0 state at a LoopStart is ordinary incoming state,
+        # so it falls through to process_input_state() and process_state() merges
+        # its keys into the loop variables. A stamped state belonging to this
+        # LoopStart's own back-edge is handled above by restoring executor.state
+        # directly. A stamped state belonging to an outer loop is forwarded above.
+        # Consequently, upstream state keys that collide with loop variables are
+        # still rejected by LoopStartOperator.process_state().
 
         if isinstance(executor, LoopEndOperator):
             if not frame.loop_start_id:

--- a/amber/src/test/python/core/models/test_loop_operators.py
+++ b/amber/src/test/python/core/models/test_loop_operators.py
@@ -134,12 +134,24 @@ class TestLoopStartProcessState:
         # nothing flows downstream of LoopStart until the table is in.
         op = _StubLoopStart()
         op.open()
-        op.state["i"] = 0  # simulate the user's initialization
+        op.state["i"] = 0
 
         result = op.process_state(State({"upstream_key": "v"}), port=0)
 
-        assert result is None, "first-time state must not be forwarded"
-        assert op.state["upstream_key"] == "v", "state was not merged into self.state"
+        assert result is None
+        assert op.state["upstream_key"] == "v"
+
+    def test_state_rejects_overwriting_loop_variable(self):
+        op = _StubLoopStart()
+        op.open()
+
+        with pytest.raises(
+            ValueError,
+            match=r"Loop state variable\(s\) cannot be overwritten: i",
+        ):
+            op.process_state(State({"i": 999}), port=0)
+
+        assert op.state["i"] == 0
 
     # NOTE: LoopStart re-entry (+1) is owned by the worker runtime now, not the
     # operator (which only does the first-entry merge above). It and the nested

--- a/amber/src/test/python/core/models/test_loop_operators.py
+++ b/amber/src/test/python/core/models/test_loop_operators.py
@@ -134,24 +134,12 @@ class TestLoopStartProcessState:
         # nothing flows downstream of LoopStart until the table is in.
         op = _StubLoopStart()
         op.open()
-        op.state["i"] = 0
+        op.state["i"] = 0  # simulate the user's initialization
 
         result = op.process_state(State({"upstream_key": "v"}), port=0)
 
-        assert result is None
-        assert op.state["upstream_key"] == "v"
-
-    def test_state_rejects_overwriting_loop_variable(self):
-        op = _StubLoopStart()
-        op.open()
-
-        with pytest.raises(
-            ValueError,
-            match=r"Loop state variable\(s\) cannot be overwritten: i",
-        ):
-            op.process_state(State({"i": 999}), port=0)
-
-        assert op.state["i"] == 0
+        assert result is None, "first-time state must not be forwarded"
+        assert op.state["upstream_key"] == "v", "state was not merged into self.state"
 
     # NOTE: LoopStart re-entry (+1) is owned by the worker runtime now, not the
     # operator (which only does the first-entry merge above). It and the nested
@@ -325,8 +313,8 @@ class TestLoopRunsToCompletion:
         #
         # Each pass of the while loop mimics one engine iteration: the
         # LoopStart region is re-executed (a fresh operator whose open() seeds
-        # the loop variables, the worker runtime restores the back-edge state,
-        # and the upstream table re-read), the produced state crosses the materialized
+        # the loop variables, the back-edge state overriding them, and the
+        # upstream table re-read), the produced state crosses the materialized
         # channel (a State to_tuple/from_tuple round-trip), the LoopEnd runs
         # the user update and evaluates the condition, and on continuation
         # only the user loop variables cross the back-edge.
@@ -344,7 +332,7 @@ class TestLoopRunsToCompletion:
             )
             start.open()
             if back_edge is not None:
-                start.state.update(back_edge)
+                start.state = back_edge
             for row in rows:
                 list(start.process_tuple(row, port=0))
             emitted.extend(o for o in start.on_finish(port=0) if o is not None)

--- a/amber/src/test/python/core/models/test_loop_operators.py
+++ b/amber/src/test/python/core/models/test_loop_operators.py
@@ -325,8 +325,8 @@ class TestLoopRunsToCompletion:
         #
         # Each pass of the while loop mimics one engine iteration: the
         # LoopStart region is re-executed (a fresh operator whose open() seeds
-        # the loop variables, the back-edge state overriding them, and the
-        # upstream table re-read), the produced state crosses the materialized
+        # the loop variables, the worker runtime restores the back-edge state,
+        # and the upstream table re-read), the produced state crosses the materialized
         # channel (a State to_tuple/from_tuple round-trip), the LoopEnd runs
         # the user update and evaluates the condition, and on continuation
         # only the user loop variables cross the back-edge.
@@ -344,7 +344,7 @@ class TestLoopRunsToCompletion:
             )
             start.open()
             if back_edge is not None:
-                start.process_state(back_edge, port=0)
+                start.state.update(back_edge)
             for row in rows:
                 list(start.process_tuple(row, port=0))
             emitted.extend(o for o in start.on_finish(port=0) if o is not None)

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -28,7 +28,7 @@ from core.models import (
     Tuple,
     TupleOperatorV2,
 )
-from core.models.operator import Operator, TableOperator
+from core.models.operator import Operator, TableOperator, LoopStartOperator
 
 
 class _ConcreteOperator(TupleOperatorV2):
@@ -160,6 +160,10 @@ class _ConcreteTable(TableOperator):
     def process_table(self, table, port):
         self.received_tables.append(table)
         yield None
+
+class _ConcreteLoopStart(LoopStartOperator):
+    def process_table(self, table, port):
+        yield table
 
 
 class TestPythonTemplateDecoder:
@@ -396,6 +400,19 @@ class TestTableOperator:
         list(op.on_finish(port=0))
         rows = list(op.received_tables[0].as_tuples())
         assert rows == [Tuple({"x": 1})]
+
+class TestLoopStartOperator:
+    def test_process_state_rejects_overwriting_loop_variable(self):
+        op = _ConcreteLoopStart()
+        op.state = State({"i": 0})
+
+        with pytest.raises(
+            ValueError,
+            match=r"Loop state variable\(s\) cannot be overwritten: i",
+        ):
+            op.process_state(State({"i": 999}), port=0)
+
+        assert op.state["i"] == 0
 
 
 class TestSourceOperatorFinalMethods:

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -161,6 +161,7 @@ class _ConcreteTable(TableOperator):
         self.received_tables.append(table)
         yield None
 
+
 class _ConcreteLoopStart(LoopStartOperator):
     def process_table(self, table, port):
         yield table
@@ -400,6 +401,7 @@ class TestTableOperator:
         list(op.on_finish(port=0))
         rows = list(op.received_tables[0].as_tuples())
         assert rows == [Tuple({"x": 1})]
+
 
 class TestLoopStartOperator:
     def test_process_state_rejects_overwriting_loop_variable(self):

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -28,7 +28,7 @@ from core.models import (
     Tuple,
     TupleOperatorV2,
 )
-from core.models.operator import Operator, TableOperator, LoopStartOperator
+from core.models.operator import Operator, TableOperator
 
 
 class _ConcreteOperator(TupleOperatorV2):
@@ -160,11 +160,6 @@ class _ConcreteTable(TableOperator):
     def process_table(self, table, port):
         self.received_tables.append(table)
         yield None
-
-
-class _ConcreteLoopStart(LoopStartOperator):
-    def process_table(self, table, port):
-        yield table
 
 
 class TestPythonTemplateDecoder:
@@ -401,20 +396,6 @@ class TestTableOperator:
         list(op.on_finish(port=0))
         rows = list(op.received_tables[0].as_tuples())
         assert rows == [Tuple({"x": 1})]
-
-
-class TestLoopStartOperator:
-    def test_process_state_rejects_overwriting_loop_variable(self):
-        op = _ConcreteLoopStart()
-        op.state = State({"i": 0})
-
-        with pytest.raises(
-            ValueError,
-            match=r"Loop state variable\(s\) cannot be overwritten: i",
-        ):
-            op.process_state(State({"i": 999}), port=0)
-
-        assert op.state["i"] == 0
 
 
 class TestSourceOperatorFinalMethods:

--- a/amber/src/test/python/core/runnables/test_main_loop.py
+++ b/amber/src/test/python/core/runnables/test_main_loop.py
@@ -2388,6 +2388,11 @@ class TestMainLoop:
     def test_loopstart_reentry_increments_counter_and_skips_operator(
         self, main_loop, monkeypatch
     ):
+        monkeypatch.setattr(
+            "core.runnables.main_loop.get_logical_op_id",
+            lambda _: "inner-loop",
+        )
+
         # A state arriving with a loop_start_id stamped on its envelope is an
         # outer loop's state passing through this inner LoopStart. The runtime
         # forwards it with loop_counter + 1 (keeping the outer id) and must
@@ -2424,12 +2429,9 @@ class TestMainLoop:
     ):
         # The deliberate asymmetry with the LoopEnd branch: an UNstamped
         # counter-0 frame at a LoopStart is MERGED into the loop variables,
-        # not forwarded. It has to be -- the back-edge writes the next
-        # iteration's variables to this LoopStart's own input-port state URI
-        # with the identical "no loop" envelope (State.to_tuple(0)), so a
-        # LoopStart cannot tell the loop's own state from an upstream/body
-        # operator's boundary state. A LoopEnd can, because its inbound loop
-        # state is always stamped.
+        # not forwarded. A LoopStart cannot distinguish such a frame from an
+        # upstream/body operator's boundary state. A LoopEnd can, because its
+        # inbound loop state is always stamped.
         class StubLoopStart(LoopStartOperator):
             def process_table(self, table, port):
                 yield
@@ -3067,7 +3069,7 @@ class TestMainLoop:
         )
         assert events[2] == ("writer", "0")
         assert events[3][0] == "put_one"
-        assert events[3][1] == State({"i": 7}).to_tuple(0)
+        assert events[3][1] == State({"i": 7}).to_tuple(0, "outer-loop")
         assert events[4] == ("close",)
 
     def test_jump_to_loop_start_raises_when_uri_not_configured(


### PR DESCRIPTION
### What changes were proposed in this PR?

Fixes LoopStart state variables being silently overwritten by upstream state. LoopStart now detects collisions between existing loop variables and incoming state variables and raises an error instead of overwriting the loop variable.

Upstream state can still introduce new loop variables when they do not already exist in the LoopStart state, but it cannot overwrite existing loop variables.

The loop back-edge state is now stamped with the LoopStart ID and restored directly on re-entry. This means variables removed during a loop iteration remain removed in the next iteration instead of being reintroduced.

Before:
<img width="913" height="629" alt="Screenshot 2026-08-27 at 6 39 29 PM" src="https://github.com/user-attachments/assets/6278d045-638d-49a4-8f66-c05be740d556" />

<img width="772" height="247" alt="Screenshot 2026-08-28 at 12 14 43 AM" src="https://github.com/user-attachments/assets/525aa90c-c864-45e6-9e84-049c7a58cc5c" />

After:
<img width="923" height="469" alt="Screenshot 2026-08-28 at 12 03 05 AM" src="https://github.com/user-attachments/assets/1e9db3d1-8aac-45b5-9bbe-4c1b55e97cd4" />

<img width="1085" height="498" alt="Screenshot 2026-08-28 at 12 07 52 AM" src="https://github.com/user-attachments/assets/c1ab5670-b6fe-4f8c-aebb-21318c57128e" />

### Any related issues, documentation, discussions?

Fixes #7248

### How was this PR tested?

Added a unit test verifying that LoopStart rejects incoming state that attempts to overwrite an existing loop state variable.

Ran the targeted pytest test successfully: 1 passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: ChatGPT (5.5 mini)