### PR TITLE
feat(amber): reject missing hub entity type

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/EntityTables.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/EntityTables.scala
@@ -25,6 +25,8 @@ import org.apache.texera.dao.jooq.generated.tables.records._
 import org.apache.texera.web.resource.dashboard.VersionedResourceTables
 import org.jooq._
 
+import javax.ws.rs.BadRequestException
+
 object EntityTables {
 
   // ==================== THE REGISTRY ====================
@@ -80,6 +82,7 @@ object EntityTables {
 
   def apply(entityType: EntityType): EntityTableSet =
     entityType match {
+      case null                => throw new BadRequestException("Missing entityType")
       case EntityType.Workflow => WorkflowTableSet
       case EntityType.Dataset  => DatasetTableSet
       case EntityType.Model    => ModelTableSet

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/EntityTablesSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/EntityTablesSpec.scala
@@ -23,6 +23,8 @@ import org.apache.texera.web.resource.dashboard.VersionedResourceTables
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+import javax.ws.rs.BadRequestException
+
 class EntityTablesSpec extends AnyFlatSpec with Matchers {
 
   // -- BaseEntityTable --------------------------------------------------------
@@ -143,6 +145,11 @@ class EntityTablesSpec extends AnyFlatSpec with Matchers {
     model.access shouldBe EntityTables.AccessTable.ModelAccessTable
     model.cloneTable shouldBe None
     model.versionedResource shouldBe Some(VersionedResourceTables.ModelTables)
+  }
+
+  it should "reject a missing entity type" in {
+    val error = intercept[BadRequestException](EntityTables(null))
+    error.getMessage shouldBe "Missing entityType"
   }
 
   // -- AccessTable ------------------------------------------------------------

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
@@ -682,6 +682,11 @@ class HubResourceSpec
     new HubResource().getCount(Wf).intValue() shouldBe 1
   }
 
+  it should "reject a missing entity type" in {
+    intercept[BadRequestException](hub.getCount(null))
+    intercept[BadRequestException](hub.getTops(null, null, null, null))
+  }
+
   it should "leave non-public workflows out of the count" in {
     // On top of the public fixture workflow (wid 7001) seeded in beforeAll.
     seedWorkflow(810501, "wf_public_a", isPublic = true, withOwnerRows = false)


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject a missing hub entity type with a clear 400 response before table lookup.

Before: missing entity type -> unhandled match error -> 500
After: missing entity type -> 400 with `Missing entityType`

### Any related issues, documentation, discussions?

Closes #8154

### How was this PR tested?

Added a regression test for the missing value. Existing tests retain positive coverage for both workflow and dataset table dispatch.

`sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.hub.EntityTablesSpec"`

`sbt scalafmtCheckAll`

`sbt "scalafixAll --check"`

Live local checks against the built branch:

| Request | Before | After |
| --- | --- | --- |
| missing `entityType` | 500 | 400 |
| invalid `entityType` | 404 | 404 |
| `entityType=workflow` | 200 | 200 |
| `entityType=dataset` | 200 | 200 |

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex