### PR TITLE
test(amber): cover the replay-log writer, manager and congestion control

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/AsyncReplayLogWriterSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/AsyncReplayLogWriterSpec.scala
@@ -64,6 +64,13 @@ class AsyncReplayLogWriterSpec extends AnyFlatSpec {
   private val shutdownBudgetMillis = 30000L
 
   /**
+    * Slack allowed off a configured flush interval when asserting that the
+    * writer really slept for it. `Thread.sleep` guarantees no upper bound and in
+    * practice can undershoot its argument by a scheduling quantum.
+    */
+  private val sleepGranularityToleranceMillis = 50L
+
+  /**
     * Shuts the writer down and returns the trace as of the instant
     * `terminate()` returned. Bounded, because `terminate()` blocks on an untimed
     * future (see `ReplayLogWriterFixtures.terminatesWithin`).
@@ -206,10 +213,16 @@ class AsyncReplayLogWriterSpec extends AnyFlatSpec {
     val elapsedMillis = (System.nanoTime() - startedAt) / 1000000L
 
     assert(shutdownTrace(writer, recorder) == List(Wrote(step), Flushed, Closed))
+    // Derived from the interval actually configured above rather than written out
+    // as a literal, so the bound follows flushIntervalMillis if it is retuned.
+    // The tolerance absorbs the platform's timer granularity: Thread.sleep is
+    // allowed to return marginally early, and on Windows it routinely does.
+    val lowerBoundMillis = flushIntervalMillis - sleepGranularityToleranceMillis
     assert(
-      elapsedMillis >= 250L,
-      s"the first flush landed after only ${elapsedMillis}ms, so the ${flushIntervalMillis}ms " +
-        "flush interval was not honoured"
+      elapsedMillis >= lowerBoundMillis,
+      s"the first flush landed after only ${elapsedMillis}ms, under the ${lowerBoundMillis}ms " +
+        s"floor implied by the ${flushIntervalMillis}ms flush interval, so the interval was " +
+        "not honoured"
     )
   }
 }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/AsyncReplayLogWriterSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/AsyncReplayLogWriterSpec.scala
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.architecture.logreplay
+
+import org.apache.texera.amber.core.virtualidentity.{ActorVirtualIdentity, ChannelIdentity}
+import org.apache.texera.amber.engine.architecture.logreplay.ReplayLogWriterFixtures.{
+  Closed,
+  Flushed,
+  Recorder,
+  RecordingRecordWriter,
+  Sent,
+  WriterEvent,
+  Wrote,
+  terminatesWithin
+}
+import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.MainThreadDelegateMessage
+import org.apache.texera.amber.engine.common.ambermessage.{DataFrame, WorkflowFIFOMessage}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class AsyncReplayLogWriterSpec extends AnyFlatSpec {
+
+  private val channel =
+    ChannelIdentity(ActorVirtualIdentity("from"), ActorVirtualIdentity("to"), isControl = false)
+
+  private def fifo(seq: Long): WorkflowFIFOMessage =
+    WorkflowFIFOMessage(channel, seq, DataFrame(Array.empty))
+
+  private def output(seq: Long): Either[MainThreadDelegateMessage, WorkflowFIFOMessage] =
+    Right(fifo(seq))
+
+  /**
+    * The other arm of the queue element's `Either`. `DPThread`,
+    * `PrepareCheckpointHandler` and `FinalizeCheckpointHandler` all push
+    * `Left(MainThreadDelegateMessage(...))` through this writer, so dropping one
+    * would break checkpointing silently rather than loudly.
+    */
+  private def delegate(): Either[MainThreadDelegateMessage, WorkflowFIFOMessage] =
+    Left(MainThreadDelegateMessage(_ => ()))
+
+  private def newWriter(recorder: Recorder): AsyncReplayLogWriter = {
+    val writer = new AsyncReplayLogWriter(recorder.handler, new RecordingRecordWriter(recorder))
+    // Daemon so that even a wedged writer can never keep a JVM from exiting.
+    writer.setDaemon(true)
+    writer
+  }
+
+  private val shutdownBudgetMillis = 30000L
+
+  /**
+    * Shuts the writer down and returns the trace as of the instant
+    * `terminate()` returned. Bounded, because `terminate()` blocks on an untimed
+    * future (see `ReplayLogWriterFixtures.terminatesWithin`).
+    */
+  private def shutdownTrace(
+      writer: AsyncReplayLogWriter,
+      recorder: Recorder
+  ): List[WriterEvent] = {
+    val (returned, trace) =
+      terminatesWithin(shutdownBudgetMillis, recorder)(() => writer.terminate())
+    assert(returned, "terminate() did not return")
+    trace
+  }
+
+  /**
+    * `logInterval` is copied from `ApplicationConfig.faultToleranceLogFlushIntervalInMs`,
+    * a memoised `val` on a shared object that must NOT be poked: amber suites run
+    * serially in one JVM, so mutating it would poison every later suite. The writer
+    * stores its own copy in a `private final long` *instance* field, and overwriting
+    * that is instance-local. Done before `start()`, so `Thread.start()`'s
+    * happens-before edge publishes the new value to the writer thread.
+    */
+  private def setLogInterval(writer: AsyncReplayLogWriter, millis: Long): Unit = {
+    val field = classOf[AsyncReplayLogWriter].getDeclaredField("logInterval")
+    field.setAccessible(true)
+    field.setLong(writer, millis)
+    assert(field.getLong(writer) == millis, "reflective logInterval override did not take effect")
+  }
+
+  /** A writer that has completed its full start/terminate lifecycle. */
+  private def startedAndTerminated(): AsyncReplayLogWriter = {
+    val recorder = new Recorder
+    val writer = newWriter(recorder)
+    writer.start()
+    shutdownTrace(writer, recorder)
+    writer
+  }
+
+  "AsyncReplayLogWriter" should
+    "write and flush queued log records before releasing the queued outputs" in {
+    // The class exists to guarantee this ordering: a message must not reach the
+    // network before the log record that would let a replay reproduce it — and
+    // "written" here has to mean flushed, not merely handed to the stream. Both
+    // items are queued *before* start(), so the writer thread's first drainTo is
+    // guaranteed to pick up both in one batch, which is exactly the batch in
+    // which the ordering can be got wrong.
+    val recorder = new Recorder
+    val writer = newWriter(recorder)
+    val step = ProcessingStep(channel, 0L)
+    val released = output(1L)
+
+    writer.putLogRecords(Array(step))
+    writer.putOutput(released)
+    writer.start()
+
+    assert(shutdownTrace(writer, recorder) == List(Wrote(step), Flushed, Sent(released), Closed))
+  }
+
+  it should "write every queued record, in queue order, before the outputs that follow them" in {
+    val recorder = new Recorder
+    val writer = newWriter(recorder)
+    val first = ProcessingStep(channel, 0L)
+    val second = MessageContent(fifo(7L))
+    val released = output(2L)
+
+    writer.putLogRecords(Array(first, second))
+    writer.putOutput(released)
+    writer.start()
+
+    assert(
+      shutdownTrace(writer, recorder) ==
+        List(Wrote(first), Wrote(second), Flushed, Sent(released), Closed)
+    )
+  }
+
+  it should "release main-thread delegates as well as FIFO messages, in queue order" in {
+    // The queue element is an Either precisely so that main-thread delegates
+    // (checkpoint closures) ride the same ordering guarantee as network
+    // messages. A writer that released only the Right arm would drop every
+    // checkpoint closure while still writing its log records.
+    val recorder = new Recorder
+    val writer = newWriter(recorder)
+    val step = ProcessingStep(channel, 0L)
+    val closure = delegate()
+    val released = output(3L)
+
+    writer.putLogRecords(Array(step))
+    writer.putOutput(closure)
+    writer.putOutput(released)
+    writer.start()
+
+    assert(
+      shutdownTrace(writer, recorder) ==
+        List(Wrote(step), Flushed, Sent(closure), Sent(released), Closed)
+    )
+  }
+
+  it should "close the underlying record writer exactly once when it shuts down" in {
+    // terminate() is the only shutdown path, and it must both stop the thread
+    // and close the record writer — a writer left open would leak the log file
+    // handle for the rest of the worker's life. Asserting on the trace captured
+    // the instant terminate() returned is what makes this an ordering claim
+    // rather than a race: an implementation that released the caller before
+    // closing is caught even though it does eventually close.
+    val recorder = new Recorder
+    val writer = newWriter(recorder)
+    writer.start()
+
+    assert(shutdownTrace(writer, recorder) == List(Closed))
+  }
+
+  it should "reject further log records once it has been terminated" in {
+    val writer = startedAndTerminated()
+    intercept[AssertionError] {
+      writer.putLogRecords(Array(ProcessingStep(channel, 0L)))
+    }
+  }
+
+  it should "reject further outputs once it has been terminated" in {
+    val writer = startedAndTerminated()
+    intercept[AssertionError] {
+      writer.putOutput(output(1L))
+    }
+  }
+
+  it should "wait for the configured flush interval before draining the queue" in {
+    // With a positive faultToleranceLogFlushIntervalInMs the writer batches by
+    // sleeping at the top of every drain loop. The default is 0 (no sleep), so
+    // this arm is only reachable with a non-default interval.
+    val recorder = new Recorder
+    val writer = newWriter(recorder)
+    val flushIntervalMillis = 300L
+    setLogInterval(writer, flushIntervalMillis)
+    val step = ProcessingStep(channel, 0L)
+    writer.putLogRecords(Array(step))
+
+    val startedAt = System.nanoTime()
+    writer.start()
+    assert(recorder.awaitFirstEvent(shutdownBudgetMillis), "the queued record was never written")
+    val elapsedMillis = (System.nanoTime() - startedAt) / 1000000L
+
+    assert(shutdownTrace(writer, recorder) == List(Wrote(step), Flushed, Closed))
+    assert(
+      elapsedMillis >= 250L,
+      s"the first flush landed after only ${elapsedMillis}ms, so the ${flushIntervalMillis}ms " +
+        "flush interval was not honoured"
+    )
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/ReplayLogManagerImplSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/ReplayLogManagerImplSpec.scala
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.architecture.logreplay
+
+import org.apache.texera.amber.core.virtualidentity.{
+  ActorVirtualIdentity,
+  ChannelIdentity,
+  EmbeddedControlMessageIdentity
+}
+import org.apache.texera.amber.engine.architecture.logreplay.ReplayLogWriterFixtures.{
+  Closed,
+  Flushed,
+  Recorder,
+  RecordingRecordWriter,
+  Sent,
+  WriterEvent,
+  Wrote,
+  terminatesWithin
+}
+import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.MainThreadDelegateMessage
+import org.apache.texera.amber.engine.common.ambermessage.{DataFrame, WorkflowFIFOMessage}
+import org.scalatest.flatspec.AnyFlatSpec
+
+/**
+  * Covers `ReplayLogManagerImpl`, the fault-tolerant implementation.
+  * `EmptyReplayLogManagerImpl` (the no-op one) and the trait's own default
+  * `withFaultTolerant` are covered by `EmptyReplayLogManagerImplSpec`.
+  *
+  * Step numbers are written as literals rather than as
+  * `ProcessingStepCursor.INIT_STEP (+ 1)`. The step recorded in the log is what
+  * a re-executed worker replays up to, so it has to be pinned against something
+  * that does not move when the production constant moves: both
+  * `ProcessingStepCursor.currentStepCounter` and `ReplayLogger.lastStep` are
+  * seeded from `INIT_STEP`, so writing it on the expected side would let the two
+  * sides slide together and pin nothing.
+  */
+class ReplayLogManagerImplSpec extends AnyFlatSpec {
+
+  private val channel =
+    ChannelIdentity(ActorVirtualIdentity("from"), ActorVirtualIdentity("to"), isControl = false)
+
+  private def fifo(seq: Long): WorkflowFIFOMessage =
+    WorkflowFIFOMessage(channel, seq, DataFrame(Array.empty))
+
+  private def output(seq: Long): Either[MainThreadDelegateMessage, WorkflowFIFOMessage] =
+    Right(fifo(seq))
+
+  /** The main-thread-delegate arm of the output `Either`; see `DPThread` line 113. */
+  private def delegate(): Either[MainThreadDelegateMessage, WorkflowFIFOMessage] =
+    Left(MainThreadDelegateMessage(_ => ()))
+
+  private val shutdownBudgetMillis = 30000L
+
+  /**
+    * Runs `body` against a live manager, then shuts the writer thread down and
+    * returns everything the writer observed, in order, as of the instant the
+    * shutdown returned. `setupWriter` starts a real `AsyncReplayLogWriter`
+    * thread, and its `terminate()` blocks on an untimed future, so the shutdown
+    * is bounded (see `terminatesWithin`).
+    *
+    * `Flushed` is filtered out here, and only here. Unlike
+    * `AsyncReplayLogWriterSpec` — which queues everything before `start()` and
+    * therefore gets one deterministic drain batch — the manager enqueues into an
+    * already-running writer, so where the writer chooses to split its batches
+    * (and hence how many flushes it performs) is genuinely racy. The
+    * write-flush-then-release ordering is pinned in `AsyncReplayLogWriterSpec`,
+    * where it is deterministic; what this spec pins is which records the manager
+    * produces and in what order.
+    */
+  private def drainedEvents(body: ReplayLogManagerImpl => Unit): List[WriterEvent] = {
+    val recorder = new Recorder
+    val manager = new ReplayLogManagerImpl(recorder.handler)
+    manager.setupWriter(new RecordingRecordWriter(recorder))
+    var trace = List.empty[WriterEvent]
+    try body(manager)
+    finally {
+      val (returned, captured) =
+        terminatesWithin(shutdownBudgetMillis, recorder)(() => manager.terminate())
+      assert(returned, "ReplayLogManagerImpl.terminate() did not return")
+      trace = captured
+    }
+    trace.filterNot(_ == Flushed)
+  }
+
+  "ReplayLogManagerImpl.markAsReplayDestination" should
+    "persist a ReplayDestination record carrying the given ECM id" in {
+    // The replay planner scans the log for ReplayDestination markers to decide
+    // where a re-executed worker should stop, so both the record *type* and the
+    // id it carries are load-bearing.
+    val ecmId = EmbeddedControlMessageIdentity("ecm-1")
+    val released = output(1L)
+
+    val events = drainedEvents { manager =>
+      manager.markAsReplayDestination(ecmId)
+      manager.sendCommitted(released)
+    }
+
+    assert(events == List(Wrote(ReplayDestination(ecmId)), Sent(released), Closed))
+  }
+
+  it should "keep one marker per call, in call order, when several destinations are marked" in {
+    val first = EmbeddedControlMessageIdentity("ecm-1")
+    val second = EmbeddedControlMessageIdentity("ecm-2")
+    val released = output(1L)
+
+    val events = drainedEvents { manager =>
+      manager.markAsReplayDestination(first)
+      manager.markAsReplayDestination(second)
+      manager.sendCommitted(released)
+    }
+
+    assert(
+      events == List(
+        Wrote(ReplayDestination(first)),
+        Wrote(ReplayDestination(second)),
+        Sent(released),
+        Closed
+      )
+    )
+  }
+
+  "ReplayLogManagerImpl.sendCommitted" should
+    "persist the pending processing steps before releasing the message" in {
+    // withFaultTolerant records the step/message pair; sendCommitted must flush
+    // those records to the log *before* the output is handed to the handler.
+    // The absolute step values matter: -1 is the "nothing processed yet" cursor
+    // and 0 is the first processed message, which is where a replay resumes.
+    val processed = fifo(7L)
+    val released = output(9L)
+
+    val events = drainedEvents { manager =>
+      manager.withFaultTolerant(channel, Some(processed)) {}
+      manager.sendCommitted(released)
+    }
+
+    assert(
+      events == List(
+        Wrote(ProcessingStep(channel, -1L)),
+        Wrote(MessageContent(processed)),
+        Wrote(ProcessingStep(channel, 0L)),
+        Sent(released),
+        Closed
+      )
+    )
+  }
+
+  it should "release a message with no log records when nothing has been processed" in {
+    val released = output(1L)
+    val events = drainedEvents(_.sendCommitted(released))
+    assert(events == List(Sent(released), Closed))
+  }
+
+  it should "release a main-thread delegate through the same committed path" in {
+    // Checkpoint closures reach the handler as Left(MainThreadDelegateMessage);
+    // WorkflowWorker wires sendCommitted up as the outputHandler for both arms,
+    // so a manager that only forwarded Rights would silently drop checkpoints.
+    val processed = fifo(2L)
+    val closure = delegate()
+
+    val events = drainedEvents { manager =>
+      manager.withFaultTolerant(channel, Some(processed)) {}
+      manager.sendCommitted(closure)
+    }
+
+    assert(
+      events == List(
+        Wrote(ProcessingStep(channel, -1L)),
+        Wrote(MessageContent(processed)),
+        Wrote(ProcessingStep(channel, 0L)),
+        Sent(closure),
+        Closed
+      )
+    )
+  }
+
+  "ReplayLogManagerImpl.withFaultTolerant" should
+    "still persist the in-flight step after the processing body throws" in {
+    // The override records the step *before* delegating to the trait, which is
+    // what makes a crashed worker replayable up to the message that killed it.
+    // Losing the record here would silently shorten every recovery.
+    val processed = fifo(3L)
+    val released = output(4L)
+
+    val events = drainedEvents { manager =>
+      intercept[RuntimeException] {
+        manager.withFaultTolerant(channel, Some(processed)) {
+          throw new RuntimeException("boom")
+        }
+      }
+      assert(manager.getStep == 0L, "the cursor must advance even when the body throws")
+      manager.sendCommitted(released)
+    }
+
+    assert(
+      events == List(
+        Wrote(ProcessingStep(channel, -1L)),
+        Wrote(MessageContent(processed)),
+        Wrote(ProcessingStep(channel, 0L)),
+        Sent(released),
+        Closed
+      )
+    )
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/ReplayLogWriterFixtures.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/ReplayLogWriterFixtures.scala
@@ -136,6 +136,19 @@ object ReplayLogWriterFixtures {
     * caller was released — not whatever it managed to do afterwards while the
     * test thread was getting around to reading.
     *
+    * Anything `shutdown()` throws is carried back and rethrown on the calling
+    * thread. Swallowing it would turn, say, a NullPointerException from an
+    * unstarted writer into a bare "expected List(...) but got List()" on an
+    * empty trace, which points nowhere near the cause.
+    *
+    * If the budget does elapse, the parked thread is interrupted before we
+    * return: `CompletableFuture.get()` is interruptible, so this actually
+    * releases it instead of leaving it holding the writer for the rest of the
+    * run. The interrupt is deliberately *not* reported as the failure — a wedge
+    * is the caller's `returned == false`, and rethrowing the resulting
+    * InterruptedException instead would rename the symptom after its own
+    * remedy.
+    *
     * @return (whether the shutdown returned inside the budget, the trace as of
     *         the moment it returned).
     */
@@ -143,15 +156,22 @@ object ReplayLogWriterFixtures {
       shutdown: () => Unit
   ): (Boolean, List[WriterEvent]) = {
     val captured = new AtomicReference[List[WriterEvent]](Nil)
-    val t = new Thread(() => {
+    val thrown = new AtomicReference[Throwable]()
+    val shutdownThread = new Thread(() => {
       try {
         shutdown()
         captured.set(recorder.snapshot)
-      } catch { case _: Throwable => () }
+      } catch { case t: Throwable => thrown.set(t) }
     })
-    t.setDaemon(true)
-    t.start()
-    t.join(timeoutMillis)
-    (!t.isAlive, captured.get())
+    shutdownThread.setDaemon(true)
+    shutdownThread.start()
+    shutdownThread.join(timeoutMillis)
+    val returned = !shutdownThread.isAlive
+    if (returned) {
+      Option(thrown.get()).foreach(t => throw t)
+    } else {
+      shutdownThread.interrupt()
+    }
+    (returned, captured.get())
   }
 }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/ReplayLogWriterFixtures.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/logreplay/ReplayLogWriterFixtures.scala
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.engine.architecture.logreplay
+
+import org.apache.texera.amber.engine.architecture.worker.WorkflowWorker.MainThreadDelegateMessage
+import org.apache.texera.amber.engine.common.ambermessage.WorkflowFIFOMessage
+import org.apache.texera.amber.engine.common.storage.SequentialRecordStorage.SequentialRecordWriter
+
+import java.io.{ByteArrayOutputStream, DataOutputStream}
+import java.util.concurrent.atomic.AtomicReference
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+/**
+  * In-process fixtures shared by `AsyncReplayLogWriterSpec` and
+  * `ReplayLogManagerImplSpec`, the two specs that drive a real
+  * `AsyncReplayLogWriter` thread. Nothing here touches the filesystem, an
+  * ActorSystem, or `AmberRuntime.serde`.
+  */
+object ReplayLogWriterFixtures {
+
+  /** Ordered trace of everything the writer thread did, in the order it did it. */
+  sealed trait WriterEvent
+  final case class Wrote(record: ReplayLogRecord) extends WriterEvent
+  final case class Sent(msg: Either[MainThreadDelegateMessage, WorkflowFIFOMessage])
+      extends WriterEvent
+
+  /**
+    * A flush that actually made previously written records durable. Without this
+    * event a trace cannot tell `write; flush; send` from `write; send; flush`,
+    * and the second is a durability inversion: the message is on the network
+    * while its log record is still in the `DataOutputStream` buffer.
+    */
+  case object Flushed extends WriterEvent
+  case object Closed extends WriterEvent
+
+  /**
+    * Thread-safe recorder. The writer thread appends; the test thread reads.
+    * `ConcurrentLinkedQueue` supplies both FIFO ordering and the happens-before
+    * edge, so no extra synchronisation is needed on the assertion side.
+    */
+  class Recorder {
+    private val events = new ConcurrentLinkedQueue[WriterEvent]()
+    private val firstEvent = new CountDownLatch(1)
+
+    def record(event: WriterEvent): Unit = {
+      events.add(event)
+      firstEvent.countDown()
+    }
+
+    /** Blocks until the writer thread produces its first event, or the timeout elapses. */
+    def awaitFirstEvent(timeoutMillis: Long): Boolean =
+      firstEvent.await(timeoutMillis, TimeUnit.MILLISECONDS)
+
+    def snapshot: List[WriterEvent] = events.asScala.toList
+
+    /** The `handler` an AsyncReplayLogWriter calls for each released output. */
+    val handler: Either[MainThreadDelegateMessage, WorkflowFIFOMessage] => Unit =
+      msg => record(Sent(msg))
+  }
+
+  /**
+    * A `SequentialRecordWriter` that records rather than serialises. Overriding
+    * `writeRecord` keeps `AmberRuntime.serde` (and therefore a Pekko
+    * `ActorSystem`) out of these specs entirely; the wrapped stream is never
+    * written to and the base class's `lazy val output` is never forced.
+    *
+    * `close()` sleeps before recording. Under pristine code that costs nothing
+    * in correctness terms — `run()` closes the writer and only then completes
+    * the future `terminate()` waits on, so the `Closed` event is ordered before
+    * `terminate()` can return no matter how long the close takes. It is what
+    * turns "did close happen before terminate returned?" from a nanosecond race
+    * into a decided question: an implementation that completed the future first
+    * would hand the assertion a trace with no `Closed` in it.
+    *
+    * `flush()` records only when something has been written since the last
+    * flush. The real writer's `flush()` is `Output.flush()`, a no-op on an empty
+    * buffer, so a flush with nothing buffered changes no durability and is not
+    * worth a trace entry — and leaving it out keeps the trace independent of how
+    * the writer thread happens to split its drain batches.
+    */
+  class RecordingRecordWriter(recorder: Recorder)
+      extends SequentialRecordWriter[ReplayLogRecord](
+        new DataOutputStream(new ByteArrayOutputStream())
+      ) {
+    // Touched only by the writer thread (writeRecord/flush/close all run there).
+    private var buffered = false
+
+    override def writeRecord(obj: ReplayLogRecord): Unit = {
+      buffered = true
+      recorder.record(Wrote(obj))
+    }
+
+    override def flush(): Unit =
+      if (buffered) {
+        buffered = false
+        recorder.record(Flushed)
+      }
+
+    override def close(): Unit = {
+      Thread.sleep(CloseDelayMillis)
+      recorder.record(Closed)
+    }
+  }
+
+  /** See `RecordingRecordWriter.close()`. */
+  val CloseDelayMillis = 250L
+
+  /**
+    * `AsyncReplayLogWriter.terminate()` blocks on an untimed
+    * `CompletableFuture.get()` that is only completed at the very end of
+    * `run()`. amber suites are strictly serial (`Tags.limit(Tags.Test, 1)`), so
+    * a writer that never finishes would hang the whole module build rather than
+    * fail one test. Run the shutdown on a daemon thread and bound the wait, so a
+    * wedge surfaces as an ordinary failed assertion instead.
+    *
+    * The trace is captured on the shutdown thread the instant `shutdown()`
+    * returns, so assertions see exactly what the writer had done by the time the
+    * caller was released — not whatever it managed to do afterwards while the
+    * test thread was getting around to reading.
+    *
+    * @return (whether the shutdown returned inside the budget, the trace as of
+    *         the moment it returned).
+    */
+  def terminatesWithin(timeoutMillis: Long, recorder: Recorder)(
+      shutdown: () => Unit
+  ): (Boolean, List[WriterEvent]) = {
+    val captured = new AtomicReference[List[WriterEvent]](Nil)
+    val t = new Thread(() => {
+      try {
+        shutdown()
+        captured.set(recorder.snapshot)
+      } catch { case _: Throwable => () }
+    })
+    t.setDaemon(true)
+    t.start()
+    t.join(timeoutMillis)
+    (!t.isAlive, captured.get())
+  }
+}

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/CongestionControlSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/CongestionControlSpec.scala
@@ -283,13 +283,23 @@ class CongestionControlSpec extends AnyFlatSpec {
 
   "CongestionControl.getStatusReport" should
     "format the three core counters in the documented order" in {
-    // Pin the exact format string (separator + ordering) so a reorder of
-    // the three fields or a tab-vs-comma swap fails this spec.
+    // Pin the exact format string: the separator, the label wording, and which
+    // counter each label is actually reading.
+    //
+    // The three counters are driven to three *distinct* values on purpose. With
+    // all three at 1 the string cannot pin the label-to-counter binding at all:
+    // a report that read `toBeSent.size` where it says "in transit" and
+    // `inTransit.size` where it says "waiting" renders byte-identically, so it
+    // would pass. Nothing else in this file catches that swap either — the
+    // report's other assertions only look at the window-size field. 2/1/3 makes
+    // every field distinguishable from the other two.
     val cc = new CongestionControl()
     cc.markMessageInTransit(msg(0L))
-    cc.enqueueMessage(msg(1L))
+    cc.ack(0L) // in-window ack: slow start doubles windowSize 1 -> 2
+    cc.markMessageInTransit(msg(1L))
+    (2L to 4L).foreach(i => cc.enqueueMessage(msg(i)))
     assert(
-      cc.getStatusReport == "current window size = 1 \t in transit = 1 \t waiting = 1",
+      cc.getStatusReport == "current window size = 2 \t in transit = 1 \t waiting = 3",
       s"unexpected format: ${cc.getStatusReport}"
     )
   }

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/CongestionControlSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/CongestionControlSpec.scala
@@ -179,6 +179,16 @@ class CongestionControlSpec extends AnyFlatSpec {
     // must lift that final 0 back to 1, because windowSize is then set from
     // ssThreshold and `canSend` is `inTransit.size < windowSize`: a window of 0
     // can never be satisfied, so the sender would wedge permanently.
+    //
+    // The window is pinned through `canSend` across an empty/full boundary
+    // rather than through the `getStatusReport` text, since it is the sender's
+    // behaviour and not the report's wording that this test is about: a drained
+    // sender that may send, and that one in-transit message then blocks, has a
+    // windowSize of exactly 1. Substring matching on the report could not do
+    // this job — "current window size = 1" is a prefix of "= 16", so it would
+    // pass a clamp that restored 16 — and the report's exact format is pinned
+    // once, in `getStatusReport`'s own test at the bottom of this file. The
+    // report is still built here, as the clue on a failure.
     val cc = new CongestionControl()
     (1L to 5L).foreach { i =>
       cc.markMessageInTransit(msg(i))
@@ -186,20 +196,29 @@ class CongestionControlSpec extends AnyFlatSpec {
       cc.ack(i)
     }
     assert(
-      cc.getStatusReport == "current window size = 1 \t in transit = 0 \t waiting = 0",
-      s"unexpected status: ${cc.getStatusReport}"
+      cc.getInTransitMessages.isEmpty,
+      s"the acks left messages in transit: ${cc.getStatusReport}"
     )
-    assert(cc.canSend, "a fully drained sender must still be permitted to send")
+    assert(
+      cc.canSend,
+      s"a fully drained sender must still be permitted to send: ${cc.getStatusReport}"
+    )
+    cc.markMessageInTransit(msg(6L))
+    assert(
+      !cc.canSend,
+      s"one in-transit message must exhaust a window of 1: ${cc.getStatusReport}"
+    )
 
     // A sixth timeout must keep it pinned at 1 rather than driving it negative.
-    cc.markMessageInTransit(msg(6L))
     backdateSentTime(cc, 6L, 5000)
     cc.ack(6L)
     assert(
-      cc.getStatusReport == "current window size = 1 \t in transit = 0 \t waiting = 0",
-      s"unexpected status: ${cc.getStatusReport}"
+      cc.getInTransitMessages.isEmpty,
+      s"the sixth ack left its message in transit: ${cc.getStatusReport}"
     )
-    assert(cc.canSend)
+    assert(cc.canSend, s"the clamp did not survive a second timeout: ${cc.getStatusReport}")
+    cc.markMessageInTransit(msg(7L))
+    assert(!cc.canSend, s"the window is no longer exactly 1: ${cc.getStatusReport}")
   }
 
   "CongestionControl.getBufferedMessagesToSend" should "be bounded by remaining window capacity" in {

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/CongestionControlSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/messaginglayer/CongestionControlSpec.scala
@@ -174,6 +174,34 @@ class CongestionControlSpec extends AnyFlatSpec {
     )
   }
 
+  it should "clamp ssThreshold at 1 so repeated timeouts never collapse the window to zero" in {
+    // Five consecutive timed-out acks halve ssThreshold 16→8→4→2→1→0. The clamp
+    // must lift that final 0 back to 1, because windowSize is then set from
+    // ssThreshold and `canSend` is `inTransit.size < windowSize`: a window of 0
+    // can never be satisfied, so the sender would wedge permanently.
+    val cc = new CongestionControl()
+    (1L to 5L).foreach { i =>
+      cc.markMessageInTransit(msg(i))
+      backdateSentTime(cc, i, 5000) // > ackTimeLimit (3000)
+      cc.ack(i)
+    }
+    assert(
+      cc.getStatusReport == "current window size = 1 \t in transit = 0 \t waiting = 0",
+      s"unexpected status: ${cc.getStatusReport}"
+    )
+    assert(cc.canSend, "a fully drained sender must still be permitted to send")
+
+    // A sixth timeout must keep it pinned at 1 rather than driving it negative.
+    cc.markMessageInTransit(msg(6L))
+    backdateSentTime(cc, 6L, 5000)
+    cc.ack(6L)
+    assert(
+      cc.getStatusReport == "current window size = 1 \t in transit = 0 \t waiting = 0",
+      s"unexpected status: ${cc.getStatusReport}"
+    )
+    assert(cc.canSend)
+  }
+
   "CongestionControl.getBufferedMessagesToSend" should "be bounded by remaining window capacity" in {
     val cc = new CongestionControl()
     cc.enqueueMessage(msg(1L))


### PR DESCRIPTION
### What changes were proposed in this PR?

Two new specs for classes that had none, plus one append. 33 tests across the three suites.

| File | Codecov lines | Newly covered |
|---|---|---|
| `AsyncReplayLogWriter.scala` | 38/44 → **42/44** | 51, 58, 71, 72 |
| `CongestionControl.scala` | 30/34 → **32/34** | 70, 71 |
| `ReplayLogManager.scala` | 30/34 → **31/34** | 122 |

**+7 fully-covered lines** (120/137 → 127/137 across the bundle). The plain line-hit metric moves only +3, because four of the seven were already executed and flip by completing a branch arm.

New files: `AsyncReplayLogWriterSpec` (7 tests), `ReplayLogManagerImplSpec` (6 tests), and a shared `ReplayLogWriterFixtures` support object. `AsyncReplayLogWriter` and `ReplayLogManagerImpl` had no spec of their own before this.

The lines closed are the terminated-writer arms of `assert(!stopped)` in `putLogRecords` and `putOutput`, the non-default `logInterval > 0` sleep arm, the `ssThreshold` clamp reached only after five consecutive ack timeouts, and `markAsReplayDestination`.

### Honesty about the bound

The measurement filter was 110 suite FQCNs — every spec under `amber/src/test/scala/.../engine/**` plus `clustering/**`. CI's full-module `WorkflowExecutionService/jacoco` runs 188. **Adding suites can only raise the before-figure, so +7 is an upper bound on the CI gain, not a floor.**

The specific lines closed are not plausibly reached by a `core/` operator, tuple or storage spec, so I believe +7 is also the actual figure — but a bound is what was measured and that is what is claimed.

### Four files from the original scope contribute nothing

`AmberFIFOChannel`, `WorkflowMessage`, `RecoveryPayload` and `RegionPlan` were in the bundle and are worth **zero**; they already have thorough specs, including `AmberMessageEnvelopesSpec`, whose name mirrors neither source class it covers.

**`NetworkOutputGateway`'s tests were written and then deleted.** It measured 22/25 before and after — lines 50, 51, 98 and 99 are already covered by pre-existing suites at this scope. A third jacoco run on the trimmed tree reproduces 127/137 exactly, confirming those tests contributed nothing. `NetworkOutputGatewaySpec.scala` is byte-identical to `HEAD` in this PR.

### Two hazards handled rather than discovered late

**`terminate()` can hang the build.** It does `stopped = true; writerQueue.put(TerminateSignal); gracefullyStopped.get()` — an untimed `CompletableFuture.get()` completed only at the end of `run()`. On a writer that was never started it blocks forever, and amber's suites are strictly serial in one JVM, so that hangs the module rather than failing a test. Every test starts before terminating, with `terminate()` in a `finally`; the class extends `Thread`, so a missed one would also leak a live thread into the shared JVM.

**`logInterval` is a JVM-global.** It comes from `ApplicationConfig.faultToleranceLogFlushIntervalInMs`, a memoized `val` that is 0 by default. Poking that object would poison every later suite. Instead the tests reflect on the **instance** field — `javap` confirms `private final long logInterval`, and setting it via `Field.setLong` on the instance was verified to work on this JDK. Instance-local, poisons nothing.

### Deliberately not included

`AmberFIFOChannel` lines 47/48/51 are `logger.debug` bodies. There is no `logback-test.xml`, ROOT governs, and CI sets `TEXERA_SERVICE_LOG_LEVEL=WARN`, so the scala-logging `isDebugEnabled` arm never fires in CI — they would look green locally and be missed in CI. Not counted, and not chased by raising the log level in a test, which would mutate a shared logging context in a serial JVM.

`NetworkOutputGateway:41` is the `AmberLogging` lazy `logger` accessor, and the class body contains no logging call at all, so there is no call site to reach it from. Covering it needs a production seam — refused.

### Verification

All mutations in the final table die, including the four the reviewers measured as surviving the first draft (complete-before-close, flush-after-release, drop-`Left`s, and the `INIT_STEP` mutant), re-verified on the final tree.

Four `NetworkOutputGateway` mutants are recorded as killed by **pre-existing** suites without help from this bundle, rather than credited to it.

Measured with one fresh sbt JVM per side, the jacoco directory removed between runs, an identical throwaway suite-name filter both times (deleted afterwards), and `STORAGE_ICEBERG_CATALOG_TYPE=postgres` with per-worktree namespaces — which takes the local baseline from 28 failures and 1 abort to **zero**, so neither run is a partial or all-zero report.

No production file is touched.

### Any related issues, documentation, discussions?

Closes #8175

### How was this PR tested?

```
sbt "WorkflowExecutionService/testOnly org.apache.texera.amber.engine.architecture.logreplay.AsyncReplayLogWriterSpec org.apache.texera.amber.engine.architecture.logreplay.ReplayLogManagerImplSpec org.apache.texera.amber.engine.architecture.messaginglayer.CongestionControlSpec"
```

```
[info] Total number of tests run: 33
[info] Tests: succeeded 33, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

`WorkflowExecutionService/Test/scalafmtCheck` and `WorkflowExecutionService/Test/scalafix --check` both pass. Re-run after rebasing onto current `main`.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
