### PR TITLE
feat(pyamber): escape state marker collisions

### DIFF
--- a/amber/src/main/python/core/models/state.py
+++ b/amber/src/main/python/core/models/state.py
@@ -82,6 +82,7 @@ class State(dict):
 _TYPE_MARKER = "__texera_type__"
 _PAYLOAD_MARKER = "payload"
 _BYTES_TYPE = "bytes"
+_DICT_TYPE = "dict"
 
 
 def _to_json_value(value: Any) -> Any:
@@ -93,7 +94,10 @@ def _to_json_value(value: Any) -> Any:
             _PAYLOAD_MARKER: base64.b64encode(value).decode("ascii"),
         }
     if isinstance(value, dict):
-        return {str(key): _to_json_value(inner) for key, inner in value.items()}
+        encoded = {str(key): _to_json_value(inner) for key, inner in value.items()}
+        if _TYPE_MARKER in encoded:
+            return {_TYPE_MARKER: _DICT_TYPE, _PAYLOAD_MARKER: encoded}
+        return encoded
     if isinstance(value, (list, tuple)):
         return [_to_json_value(inner) for inner in value]
     raise TypeError(
@@ -105,7 +109,13 @@ def _from_json_value(value: Any) -> Any:
     if isinstance(value, list):
         return [_from_json_value(inner) for inner in value]
     if isinstance(value, dict):
-        if value.get(_TYPE_MARKER) == _BYTES_TYPE:
+        marker_keys = {_TYPE_MARKER, _PAYLOAD_MARKER}
+        if set(value) == marker_keys and value.get(_TYPE_MARKER) == _BYTES_TYPE:
             return base64.b64decode(value[_PAYLOAD_MARKER])
+        if set(value) == marker_keys and value.get(_TYPE_MARKER) == _DICT_TYPE:
+            return {
+                key: _from_json_value(inner)
+                for key, inner in value[_PAYLOAD_MARKER].items()
+            }
         return {key: _from_json_value(inner) for key, inner in value.items()}
     return value

--- a/amber/src/test/python/core/models/test_state.py
+++ b/amber/src/test/python/core/models/test_state.py
@@ -67,6 +67,19 @@ class TestState:
         decoded = State.from_json(original.to_json())
         assert decoded == original
 
+    @pytest.mark.parametrize(
+        "user_value",
+        [
+            {"__texera_type__": "bytes", "payload": "aGVsbG8="},
+            {"__texera_type__": "bytes", "payload": "aGVsbG8=", "owner": "user"},
+            {"__texera_type__": "dict", "payload": {"nested": 1}},
+        ],
+    )
+    def test_json_round_trip_preserves_user_type_markers(self, user_value):
+        original = State({"config": user_value})
+
+        assert State.from_json(original.to_json()) == original
+
     def test_json_round_trip_list_of_mixed_values(self):
         original = State({"items": [1, "two", 3.0, True, None]})
         decoded = State.from_json(original.to_json())


### PR DESCRIPTION
### What changes were proposed in this PR?

Escape user dictionaries containing Texera's internal type-marker key before JSON serialization.

The decoder now recognizes only exact internal envelopes and restores escaped dictionaries without interpreting their own top-level keys. Existing byte envelopes remain compatible.

### Any related issues, documentation, discussions?

Closes #8213

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_state.py','-q','-p','no:cacheprovider']))"
16 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

The direct runtime round trip now reports:

```text
decoded= {'config': {'__texera_type__': 'bytes', 'payload': 'aGVsbG8=', 'owner': 'user'}}
round_trip_equal= True
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex