### PR TITLE
feat(pyamber): include schema in tuple equality

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -441,6 +441,7 @@ class Tuple:
     def __eq__(self, other: Any) -> bool:
         return (
             isinstance(other, Tuple)
+            and self._schema == other._schema
             and self.get_field_names() == other.get_field_names()
             and all(self[i] == other[i] for i in self.get_field_names())
         )

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -98,6 +98,17 @@ class TestTuple:
         assert target_tuple == target_tuple
         assert not Tuple({"x": 2, "y": "a"}) == target_tuple
 
+    def test_tuple_equality_includes_schema(self):
+        int_schema = Schema(raw_schema={"value": "INTEGER"})
+        integer = Tuple({"value": 1}, int_schema)
+        same_integer = Tuple({"value": 1}, int_schema)
+        decimal = Tuple({"value": 1.0}, Schema(raw_schema={"value": "DOUBLE"}))
+
+        assert integer == same_integer
+        assert hash(integer) == hash(same_integer)
+        assert integer != decimal
+        assert integer != Tuple({"value": 1})
+
     def test_tuple_ne(self, target_tuple):
         assert not target_tuple != target_tuple
         assert Tuple({"x": 1, "y": "b"}) != target_tuple


### PR DESCRIPTION
### What changes were proposed in this PR?

Include schema equality when comparing Python tuples. This aligns equality with the schema types already used by tuple hashing.

Before: `INTEGER` 1 and `DOUBLE` 1.0 compared equal but hashed to 32 and 1072693279.

After: different schemas compare unequal, while same-schema tuples remain equal and hash-compatible.

### Any related issues, documentation, discussions?

Closes #8183

### How was this PR tested?

The new regression was red before the source change at the different-schema comparison, then passed after the one-line fix.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_tuple_equality_includes_schema','-q','-p','no:cacheprovider']))"
```

The model layer and partitioner suites pass:

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models','-k','not test_hash','-q','-p','no:cacheprovider']))"
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_treats_none_fields_as_zero',r'amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
```

Results: 314 model tests passed with one expected failure, then the separately selected null-hash test and all 35 partitioner tests passed. Hash-named fixtures were separated because the existing `TestTuple.test_hash` uses a naive epoch timestamp that fails on Windows; PR #8174 makes it explicitly UTC.

```text
ruff check amber/src/main/python amber/src/test/python
ruff format --check amber/src/main/python amber/src/test/python
```

Ruff checked 213 files successfully. A direct production-class check confirmed same-schema dictionary lookup still works and different schemas remain two distinct keys.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex