### PR TITLE
feat(pyamber): keep empty Iceberg ranges empty

### DIFF
--- a/amber/src/main/python/core/storage/iceberg/iceberg_document.py
+++ b/amber/src/main/python/core/storage/iceberg/iceberg_document.py
@@ -170,7 +170,9 @@ class IcebergIterator(Iterator[T]):
         self.num_of_returned_records = 0
         # Total number of records to return, used for termination condition
         self.total_records_to_return = (
-            self.until_index - self.from_index if until_index else float("inf")
+            self.until_index - self.from_index
+            if until_index is not None
+            else float("inf")
         )
         # Load the table instance, initially the table instance may not exist
         self.table = self._load_table_metadata()

--- a/amber/src/test/python/core/storage/iceberg/test_iceberg_document.py
+++ b/amber/src/test/python/core/storage/iceberg/test_iceberg_document.py
@@ -545,6 +545,12 @@ class TestIcebergDocumentWithMockCatalog:
 
         assert load_table_metadata.call_args.args == (document.catalog, "ns", "tbl")
 
+    def test_an_empty_range_returns_no_records(self, document):
+        with patch.object(iceberg_document, "load_table_metadata", return_value=None):
+            iterator = document.get_range(0, 0)
+            iterator.current_record_iterator = iter(["unexpected row"])
+            assert list(iterator) == []
+
     @pytest.mark.parametrize(
         "read, from_index, until_index, total",
         [


### PR DESCRIPTION
### What changes were proposed in this PR?

Treat only a missing Iceberg range end as unbounded. Preserve an explicit zero end so the documented half-open range from zero to zero remains empty.

Before: get_range(0, 0) computed an infinite limit and could return every row.

After: get_range(0, 0) computes a zero limit and returns no rows. Unbounded get and get_after behavior is unchanged.

### Any related issues, documentation, discussions?

Closes #8193

### How was this PR tested?

Regression test first:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-empty-iceberg-range\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\storage\iceberg\test_iceberg_document.py::TestIcebergDocumentWithMockCatalog','-q','-p','no:cacheprovider']))"

Before the source change: 13 passed and 1 failed. The new regression returned an injected row from the empty range.

After the fix: 14 passed.

    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python
    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python amber/src/test/python

Result: all checks passed and 213 files were already formatted.

The production iterator probe used the same controlled record source before and after the change. Before, the zero end produced an infinite limit and returned the row. After, it produced a zero limit and an empty result.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex