### PR TITLE
feat(pyamber): compare table row counts

### DIFF
--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -77,7 +77,9 @@ class Table(pandas.DataFrame):
 
     def __eq__(self, other: "Table") -> bool:
         if isinstance(other, Table):
-            return all(a == b for a, b in zip(self.as_tuples(), other.as_tuples()))
+            return len(self) == len(other) and all(
+                a == b for a, b in zip(self.as_tuples(), other.as_tuples())
+            )
         else:
             return super().__eq__(other).all()
 

--- a/amber/src/test/python/core/models/test_table.py
+++ b/amber/src/test/python/core/models/test_table.py
@@ -215,10 +215,12 @@ class TestTable:
         # test in this file compares two *equal* Tables, so replacing the arm's
         # body with `return True` survived the whole suite. One negative case
         # closes that.
-        #
-        # Deliberately NOT pinned here: `zip` truncates to the shorter operand,
-        # so `Table(frame.head(1)) == Table(frame)` is True today. That is a
-        # defect, not a contract, and asserting it would cement it.
         differing = comparable_frame.copy()
         differing.loc[0, "field2"] = "goodbye"
         assert (Table(comparable_frame) == Table(differing)) is False
+
+    def test_two_tables_with_different_row_counts_are_not_equal(self, comparable_frame):
+        short = Table(comparable_frame.head(1))
+        full = Table(comparable_frame)
+        assert (short == full) is False
+        assert (full == short) is False


### PR DESCRIPTION
### What changes were proposed in this PR?

Require equal row counts before comparing table rows. This prevents the existing `zip` comparison from treating a shorter matching prefix as a fully equal table.

### Any related issues, documentation, discussions?

Closes #8229

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source, main amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/models/test_table.py','amber/src/test/python/pytexera/udf/test_udf_operator.py','-q','-p','no:cacheprovider']))"
71 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct post-fix probe covered different lengths in both directions and the equal case:

```text
short_equals_long=False
long_equals_short=False
short_equals_same=True
lengths=1 2
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex