### PR TITLE
feat(pyamber): report batch element failures

### DIFF
--- a/amber/src/main/python/core/runnables/main_loop.py
+++ b/amber/src/main/python/core/runnables/main_loop.py
@@ -811,7 +811,8 @@ class MainLoop(StoppableQueueBlockingRunnable):
                     self._process_state_frame,
                 )
             except Exception as err:
-                logger.exception(err)
+                self.context.report_exception(err)
+        self._check_exception()
 
     def _send_console_message(self, console_message: ConsoleMessage):
         self._async_rpc_client.coordinator_stub().console_message_triggered(

--- a/amber/src/test/python/core/runnables/test_main_loop.py
+++ b/amber/src/test/python/core/runnables/test_main_loop.py
@@ -3745,13 +3745,6 @@ class TestMainLoop:
         # so letting a failure on one element escape the loop would silently
         # drop every element behind it. _process_data_element's per-element
         # backstop keeps iterating instead.
-        #
-        # Deliberately NOT asserted: that nothing is reported to the
-        # coordinator. The backstop only logs, so a runtime-level per-element
-        # failure never reaches Context.report_exception and the workflow can
-        # report success on a short result -- arguably a silent-wrong-result
-        # defect. Pinning that half would cement it, so this test asserts only
-        # that iteration continues and that nothing propagates.
         schema = Schema(raw_schema=mock_raw_schema)
         port_0 = PortIdentity(0, internal=False)
         channel = self._register_input_port(main_loop, schema, port_0, "sender")
@@ -3783,30 +3776,6 @@ class TestMainLoop:
             main_loop.context.statistics_manager, "increase_input_statistics", _boom
         )
 
-        # Because the coordinator report is deliberately not asserted (above),
-        # the log line is the swallow's ONLY remaining trace -- so pin it.
-        # `except Exception: pass` is a strictly worse regression than the
-        # defect described above (a short result with no evidence anywhere
-        # rather than a stack trace in the worker log) and is not a defensible
-        # production change, so this is a gap rather than a bug to cement.
-        # The proxy delegates every other level to the real logger so the
-        # module's debug/info calls keep working.
-        from core.runnables import main_loop as main_loop_module
-
-        class _RecordingLogger:
-            def __init__(self, delegate):
-                self.exceptions = []
-                self._delegate = delegate
-
-            def exception(self, err):
-                self.exceptions.append(err)
-
-            def __getattr__(self, name):
-                return getattr(self._delegate, name)
-
-        recorder = _RecordingLogger(main_loop_module.logger)
-        monkeypatch.setattr(main_loop_module, "logger", recorder)
-
         # Must not raise.
         main_loop._process_data_element(element)
 
@@ -3814,13 +3783,7 @@ class TestMainLoop:
             "a failure on one element must not abandon the rest of the batch; "
             f"attempted: {attempted}"
         )
-        assert [type(err) for err in recorder.exceptions] == [
-            RuntimeError,
-            RuntimeError,
-        ], (
-            "every swallowed per-element failure must leave a log trace; "
-            f"logged: {recorder.exceptions}"
-        )
-        assert all(
-            "statistics backend unavailable" in str(err) for err in recorder.exceptions
-        ), f"the logged trace must carry the real error; logged: {recorder.exceptions}"
+        assert main_loop.context.exception_manager.has_exception()
+        history = main_loop.context.exception_manager.exc_info_history
+        assert len(history) == 2
+        assert all("statistics backend unavailable" in str(info[1]) for info in history)


### PR DESCRIPTION
### What changes were proposed in this PR?

Route per-element batch failures through the normal exception reporter, then check the recorded exception after the batch finishes iterating. This preserves the existing attempt-all-rows behavior while preventing a workflow from silently succeeding with missing rows.

### Any related issues, documentation, discussions?

Closes #8233

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source, main amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/runnables/test_main_loop.py::TestMainLoop::test_a_failing_element_does_not_abandon_the_rest_of_the_batch','amber/src/test/python/core/runnables/test_data_processor.py','amber/src/test/python/core/architecture/managers/test_exception_manager.py','-q','-p','no:cacheprovider']))"
12 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

The regression processes two failing rows, confirms both were attempted, and confirms both failures were retained in exception history before the worker enters exception handling.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex