### PR TITLE
feat(amber): reject invalid dashboard pagination

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
@@ -50,6 +50,9 @@ object DashboardResource {
       hasMismatch: Boolean = false
   )
 
+  private val SearchResultLookahead = 1
+  private[dashboard] val MaxSearchCount = Int.MaxValue - SearchResultLookahead
+
   /*
    The following class describe the available params from the frontend for full text search.
    * @param user       The authenticated user performing the search.
@@ -64,7 +67,7 @@ object DashboardResource {
    * @param operators         A list of operators to include in the search results.
    * @param projectIds        A list of project IDs to include in the search results.
    * @param offset            The number of initial results to skip. This is useful for implementing pagination.
-   * @param count             The maximum number of results to return.
+   * @param count             The maximum number of results to return, from 0 through [[MaxSearchCount]].
    * @param orderBy           The order in which to sort the results. Acceptable values are 'NameAsc', 'NameDesc', 'CreateTimeDesc', and 'EditTimeDesc'.
    */
   case class SearchQueryParams(
@@ -91,6 +94,10 @@ object DashboardResource {
       @BeanParam params: SearchQueryParams,
       includePublic: Boolean = false
   ): DashboardSearchResult = {
+    if (params.offset < 0 || params.count < 0 || params.count > MaxSearchCount)
+      throw new BadRequestException(
+        s"start must be non-negative and count must be between 0 and $MaxSearchCount"
+      )
     val uid = user.getUid
     val query = params.resourceType match {
       case SearchQueryBuilder.WORKFLOW_RESOURCE_TYPE =>
@@ -108,7 +115,10 @@ object DashboardResource {
     }
 
     val finalQuery =
-      query.orderBy(getOrderFields(params): _*).offset(params.offset).limit(params.count + 1)
+      query
+        .orderBy(getOrderFields(params): _*)
+        .offset(params.offset)
+        .limit(params.count + SearchResultLookahead)
     val queryResult = finalQuery.fetch()
 
     val allEntries = queryResult.asScala.toList

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
@@ -25,12 +25,13 @@ import org.apache.texera.web.resource.dashboard.DashboardResource.SearchQueryPar
 import org.jooq.impl.{DSL => JDSL}
 import org.jooq.{OrderField, SQLDialect}
 
+import javax.ws.rs.BadRequestException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 /**
   * Covers the connection-free surface of [[DashboardResource]]: the `orderBy`
-  * translation and the resource-type dispatch guard.
+  * translation, resource-type dispatch, and pagination guard.
   *
   * Breakage this catches:
   *   - a column of the `orderBy` grammar wired to the wrong unified-schema
@@ -42,7 +43,8 @@ import org.scalatest.matchers.should.Matchers
   *   - the regex losing its implicit anchoring (`Regex.unapplySeq` requires a
   *     full match), which would start accepting junk like `SortByNameAsc`;
   *   - an unrecognised `orderBy` no longer degrading to "no ORDER BY", or the
-  *     unknown-resourceType guard no longer throwing before the query is built.
+  *     unknown-resourceType guard no longer throwing before the query is built;
+  *   - invalid pagination reaching the database query.
   *
   * Note on the shared global `FulltextSearchQueryUtils.usePgroonga`: nothing
   * exercised here reads or writes it, so this spec neither depends on its value
@@ -59,6 +61,15 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
 
   private def orderSql(orderBy: String): List[String] =
     DashboardResource.getOrderFields(SearchQueryParams(orderBy = orderBy)).map(sqlOf)
+
+  private def assertInvalidPagination(params: SearchQueryParams): Unit = {
+    val thrown = the[BadRequestException] thrownBy DashboardResource.searchAllResources(
+      new SessionUser(new User()),
+      params
+    )
+    thrown.getMessage shouldBe
+      "start must be non-negative and count must be between 0 and 2147483646"
+  }
 
   // -- getOrderFields: the recognised grammar ---------------------------------
 
@@ -121,9 +132,44 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
   // every one of them maps to a non-null Field, so getColumnField never
   // returns None.
 
-  // -- searchAllResources: the dispatch guard --------------------------------
+  // -- searchAllResources: pagination and dispatch guards --------------------
 
-  "searchAllResources" should "reject an unknown resourceType before it builds any query" in {
+  "searchAllResources" should "reject a negative start" in {
+    assertInvalidPagination(SearchQueryParams(offset = -1))
+  }
+
+  it should "reject a negative count" in {
+    assertInvalidPagination(SearchQueryParams(count = -1))
+  }
+
+  it should "reject a count that overflows the query limit" in {
+    assertInvalidPagination(SearchQueryParams(count = Int.MaxValue))
+  }
+
+  it should "allow the largest valid count" in {
+    // The maximum passes pagination validation, so dispatch must reject the unknown resource type.
+    intercept[IllegalArgumentException](
+      DashboardResource.searchAllResources(
+        new SessionUser(new User()),
+        SearchQueryParams(
+          count = DashboardResource.MaxSearchCount,
+          resourceType = "notAResourceType"
+        )
+      )
+    )
+  }
+
+  it should "allow zero pagination values" in {
+    // Zero passes pagination validation, so dispatch must reject the unknown resource type.
+    intercept[IllegalArgumentException](
+      DashboardResource.searchAllResources(
+        new SessionUser(new User()),
+        SearchQueryParams(offset = 0, count = 0, resourceType = "notAResourceType")
+      )
+    )
+  }
+
+  it should "reject an unknown resourceType before it builds any query" in {
     // The `case _ => throw` arm sits in the dispatch match, ahead of
     // constructQuery / SqlServer, so this is reachable with no database. The
     // exception *type* is the real assertion: if the guard were moved below the


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject negative dashboard search start and count values, and reject counts above the largest value that can safely include the one-row lookahead. Define the lookahead and maximum count once, and cover both accepted boundaries.

Before: negative start returned 500, negative count returned an inconsistent 200 response, and Int.MaxValue overflowed the query limit.

After: invalid pagination returns 400, while zero and the maximum safe count remain valid.

### Any related issues, documentation, discussions?

Closes #8145

### How was this PR tested?

- sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.DashboardResourceSpec"
- sbt scalafmtCheckAll
- The focused suite is currently blocked before the spec by upstream JOOQ generation mismatches for DefaultViewEnum and LAKEKEEPER_WAREHOUSE_NAME.
- Earlier live checks confirmed negative start and count return 400 while zero remains valid.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex