### PR TITLE
feat(amber): reject invalid dashboard resource type

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/DashboardResource.scala
@@ -104,7 +104,7 @@ object DashboardResource {
         val q3 = ProjectSearchQueryBuilder.constructQuery(uid, params, includePublic)
         val q4 = DatasetSearchQueryBuilder.constructQuery(uid, params, includePublic)
         q1.unionAll(q3).unionAll(q4)
-      case _ => throw new IllegalArgumentException(s"Unknown resource type: ${params.resourceType}")
+      case _ => throw new BadRequestException(s"Unknown resource type: ${params.resourceType}")
     }
 
     val finalQuery =

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/DashboardResourceSpec.scala
@@ -25,6 +25,7 @@ import org.apache.texera.web.resource.dashboard.DashboardResource.SearchQueryPar
 import org.jooq.impl.{DSL => JDSL}
 import org.jooq.{OrderField, SQLDialect}
 
+import javax.ws.rs.BadRequestException
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -128,7 +129,7 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
     // constructQuery / SqlServer, so this is reachable with no database. The
     // exception *type* is the real assertion: if the guard were moved below the
     // query construction, this would surface as a SqlServer failure instead.
-    val thrown = the[IllegalArgumentException] thrownBy DashboardResource.searchAllResources(
+    val thrown = the[BadRequestException] thrownBy DashboardResource.searchAllResources(
       new SessionUser(new User()), // uid stays null; unused on this path
       SearchQueryParams(resourceType = "notAResourceType")
     )
@@ -138,7 +139,7 @@ class DashboardResourceSpec extends AnyFlatSpec with Matchers {
   it should "reject a resourceType that only differs from a valid one by case" in {
     // Guards against someone relaxing the match to be case-insensitive on one
     // side only: "Workflow" is not "workflow" today.
-    val thrown = the[IllegalArgumentException] thrownBy DashboardResource.searchAllResources(
+    val thrown = the[BadRequestException] thrownBy DashboardResource.searchAllResources(
       new SessionUser(new User()),
       SearchQueryParams(resourceType = "Workflow")
     )


### PR DESCRIPTION
### What changes were proposed in this PR?

Return HTTP 400 when dashboard search receives an unknown resource type.

The resource dispatch currently throws `IllegalArgumentException`, which Dropwizard reports as HTTP 500. The change uses `BadRequestException` and updates both invalid input cases in the focused spec.

Before: unknown resource type returns 500.

After: unknown resource type returns 400 with the existing message.

Valid resource types are unchanged.

### Any related issues, documentation, discussions?

Closes #8161

### How was this PR tested?

Focused tests:

`sbt -no-colors "WorkflowExecutionService/testOnly org.apache.texera.web.resource.dashboard.DashboardResourceSpec"`

Result: 7 tests passed.

Checks:

`sbt -no-colors scalafmtCheckAll`

`sbt -no-colors "scalafixAll --check"`

Localhost verification on the built service:

`GET /api/dashboard/publicSearch?resourceType=workflow` returned 200.

`GET /api/dashboard/publicSearch?resourceType=not-a-resource` returned 400 with `Unknown resource type: not-a-resource`. The same request returned 500 before the change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5