### PR TITLE
feat(pyamber): preserve VFS resource type case

### DIFF
--- a/amber/src/main/python/core/storage/vfs_uri_factory.py
+++ b/amber/src/main/python/core/storage/vfs_uri_factory.py
@@ -88,7 +88,7 @@ class VFSURIFactory:
             else None
         )
 
-        resource_type_str = segments[-1].lower()
+        resource_type_str = segments[-1]
         try:
             resource_type = VFSResourceType(resource_type_str)
         except ValueError:

--- a/amber/src/test/python/core/storage/test_vfs_uri_factory.py
+++ b/amber/src/test/python/core/storage/test_vfs_uri_factory.py
@@ -71,6 +71,17 @@ class TestCreatePortBaseUri:
 
 
 class TestDecodeUriRoundTrip:
+    @pytest.mark.parametrize(
+        ("suffix", "resource_type"),
+        [
+            ("runtimeStatistics", VFSResourceType.RUNTIME_STATISTICS),
+            ("consoleMessages", VFSResourceType.CONSOLE_MESSAGES),
+        ],
+    )
+    def test_decode_accepts_camel_case_resource_types(self, suffix, resource_type):
+        components = VFSURIFactory.decode_uri(f"vfs:///wid/1/eid/2/{suffix}")
+        assert components.resource_type == resource_type
+
     def test_result_uri_round_trips_through_decode(self):
         wid, eid, gpi = (
             WorkflowIdentity(id=42),


### PR DESCRIPTION
### What changes were proposed in this PR?

Preserve the canonical VFS resource suffix when the Python decoder looks it up. This lets Python decode the runtimeStatistics and consoleMessages URIs that Texera already produces and that Scala accepts.

Before: both camel-case resource suffixes were lowercased and rejected.

After: all canonical resource suffixes decode, while the existing unknown-resource check still rejects invalid suffixes.

### Any related issues, documentation, discussions?

Closes #8191

### How was this PR tested?

Regression test first:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-vfs-resource-case\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\storage\test_vfs_uri_factory.py','-q','-p','no:cacheprovider']))"

Before the source change: 19 passed and 2 failed. Both failures were the newly covered valid camel-case resource types.

After the fix, the VFS URI and document factory suites reported 32 passed:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-vfs-resource-case\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\storage\test_vfs_uri_factory.py',r'amber\src\test\python\core\storage\test_document_factory.py','-q','-p','no:cacheprovider']))"

    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python
    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python amber/src/test/python

Result: all checks passed and 213 files were already formatted.

A live production decoder probe confirmed runtimeStatistics, consoleMessages, result, and state all decode to their canonical resource types after the fix.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex