### PR TITLE
feat(pyamber): validate table row fields

### DIFF
--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -43,8 +43,8 @@ class Table(pandas.DataFrame):
             tuple_ = Tuple(tuple_like)
             field_names = tuple_.get_field_names()
 
-            if column_names is not None:
-                assert field_names == column_names
+            if column_names is not None and field_names != column_names:
+                raise ValueError("all table rows must have the same fields")
             else:
                 column_names = field_names
 

--- a/amber/src/test/python/core/models/test_table.py
+++ b/amber/src/test/python/core/models/test_table.py
@@ -142,7 +142,7 @@ class TestTable:
         assert target_table.equals(target_data_frame)
 
     def test_validation_of_schema(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="same fields"):
             Table([{"text": "hello"}, {"book": "harry"}])
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### What changes were proposed in this PR?

Use an explicit ValueError when table rows have different field names, so optimized Python cannot remove the validation.

### Any related issues, documentation, discussions?

Closes #8205

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_table.py','-q','-p','no:cacheprovider']))"
18 passed

python -O -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_table.py::TestTable::test_validation_of_schema','-q','-p','no:cacheprovider']))"
1 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex