### PR TITLE
feat(amber): preserve decimal range keys

### DIFF
--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/sendsemantics/partitioners/RangeBasedShufflePartitioner.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/sendsemantics/partitioners/RangeBasedShufflePartitioner.scala
@@ -33,14 +33,13 @@ case class RangeBasedShufflePartitioner(partitioning: RangeBasedShufflePartition
   override def getBucketIndex(tuple: Tuple): Iterator[Int] = {
     // Do range partitioning only on the first attribute in `rangeAttributeNames`.
     val attribute = tuple.getSchema.getAttribute(partitioning.rangeAttributeNames.head)
-    var fieldVal: Long = -1
-    attribute.getType match {
+    val fieldVal = attribute.getType match {
       case AttributeType.LONG =>
-        fieldVal = tuple.getField[Long](attribute)
+        BigDecimal(tuple.getField[Long](attribute))
       case AttributeType.INTEGER =>
-        fieldVal = tuple.getField[Int](attribute)
+        BigDecimal(tuple.getField[Int](attribute))
       case AttributeType.DOUBLE =>
-        fieldVal = tuple.getField[Double](attribute).toLong
+        BigDecimal(tuple.getField[Double](attribute))
       case _ =>
         throw new RuntimeException(s"unsupported attribute type: ${attribute.getType}")
     }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/RangeBasedShuffleSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/RangeBasedShuffleSpec.scala
@@ -206,4 +206,32 @@ class RangeBasedShuffleSpec extends AnyFlatSpec with MockFactory {
     )
   }
 
+  it should "preserve decimals around a range boundary" in {
+    val decimalPartitioner = RangeBasedShufflePartitioner(
+      RangeBasedShufflePartitioning(
+        400,
+        List(
+          ChannelIdentity(identifier, fakeID1, isControl = false),
+          ChannelIdentity(identifier, fakeID2, isControl = false)
+        ),
+        Seq("decimal"),
+        -10,
+        9
+      )
+    )
+    val decimalAttr = new Attribute("decimal", AttributeType.DOUBLE)
+    val decimalSchema = Schema().add(decimalAttr)
+
+    assert(
+      decimalPartitioner
+        .getBucketIndex(Tuple.builder(decimalSchema).add(decimalAttr, -0.5).build())
+        .next() == 0
+    )
+    assert(
+      decimalPartitioner
+        .getBucketIndex(Tuple.builder(decimalSchema).add(decimalAttr, 0.0).build())
+        .next() == 1
+    )
+  }
+
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Preserve numeric precision while the Scala range shuffle calculates a bucket. `DOUBLE` keys no longer lose their fractional part, while integer and long keys retain exact arithmetic.

Before: with two receivers over -10 to 9, -0.5 went to bucket 1 in Scala and bucket 0 in Python.

After: both implementations send -0.5 to bucket 0, while the 0.0 boundary remains in bucket 1.

### Any related issues, documentation, discussions?

Closes #8171

### How was this PR tested?

Added a regression test that covers a negative fractional key and the adjacent zero boundary.

Red before the source change, then 7 tests passed:

```text
sbt -no-colors "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.architecture.messaginglayer.RangeBasedShuffleSpec"
```

Formatting and static checks passed:

```text
sbt -no-colors scalafmtCheckAll "scalafixAll --check"
```

The production Scala partitioner was also run directly in the Scala console. It returned bucket 0 for -0.5 and bucket 1 for 0.0.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex