### PR TITLE
feat(pyamber): validate executor definitions

### DIFF
--- a/amber/src/main/python/core/architecture/managers/executor_manager.py
+++ b/amber/src/main/python/core/architecture/managers/executor_manager.py
@@ -125,7 +125,8 @@ class ExecutorManager:
         executors = list(
             filter(self.is_concrete_operator, executor_module.__dict__.values())
         )
-        assert len(executors) == 1, "There should be one and only one Operator defined"
+        if len(executors) != 1:
+            raise ValueError("There should be one and only one Operator defined")
         return executors[0]
 
     def close(self) -> None:

--- a/amber/src/test/python/core/architecture/managers/test_executor_manager.py
+++ b/amber/src/test/python/core/architecture/managers/test_executor_manager.py
@@ -407,17 +407,15 @@ class TestUpdateExecutor:
             )
         assert "SourceOperator API" in str(exc_info.value)
 
-    def test_update_with_no_operator_class_raises_assertion(self, initialized_manager):
-        # load_executor_definition asserts exactly one Operator subclass exists
-        # in the module — an empty module trips that assertion.
-        with pytest.raises(AssertionError) as exc_info:
+    def test_update_with_no_operator_class_is_rejected(self, initialized_manager):
+        with pytest.raises(ValueError) as exc_info:
             initialized_manager.update_executor(code=NO_OPERATOR_CODE, is_source=False)
         assert "one and only one Operator" in str(exc_info.value)
 
-    def test_update_with_multiple_operator_classes_raises_assertion(
+    def test_update_with_multiple_operator_classes_is_rejected(
         self, initialized_manager
     ):
-        with pytest.raises(AssertionError) as exc_info:
+        with pytest.raises(ValueError) as exc_info:
             initialized_manager.update_executor(
                 code=TWO_OPERATORS_CODE, is_source=False
             )


### PR DESCRIPTION
### What changes were proposed in this PR?

Replace the removable assert on executor definition count with an explicit ValueError.

The regression covers both missing and multiple operator definitions under normal and optimized Python.

### Any related issues, documentation, discussions?

Closes #8207

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/managers/test_executor_manager.py','-q','-p','no:cacheprovider']))"
25 passed

python -O -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/managers/test_executor_manager.py','-q','-p','no:cacheprovider','-k','no_operator_class_is_rejected or multiple_operator_classes_is_rejected']))"
2 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex