### PR TITLE
feat(pyamber): truncate range double keys

### DIFF
--- a/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import math
 import typing
 from loguru import logger
 from overrides import overrides
@@ -63,6 +64,8 @@ class RangeBasedShufflePartitioner(Partitioner):
         self, tuple_: Tuple
     ) -> Iterator[typing.Tuple[ActorVirtualIdentity, typing.List[Tuple]]]:
         column_val = tuple_[self.range_attribute_names[0]]
+        if isinstance(column_val, float) and math.isfinite(column_val):
+            column_val = int(column_val)
         receiver_index = self.get_receiver_index(column_val)
         receiver, batch = self.receivers[receiver_index]
         batch.append(tuple_)

--- a/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
+++ b/amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py
@@ -331,6 +331,29 @@ class TestRangeBasedShufflePartitioner:
         assert partitioner.get_receiver_index(8) == 2
         assert partitioner.get_receiver_index(9) == 2
 
+    def test_finite_double_key_is_truncated_like_scala(self):
+        p = RangeBasedShufflePartitioner(
+            RangeBasedShufflePartitioning(
+                batch_size=1,
+                channels=[_channel("S", "A"), _channel("S", "B")],
+                range_attribute_names=["k"],
+                range_min=-10,
+                range_max=9,
+            )
+        )
+        out = list(p.add_tuple_to_batch(_tuple(k=-0.5)))
+        assert out[0][0] == _worker("B")
+
+    @pytest.mark.parametrize(
+        ("value", "receiver"), [(-float("inf"), "A"), (float("inf"), "C")]
+    )
+    def test_infinite_double_keys_still_route_to_range_ends(
+        self, partitioner, value, receiver
+    ):
+        partitioner.batch_size = 1
+        out = list(partitioner.add_tuple_to_batch(_tuple(k=value)))
+        assert out[0][0] == _worker(receiver)
+
     def test_add_tuple_routes_using_first_attribute(self, partitioner):
         list(partitioner.add_tuple_to_batch(_tuple(k=2)))
         list(partitioner.add_tuple_to_batch(_tuple(k=5)))


### PR DESCRIPTION
### What changes were proposed in this PR?

Python range shuffle now truncates finite double keys toward zero before bucket calculation, matching the JVM partitioner. Infinite values retain their existing endpoint routing.

### Any related issues, documentation, discussions?

Closes #8255

### How was this PR tested?

```text
python -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug64\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main(['amber/src/test/python/core/architecture/sendsemantics/test_partitioners.py','-q','-p','no:cacheprovider']))"
38 passed

ruff check amber/src/main/python amber/src/test/python
All checks passed

ruff format --check amber/src/main/python amber/src/test/python
213 files already formatted
```

Direct reproduction after the fix:

```text
receiver=B truncated_index=1
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex