### PR TITLE
feat(pyamber): reject non-string state keys

### DIFF
--- a/amber/src/main/python/core/models/state.py
+++ b/amber/src/main/python/core/models/state.py
@@ -93,7 +93,9 @@ def _to_json_value(value: Any) -> Any:
             _PAYLOAD_MARKER: base64.b64encode(value).decode("ascii"),
         }
     if isinstance(value, dict):
-        return {str(key): _to_json_value(inner) for key, inner in value.items()}
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("State dictionary keys must be strings")
+        return {key: _to_json_value(inner) for key, inner in value.items()}
     if isinstance(value, (list, tuple)):
         return [_to_json_value(inner) for inner in value]
     raise TypeError(

--- a/amber/src/test/python/core/models/test_state.py
+++ b/amber/src/test/python/core/models/test_state.py
@@ -90,6 +90,13 @@ class TestState:
         with pytest.raises(TypeError):
             State({"bad": Custom()}).to_json()
 
+    @pytest.mark.parametrize(
+        "state", [State({1: "value"}), State({"nested": {1: "value"}})]
+    )
+    def test_to_json_rejects_non_string_keys(self, state):
+        with pytest.raises(TypeError, match="keys must be strings"):
+            state.to_json()
+
     def test_tuple_round_trip(self):
         original = State({"i": 3, "label": "outer", "blob": b"\x01\x02"})
         decoded = State.from_tuple(original.to_tuple())


### PR DESCRIPTION
### What changes were proposed in this PR?

Reject non-string state dictionary keys before JSON serialization instead of coercing them and risking collisions.

The regression covers both top-level and nested mappings.

### Any related issues, documentation, discussions?

Closes #8215

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_state.py','-q','-p','no:cacheprovider']))"
15 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct runtime probe now raises:

```text
TypeError: State dictionary keys must be strings
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex