### PR TITLE
feat(pyamber): clear flushed shuffle batches

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
@@ -65,6 +65,7 @@ class HashBasedShufflePartitioner(Partitioner):
             if receiver == to:
                 if len(batch) > 0:
                     yield batch
+                    batch.clear()
                 yield ecm
 
     @overrides
@@ -76,4 +77,5 @@ class HashBasedShufflePartitioner(Partitioner):
         for receiver, batch in self.receivers:
             if len(batch) > 0:
                 yield receiver, batch
+                batch.clear()
             yield receiver, state

--- a/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -78,6 +78,7 @@ class RangeBasedShufflePartitioner(Partitioner):
             if receiver == to:
                 if len(batch) > 0:
                     yield batch
+                    batch.clear()
                 yield ecm
 
     @overrides
@@ -89,4 +90,5 @@ class RangeBasedShufflePartitioner(Partitioner):
         for receiver, batch in self.receivers:
             if len(batch) > 0:
                 yield receiver, batch
+                batch.clear()
             yield receiver, state

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -281,6 +281,7 @@ class TestHashBasedShufflePartitioner:
         ecm = EmbeddedControlMessage()
         a_out = _snapshot(p.flush(p.receivers[0][0], ecm))
         assert a_out == [[_hashable_tuple(k=1)], ecm]
+        assert _snapshot(p.flush(p.receivers[0][0], ecm)) == [ecm]
 
     def test_flush_state_emits_pending_batches_and_state(self):
         p = self._partitioner(batch_size=10)
@@ -293,6 +294,7 @@ class TestHashBasedShufflePartitioner:
         assert (p.receivers[0][0], [_hashable_tuple(k=1)]) in out
         # Each receiver still emits the state record.
         assert sum(1 for r, payload in out if payload is state) == len(p.receivers)
+        assert all(not batch for _, batch in p.receivers)
 
 
 class TestRangeBasedShufflePartitioner:
@@ -364,6 +366,7 @@ class TestRangeBasedShufflePartitioner:
         ecm = EmbeddedControlMessage()
         a_out = _snapshot(partitioner.flush(_worker("A"), ecm))
         assert a_out == [[_tuple(k=2)], ecm]
+        assert _snapshot(partitioner.flush(_worker("A"), ecm)) == [ecm]
         # B is untouched.
         assert partitioner.receivers[1][1] == [_tuple(k=5)]
 
@@ -377,6 +380,7 @@ class TestRangeBasedShufflePartitioner:
         assert (_worker("A"), [_tuple(k=2)]) in out
         # Every receiver still emits the state, even with empty pending batch.
         assert sum(1 for r, payload in out if payload is state) == 3
+        assert all(not batch for _, batch in partitioner.receivers)
 
 
 class TestOneToOnePartitioner:


### PR DESCRIPTION
### What changes were proposed in this PR?

Clear hash and range partitioner batches immediately after they are emitted by `flush` or `flush_state`, matching the other Python partitioners.

Before: a second control marker resent the same pending tuple.

After: the first flush sends the tuple and marker, while the second sends only the marker.

### Any related issues, documentation, discussions?

Closes #8187

### How was this PR tested?

The full partitioner suite was red before the source change with four failures and 31 passes. Only hash and range `flush` and `flush_state` failed. After the four-line fix, all tests pass.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
```

Result: 35 tests passed.

```text
ruff check amber/src/main/python amber/src/test/python
ruff format --check amber/src/main/python amber/src/test/python
```

Ruff checked 213 files successfully. A direct production-class run confirmed both hash and range partitioners emit the tuple only on the first marker and only the marker on the second.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex