### PR TITLE
feat(pyamber): reject invalid port booleans

### DIFF
--- a/amber/src/main/python/core/util/virtual_identity.py
+++ b/amber/src/main/python/core/util/virtual_identity.py
@@ -111,6 +111,9 @@ def deserialize_global_port_identity(encoded_str: str) -> GlobalPortIdentity:
     port_id = int(port_id_str)
     if port_id < 0:
         raise ValueError(f"portId must be non-negative: {port_id}")
+    for field, value in (("isInternal", is_internal_str), ("isInput", is_input_str)):
+        if value.lower() not in ("true", "false"):
+            raise ValueError(f"Invalid {field}: {value}")
     is_internal = is_internal_str.lower() == "true"
     is_input_port = is_input_str.lower() == "true"
     op_id = PhysicalOpIdentity(

--- a/amber/src/main/python/core/util/virtual_identity.py
+++ b/amber/src/main/python/core/util/virtual_identity.py
@@ -113,7 +113,10 @@ def deserialize_global_port_identity(encoded_str: str) -> GlobalPortIdentity:
         raise ValueError(f"portId must be non-negative: {port_id}")
     for field, value in (("isInternal", is_internal_str), ("isInput", is_input_str)):
         if value.lower() not in ("true", "false"):
-            raise ValueError(f"Invalid {field}: {value}")
+            raise ValueError(
+                f"Invalid {field}: {value}. Expected true/false in GlobalPortIdentity "
+                f"encoding: {encoded_str}"
+            )
     is_internal = is_internal_str.lower() == "true"
     is_input_port = is_input_str.lower() == "true"
     op_id = PhysicalOpIdentity(

--- a/amber/src/test/python/core/util/test_virtual_identity.py
+++ b/amber/src/test/python/core/util/test_virtual_identity.py
@@ -195,6 +195,16 @@ class TestDeserializeGlobalPortIdentity:
         assert result.port_id.internal is True
         assert result.input is False
 
+    @pytest.mark.parametrize(
+        ("field", "valid"), [("isInternal", "false"), ("isInput", "true")]
+    )
+    def test_rejects_invalid_boolean_value(self, field, valid):
+        encoded = (
+            "(logicalOpId=op,layerName=l,portId=0,isInternal=false,isInput=true)"
+        ).replace(f"{field}={valid}", f"{field}=maybe")
+        with pytest.raises(ValueError, match=f"Invalid {field}"):
+            deserialize_global_port_identity(encoded)
+
     def test_raises_value_error_on_malformed_input(self):
         with pytest.raises(ValueError, match="Invalid GlobalPortIdentity format"):
             deserialize_global_port_identity("not-a-port-id")


### PR DESCRIPTION
### What changes were proposed in this PR?

The Python GlobalPortIdentity decoder now rejects invalid boolean tokens instead of silently treating them as false. Valid mixed-case true and false values remain supported.

### Any related issues, documentation, discussions?

Closes #8239

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug56\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/util/test_virtual_identity.py','amber/src/test/python/core/storage/test_vfs_uri_factory.py','-q','-p','no:cacheprovider']))"
48 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
ValueError: Invalid isInternal: maybe
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex