### PR TITLE
feat(pyamber): insert queue priorities in order

### DIFF
--- a/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
+++ b/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
@@ -423,7 +423,7 @@ class LinkedBlockingMultiQueue(IKeyedQueue):
                     elif pg.priority > priority:
                         new_pg = self.PriorityGroup(priority)
                         new_pg.add_queue(sub_queue)
-                        self.priority_groups.append(new_pg)
+                        self.priority_groups.insert(i, new_pg)
                         added = True
                         break
 

--- a/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
+++ b/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
@@ -72,6 +72,17 @@ class TestLinkedBlockingMultiQueue:
         assert queue.get() == 1
         assert queue.is_empty()
 
+    def test_late_higher_priority_queue_is_selected_first(self):
+        queue = LinkedBlockingMultiQueue()
+        queue.add_sub_queue("data", 2)
+        queue.add_sub_queue("control", 1)
+        queue.put("data", "data message")
+        queue.put("control", "control message")
+
+        assert [group.priority for group in queue.priority_groups] == [1, 2]
+        assert queue.get() == "control message"
+        assert queue.get() == "data message"
+
     def test_can_maintain_order_respectively(self, queue):
         queue.put("data", 1)
         queue.put("control", "s1")


### PR DESCRIPTION
### What changes were proposed in this PR?

Insert a newly discovered priority group at the calculated position instead of appending it.

This preserves control-before-data ordering regardless of subqueue registration order.

### Any related issues, documentation, discussions?

Closes #8221

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'<worktree>ambersrcmainpython',r'<main-checkout>ambersrcmainpython']; raise SystemExit(pytest.main([r'amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py',r'amber/src/test/python/core/models/test_internal_queue.py','-q','-p','no:cacheprovider']))"
77 passed, 1 xpassed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

The direct runtime probe now reports priority order 1, 2 and returns the control message first.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex