### PR TITLE
fix(amber): preserve evaluated values

### DIFF
--- a/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/rpc/controlreturns.proto
+++ b/amber/src/main/protobuf/org/apache/texera/amber/engine/architecture/rpc/controlreturns.proto
@@ -43,6 +43,7 @@ message ControlReturn {
     WorkerStateResponse workerStateResponse = 50;
     WorkerMetricsResponse workerMetricsResponse = 51;
     FinalizeCheckpointResponse finalizeCheckpointResponse = 52;
+    EvaluatedValue evaluatedValue = 53;
 
     // common responses
     ControlError controlError = 101;

--- a/amber/src/test/python/core/architecture/rpc/test_async_rpc_handler_initializer.py
+++ b/amber/src/test/python/core/architecture/rpc/test_async_rpc_handler_initializer.py
@@ -70,15 +70,6 @@ UNIMPLEMENTED_RPCS = frozenset(
     }
 )
 
-# Worker replies with no slot in ControlReturn's oneof. The worker service
-# declares EvaluatedValue as EvaluatePythonExpression's reply, but the oneof
-# registers only the coordinator-side wrapper, so set_one_of() packs an EMPTY
-# ControlReturn: the answer is silently dropped (verified by hand).
-# test_async_rpc_server.py pins that swallowing mechanism with a synthetic
-# type; this names the real RPC that hits it. The fix is a .proto change in
-# its own PR -- this spec only pins the current, broken shape.
-REPLIES_MISSING_FROM_CONTROL_RETURN = frozenset({"evaluate_python_expression"})
-
 # Scanned on disk to catch handler classes the MRO cannot see.
 HANDLER_PACKAGE = "core.architecture.handlers.control"
 
@@ -218,14 +209,12 @@ class TestTransportOneofs:
         )
         assert unroutable == []
 
-    def test_reply_types_missing_from_control_return_are_exactly_the_known_hole(self):
+    def test_every_reply_type_is_a_control_return_oneof_member(self):
         members = _oneof_member_types(ControlReturn)
         missing = {
             name for name, rpc in RPCS.items() if rpc.handler.reply_type not in members
         }
-        # Both directions: fixing the proto without updating the constant
-        # fails, and so does padding the constant with a routable RPC.
-        assert missing == set(REPLIES_MISSING_FROM_CONTROL_RETURN)
+        assert missing == set()
 
 
 class TestHandlerCoverage:


### PR DESCRIPTION
### What changes were proposed in this PR?

Add the worker's `EvaluatedValue` reply to the generic `ControlReturn` transport. This prevents evaluated Python expression results from being replaced by an empty return before they reach the coordinator.

### Any related issues, documentation, discussions?

Closes #8235

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[worktree amber source]; raise SystemExit(pytest.main(['amber/src/test/python/core/architecture/rpc/test_async_rpc_handler_initializer.py','amber/src/test/python/core/architecture/rpc/test_async_rpc_server.py','amber/src/test/python/core/architecture/handlers/control/test_evaluate_expression_handler.py','-q','-p','no:cacheprovider']))"
81 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

The Python protobuf bindings were regenerated from the changed descriptor for verification and remain ignored as required by the repository. A direct post-fix transport probe produced:

```text
packed_type=EvaluatedValue
packed_value=42
round_trip=True
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex