### PR TITLE
feat(amber): reject missing top-list entity type

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
@@ -418,7 +418,9 @@ class HubResource {
       @QueryParam("uid") uid: Integer,
       @QueryParam("limit") limit: Integer
   ): java.util.Map[String, java.util.List[DashboardClickableFileEntry]] = {
-    val tableSet = EntityTables(entityType)
+    val tableSet = EntityTables(
+      Option(entityType).getOrElse(throw new BadRequestException("entityType is required"))
+    )
     val baseTable = tableSet.base
     val isPublicColumn = baseTable.isPublicColumn
     val baseIdColumn = baseTable.idColumn

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
@@ -408,6 +408,8 @@ class HubResource {
     * @return             A Map from each actionType.value (e.g. "like", "clone")
     *                     to a List of DashboardClickableFileEntry containing the top 8
     *                     public entities of that type.
+    * @throws javax.ws.rs.BadRequestException if entityType is missing, or if actionTypes
+    *         contains an unsupported value.
     */
   @GET
   @Path("/getTops")
@@ -418,9 +420,9 @@ class HubResource {
       @QueryParam("uid") uid: Integer,
       @QueryParam("limit") limit: Integer
   ): java.util.Map[String, java.util.List[DashboardClickableFileEntry]] = {
-    val tableSet = EntityTables(
-      Option(entityType).getOrElse(throw new BadRequestException("entityType is required"))
-    )
+    if (entityType == null)
+      throw new BadRequestException("entityType is required")
+    val tableSet = EntityTables(entityType)
     val baseTable = tableSet.base
     val isPublicColumn = baseTable.isPublicColumn
     val baseIdColumn = baseTable.idColumn

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
@@ -759,6 +759,11 @@ class HubResourceSpec
     hub.getTops(Wf, null, null, null).asScala.keySet shouldBe Set("like", "clone")
   }
 
+  it should "reject a missing entity type as a bad request" in {
+    val thrown = intercept[BadRequestException](hub.getTops(null, null, null, null))
+    thrown.getMessage shouldBe "entityType is required"
+  }
+
   // Regression: the default bucket list ([like, clone]) used to drive getTops into a
   // throwing CloneTable(Dataset), making this plain request a 500.
   it should "answer for a cloneless entity type instead of failing on its absent clone table" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject a missing `entityType` on the hub top-list endpoint with a 400 response before selecting an entity table. Add a regression test for the missing parameter while preserving valid top-list requests.

Before: missing `entityType` returned 500.

After: missing `entityType` returns 400 with `entityType is required`.

### Any related issues, documentation, discussions?

Closes #8135

### How was this PR tested?

- `sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.hub.HubResourceSpec"`
- `sbt scalafmtCheckAll`
- `sbt "scalafixAll --check"`
- Built and launched `texera-web` from this worktree. `GET /api/hub/getTops` returned 400 with the expected message, and `GET /api/hub/getTops?entityType=workflow&limit=1` returned 200.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex