### PR TITLE
feat(pyamber): flush broadcast batch to all receivers

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/broad_cast_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/broad_cast_partitioner.py
@@ -39,6 +39,7 @@ class BroadcastPartitioner(Partitioner):
         self.receivers = list(
             {channel.to_worker_id for channel in partitioning.channels}
         )
+        self._flushed_receivers = set()
 
     @overrides
     def add_tuple_to_batch(
@@ -54,14 +55,14 @@ class BroadcastPartitioner(Partitioner):
     def flush(
         self, to: ActorVirtualIdentity, ecm: EmbeddedControlMessage
     ) -> Iterator[typing.Union[EmbeddedControlMessage, typing.List[Tuple]]]:
-        if len(self.batch) > 0:
-            for receiver in self.receivers:
-                if receiver == to:
-                    yield self.batch
-        self.reset()
-        for receiver in self.receivers:
-            if receiver == to:
-                yield ecm
+        if to not in self.receivers:
+            return
+        if self.batch and to not in self._flushed_receivers:
+            yield self.batch
+            self._flushed_receivers.add(to)
+            if len(self._flushed_receivers) == len(self.receivers):
+                self.reset()
+        yield ecm
 
     @overrides
     def flush_state(
@@ -80,3 +81,4 @@ class BroadcastPartitioner(Partitioner):
     @overrides
     def reset(self) -> None:
         self.batch = list()
+        self._flushed_receivers.clear()

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -120,8 +120,15 @@ class TestBroadcastPartitioner:
     def test_flush_emits_pending_batch_and_ecm_only_to_target(self, partitioner):
         list(partitioner.add_tuple_to_batch(_tuple(k=1)))
         ecm = EmbeddedControlMessage()
-        out = list(partitioner.flush(_worker("A"), ecm))
-        assert out == [[_tuple(k=1)], ecm]
+        assert _snapshot(partitioner.flush(_worker("A"), ecm)) == [
+            [_tuple(k=1)],
+            ecm,
+        ]
+        assert _snapshot(partitioner.flush(_worker("A"), ecm)) == [ecm]
+        assert _snapshot(partitioner.flush(_worker("B"), ecm)) == [
+            [_tuple(k=1)],
+            ecm,
+        ]
         assert partitioner.batch == []
 
     def test_flush_with_empty_batch_emits_only_ecm_for_target(self, partitioner):
@@ -134,6 +141,7 @@ class TestBroadcastPartitioner:
         ecm = EmbeddedControlMessage()
         out = list(partitioner.flush(_worker("Z"), ecm))
         assert out == []
+        assert partitioner.batch == [_tuple(k=1)]
 
     def test_flush_state_emits_pending_batch_and_state_to_every_receiver(
         self, partitioner


### PR DESCRIPTION
### What changes were proposed in this PR?

Track which broadcast receivers have consumed the shared pending batch during a targeted control-boundary flush. Keep that batch until every configured receiver has received it, suppress repeated delivery to one receiver, and preserve it when an unknown receiver is requested.

Before: the first receiver got pending tuples and later receivers got only the control message.

After: every configured receiver gets pending tuples exactly once before the batch is cleared.

### Any related issues, documentation, discussions?

Closes #8189

### How was this PR tested?

Regression test first: the full partitioner suite reported 33 passed and 2 failed before the source change. The failures reproduced tuple loss for the second receiver and data loss on an unknown receiver.

After the fix:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-broadcast-flush-all\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\architecture\sendsemantics\test_partitioners.py','-q','-p','no:cacheprovider']))"

Result: 35 passed.

    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python
    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python amber/src/test/python

Result: all checks passed and 213 files were already formatted.

A live production-class probe flushed A, repeated A, flushed B, and tried unknown Z. A and B each received one tuple batch, repeated A received only the marker, Z received nothing, and the pending batch survived Z.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex