### PR TITLE
feat(amber): reject missing hub entity type

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
@@ -320,9 +320,12 @@ class HubResource {
       .getInstance()
       .createDSLContext()
 
+  /** @throws javax.ws.rs.BadRequestException if entityType is missing */
   @GET
   @Path("/count")
   def getCount(@QueryParam("entityType") entityType: EntityType): Integer = {
+    if (entityType == null)
+      throw new BadRequestException("entityType is required")
     val entityTables = EntityTables(entityType).base
     val (table, isPublicColumn) = (entityTables.table, entityTables.isPublicColumn)
 

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
@@ -683,7 +683,8 @@ class HubResourceSpec
   }
 
   it should "reject a missing entity type" in {
-    intercept[BadRequestException](hub.getCount(null))
+    val thrown = intercept[BadRequestException](hub.getCount(null))
+    thrown.getMessage shouldBe "entityType is required"
     intercept[BadRequestException](hub.getTops(null, null, null, null))
   }
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject a missing `entityType` on the hub count endpoint with a 400 response before selecting an entity table. Add a regression test for the missing parameter while preserving the valid workflow count behavior.

Before: missing `entityType` returned 500.

After: missing `entityType` returns 400 with `entityType is required`.

### Any related issues, documentation, discussions?

Closes #8129

### How was this PR tested?

- `sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.hub.HubResourceSpec"`
- `sbt scalafmtCheckAll`
- `sbt "scalafixAll --check"`
- Built and launched `texera-web` from this worktree. `GET /api/hub/count` returned 400 with the expected message, and `GET /api/hub/count?entityType=workflow` returned 200.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex