### PR TITLE
feat(pyamber): route range shuffle by receivers

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -43,10 +43,7 @@ class RangeBasedShufflePartitioner(Partitioner):
         self.range_min = partitioning.range_min
         self.range_max = partitioning.range_max
         self.keys_per_receiver = int(
-            (
-                (partitioning.range_max - partitioning.range_min)
-                // len(partitioning.channels)
-            )
+            ((partitioning.range_max - partitioning.range_min) // len(self.receivers))
             + 1
         )
 

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -316,6 +316,20 @@ class TestRangeBasedShufflePartitioner:
         # (9 - 0) // 3 + 1 = 4
         assert partitioner.keys_per_receiver == 4
 
+    def test_duplicate_channels_use_distinct_receivers_for_range_width(self):
+        partitioner = RangeBasedShufflePartitioner(
+            RangeBasedShufflePartitioning(
+                batch_size=10,
+                channels=[_channel("S", "A"), _channel("S", "A"), _channel("S", "B")],
+                range_attribute_names=["k"],
+                range_min=0,
+                range_max=8,
+            )
+        )
+
+        list(partitioner.add_tuple_to_batch(_tuple(k=8)))
+        assert partitioner.receivers[1] == (_worker("B"), [_tuple(k=8)])
+
     def test_value_below_range_min_routes_to_first_receiver(self, partitioner):
         assert partitioner.get_receiver_index(-100) == 0
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Calculate Python range-shuffle widths from the distinct receiver list that the partitioner actually indexes, matching the Scala implementation.

A regression test covers repeated channels to one downstream worker and verifies that an upper-range tuple reaches the final distinct receiver.

### Any related issues, documentation, discussions?

Closes #8169

### How was this PR tested?

```shell
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-range-duplicate-channels\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q']))"
python -m ruff check amber/src/main/python amber/src/test/python
python -m ruff format --check amber/src/main/python amber/src/test/python
```

All 36 focused partitioner tests passed. Ruff lint and formatting passed across 213 Python files.

For the live check, I constructed the actual Python range partitioner with channels A, A, and B over range 0 through 8, then sent key 8.

Before: it calculated index 2 for a two-receiver list and raised `IndexError`.

After: it calculates index 1 and stores the tuple in receiver B's batch.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5