### PR TITLE
feat(amber): avoid writing missing view counts

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/hub/HubResource.scala
@@ -562,16 +562,6 @@ class HubResource {
               .toMap
 
             val missing = ids.filterNot(id => raw.contains(id.intValue()))
-
-            missing.foreach { id =>
-              context
-                .insertInto(viewTbl.table)
-                .set(viewTbl.idColumn, id)
-                .set(viewTbl.viewCountColumn, Integer.valueOf(0))
-                .onDuplicateKeyIgnore()
-                .execute()
-            }
-
             raw ++ missing.map(id => id.intValue() -> 0).toMap
           } else Map.empty
 

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/hub/HubResourceSpec.scala
@@ -686,7 +686,7 @@ class HubResourceSpec
     counts shouldBe Map((ActionType.Like: ActionType) -> 2)
   }
 
-  it should "backfill a zero view-count row for an entity that has never been viewed" in {
+  it should "return zero without writing for an entity that has never been viewed" in {
     seedWorkflow(810803, "wf_counts_backfill")
     workflowViewCount(810803) shouldBe None
 
@@ -699,8 +699,17 @@ class HubResourceSpec
       .toMap
 
     counts shouldBe Map((ActionType.View: ActionType) -> 0)
-    // The backfill is a real side effect: the row is written by getCounts itself.
-    workflowViewCount(810803) shouldBe Some(0)
+    workflowViewCount(810803) shouldBe None
+  }
+
+  it should "return zero for an unknown entity id" in {
+    val response = hub
+      .getCounts(types(Wf), ids(899999), actions(ActionType.View))
+      .asScala
+      .head
+
+    response.counts.get(ActionType.View) shouldBe 0
+    workflowViewCount(899999) shouldBe None
   }
 
   it should "not touch the view-count table when view is not among the requested actions" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

Return zero for missing hub view counts without inserting a database row during the GET request.

Before: unknown entity view count -> zero-row insert -> foreign-key failure -> 500
After: unknown entity view count -> zero in response without a write -> 200

### Any related issues, documentation, discussions?

Closes #8158

### How was this PR tested?

Updated the existing database integration coverage to require no write for an unviewed entity and added an unknown-ID regression case. The suite also retains coverage for stored counts, both entity types, action filters, and mixed batches.

`sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.web.resource.dashboard.hub.HubResourceSpec"`

`sbt scalafmtCheckAll`

`sbt "scalafixAll --check"`

The focused suite passed all 50 tests.

Live local checks against the built branch:

| Request | Before | After |
| --- | --- | --- |
| unknown workflow view count | 500 | 200 with zero |
| unknown dataset view count | 500 | 200 with zero |
| unknown workflow like count | 200 with zero | 200 with zero |

A read-only database check after both view requests returned zero stored rows for both IDs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex