### PR TITLE
feat(pyamber): route ranges by unique receivers

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -43,10 +43,7 @@ class RangeBasedShufflePartitioner(Partitioner):
         self.range_min = partitioning.range_min
         self.range_max = partitioning.range_max
         self.keys_per_receiver = int(
-            (
-                (partitioning.range_max - partitioning.range_min)
-                // len(partitioning.channels)
-            )
+            ((partitioning.range_max - partitioning.range_min) // len(self.receivers))
             + 1
         )
 

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -316,6 +316,19 @@ class TestRangeBasedShufflePartitioner:
         # (9 - 0) // 3 + 1 = 4
         assert partitioner.keys_per_receiver == 4
 
+    def test_duplicate_channels_use_unique_receiver_count(self):
+        p = RangeBasedShufflePartitioner(
+            RangeBasedShufflePartitioning(
+                batch_size=10,
+                channels=[_channel("S", dst) for dst in ("A", "A", "A", "B")],
+                range_attribute_names=["k"],
+                range_min=0,
+                range_max=9,
+            )
+        )
+        list(p.add_tuple_to_batch(_tuple(k=9)))
+        assert p.receivers[1][1] == [_tuple(k=9)]
+
     def test_value_below_range_min_routes_to_first_receiver(self, partitioner):
         assert partitioner.get_receiver_index(-100) == 0
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Range shuffle now divides its key range by the deduplicated receiver count used for routing. Repeated topology channels therefore cannot produce an index beyond the receiver list.

### Any related issues, documentation, discussions?

Closes #8245

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug59\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
36 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
receivers=2 keys_per_receiver=5 index_for_9=1 target=B
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex