### PR TITLE
feat(pyamber): prevent tuple refinalization

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -300,7 +300,8 @@ class Tuple:
         :param schema: target Schema to finalize the Tuple.
         :return:
         """
-        assert self._schema is None
+        if self._schema is not None:
+            raise ValueError("Tuple is already finalized")
         self.cast_to_schema(schema)
         self.validate_schema(schema)
         self._schema = schema

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -154,6 +154,15 @@ class TestTuple:
         assert isinstance(tuple_["scores"], bytes)
         assert tuple_["height"] is None
 
+    def test_finalize_rejects_an_already_finalized_tuple(self):
+        tuple_ = Tuple({"value": 1})
+        tuple_.finalize(Schema(raw_schema={"value": "INTEGER"}))
+
+        with pytest.raises(ValueError, match="already finalized"):
+            tuple_.finalize(Schema(raw_schema={"value": "BINARY"}))
+
+        assert tuple_["value"] == 1
+
     # Pandas-based operators (e.g. TableOperator via Table.from_tuple_likes)
     # promote an int column containing nulls to float64, so an INT field can
     # arrive at finalize() as 119.0. finalize() must coerce such integral


### PR DESCRIPTION
### What changes were proposed in this PR?

Replace the removable finalization assert with an explicit ValueError before any second schema conversion can mutate the tuple.

### Any related issues, documentation, discussions?

Closes #8219

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-q','-p','no:cacheprovider','-k','not test_hash']))"
102 passed, 2 deselected

python -O -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py::TestTuple::test_finalize_rejects_an_already_finalized_tuple','-q','-p','no:cacheprovider']))"
1 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex