### PR TITLE
feat(amber): reject invalid dashboard sort

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
@@ -66,7 +66,7 @@ object DashboardResource {
    * @param modelIds          A list of model IDs to include in the search results.
    * @param offset            The number of initial results to skip. This is useful for implementing pagination.
    * @param count             The maximum number of results to return.
-   * @param orderBy           The order in which to sort the results. Acceptable values are 'NameAsc', 'NameDesc', 'CreateTimeDesc', and 'EditTimeDesc'.
+   * @param orderBy           The order in which to sort the results. Acceptable values are 'NameAsc', 'NameDesc', 'CreateTimeAsc', 'CreateTimeDesc', 'EditTimeAsc', 'EditTimeDesc', 'ExecutionTimeAsc', and 'ExecutionTimeDesc'.
    */
   case class SearchQueryParams(
       @QueryParam("query") keywords: java.util.List[String] = new util.ArrayList[String](),
@@ -152,28 +152,23 @@ object DashboardResource {
     searchQueryParams.orderBy match {
       case pattern(column, order) =>
         val field = getColumnField(column)
-        field match {
-          case Some(value) =>
-            List(order match {
-              case "Asc"  => value.asc()
-              case "Desc" => value.desc().nullsLast()
-            })
-          case None => List()
-        }
-      case _ => List() // Default case if the orderBy string doesn't match the pattern
+        List(order match {
+          case "Asc"  => field.asc()
+          case "Desc" => field.desc().nullsLast()
+        })
+      case _ => throw new BadRequestException(s"Unknown orderBy: ${searchQueryParams.orderBy}")
     }
   }
 
-  // Helper method to map column names to actual database fields based on resource type
-  private def getColumnField(columnName: String): Option[Field[_]] = {
-    Option(columnName match {
+  // Maps an order-column name from the orderBy grammar to its unified-schema field.
+  private def getColumnField(columnName: String): Field[_] =
+    columnName match {
       case "Name"          => UnifiedResourceSchema.resourceNameField
       case "CreateTime"    => UnifiedResourceSchema.resourceCreationTimeField
       case "EditTime"      => UnifiedResourceSchema.resourceLastModifiedTimeField
       case "ExecutionTime" => UnifiedResourceSchema.resourceExecutionTimeField
-      case _               => null // Default case for unmatched resource types or column names
-    })
-  }
+      case _               => throw new IllegalStateException(s"Unknown order column: $columnName")
+    }
 
 }
 

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
@@ -25,6 +25,7 @@ import org.apache.texera.web.resource.dashboard.DashboardResource.SearchQueryPar
 import org.jooq.impl.{DSL => JDSL}
 import org.jooq.{OrderField, SQLDialect}
 
+import javax.ws.rs.BadRequestException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -41,7 +42,7 @@ import org.scalatest.matchers.should.Matchers
   *     execution time land;
   *   - the regex losing its implicit anchoring (`Regex.unapplySeq` requires a
   *     full match), which would start accepting junk like `SortByNameAsc`;
-  *   - an unrecognised `orderBy` no longer degrading to "no ORDER BY", or the
+  *   - an unrecognised `orderBy` not being rejected, or the
   *     unknown-resourceType guard no longer throwing before the query is built.
   *
   * Note on the shared global `FulltextSearchQueryUtils.usePgroonga`: nothing
@@ -101,25 +102,24 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
 
   // -- getOrderFields: everything the grammar rejects -------------------------
 
-  it should "fall back to no ordering at all when orderBy does not match the pattern" in {
-    // Consequence of the empty list: the query runs unordered while
-    // offset/limit still apply, so pagination silently becomes
-    // non-deterministic. Pin the inputs that take this branch.
-    orderSql("") shouldBe empty // the frontend can send an empty query param
-    orderSql("Bogus") shouldBe empty
-    orderSql("NameSideways") shouldBe empty // known column, junk direction
-    orderSql("Name") shouldBe empty // direction missing entirely
-    orderSql("nameAsc") shouldBe empty // the regex is case-sensitive
-    orderSql("SortByNameAsc") shouldBe empty // Regex.unapplySeq anchors the
-    orderSql("NameAscending") shouldBe empty // whole string, both ends
+  it should "reject values outside the orderBy grammar" in {
+    Seq(
+      "", // present but empty query parameter
+      "Bogus", // unknown column and direction
+      "NameSideways", // known column with an unknown direction
+      "Name", // missing direction
+      "nameAsc", // case-sensitive grammar
+      "SortByNameAsc", // invalid prefix proves start anchoring
+      "NameAscending" // invalid suffix proves end anchoring
+    )
+      .foreach { orderBy =>
+        val thrown = the[BadRequestException] thrownBy orderSql(orderBy)
+        thrown.getMessage shouldBe s"Unknown orderBy: $orderBy"
+      }
   }
 
-  // Two branches in this area are unreachable and are therefore deliberately
-  // NOT tested: `case None => List()` inside getOrderFields and
-  // `case _ => null` inside the private getColumnField. The regex can only
-  // yield the four column names Name/CreateTime/EditTime/ExecutionTime, and
-  // every one of them maps to a non-null Field, so getColumnField never
-  // returns None.
+  // The defensive default inside getColumnField is unreachable because the
+  // regex can only yield the four mapped column names.
 
   // -- searchAllResources: the dispatch guard --------------------------------
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject dashboard sort values outside the documented `orderBy` grammar instead of silently removing query ordering. Keep all existing valid sort mappings unchanged. A present but empty `orderBy` value is invalid and now returns 400. Omitting the parameter still uses the default sort.

Before: an unknown or empty sort value returned 200 with unordered pagination.
After: an unknown or empty sort value returns 400 with the rejected value.

### Any related issues, documentation, discussions?

Closes #8147

### How was this PR tested?

- `sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.DashboardResourceSpec"`
- `sbt scalafmtCheckAll`
- `sbt "scalafixAll --check"`
- Built with `bin/local-dev.sh up texera-web --build --json` and ran the generated distribution on localhost.
- Verified `orderBy=Bogus` returns 400 and `orderBy=NameAsc` still returns 200.
- The latest focused local rerun is blocked before the spec by unrelated generated JOOQ mismatches on the shared development database. `sbt scalafmtCheckAll` passes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex