### PR TITLE
feat(pyamber): canonicalize NaN hashes

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -124,6 +124,8 @@ def double_to_long(value: float) -> int:
     :param value: A double (Python float) value.
     :return: The converted long (Python int) value.
     """
+    if numpy.isnan(value):
+        return 0x7FF8000000000000
     # Pack the double value into a binary string of 8 bytes
     packed_value = struct.pack("d", value)
     # Unpack the binary string to a 64-bit integer (int in Python 3)

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -20,6 +20,7 @@ import pandas
 import pickle
 import pyarrow
 import pytest
+import struct
 import numpy as np
 from copy import deepcopy
 from loguru import logger
@@ -560,6 +561,11 @@ class TestTuple:
             schema,
         )
         assert hash(tuple5) == -2099556631  # calculated with Java
+
+    def test_hash_noncanonical_nan_matches_java(self):
+        nan = struct.unpack(">d", bytes.fromhex("7ff0000000000001"))[0]
+        schema = Schema(raw_schema={"value": "DOUBLE"})
+        assert hash(Tuple({"value": nan}, schema)) == 2146959391
 
     def test_tuple_with_large_binary(self):
         """Test tuple with largebinary field."""


### PR DESCRIPTION
### What changes were proposed in this PR?

Python tuple hashing now canonicalizes every NaN bit pattern before applying the Java double hash. Finite values, infinities, and signed zero remain unchanged.

### Any related issues, documentation, discussions?

Closes #8251

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug62\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/models/test_tuple.py::TestTuple::test_hash_noncanonical_nan_matches_java','amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
36 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
2146959391
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex