### PR TITLE
feat(pyamber): hash timestamp milliseconds

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import ctypes
+import math
 import numpy
 import pandas
 import pickle
@@ -472,7 +473,9 @@ class Tuple:
             AttributeType.LONG: lambda f: java_hash_long(f),
             AttributeType.DOUBLE: lambda f: java_hash_long(double_to_long(f)),
             AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
-            AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
+            AttributeType.TIMESTAMP: lambda f: java_hash_long(
+                math.floor(f.timestamp() * 1000)
+            ),
             AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
         }
 

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -476,7 +476,20 @@ class TestTuple:
         with pytest.raises(TypeError, match="Unmatched type"):
             tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
 
+    @pytest.mark.parametrize(
+        ("milliseconds", "java_hash"), [(-1.5, 32), (0, 31), (500, 531)]
+    )
+    def test_timestamp_hash_matches_java_milliseconds(self, milliseconds, java_hash):
+        timestamp = datetime.datetime.fromtimestamp(milliseconds / 1000, datetime.UTC)
+        tuple_ = Tuple(
+            {"timestamp": timestamp},
+            Schema(raw_schema={"timestamp": "TIMESTAMP"}),
+        )
+
+        assert hash(tuple_) == java_hash
+
     def test_hash(self):
+        utc = datetime.UTC
         schema = Schema(
             raw_schema={
                 "col-int": "INTEGER",
@@ -496,12 +509,12 @@ class TestTuple:
                 "col-bool": True,
                 "col-long": 1123213213213,
                 "col-double": 214214.9969346,
-                "col-timestamp": datetime.datetime.fromtimestamp(100000000),
+                "col-timestamp": datetime.datetime.fromtimestamp(100000000, utc),
                 "col-binary": b"hello",
             },
             schema,
         )
-        assert hash(tuple_) == -1335416166  # calculated with Java
+        assert hash(tuple_) == -1106835869  # calculated with Java
 
         tuple2 = Tuple(
             {
@@ -510,7 +523,7 @@ class TestTuple:
                 "col-bool": False,
                 "col-long": 0,
                 "col-double": 0.0,
-                "col-timestamp": datetime.datetime.fromtimestamp(0),
+                "col-timestamp": datetime.datetime.fromtimestamp(0, utc),
                 "col-binary": b"",
             },
             schema,
@@ -540,12 +553,12 @@ class TestTuple:
                 "col-bool": True,
                 "col-long": -8965536434247,
                 "col-double": 1 / 3,
-                "col-timestamp": datetime.datetime.fromtimestamp(-1990),
+                "col-timestamp": datetime.datetime.fromtimestamp(-1990, utc),
                 "col-binary": None,
             },
             schema,
         )
-        assert hash(tuple4) == -592643630  # calculated with Java
+        assert hash(tuple4) == -531015320  # calculated with Java
 
         tuple5 = Tuple(
             {
@@ -554,12 +567,12 @@ class TestTuple:
                 "col-bool": True,
                 "col-long": 0x7FFFFFFFFFFFFFFF,
                 "col-double": 7 / 17,
-                "col-timestamp": datetime.datetime.fromtimestamp(1234567890),
+                "col-timestamp": datetime.datetime.fromtimestamp(1234567890, utc),
                 "col-binary": b"o" * 4097,
             },
             schema,
         )
-        assert hash(tuple5) == -2099556631  # calculated with Java
+        assert hash(tuple5) == 1729534988  # calculated with Java
 
     def test_tuple_with_large_binary(self):
         """Test tuple with largebinary field."""


### PR DESCRIPTION
### What changes were proposed in this PR?

Hash Python timestamp fields using epoch milliseconds, matching Java `Timestamp.hashCode`. Negative submillisecond values use floor semantics, preserving Java behavior before the epoch.

Before: with three receivers, `1970-01-01T00:00:00.500Z` produced Python hash 31 and Scala hash 531, selecting different workers.

After: both hashes are 531 and both select worker 0.

### Any related issues, documentation, discussions?

Closes #8173

### How was this PR tested?

The new regression was red before the source change with two failures and one pass. After the fix, its negative, zero, and positive timestamp cases all pass.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_timestamp_hash_matches_java_milliseconds','-q','-p','no:cacheprovider']))"
```

The complete tuple and partitioner suites pass:

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-q','-p','no:cacheprovider']))"
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
```

Results: 106 tuple tests and 35 partitioner tests passed.

```text
ruff check amber/src/main/python amber/src/test/python
ruff format --check amber/src/main/python amber/src/test/python
```

Ruff checked 213 files successfully. JDK 17 independently confirmed all affected expected hashes. The fixed production hash partitioner selected receiver A for the half-second timestamp, matching Scala bucket 0.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex