### PR TITLE
feat(pyamber): hash large binary tuples

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -172,6 +172,11 @@ def java_hash_bytes(bytes: Iterator[int], init: int, salt: int):
     return h
 
 
+def java_hash_string(value: str, salt: int):
+    units = (unit[0] for unit in struct.iter_unpack(">H", value.encode("utf-16-be")))
+    return java_hash_bytes(units, 0, salt)
+
+
 class Tuple:
     """
     Lazy-Tuple implementation.
@@ -474,6 +479,7 @@ class Tuple:
             AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
             AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
             AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
+            AttributeType.LARGE_BINARY: lambda f: salt + java_hash_string(f.uri, salt),
         }
 
         for name, field in self.as_key_value_pairs():

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -476,6 +476,22 @@ class TestTuple:
         with pytest.raises(TypeError, match="Unmatched type"):
             tuple_.finalize(Schema(raw_schema={"count": "INTEGER"}))
 
+    @pytest.mark.parametrize(
+        ("uri", "java_hash"),
+        [
+            ("s3://bucket/object", -46745592),
+            ("s3://bucket/\U0001f600", 1443831724),
+        ],
+    )
+    def test_hash_supports_large_binary(self, uri, java_hash):
+        from core.models.type.large_binary import largebinary
+
+        schema = Schema(raw_schema={"blob": "LARGE_BINARY"})
+        blob = Tuple({"blob": largebinary(uri)}, schema)
+
+        assert hash(blob) == java_hash
+        assert hash(Tuple({"blob": None}, schema)) == 31
+
     def test_hash(self):
         schema = Schema(
             raw_schema={


### PR DESCRIPTION
### What changes were proposed in this PR?

Add Java-compatible hashing for Python `LARGE_BINARY` tuple fields. The URI is hashed as UTF-16 code units, then wrapped with the same `Objects.hash` seed used by Scala `LargeBinary`.

Before: a hash shuffle on a large-binary key raised `KeyError` before choosing a worker.

After: `s3://bucket/object` hashes to -46745592 and selects worker 0 with two receivers.

### Any related issues, documentation, discussions?

Closes #8185

### How was this PR tested?

The new regression was red before the source change for both ASCII and Unicode URIs, then both passed after the mapping was added. Null values continue to use the existing zero hash.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_supports_large_binary','-q','-p','no:cacheprovider']))"
```

The model layer and partitioner suites pass:

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models','-k','not test_hash','-q','-p','no:cacheprovider']))"
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
```

Results: 313 model tests passed with one expected failure, and all 35 partitioner tests passed. Hash-named fixtures were run separately because the existing `TestTuple.test_hash` uses a naive epoch timestamp that fails on Windows; PR #8174 makes it explicitly UTC.

```text
ruff check amber/src/main/python amber/src/test/python
ruff format --check amber/src/main/python amber/src/test/python
```

Ruff checked 213 files successfully. JDK 17 independently verified both expected hashes. The fixed production hash partitioner selected receiver A instead of raising.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex