### PR TITLE
feat(pyamber): hash strings as UTF-16

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -172,6 +172,11 @@ def java_hash_bytes(bytes: Iterator[int], init: int, salt: int):
     return h
 
 
+def java_hash_string(value: str, salt: int):
+    units = (unit[0] for unit in struct.iter_unpack(">H", value.encode("utf-16-be")))
+    return java_hash_bytes(units, 0, salt)
+
+
 class Tuple:
     """
     Lazy-Tuple implementation.
@@ -471,7 +476,7 @@ class Tuple:
             AttributeType.INT: lambda f: int_32(f),
             AttributeType.LONG: lambda f: java_hash_long(f),
             AttributeType.DOUBLE: lambda f: java_hash_long(double_to_long(f)),
-            AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
+            AttributeType.STRING: lambda f: java_hash_string(f, salt),
             AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
             AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
         }

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -476,6 +476,14 @@ class TestTuple:
         with pytest.raises(TypeError, match="Unmatched type"):
             tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
 
+    @pytest.mark.parametrize(
+        ("value", "java_hash"), [("A", 96), ("é", 264), ("\U0001f600", 1772930)]
+    )
+    def test_string_hash_uses_java_utf16_units(self, value, java_hash):
+        tuple_ = Tuple({"text": value}, Schema(raw_schema={"text": "STRING"}))
+
+        assert hash(tuple_) == java_hash
+
     def test_hash(self):
         schema = Schema(
             raw_schema={


### PR DESCRIPTION
### What changes were proposed in this PR?

Hash Python strings as Java UTF-16 code units before applying the existing Java-compatible string hash.

Before: with two receivers, key `U+1F600` produced Python hash 128543 and Scala hash 1772930, selecting different workers.

After: both hashes are 1772930 and both select worker 0.

### Any related issues, documentation, discussions?

Closes #8181

### How was this PR tested?

The new Unicode-boundary regression was red before the source change with one failure and two passes. After the fix, ASCII, BMP Unicode, and supplementary Unicode all pass.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_string_hash_uses_java_utf16_units','-q','-p','no:cacheprovider']))"
```

The remaining tuple tests and complete partitioner suite pass:

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-k','not test_hash','-q','-p','no:cacheprovider']))"
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_treats_none_fields_as_zero',r'amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
```

Results: 104 tuple tests passed, then the separately selected null-hash test and all 35 partitioner tests passed. The existing `TestTuple.test_hash` fixture is excluded because its naive epoch timestamp fails on Windows; PR #8174 makes those timestamps explicitly UTC.

```text
ruff check amber/src/main/python amber/src/test/python
ruff format --check amber/src/main/python amber/src/test/python
```

Ruff checked 213 files successfully. The fixed production hash partitioner selected receiver A for `U+1F600`, matching Scala bucket 0.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex