### PR TITLE
feat(pyamber): preserve duplicate subqueues

### DIFF
--- a/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
+++ b/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
@@ -411,7 +411,7 @@ class LinkedBlockingMultiQueue(IKeyedQueue):
 
         try:
             old_queue = self.sub_queues.get(key)
-            self.sub_queues[key] = sub_queue
+            self.sub_queues[key] = sub_queue if old_queue is None else old_queue
             if old_queue is None:
                 i = 0
                 added = False

--- a/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
+++ b/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
@@ -72,6 +72,19 @@ class TestLinkedBlockingMultiQueue:
         assert queue.get() == 1
         assert queue.is_empty()
 
+    def test_duplicate_subqueue_registration_keeps_existing_queue(self):
+        queue = LinkedBlockingMultiQueue()
+        queue.add_sub_queue("data", 1)
+        original = queue.get_sub_queue("data")
+        queue.put("data", "first")
+
+        assert queue.add_sub_queue("data", 1) is original
+        assert queue.get_sub_queue("data") is original
+
+        queue.put("data", "second")
+        assert queue.size() == queue.size("data") == 2
+        assert [queue.get(), queue.get()] == ["first", "second"]
+
     def test_can_maintain_order_respectively(self, queue):
         queue.put("data", 1)
         queue.put("control", "s1")


### PR DESCRIPTION
### What changes were proposed in this PR?

Preserve the existing subqueue when the same key is registered twice. This keeps the key lookup and priority group aligned so queued messages remain reachable.

### Any related issues, documentation, discussions?

Closes #8223

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source, main amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py','amber/src/test/python/core/models/test_internal_queue.py','-q','-p','no:cacheprovider']))"
77 passed, 1 xfailed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct post-fix probe registered the same key twice and then read both messages:

```text
preserved=True
returned_old=True
sizes=2 2
messages=first second
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex