### PR TITLE
feat(pyamber): match Java Unicode hashes

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -172,6 +172,12 @@ def java_hash_bytes(bytes: Iterator[int], init: int, salt: int):
     return h
 
 
+def java_hash_string(value: str) -> int:
+    utf16 = value.encode("utf-16-be")
+    units = (utf16[i] << 8 | utf16[i + 1] for i in range(0, len(utf16), 2))
+    return java_hash_bytes(units, 0, 31)
+
+
 class Tuple:
     """
     Lazy-Tuple implementation.
@@ -471,7 +477,7 @@ class Tuple:
             AttributeType.INT: lambda f: int_32(f),
             AttributeType.LONG: lambda f: java_hash_long(f),
             AttributeType.DOUBLE: lambda f: java_hash_long(double_to_long(f)),
-            AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
+            AttributeType.STRING: java_hash_string,
             AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
             AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
         }

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -561,6 +561,10 @@ class TestTuple:
         )
         assert hash(tuple5) == -2099556631  # calculated with Java
 
+    def test_hash_non_bmp_string_matches_java(self):
+        schema = Schema(raw_schema={"text": "STRING"})
+        assert hash(Tuple({"text": "😀"}, schema)) == 1772930
+
     def test_tuple_with_large_binary(self):
         """Test tuple with largebinary field."""
         from core.models.type.large_binary import largebinary


### PR DESCRIPTION
### What changes were proposed in this PR?

Python tuple hashing now processes strings as UTF-16 code units, matching Java String hashing for characters outside the basic multilingual plane. Existing string hashes remain unchanged.

### Any related issues, documentation, discussions?

Closes #8247

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug60\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_non_bmp_string_matches_java','amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
36 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
1772930
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex