### PR TITLE
feat(pyamber): drain shuffle flush batches

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
@@ -65,6 +65,7 @@ class HashBasedShufflePartitioner(Partitioner):
             if receiver == to:
                 if len(batch) > 0:
                     yield batch
+                    batch.clear()
                 yield ecm
 
     @overrides
@@ -76,4 +77,5 @@ class HashBasedShufflePartitioner(Partitioner):
         for receiver, batch in self.receivers:
             if len(batch) > 0:
                 yield receiver, batch
+                batch.clear()
             yield receiver, state

--- a/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -78,6 +78,7 @@ class RangeBasedShufflePartitioner(Partitioner):
             if receiver == to:
                 if len(batch) > 0:
                     yield batch
+                    batch.clear()
                 yield ecm
 
     @overrides
@@ -89,4 +90,5 @@ class RangeBasedShufflePartitioner(Partitioner):
         for receiver, batch in self.receivers:
             if len(batch) > 0:
                 yield receiver, batch
+                batch.clear()
             yield receiver, state

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -281,6 +281,7 @@ class TestHashBasedShufflePartitioner:
         ecm = EmbeddedControlMessage()
         a_out = _snapshot(p.flush(p.receivers[0][0], ecm))
         assert a_out == [[_hashable_tuple(k=1)], ecm]
+        assert p.receivers[0][1] == []
 
     def test_flush_state_emits_pending_batches_and_state(self):
         p = self._partitioner(batch_size=10)
@@ -293,6 +294,7 @@ class TestHashBasedShufflePartitioner:
         assert (p.receivers[0][0], [_hashable_tuple(k=1)]) in out
         # Each receiver still emits the state record.
         assert sum(1 for r, payload in out if payload is state) == len(p.receivers)
+        assert p.receivers[0][1] == []
 
 
 class TestRangeBasedShufflePartitioner:
@@ -366,6 +368,7 @@ class TestRangeBasedShufflePartitioner:
         assert a_out == [[_tuple(k=2)], ecm]
         # B is untouched.
         assert partitioner.receivers[1][1] == [_tuple(k=5)]
+        assert partitioner.receivers[0][1] == []
 
     def test_flush_state_emits_pending_batches_and_state(self, partitioner):
         list(partitioner.add_tuple_to_batch(_tuple(k=2)))  # → A
@@ -377,6 +380,7 @@ class TestRangeBasedShufflePartitioner:
         assert (_worker("A"), [_tuple(k=2)]) in out
         # Every receiver still emits the state, even with empty pending batch.
         assert sum(1 for r, payload in out if payload is state) == 3
+        assert partitioner.receivers[0][1] == []
 
 
 class TestOneToOnePartitioner:


### PR DESCRIPTION
### What changes were proposed in this PR?

Hash-based and range-based shuffle partitioners now drain a receiver buffer after emitting it during control and state flushes. Other receiver buffers remain untouched.

### Any related issues, documentation, discussions?

Closes #8241

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug57\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
35 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
first=['list', 'EmbeddedControlMessage']
second=['EmbeddedControlMessage']
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex