### PR TITLE
feat(amber): return 404 for unavailable public workflow

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -840,8 +840,9 @@ class WorkflowResource extends LazyLogging {
       .where(WORKFLOW.WID.eq(wid))
       .and(WORKFLOW.IS_PUBLIC.isTrue)
       .fetchOne()
-    if (workflow == null)
+    if (workflow == null) {
       throw new NotFoundException(s"Public workflow with id $wid not found")
+    }
     WorkflowWithPrivilege(
       workflow.getName,
       workflow.getDescription,

--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -840,6 +840,8 @@ class WorkflowResource extends LazyLogging {
       .where(WORKFLOW.WID.eq(wid))
       .and(WORKFLOW.IS_PUBLIC.isTrue)
       .fetchOne()
+    if (workflow == null)
+      throw new NotFoundException(s"Public workflow with id $wid not found")
     WorkflowWithPrivilege(
       workflow.getName,
       workflow.getDescription,

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -1027,6 +1027,12 @@ class WorkflowResourceSpec
     assertThrows[ForbiddenException](workflowResource.makePublic(wid, sessionUser2))
   }
 
+  "WorkflowResource.retrievePublicWorkflow" should "hide private and missing workflows" in {
+    val wid = seedWorkflow(sessionUser1, "private-wf").workflow.getWid
+    assertThrows[NotFoundException](workflowResource.retrievePublicWorkflow(wid))
+    assertThrows[NotFoundException](workflowResource.retrievePublicWorkflow(wid + 100000))
+  }
+
   "WorkflowResource.searchWorkflowByOperator" should "return only workflows whose content contains the operator" in {
     val wid = seedWorkflow(
       sessionUser1,

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResourceCoverSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResourceCoverSpec.scala
@@ -152,21 +152,6 @@ class WorkflowResourceCoverSpec
       .execute()
   }
 
-  "retrievePublicWorkflow" should "return a public workflow" in {
-    val workflow = workflowDao.fetchOneByWid(testWid)
-    workflow.setIsPublic(true)
-    workflowDao.update(workflow)
-
-    val result = resource.retrievePublicWorkflow(testWid)
-    result.wid shouldBe Integer.valueOf(testWid)
-    result.readonly shouldBe true
-  }
-
-  it should "reject private and missing workflows as not found" in {
-    assertThrows[NotFoundException](resource.retrievePublicWorkflow(testWid))
-    assertThrows[NotFoundException](resource.retrievePublicWorkflow(testWid + 1))
-  }
-
   "getCoverImage" should "throw NotFoundException when no cover is set" in {
     assertThrows[NotFoundException] {
       resource.getCoverImage(testWid, session(owner))

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResourceCoverSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResourceCoverSpec.scala
@@ -152,6 +152,21 @@ class WorkflowResourceCoverSpec
       .execute()
   }
 
+  "retrievePublicWorkflow" should "return a public workflow" in {
+    val workflow = workflowDao.fetchOneByWid(testWid)
+    workflow.setIsPublic(true)
+    workflowDao.update(workflow)
+
+    val result = resource.retrievePublicWorkflow(testWid)
+    result.wid shouldBe Integer.valueOf(testWid)
+    result.readonly shouldBe true
+  }
+
+  it should "reject private and missing workflows as not found" in {
+    assertThrows[NotFoundException](resource.retrievePublicWorkflow(testWid))
+    assertThrows[NotFoundException](resource.retrievePublicWorkflow(testWid + 1))
+  }
+
   "getCoverImage" should "throw NotFoundException when no cover is set" in {
     assertThrows[NotFoundException] {
       resource.getCoverImage(testWid, session(owner))


### PR DESCRIPTION
### What changes were proposed in this PR?

Return 404 when the public-workflow query finds no record instead of dereferencing a null result. The existing makePublic test supplies the positive case. This PR adds private and missing regression coverage in WorkflowResourceSpec.

Before: private and missing workflows returned 500.

After: private and missing workflows return 404, while a public workflow still returns 200.

### Any related issues, documentation, discussions?

Closes #8139

### How was this PR tested?

- `sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.file.WorkflowResourceSpec"`
- `sbt scalafmtCheckAll`
- `sbt "scalafixAll --check"`
- Built and launched `texera-web` from this worktree. Missing and private workflow requests returned 404. A temporarily public local workflow returned 200 and was restored to private afterward.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex