### PR TITLE
feat(pyamber): keep peek side effect free

### DIFF
--- a/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
+++ b/amber/src/main/python/core/util/customized_queue/linked_blocking_multi_queue.py
@@ -227,16 +227,13 @@ class LinkedBlockingMultiQueue(IKeyedQueue):
             return None
 
         def peek(self) -> Optional[T]:
-            start_idx = self.next_idx
+            idx = self.next_idx
             while True:
-                child = self.queues[self.next_idx]
+                child = self.queues[idx]
                 if child.enabled and child.size() > 0:
                     return child.head.next.item
-                else:
-                    self.next_idx += 1
-                    if self.next_idx == len(self.queues):
-                        self.next_idx = 0
-                if self.next_idx == start_idx:
+                idx = (idx + 1) % len(self.queues)
+                if idx == self.next_idx:
                     break
             return None
 

--- a/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
+++ b/amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py
@@ -273,7 +273,7 @@ class TestPeek:
         queue.disable("data")
         assert queue.peek() is None
 
-    def test_priority_group_peek_perturbs_round_robin_state(self):
+    def test_priority_group_peek_preserves_round_robin_state(self):
         lbmq = LinkedBlockingMultiQueue()
         lbmq.add_sub_queue("first", 1)
         lbmq.add_sub_queue("second", 1)
@@ -282,9 +282,10 @@ class TestPeek:
 
         assert group.next_idx == 0
         assert group.peek() == "s"
-        # Skipping the empty `first` queue advanced next_idx, so peek is not
-        # side-effect free on the group's round-robin cursor.
-        assert group.next_idx == 1
+        assert group.next_idx == 0
+
+        lbmq.put("first", "f")
+        assert lbmq.get() == "f"
 
     def test_priority_group_peek_returns_none_when_all_queues_empty(self, queue):
         group = queue.get_sub_queue("control").priority_group


### PR DESCRIPTION
### What changes were proposed in this PR?

Scan subqueues with a local index when peeking so observation does not advance the round-robin cursor or alter the next message returned by `get()`.

### Any related issues, documentation, discussions?

Closes #8225

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source, main amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/util/customized_queue/test_linked_blocking_multi_queue.py','amber/src/test/python/core/models/test_internal_queue.py','-q','-p','no:cacheprovider']))"
76 passed, 1 xfailed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct post-fix probe confirmed that peek does not change the cursor or the next message:

```text
cursor_before_peek=0
peek=second
cursor_after_peek=0
next_after_peek=first
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex