### PR TITLE
feat(pyamber): align VFS resource wire values

### DIFF
--- a/amber/src/main/python/core/storage/vfs_uri_factory.py
+++ b/amber/src/main/python/core/storage/vfs_uri_factory.py
@@ -33,8 +33,8 @@ from proto.org.apache.texera.amber.core import (
 
 class VFSResourceType(str, Enum):
     RESULT = "result"
-    RUNTIME_STATISTICS = "runtimeStatistics"
-    CONSOLE_MESSAGES = "consoleMessages"
+    RUNTIME_STATISTICS = "runtimestatistics"
+    CONSOLE_MESSAGES = "consolemessages"
     STATE = "state"
 
 

--- a/amber/src/test/python/core/storage/test_vfs_uri_factory.py
+++ b/amber/src/test/python/core/storage/test_vfs_uri_factory.py
@@ -113,6 +113,17 @@ class TestDecodeUriRoundTrip:
         assert components.global_port_id is None
         assert components.resource_type == VFSResourceType.RESULT
 
+    @pytest.mark.parametrize(
+        ("suffix", "resource_type"),
+        [
+            ("runtimestatistics", VFSResourceType.RUNTIME_STATISTICS),
+            ("consolemessages", VFSResourceType.CONSOLE_MESSAGES),
+        ],
+    )
+    def test_scala_resource_type_wire_format_decodes(self, suffix, resource_type):
+        uri = f"vfs:///wid/11/eid/22/{suffix}"
+        assert VFSURIFactory.decode_uri(uri).resource_type == resource_type
+
 
 class TestDecodeUriErrorPaths:
     def test_rejects_non_vfs_scheme(self):


### PR DESCRIPTION
### What changes were proposed in this PR?

Align the Python runtime statistics and console message resource values with the lowercase VFS wire format produced by Scala. The decoder keeps its existing case normalization.

The regression test uses literal Scala wire values instead of values read from the Python enum.

### Any related issues, documentation, discussions?

Closes #8237

### How was this PR tested?

Before the implementation change:

```text
2 failed, 19 passed
```

After the implementation change:

```text
C:\Users\carlo\texera\venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug55\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/storage/test_vfs_uri_factory.py','amber/src/test/python/core/storage/test_document_factory.py','-q','-p','no:cacheprovider']))"
32 passed

C:\Users\carlo\texera\venv312\Scripts\python.exe -m ruff check amber/src/main/python/core/storage/vfs_uri_factory.py amber/src/test/python/core/storage/test_vfs_uri_factory.py
All checks passed

C:\Users\carlo\texera\venv312\Scripts\python.exe -m ruff format --check amber/src/main/python/core/storage/vfs_uri_factory.py amber/src/test/python/core/storage/test_vfs_uri_factory.py
2 files already formatted
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex