### PR TITLE
feat(pyamber): hash large binary tuples

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -474,6 +474,9 @@ class Tuple:
             AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
             AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
             AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
+            AttributeType.LARGE_BINARY: lambda f: int_32(
+                salt + java_hash_bytes(map(ord, f.uri), 0, salt)
+            ),
         }
 
         for name, field in self.as_key_value_pairs():

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -561,6 +561,13 @@ class TestTuple:
         )
         assert hash(tuple5) == -2099556631  # calculated with Java
 
+    def test_hash_large_binary_matches_java(self):
+        from core.models.type.large_binary import largebinary
+
+        schema = Schema(raw_schema={"blob": "LARGE_BINARY"})
+        tuple_ = Tuple({"blob": largebinary("s3://bucket/key")}, schema)
+        assert hash(tuple_) == 1754254834
+
     def test_tuple_with_large_binary(self):
         """Test tuple with largebinary field."""
         from core.models.type.large_binary import largebinary


### PR DESCRIPTION
### What changes were proposed in this PR?

Python tuple hashing now supports large binary fields by hashing their stored URI with the same nested hash structure used by the Java `LargeBinary` and `Tuple` implementations.

### Any related issues, documentation, discussions?

Closes #8243

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug58\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_large_binary_matches_java','amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
36 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
1754254834
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex