### PR TITLE
feat(workflow-operator): validate pie chart name

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/pieChart/PieChartOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/pieChart/PieChartOpDesc.scala
@@ -75,6 +75,7 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
 
   def manipulateTable(): PythonTemplateBuilder = {
     assert(value.nonEmpty, "Value Column cannot be empty")
+    assert(name.nonEmpty, "Name Column cannot be empty")
     pyb"""
          |        table.dropna(subset = [$value, $name], inplace = True) #remove missing values
          |"""
@@ -82,6 +83,7 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
 
   def createPlotlyFigure(): PythonTemplateBuilder = {
     assert(value.nonEmpty, "Value Column cannot be empty")
+    assert(name.nonEmpty, "Name Column cannot be empty")
     pyb"""
        |        fig = px.pie(table, names=$name, values=$value)
        |        fig.update_traces(textposition='inside', textinfo='percent+label')

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/pieChart/PieChartOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/pieChart/PieChartOpDescSpec.scala
@@ -114,14 +114,13 @@ class PieChartOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
     plain should include("dropna")
   }
 
-  it should "render successfully when only name is empty (asymmetric guard, current behavior)" in {
-    // Pin: name has no assert guard. With value set and name empty, the
-    // generated Python still renders — only the runtime call site receives
-    // an empty decode. This asymmetry between value (asserted) and name
-    // (not asserted) is documented here.
+  it should "reject an empty name column" in {
     opDesc.value = "amount"
-    opDesc.name = ""
-    val code = opDesc.generatePythonCode()
-    code should include("class ProcessTableOperator(UDFTableOperator)")
+
+    val tableError = intercept[AssertionError](opDesc.manipulateTable())
+    tableError.getMessage should include("Name Column cannot be empty")
+
+    val figureError = intercept[AssertionError](opDesc.createPlotlyFigure())
+    figureError.getMessage should include("Name Column cannot be empty")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Validate the required Pie Chart Name Column in both generated table-processing stages. An empty name is now rejected before the generated Python reaches pandas.

The existing valid chart test remains, and the previous empty-name characterization is now a regression test for both stages.

### Any related issues, documentation, discussions?

Closes #8167

### How was this PR tested?

```shell
sbt -no-colors "WorkflowOperator/testOnly org.apache.texera.amber.operator.visualization.pieChart.PieChartOpDescSpec"
sbt -no-colors scalafmtCheckAll "scalafixAll --check"
sbt -no-colors "WorkflowOperator/console"
```

The focused suite passed 10 tests.

For the live check, I first executed the generated pandas `dropna` shape with Value Column set and Name Column empty. It failed with a KeyError for the empty column name. I then invoked the fixed `PieChartOpDesc.manipulateTable` in Texera's Scala console with the same configuration. It rejected the configuration with `Name Column cannot be empty` before Python generation.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5