### PR TITLE
feat(pyamber): hash binary bytes as signed

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -473,7 +473,9 @@ class Tuple:
             AttributeType.DOUBLE: lambda f: java_hash_long(double_to_long(f)),
             AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
             AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
-            AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
+            AttributeType.BINARY: lambda f: java_hash_bytes(
+                (b - 256 if b >= 128 else b for b in f), 1, salt
+            ),
         }
 
         for name, field in self.as_key_value_pairs():

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -476,6 +476,14 @@ class TestTuple:
         with pytest.raises(TypeError, match="Unmatched type"):
             tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
 
+    @pytest.mark.parametrize(
+        ("value", "java_hash"), [(b"\x7f", 189), (b"\x80", -66), (b"\xff", 61)]
+    )
+    def test_binary_hash_uses_java_signed_bytes(self, value, java_hash):
+        tuple_ = Tuple({"payload": value}, Schema(raw_schema={"payload": "BINARY"}))
+
+        assert hash(tuple_) == java_hash
+
     def test_hash(self):
         schema = Schema(
             raw_schema={


### PR DESCRIPTION
### What changes were proposed in this PR?

Convert Python binary values to Java signed-byte values before applying the existing Java-compatible array hash.

Before: with three receivers, binary key `0xFF` produced Python hash 317 and Scala hash 61, selecting different workers.

After: both hashes are 61 and both select worker 1.

### Any related issues, documentation, discussions?

Closes #8179

### How was this PR tested?

The new signed-boundary regression was red before the source change with two failures and one pass. After the fix, `0x7F`, `0x80`, and `0xFF` all pass.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_binary_hash_uses_java_signed_bytes','-q','-p','no:cacheprovider']))"
```

The remaining tuple tests and the complete partitioner suite pass:

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-k','not test_hash','-q','-p','no:cacheprovider']))"
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_treats_none_fields_as_zero',r'amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
```

Results: 104 tuple tests passed in the first run, then the separately selected null-hash test and all 35 partitioner tests passed. The existing `TestTuple.test_hash` fixture is excluded because its naive epoch timestamp fails on Windows; PR #8174 makes those timestamps explicitly UTC.

```text
ruff check amber/src/main/python amber/src/test/python
ruff format --check amber/src/main/python amber/src/test/python
```

Ruff checked 213 files successfully. The fixed production hash partitioner selected receiver B for `0xFF`, matching Scala bucket 1.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex