### PR TITLE
feat(pyamber): return boolean table equality

### DIFF
--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -79,7 +79,7 @@ class Table(pandas.DataFrame):
         if isinstance(other, Table):
             return all(a == b for a, b in zip(self.as_tuples(), other.as_tuples()))
         else:
-            return super().__eq__(other).all()
+            return bool(super().__eq__(other).all(axis=None))
 
 
 def all_output_to_tuple(output) -> Iterator[Tuple]:

--- a/amber/src/test/python/core/models/test_table.py
+++ b/amber/src/test/python/core/models/test_table.py
@@ -194,21 +194,10 @@ class TestTable:
         # has at least one matching row, so the reduction would come back True).
         assert not numpy.all(table == differing)
 
-    def test_comparing_to_a_data_frame_currently_yields_a_per_column_series(
-        self, comparable_frame
-    ):
-        # CHARACTERIZATION, not a contract. `Table.__eq__` is annotated
-        # `-> bool`, but its non-Table branch returns
-        # `super().__eq__(other).all()`, which for a DataFrame operand reduces
-        # only over rows and leaves a Series indexed by column name. A bare
-        # `assert table == frame` therefore raises "truth value of a Series is
-        # ambiguous". This test records today's shape so that narrowing the
-        # branch to a real bool surfaces here deliberately, with a name that
-        # says so, rather than silently through the behavioural tests above.
+    def test_comparing_to_a_data_frame_returns_a_boolean(self, comparable_frame):
         table = Table(comparable_frame)
         comparison = table == comparable_frame
-        assert isinstance(comparison, pandas.Series)
-        assert list(comparison.index) == ["field1", "field2", "field3"]
+        assert comparison is True
 
     def test_two_tables_with_differing_rows_are_not_equal(self, comparable_frame):
         # The Table-vs-Table arm had only positive coverage: every pre-existing


### PR DESCRIPTION
### What changes were proposed in this PR?

Reduce DataFrame equality across all rows and columns, then return a Python boolean. This makes `Table.__eq__` match its declared contract and avoids ambiguous-Series failures in callers.

### Any related issues, documentation, discussions?

Closes #8231

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source, main amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/models/test_table.py','amber/src/test/python/pytexera/udf/test_udf_operator.py','-q','-p','no:cacheprovider']))"
70 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

A direct post-fix probe covered equal and differing DataFrames:

```text
equal_type=bool
equal_result=True
different_type=bool
different_result=False
truth=True
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex