### PR TITLE
feat(amber): reject mismatched hub access queries

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
@@ -89,18 +89,24 @@ object HubResource {
   )
 
   /**
-    * Checks if a given user has liked a specific entity.
+    * Checks, for each requested entity, whether the given user has liked it.
     *
     * @param userId The ID of the user.
-    * @param entityId The ID of the entity.
-    * @param entityType The type of entity being checked (must be validated).
-    * @return `true` if the user has liked the entity, otherwise `false`.
+    * @param entityIds The entity IDs. Must have the same length as entityTypes.
+    * @param entityTypes The entity types. Must have the same length as entityIds.
+    * @return The liked status for each entity.
+    * @throws javax.ws.rs.BadRequestException if the lists have different lengths
     */
   def isLikedHelper(
       userId: Integer,
       entityIds: java.util.List[Integer],
       entityTypes: java.util.List[EntityType]
   ): java.util.List[LikedResponse] = {
+    if (entityTypes.size() != entityIds.size())
+      throw new BadRequestException(
+        "'entityType' and 'entityId' query parameter lists must have equal length."
+      )
+
     val reqs: List[UserRequest] =
       entityTypes.asScala
         .zip(entityIds.asScala)
@@ -639,6 +645,7 @@ class HubResource {
     *                     - entityType: the resource type
     *                     - entityId: the resource ID
     *                     - userIds:  the list of user IDs with access to that resource
+    * @throws javax.ws.rs.BadRequestException if the lists have different lengths
     */
   @GET
   @Path("/user-access")
@@ -647,6 +654,11 @@ class HubResource {
       @QueryParam("entityType") entityTypes: java.util.List[EntityType],
       @QueryParam("entityId") entityIds: java.util.List[Integer]
   ): java.util.List[AccessResponse] = {
+    if (entityTypes.size() != entityIds.size())
+      throw new BadRequestException(
+        "'entityType' and 'entityId' query parameter lists must have equal length."
+      )
+
     val reqs =
       entityIds.asScala
         .zip(entityTypes.asScala)

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
@@ -561,6 +561,15 @@ class HubResourceSpec
     isLikedHelper(Integer.valueOf(ownerUid), ids(), types()).asScala shouldBe empty
   }
 
+  it should "reject mismatched entity type and id lists" in {
+    intercept[BadRequestException](
+      isLikedHelper(Integer.valueOf(ownerUid), ids(wid, 810000), types(Wf))
+    )
+    intercept[BadRequestException](
+      isLikedHelper(Integer.valueOf(ownerUid), ids(wid), types(Wf, Ds))
+    )
+  }
+
   "isLiked" should "resolve the liked flag against the session user, not another user" in {
     seedWorkflow(810304, "wf_session_like")
     seedWorkflowLike(810304, ownerUid)
@@ -843,6 +852,11 @@ class HubResourceSpec
     val response = new HubResource().userAccess(types(Wf), ids(wid)).asScala.head
     response.entityId shouldBe Integer.valueOf(wid)
     response.userIds.asScala should contain(Integer.valueOf(ownerUid))
+  }
+
+  it should "reject mismatched entity type and id lists" in {
+    intercept[BadRequestException](hub.userAccess(types(Wf), ids(wid, 810000)))
+    intercept[BadRequestException](hub.userAccess(types(Wf, Ds), ids(wid)))
   }
 
   it should "return each entity's grantees from that entity's own access table" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject hub user-access and isLiked requests whose entityType and entityId query lists have different lengths. Cover both mismatch directions while preserving empty and equal-length requests.

Before: unmatched query values were silently dropped.

After: mismatched lists return 400 with a clear message.

### Any related issues, documentation, discussions?

Closes #8137

### How was this PR tested?

- sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.hub.HubResourceSpec"
- sbt scalafmtCheckAll
- The focused suite is currently blocked before the spec by upstream JOOQ generation mismatches for DefaultViewEnum and LAKEKEEPER_WAREHOUSE_NAME.
- Earlier live checks confirmed both mismatch directions return 400 and an equal-length request returns 200.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex