### PR TITLE
feat(pyamber): avoid duplicate storage writers

### DIFF
--- a/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -124,11 +124,10 @@ class OutputManager:
         if port_id.internal is None:
             port_id.internal = False
 
-        if storage_uri_base is not None:
-            self.set_up_port_storage_writer(port_id, storage_uri_base)
-
         # each port can only be added and initialized once.
         if port_id not in self._ports:
+            if storage_uri_base is not None:
+                self.set_up_port_storage_writer(port_id, storage_uri_base)
             self._ports[port_id] = WorkerPort(schema)
 
     def set_up_port_storage_writer(self, port_id: PortIdentity, storage_uri_base: str):

--- a/amber/src/test/python/core/architecture/packaging/test_output_manager.py
+++ b/amber/src/test/python/core/architecture/packaging/test_output_manager.py
@@ -385,16 +385,22 @@ class TestAddOutputPort:
     def test_port_can_only_be_added_once(self, output_manager):
         # A second add of the same port id must not replace the port (or
         # its schema) registered by the first add.
+        output_manager.set_up_port_storage_writer = MagicMock()
         schema_first = MagicMock(name="schema_first")
         port_id = PortIdentity(id=0, internal=False)
 
-        output_manager.add_output_port(port_id, schema_first)
+        output_manager.add_output_port(port_id, schema_first, "vfs:///base")
         output_manager.add_output_port(
-            PortIdentity(id=0, internal=False), MagicMock(name="schema_second")
+            PortIdentity(id=0, internal=False),
+            MagicMock(name="schema_second"),
+            "vfs:///base",
         )
 
         assert output_manager.get_port_ids() == [port_id]
         assert output_manager.get_port().get_schema() is schema_first
+        output_manager.set_up_port_storage_writer.assert_called_once_with(
+            port_id, "vfs:///base"
+        )
 
     def test_sets_up_storage_writer_only_when_uri_given(self, output_manager):
         output_manager.set_up_port_storage_writer = MagicMock()


### PR DESCRIPTION
### What changes were proposed in this PR?

Initialize output-port storage writers under the same first-registration guard that protects the port schema. Replaying an existing port assignment now leaves its original tracked writer pair intact.

Before: one logical port remained registered, but each repeated assignment started another result and state writer pair.

After: the first assignment initializes the port and its writers; repeated assignments do neither.

### Any related issues, documentation, discussions?

Closes #8199

### How was this PR tested?

Regression test first:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-duplicate-output-writers\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\architecture\packaging\test_output_manager.py','-q','-p','no:cacheprovider']))"

Before the source change: 38 passed and 1 failed. The failure showed two setup calls for one registered port.

After the fix, the OutputManager and port storage-writer lifecycle suites reported 44 passed:

    $env:PYTHONDONTWRITEBYTECODE='1'; C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\fix-pyamber-duplicate-output-writers\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\architecture\packaging\test_output_manager.py',r'amber\src\test\python\core\storage\runnables\test_port_storage_writer.py','-q','-p','no:cacheprovider']))"

    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python
    C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python amber/src/test/python

Result: all checks passed and 213 files were already formatted.

The production add_output_port probe now reports one registered port and one storage setup call after the assignment is repeated.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex