### PR TITLE
feat(pyamber): match Java binary hashes

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -473,7 +473,9 @@ class Tuple:
             AttributeType.DOUBLE: lambda f: java_hash_long(double_to_long(f)),
             AttributeType.STRING: lambda f: java_hash_bytes(map(ord, f), 0, salt),
             AttributeType.TIMESTAMP: lambda f: java_hash_long(int(f.timestamp())),
-            AttributeType.BINARY: lambda f: java_hash_bytes(f, 1, salt),
+            AttributeType.BINARY: lambda f: java_hash_bytes(
+                (b if b < 128 else b - 256 for b in f), 1, salt
+            ),
         }
 
         for name, field in self.as_key_value_pairs():

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -561,6 +561,10 @@ class TestTuple:
         )
         assert hash(tuple5) == -2099556631  # calculated with Java
 
+    def test_hash_binary_with_high_byte_matches_java(self):
+        schema = Schema(raw_schema={"data": "BINARY"})
+        assert hash(Tuple({"data": b"\xff"}, schema)) == 61
+
     def test_tuple_with_large_binary(self):
         """Test tuple with largebinary field."""
         from core.models.type.large_binary import largebinary


### PR DESCRIPTION
### What changes were proposed in this PR?

Python tuple hashing now converts binary field bytes to signed Java byte values before applying the array hash. Existing values below `0x80` remain unchanged.

### Any related issues, documentation, discussions?

Closes #8249

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug61\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_binary_with_high_byte_matches_java','amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
36 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
61
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex