### PR TITLE
feat(amber): reject invalid dashboard resource type

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
@@ -105,7 +105,7 @@ object DashboardResource {
         val datasetQuery = DatasetSearchQueryBuilder.constructQuery(uid, params, includePublic)
         val modelQuery = ModelSearchQueryBuilder.constructQuery(uid, params, includePublic)
         workflowQuery.unionAll(datasetQuery).unionAll(modelQuery)
-      case _ => throw new IllegalArgumentException(s"Unknown resource type: ${params.resourceType}")
+      case _ => throw new BadRequestException(s"Unknown resource type: ${params.resourceType}")
     }
 
     val finalQuery =

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
@@ -28,6 +28,8 @@ import org.jooq.{OrderField, SQLDialect}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import javax.ws.rs.BadRequestException
+
 /**
   * Covers the connection-free surface of [[DashboardResource]]: the `orderBy`
   * translation and the resource-type dispatch guard.
@@ -128,7 +130,7 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
     // constructQuery / SqlServer, so this is reachable with no database. The
     // exception *type* is the real assertion: if the guard were moved below the
     // query construction, this would surface as a SqlServer failure instead.
-    val thrown = the[IllegalArgumentException] thrownBy DashboardResource.searchAllResources(
+    val thrown = the[BadRequestException] thrownBy DashboardResource.searchAllResources(
       new SessionUser(new User()), // uid stays null; unused on this path
       SearchQueryParams(resourceType = "notAResourceType")
     )
@@ -138,7 +140,7 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
   it should "reject a resourceType that only differs from a valid one by case" in {
     // Guards against someone relaxing the match to be case-insensitive on one
     // side only: "Workflow" is not "workflow" today.
-    val thrown = the[IllegalArgumentException] thrownBy DashboardResource.searchAllResources(
+    val thrown = the[BadRequestException] thrownBy DashboardResource.searchAllResources(
       new SessionUser(new User()),
       SearchQueryParams(resourceType = "Workflow")
     )


### PR DESCRIPTION
### What changes were proposed in this PR?

Map an unknown dashboard `resourceType` to `BadRequestException` instead of an unhandled `IllegalArgumentException`. Update the existing invalid-type regression coverage for the HTTP-facing exception.

Before: unknown resource type returned 500.
After: unknown resource type returns 400 with a specific message.

### Any related issues, documentation, discussions?

Closes #8143

### How was this PR tested?

- `sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.DashboardResourceSpec"`
- `sbt scalafmtCheckAll`
- `sbt "scalafixAll --check"`
- Built with `bin/local-dev.sh up texera-web --build --json` and ran the generated distribution on localhost.
- Verified `resourceType=bogus` returns 400 with `Unknown resource type: bogus` and `resourceType=workflow` still returns 200.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex