### PR TITLE
feat(pyamber): validate materialization configuration

### DIFF
--- a/amber/src/main/python/core/architecture/packaging/input_manager.py
+++ b/amber/src/main/python/core/architecture/packaging/input_manager.py
@@ -80,7 +80,8 @@ class InputManager:
     def set_up_input_port_mat_reader_threads(
         self, port_id: PortIdentity, uris: List[str], partitionings: List[Partitioning]
     ) -> None:
-        assert len(uris) == len(partitionings)
+        if len(uris) != len(partitionings):
+            raise ValueError("storage URIs and partitionings must have the same length")
         if uris is not None:
             reader_runnables = [
                 InputPortMaterializationReaderRunnable(

--- a/amber/src/test/python/core/architecture/packaging/test_input_manager.py
+++ b/amber/src/test/python/core/architecture/packaging/test_input_manager.py
@@ -183,10 +183,16 @@ class TestInputPortMaterializationReaderThreads:
 
         assert manager.get_input_port_mat_reader_threads() == {port_id: []}
 
-    def test_mismatched_uris_and_partitionings_are_rejected(self, manager):
-        with pytest.raises(AssertionError):
+    @pytest.mark.parametrize(
+        ("uris", "partitionings"),
+        [(["vfs:///a"], []), ([], [MagicMock()])],
+    )
+    def test_mismatched_uris_and_partitionings_are_rejected(
+        self, manager, uris, partitionings
+    ):
+        with pytest.raises(ValueError, match="same length"):
             manager.set_up_input_port_mat_reader_threads(
-                PortIdentity(0, False), ["vfs:///a"], []
+                PortIdentity(0, False), uris, partitionings
             )
 
     def test_second_set_up_replaces_previous_readers(self, manager):


### PR DESCRIPTION
### What changes were proposed in this PR?

Replace the removable assert on materialization URI and partitioning counts with an explicit ValueError.

The regression covers both mismatch directions and runs with normal and optimized Python.

### Any related issues, documentation, discussions?

Closes #8203

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/packaging/test_input_manager.py','-q','-p','no:cacheprovider']))"
22 passed

python -O -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/packaging/test_input_manager.py::TestInputPortMaterializationReaderThreads::test_mismatched_uris_and_partitionings_are_rejected','-q','-p','no:cacheprovider']))"
2 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct optimized-mode run now raises:

```text
ValueError: storage URIs and partitionings must have the same length
optimized= True
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex