### PR TITLE
feat(amber): reject missing workflow metadata ID

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -859,6 +859,8 @@ class WorkflowResource extends LazyLogging {
   @Produces(Array(MediaType.TEXT_PLAIN))
   @Path("/owner_name")
   def getOwnerName(@QueryParam("wid") wid: Integer): String = {
+    if (wid == null)
+      throw new BadRequestException("wid is required")
     context
       .select(USER.NAME)
       .from(USER)
@@ -871,6 +873,8 @@ class WorkflowResource extends LazyLogging {
   @GET
   @Path("/workflow_name")
   def getWorkflowName(@QueryParam("wid") wid: Integer): String = {
+    if (wid == null)
+      throw new BadRequestException("wid is required")
     context
       .select(
         WORKFLOW.NAME
@@ -906,6 +910,8 @@ class WorkflowResource extends LazyLogging {
   @GET
   @Path("/workflow_description")
   def getWorkflowDescription(@QueryParam("wid") wid: Integer): String = {
+    if (wid == null)
+      throw new BadRequestException("wid is required")
     context
       .select(
         WORKFLOW.DESCRIPTION

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResourceCoverSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResourceCoverSpec.scala
@@ -152,6 +152,18 @@ class WorkflowResourceCoverSpec
       .execute()
   }
 
+  "workflow metadata" should "return the workflow owner, name and description" in {
+    resource.getOwnerName(testWid) shouldBe "cover_owner"
+    resource.getWorkflowName(testWid) shouldBe "cover_test_workflow"
+    resource.getWorkflowDescription(testWid) shouldBe "desc"
+  }
+
+  it should "reject a missing workflow id" in {
+    assertThrows[BadRequestException](resource.getOwnerName(null))
+    assertThrows[BadRequestException](resource.getWorkflowName(null))
+    assertThrows[BadRequestException](resource.getWorkflowDescription(null))
+  }
+
   "getCoverImage" should "throw NotFoundException when no cover is set" in {
     assertThrows[NotFoundException] {
       resource.getCoverImage(testWid, session(owner))


### PR DESCRIPTION
### What changes were proposed in this PR?

Return `400 Bad Request` when the workflow name or description endpoint is called without the required workflow ID. Add positive coverage for existing metadata and negative coverage for the missing ID.

Before: missing workflow ID returned `204 No Content`.
After: missing workflow ID returns `400 Bad Request` with `wid is required`.

### Any related issues, documentation, discussions?

Closes #8141

### How was this PR tested?

- `sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.user.workflow.WorkflowResourceCoverSpec"`
- `sbt scalafmtCheckAll`
- `sbt "scalafixAll --check"`
- Built with `bin/local-dev.sh up texera-web --build --json` and ran the generated distribution on localhost.
- Verified both metadata endpoints without `wid` return 400 and both requests with `wid=7` still return 200 with the stored values.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex