### PR TITLE
feat(pyamber): clean up reassigned channels

### DIFF
--- a/amber/src/main/python/core/architecture/packaging/input_manager.py
+++ b/amber/src/main/python/core/architecture/packaging/input_manager.py
@@ -148,6 +148,9 @@ class InputManager:
             port_id.id = 0
         if port_id.internal is None:
             port_id.internal = False
+        if channel_id in self._channels:
+            old_port_id = self._channels[channel_id].port_id
+            self._ports[old_port_id].get_channels().discard(channel_id)
         channel = Channel()
         channel.set_port_id(port_id)
         self._channels[channel_id] = channel

--- a/amber/src/test/python/core/architecture/packaging/test_input_manager.py
+++ b/amber/src/test/python/core/architecture/packaging/test_input_manager.py
@@ -106,7 +106,7 @@ class TestChannelRegistration:
     def manager(self):
         return InputManager(worker_id=WORKER_ID, input_queue=MagicMock())
 
-    def test_re_registering_channel_leaves_stale_reverse_mapping(self, manager):
+    def test_re_registering_channel_moves_reverse_mapping(self, manager):
         port_a, port_b = PortIdentity(0, False), PortIdentity(1, False)
         channel_id = _channel("upstream")
         for port_id in (port_a, port_b):
@@ -115,12 +115,9 @@ class TestChannelRegistration:
         manager.register_input(channel_id, port_a)
         manager.register_input(channel_id, port_b)
 
-        # The forward mapping is updated to the new port ...
         assert manager.get_port_id(channel_id) == port_b
         assert channel_id in manager.get_port(port_b).get_channels()
-        # ... but the old port's channel set is never cleaned up, so the
-        # channel remains in both reverse mappings (current behavior).
-        assert channel_id in manager.get_port(port_a).get_channels()
+        assert channel_id not in manager.get_port(port_a).get_channels()
 
     def test_data_channel_ids_exclude_control_channels(self, manager):
         port_id = PortIdentity(0, False)


### PR DESCRIPTION
### What changes were proposed in this PR?

Remove a channel from its previous input port before registering it with another port. This keeps the forward mapping and each port's channel set consistent for port-aligned control messages.

### Any related issues, documentation, discussions?

Closes #8227

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source, main amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/architecture/packaging/test_input_manager.py','amber/src/test/python/core/architecture/managers/test_embedded_control_message_manager.py','amber/src/test/python/core/architecture/handlers/control/test_add_input_channel_handler.py','-q','-p','no:cacheprovider']))"
40 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct post-fix probe confirmed both mapping directions agree:

```text
mapped_port=1
old_port_contains_channel=False
new_port_contains_channel=True
old_port_channel_count=0
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex