### PR TITLE
feat(pyamber): hash epoch timestamps on Windows

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -24,6 +24,7 @@ import struct
 import typing
 from collections import OrderedDict
 from copy import deepcopy as _deepcopy
+from dateutil.tz import tzlocal
 from loguru import logger
 from pandas._libs.missing import checknull
 from pympler import asizeof
@@ -472,7 +473,9 @@ class Tuple:
             AttributeType.LONG: lambda f: java_hash_long(f),
             AttributeType.DOUBLE: lambda f: java_hash_long(double_to_long(f)),
             AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
-            AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
+            AttributeType.TIMESTAMP: lambda f: java_hash_long(
+                int((f if f.tzinfo else f.replace(tzinfo=tzlocal())).timestamp())
+            ),
             AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
         }
 

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -561,6 +561,14 @@ class TestTuple:
         )
         assert hash(tuple5) == -2099556631  # calculated with Java
 
+    def test_hash_supports_local_epoch_timestamp(self):
+        tuple_ = Tuple(
+            {"value": datetime.datetime.fromtimestamp(0)},
+            Schema(raw_schema={"value": "TIMESTAMP"}),
+        )
+
+        assert hash(tuple_) == 31
+
     def test_tuple_with_large_binary(self):
         """Test tuple with largebinary field."""
         from core.models.type.large_binary import largebinary


### PR DESCRIPTION
### What changes were proposed in this PR?

Attach the system local timezone before converting naive timestamps for tuple hashing. This avoids the Windows pre-epoch failure while preserving aware timestamps and Java-compatible epoch seconds.

### Any related issues, documentation, discussions?

Closes #8211

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_supports_local_epoch_timestamp','-q','-p','no:cacheprovider']))"
1 passed

python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-q','-p','no:cacheprovider','-k','not test_hash']))"
101 passed, 3 deselected

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

The broader existing test_hash now passes its epoch assertion but later fails while its Windows fixture calls datetime.fromtimestamp with a negative value, before Texera hashing runs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex