### PR TITLE
feat(pyamber): compare table row counts

### DIFF
--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -77,7 +77,9 @@ class Table(pandas.DataFrame):
 
     def __eq__(self, other: "Table") -> bool:
         if isinstance(other, Table):
-            return all(a == b for a, b in zip(self.as_tuples(), other.as_tuples()))
+            return len(self) == len(other) and all(
+                a == b for a, b in zip(self.as_tuples(), other.as_tuples())
+            )
         else:
             return super().__eq__(other).all()
 

--- a/amber/src/test/python/core/models/test_table.py
+++ b/amber/src/test/python/core/models/test_table.py
@@ -216,9 +216,14 @@ class TestTable:
         # body with `return True` survived the whole suite. One negative case
         # closes that.
         #
-        # Deliberately NOT pinned here: `zip` truncates to the shorter operand,
-        # so `Table(frame.head(1)) == Table(frame)` is True today. That is a
-        # defect, not a contract, and asserting it would cement it.
         differing = comparable_frame.copy()
         differing.loc[0, "field2"] = "goodbye"
         assert (Table(comparable_frame) == Table(differing)) is False
+
+    def test_tables_with_different_row_counts_are_not_equal(self):
+        shorter = Table([{"id": 1}])
+        longer = Table([{"id": 1}, {"id": 2}])
+        empty = Table([])
+        assert (shorter == longer) is False
+        assert (longer == shorter) is False
+        assert (empty == longer) is False


### PR DESCRIPTION
### What changes were proposed in this PR?

Require two Python Tables to have the same row count before comparing their rows. This prevents zip from hiding extra rows in either operand.

Before: a table matched any longer table with the same prefix, and an empty table matched a non-empty table.

After: unequal row counts compare false in both directions, while equal tables still compare true.

### Any related issues, documentation, discussions?

Closes #8195

### How was this PR tested?

Regression test first:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-table-length-equality\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\models\test_table.py','-q','-p','no:cacheprovider']))"

Before the source change: 18 passed and 1 failed. The failure reproduced the prefix truncation.

After the fix: 19 passed.

    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python
    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python amber/src/test/python

Result: all checks passed and 213 files were already formatted.

A broader Python model run reported 316 passed, 1 expected failure, and the unrelated upstream Windows epoch timestamp error already covered by PR #8174.

The live production comparison now returns false for one versus two rows in both directions and for empty versus non-empty, while an equal two-row copy returns true.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex