### PR TITLE
feat(pyamber): remove stale channel membership

### DIFF
--- a/amber/src/main/python/core/architecture/packaging/input_manager.py
+++ b/amber/src/main/python/core/architecture/packaging/input_manager.py
@@ -148,6 +148,9 @@ class InputManager:
             port_id.id = 0
         if port_id.internal is None:
             port_id.internal = False
+        if channel_id in self._channels:
+            old_port_id = self._channels[channel_id].port_id
+            self._ports[old_port_id].get_channels().discard(channel_id)
         channel = Channel()
         channel.set_port_id(port_id)
         self._channels[channel_id] = channel

--- a/amber/src/test/python/core/architecture/packaging/test_input_manager.py
+++ b/amber/src/test/python/core/architecture/packaging/test_input_manager.py
@@ -106,7 +106,7 @@ class TestChannelRegistration:
     def manager(self):
         return InputManager(worker_id=WORKER_ID, input_queue=MagicMock())
 
-    def test_re_registering_channel_leaves_stale_reverse_mapping(self, manager):
+    def test_re_registering_channel_removes_old_port_membership(self, manager):
         port_a, port_b = PortIdentity(0, False), PortIdentity(1, False)
         channel_id = _channel("upstream")
         for port_id in (port_a, port_b):
@@ -115,12 +115,9 @@ class TestChannelRegistration:
         manager.register_input(channel_id, port_a)
         manager.register_input(channel_id, port_b)
 
-        # The forward mapping is updated to the new port ...
         assert manager.get_port_id(channel_id) == port_b
         assert channel_id in manager.get_port(port_b).get_channels()
-        # ... but the old port's channel set is never cleaned up, so the
-        # channel remains in both reverse mappings (current behavior).
-        assert channel_id in manager.get_port(port_a).get_channels()
+        assert channel_id not in manager.get_port(port_a).get_channels()
 
     def test_data_channel_ids_exclude_control_channels(self, manager):
         port_id = PortIdentity(0, False)


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove a channel from its previous input port when registration reassigns it to another port. The existing forward mapping update and new-port registration remain unchanged.

Before: the forward map pointed to the new port, but both old and new port alignment sets contained the channel.

After: only the new port contains the channel, so port control-message alignment uses current membership.

### Any related issues, documentation, discussions?

Closes #8197

### How was this PR tested?

Regression test first:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-channel-reregistration\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\architecture\packaging\test_input_manager.py','-q','-p','no:cacheprovider']))"

Before the source change: 20 passed and 1 failed. The failure showed the reassigned channel still present on the old port.

After the fix, the input manager and embedded control-message manager suites reported 28 passed:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-channel-reregistration\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\architecture\packaging\test_input_manager.py',r'amber\src\test\python\core\architecture\managers\test_embedded_control_message_manager.py','-q','-p','no:cacheprovider']))"

    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python
    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python amber/src/test/python

Result: all checks passed and 213 files were already formatted.

The production InputManager probe now reports zero channels on the old port, one on the new port, and false for membership in both.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex