### PR TITLE
feat(amber): report malformed websocket frames

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/WorkflowWebsocketResource.scala
@@ -78,7 +78,6 @@ class WorkflowWebsocketResource extends LazyLogging {
 
   @OnMessage
   def myOnMsg(session: Session, message: String): Unit = {
-    val request = objectMapper.readValue(message, classOf[TexeraWebSocketRequest])
     val userOpt = session.getUserProperties.asScala
       .get(classOf[User].getName)
       .map(_.asInstanceOf[User])
@@ -88,6 +87,7 @@ class WorkflowWebsocketResource extends LazyLogging {
     val workflowStateOpt = sessionState.getCurrentWorkflowState
     val executionStateOpt = workflowStateOpt.flatMap(x => Option(x.executionService.getValue))
     try {
+      val request = objectMapper.readValue(message, classOf[TexeraWebSocketRequest])
       request match {
         case heartbeat: HeartBeatRequest =>
           sessionState.send(HeartBeatResponse())

--- a/amber/src/test/scala/org/apache/texera/web/resource/WorkflowWebsocketResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/WorkflowWebsocketResourceSpec.scala
@@ -82,10 +82,6 @@ import scala.jdk.CollectionConverters.{IteratorHasAsScala, MapHasAsJava, SeqHasA
   *     then rethrows so the container sees it too. Both halves are asserted: dropping either the
   *     send or the rethrow would leave the other silently missing.
   *
-  * Worth knowing, and the reason there is no malformed-frame test here: `objectMapper.readValue`
-  * sits OUTSIDE the try, so an unparseable frame escapes un-mapped and the client is told nothing.
-  * That looks like an oversight, but pinning today's behaviour would cement it.
-  *
   * Everything here drives a mocked `javax.websocket.Session` (the pattern `CollaborationResourceSpec`
   * established) and registers a `SessionState` directly, so no real workflow is created.
   *
@@ -381,6 +377,18 @@ class WorkflowWebsocketResourceSpec
     resource.myOnMsg(session, frameOf(HeartBeatRequest()))
 
     sentTypes(sent) shouldBe Seq("HeartBeatResponse")
+  }
+
+  it should "report a malformed frame to the client" in {
+    val (session, sent) = mockSession()
+    registerState(session, PrivilegeEnum.WRITE)
+
+    intercept[Exception] {
+      resource.myOnMsg(session, "{")
+    }
+
+    sentTypes(sent) shouldBe Seq("WorkflowErrorEvent")
+    fatalErrorMessages(sent).head should include("Unexpected end-of-input")
   }
 
   // -- the write-access gate ----------------------------------------------------


### PR DESCRIPTION
### What changes were proposed in this PR?

Route workflow WebSocket deserialization failures through the endpoint's existing error handler.

JSON parsing currently happens before the `try` block, so malformed frames are logged by the container but never become a `WorkflowErrorEvent`. Moving that one line into the guarded block gives the editor the same structured error event used for other workflow request failures.

Before: malformed frame sends no error event and the client waits.

After: malformed frame immediately sends `WorkflowErrorEvent` with the parse failure.

Valid frames are unchanged.

### Any related issues, documentation, discussions?

Closes #8163

### How was this PR tested?

Focused tests:

`sbt -no-colors "WorkflowExecutionService/testOnly org.apache.texera.web.resource.WorkflowWebsocketResourceSpec"`

Result: 16 tests passed.

Checks:

`sbt -no-colors scalafmtCheckAll`

`sbt -no-colors "scalafixAll --check"`

Localhost verification against the computing unit master:

1. Connected to the workflow WebSocket with workflow and computing unit parameters.
2. Sent the incomplete JSON frame `{`.
3. Before the change, only startup events arrived and the client timed out.
4. After the change, `WorkflowErrorEvent` arrived immediately with `Unexpected end-of-input`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5