### PR TITLE
feat(pyamber): preserve minus-one shuffle hashes

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
@@ -50,7 +50,7 @@ class HashBasedShufflePartitioner(Partitioner):
             if not self.hash_attribute_names
             else tuple_.get_partial_tuple(self.hash_attribute_names)
         )
-        hash_code = hash(partial_tuple) % len(self.receivers)
+        hash_code = partial_tuple.__hash__() % len(self.receivers)
         receiver, batch = self.receivers[hash_code]
         batch.append(tuple_)
         if len(batch) == self.batch_size:

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -274,6 +274,11 @@ class TestHashBasedShufflePartitioner:
         total = sum(len(b) for _, b in p.receivers)
         assert total == 2
 
+    def test_java_hash_minus_one_is_not_normalized_by_python(self):
+        p = self._partitioner(batch_size=1)
+        out = list(p.add_tuple_to_batch(_hashable_tuple(k=-32)))
+        assert out[0][0] == _worker("B")
+
     def test_flush_emits_pending_batch_and_ecm_for_target_only(self):
         p = self._partitioner(batch_size=10)
         # Force a tuple into receiver A regardless of hash outcome.


### PR DESCRIPTION
### What changes were proposed in this PR?

Hash shuffle now uses the tuple's raw Java-compatible hash method directly, avoiding Python's reserved `-1` to `-2` normalization before receiver selection.

### Any related issues, documentation, discussions?

Closes #8253

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug63\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
36 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
raw_java_hash=-1 builtin_hash=-2 receiver=B
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex