### PR TITLE
feat(amber): ignore blank dashboard keywords

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
@@ -40,7 +40,7 @@ object FulltextSearchQueryUtils {
       return noCondition()
     }
     // Filter out empty keywords and trim
-    val trimmedKeywords = keywords.filter(_.nonEmpty).map(_.trim)
+    val trimmedKeywords = keywords.map(_.trim).filter(_.nonEmpty)
     // If no keywords, skip fulltext search
     if (trimmedKeywords.isEmpty) {
       return noCondition()

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DatasetSearchQueryBuilderSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DatasetSearchQueryBuilderSpec.scala
@@ -142,8 +142,8 @@ import scala.jdk.CollectionConverters._
   *
   * Covered but unconstrainable, so no reviewer should count it as pinned behaviour:
   *   - the `.filter(_.nonEmpty)` after the keyword split. `getFullTextSearchFilter` re-applies
-  *     `keywords.filter(_.nonEmpty)` itself (`FulltextSearchQueryUtils:43`), so dropping it here is
-  *     an equivalent mutation — no observable differs.
+  *     `keywords.map(_.trim).filter(_.nonEmpty)` itself (`FulltextSearchQueryUtils:43`), so
+  *     dropping it here is an equivalent mutation — no observable differs.
   */
 class DatasetSearchQueryBuilderSpec
     extends AnyFlatSpec

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtilsSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/FulltextSearchQueryUtilsSpec.scala
@@ -55,16 +55,10 @@ class FulltextSearchQueryUtilsSpec extends AnyFlatSpec with Matchers with Before
     sqlOf(cond) shouldBe sqlOf(JDSL.noCondition())
   }
 
-  it should "currently still build a pgroonga predicate for whitespace-only keywords (subtle quirk)" in {
-    // `keywords.filter(_.nonEmpty)` checks for empty BEFORE trimming, so
-    // a "   " input survives the filter and is trimmed to "" — but only
-    // after the emptiness check. The resulting predicate searches for the
-    // empty string. Pin the behavior so a future fix (move the trim into
-    // the filter step) deliberately breaks this test.
-    FulltextSearchQueryUtils.usePgroonga = true
+  it should "return noCondition when all keywords contain only whitespace" in {
     val field: Field[String] = JDSL.field("name", classOf[String])
-    val cond = FulltextSearchQueryUtils.getFullTextSearchFilter(Seq("   "), List(field))
-    sqlOf(cond) should include("pgroonga_condition('',")
+    val cond = FulltextSearchQueryUtils.getFullTextSearchFilter(Seq("   ", "\t"), List(field))
+    sqlOf(cond) shouldBe sqlOf(JDSL.noCondition())
   }
 
   it should "emit a pgroonga fuzzy-match expression when usePgroonga is true" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Trim dashboard search keywords before removing empty values so whitespace-only input behaves like an empty search.

Before: blank keyword -> empty full-text predicate
After: blank keyword -> no full-text condition

### Any related issues, documentation, discussions?

Closes #8156

### How was this PR tested?

Updated the regression test to cover spaces and a tab. Existing tests retain coverage for empty input, normal keywords, multiple fields, and both full-text implementations.

`sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.FulltextSearchQueryUtilsSpec"`

`sbt scalafmtCheckAll`

`sbt "scalafixAll --check"`

Live local checks against the built branch:

| Search input | Before | After |
| --- | --- | --- |
| omitted | 200 | 200 |
| three spaces | 500 | 200 |
| tab | empty full-text predicate | 200 |

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex