### PR TITLE
feat(amber): exclude control channels from port alignment

### DIFF
--- a/amber/src/main/python/core/architecture/managers/embedded_control_message_manager.py
+++ b/amber/src/main/python/core/architecture/managers/embedded_control_message_manager.py
@@ -57,11 +57,11 @@ class EmbeddedControlMessageManager:
             ecm_completed = ecm_received_from_all_channels
         elif ecm.ecm_type == EmbeddedControlMessageType.PORT_ALIGNMENT:
             port_id = self.input_gateway.get_port_id(from_channel)
-            ecm_completed = (
-                self.input_gateway.get_port(port_id)
-                .get_channels()
-                .issubset(self.ecm_received[ecm.id])
-            )
+            ecm_completed = {
+                channel
+                for channel in self.input_gateway.get_port(port_id).get_channels()
+                if not channel.is_control
+            }.issubset(self.ecm_received[ecm.id])
         elif ecm.ecm_type == EmbeddedControlMessageType.NO_ALIGNMENT:
             ecm_completed = (
                 len(self.ecm_received[ecm.id]) == 1

--- a/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/EmbeddedControlMessageManager.scala
+++ b/amber/src/main/scala/org/apache/texera/amber/engine/architecture/worker/EmbeddedControlMessageManager.scala
@@ -71,7 +71,11 @@ class EmbeddedControlMessageManager(
       case ALL_ALIGNMENT =>
         ecmReceivedFromAllChannels
       case PORT_ALIGNMENT =>
-        inputManager.getPort(portId).channels.subsetOf(ecmReceived(ecm.id))
+        inputManager
+          .getPort(portId)
+          .channels
+          .filterNot(_.isControl)
+          .subsetOf(ecmReceived(ecm.id))
       case NO_ALIGNMENT =>
         ecmReceived(ecm.id).size == 1 // only the first ECM triggers
       case _ =>

--- a/amber/src/test/python/core/architecture/managers/test_embedded_control_message_manager.py
+++ b/amber/src/test/python/core/architecture/managers/test_embedded_control_message_manager.py
@@ -141,6 +141,15 @@ class TestEcmPortAlignment:
         # Port B is single-channel, so b1 alone completes its port.
         assert mgr.is_ecm_aligned(b1, ecm) is True
 
+    def test_control_channel_does_not_block_data_port_alignment(self):
+        data = _channel("data")
+        control = _channel("control", is_control=True)
+        gw = _gateway_with_ports({"port": {data, control}}, all_channels={data})
+        mgr = EmbeddedControlMessageManager(SELF_ID, gw)
+        ecm = _make_ecm(EmbeddedControlMessageType.PORT_ALIGNMENT)
+
+        assert mgr.is_ecm_aligned(data, ecm) is True
+
     def test_unsupported_ecm_type_raises_value_error(self):
         # The `else: raise ValueError(...)` branch — guard against any new
         # enum value silently falling through.

--- a/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/EmbeddedControlMessageManagerSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/architecture/worker/EmbeddedControlMessageManagerSpec.scala
@@ -119,6 +119,25 @@ class EmbeddedControlMessageManagerSpec extends AnyFlatSpec with Matchers {
     mgr.isECMAligned(chB, ecm) shouldBe true
   }
 
+  it should "exclude control channels from PORT_ALIGNMENT" in {
+    val gateway = mkGateway
+    val inputManager = mkInputManager
+    val portId = PortIdentity()
+    val data = ChannelIdentity(senderA, actorId, isControl = false)
+    val control = ChannelIdentity(senderB, actorId, isControl = true)
+    gateway.getChannel(data).setPortId(portId)
+    gateway.getChannel(control).setPortId(portId)
+    inputManager.addPort(portId, Schema(), List.empty, List.empty)
+    inputManager.getPort(portId).channels.add(data)
+    inputManager.getPort(portId).channels.add(control)
+    val mgr = new EmbeddedControlMessageManager(actorId, gateway, inputManager)
+
+    mgr.isECMAligned(
+      data,
+      mkEcm(EmbeddedControlMessageType.PORT_ALIGNMENT, Seq.empty)
+    ) shouldBe true
+  }
+
   it should "align NO_ALIGNMENT only on the first received ECM" in {
     val gateway = mkGateway
     val inputManager = mkInputManager


### PR DESCRIPTION
### What changes were proposed in this PR?

Exclude control channels when deciding whether all data channels on an input port have received a port alignment marker.

The same correction and regression coverage are applied to the Scala and Python execution paths.

### Any related issues, documentation, discussions?

Closes #8201

### How was this PR tested?

Regression tests were added before the source change. They failed because the control channel remained in the required port set, then passed after the fix.

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>\amber\src\main\python',r'<main-checkout>\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/managers/test_embedded_control_message_manager.py',r'amber/src/test/python/core/architecture/packaging/test_input_manager.py','-q','-p','no:cacheprovider']))"
29 passed

sbt "WorkflowExecutionService / Test / testOnly org.apache.texera.amber.engine.architecture.worker.EmbeddedControlMessageManagerSpec"
6 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted

sbt scalafmtCheckAll
success
```

The Scala spec was executed with process-local source filters and ignored compiled outputs from a recent upstream-based worktree because the normal fresh-worktree build is currently blocked by unrelated JOOQ warehouse class generation. No generated output is included in this PR.

A direct local runtime probe with one data and one control channel on one port returned:

```text
data_channels= 1
port_channels= 2
data_marker_aligned= True
alignment_state_retained= False
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex