### PR TITLE
feat(amber): validate dashboard date filters

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
@@ -23,13 +23,21 @@ import org.jooq.impl.DSL.{condition, noCondition}
 import org.jooq.{Condition, Field}
 
 import java.sql.Timestamp
-import java.text.{ParseException, SimpleDateFormat}
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
 import java.util.concurrent.TimeUnit
+import javax.ws.rs.BadRequestException
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object FulltextSearchQueryUtils {
 
   var usePgroonga: Boolean = true // only override by tests
+
+  private def parseDate(value: String): Timestamp =
+    try Timestamp.valueOf(LocalDate.parse(value).atStartOfDay)
+    catch {
+      case _: DateTimeParseException => throw new BadRequestException(s"Invalid date: $value")
+    }
 
   def getFullTextSearchFilter(
       keywords: Seq[String],
@@ -101,7 +109,6 @@ object FulltextSearchQueryUtils {
     * @param fieldToFilterOn the field for applying the start and end dates.
     * @return A Condition object that can be used to filter workflows based on the date range and type.
     */
-  @throws[ParseException]
   def getDateFilter(
       startDate: String,
       endDate: String,
@@ -110,15 +117,14 @@ object FulltextSearchQueryUtils {
     if (startDate.nonEmpty || endDate.nonEmpty) {
       val start = if (startDate.nonEmpty) startDate else "1970-01-01"
       val end = if (endDate.nonEmpty) endDate else "9999-12-31"
-      val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
 
-      val startTimestamp = new Timestamp(dateFormat.parse(start).getTime)
+      val startTimestamp = parseDate(start)
       val endTimestamp =
         if (end == "9999-12-31") {
-          new Timestamp(dateFormat.parse(end).getTime)
+          parseDate(end)
         } else {
           new Timestamp(
-            dateFormat.parse(end).getTime + TimeUnit.DAYS.toMillis(1) - 1
+            parseDate(end).getTime + TimeUnit.DAYS.toMillis(1) - 1
           )
         }
       fieldToFilterOn.between(startTimestamp, endTimestamp)

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtilsSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtilsSpec.scala
@@ -26,8 +26,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.sql.Timestamp
-import java.text.{ParseException, SimpleDateFormat}
-import java.util.concurrent.TimeUnit
+import javax.ws.rs.BadRequestException
 
 class FulltextSearchQueryUtilsSpec extends AnyFlatSpec with Matchers with BeforeAndAfter {
 
@@ -155,18 +154,18 @@ class FulltextSearchQueryUtilsSpec extends AnyFlatSpec with Matchers with Before
     sqlOf(cond) shouldBe sqlOf(JDSL.noCondition())
   }
 
-  it should "throw ParseException for a malformed start date" in {
+  it should "reject a malformed start date" in {
     val field: Field[Timestamp] = JDSL.field("created_at", classOf[Timestamp])
-    a[ParseException] should be thrownBy
+    val thrown = the[BadRequestException] thrownBy
       FulltextSearchQueryUtils.getDateFilter("not-a-date", "2026-01-31", field)
+    thrown.getMessage shouldBe "Invalid date: not-a-date"
   }
 
-  // Sanity check that the SimpleDateFormat used inside getDateFilter parses
-  // the documented format — guards against a future locale-dependent bug.
-  it should "accept the documented yyyy-MM-dd format" in {
-    val parsed = new SimpleDateFormat("yyyy-MM-dd").parse("2026-01-01")
-    val ts = new Timestamp(parsed.getTime + TimeUnit.DAYS.toMillis(0))
-    ts.getTime should be > 0L
+  it should "reject an impossible end date" in {
+    val field: Field[Timestamp] = JDSL.field("created_at", classOf[Timestamp])
+    val thrown = the[BadRequestException] thrownBy
+      FulltextSearchQueryUtils.getDateFilter("2026-01-01", "2026-99-99", field)
+    thrown.getMessage shouldBe "Invalid date: 2026-99-99"
   }
 
   // -- getOperatorsFilter -----------------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this PR?

Parse dashboard date filters strictly and return a clear 400 response for malformed or impossible calendar dates.

Before: invalid date -> 500 or silently normalized date
After: invalid date -> 400 with the invalid value

### Any related issues, documentation, discussions?

Closes #8152

### How was this PR tested?

Added regression coverage for malformed and impossible dates while retaining valid, empty, and open-ended range coverage.

`sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.FulltextSearchQueryUtilsSpec"`

`sbt scalafmtCheckAll`

`sbt "scalafixAll --check"`

Live local checks against the built branch:

| Request | Before | After |
| --- | --- | --- |
| `createDateStart=bogus` | 500 | 400 |
| `modifiedDateEnd=2026-99-99` | 200 | 400 |
| `createDateStart=2026-01-01` | 200 | 200 |

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex