### PR TITLE
feat(pyamber): reject empty tuples

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -189,7 +189,8 @@ class Tuple:
         :param tuple_like: in which the field value could be the actual value in
             memory, or a callable accessor.
         """
-        assert len(tuple_like) != 0
+        if len(tuple_like) == 0:
+            raise ValueError("Tuple cannot be empty")
         self._field_data: "OrderedDict[str, Field]"
         if isinstance(tuple_like, Tuple):
             self._field_data = tuple_like._field_data

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -103,11 +103,11 @@ class TestTuple:
         assert Tuple({"x": 1, "y": "b"}) != target_tuple
 
     def test_reject_empty_tuplelike(self):
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="cannot be empty"):
             Tuple([])
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="cannot be empty"):
             Tuple({})
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError, match="cannot be empty"):
             Tuple(pandas.Series(dtype=pandas.StringDtype()))
 
     def test_reject_invalid_tuplelike(self):


### PR DESCRIPTION
### What changes were proposed in this PR?

Replace the removable empty-tuple assert with an explicit ValueError.

Existing coverage for empty lists, dictionaries, and pandas Series now verifies the stable exception, including optimized Python.

### Any related issues, documentation, discussions?

Closes #8217

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-q','-p','no:cacheprovider','-k','not test_hash']))"
101 passed, 2 deselected

python -O -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_reject_empty_tuplelike','-q','-p','no:cacheprovider']))"
1 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex