### PR TITLE
feat(pytexera): stop writes after upload failure

### DIFF
--- a/amber/src/main/python/pytexera/storage/large_binary_output_stream.py
+++ b/amber/src/main/python/pytexera/storage/large_binary_output_stream.py
@@ -181,7 +181,18 @@ class LargeBinaryOutputStream(IOBase):
         # Write data in chunks
         data = bytes(b)
         for offset in range(0, len(data), _CHUNK_SIZE):
-            self._queue.put(data[offset : offset + _CHUNK_SIZE], block=True)
+            chunk = data[offset : offset + _CHUNK_SIZE]
+            while True:
+                try:
+                    self._queue.put(chunk, timeout=_QUEUE_TIMEOUT)
+                    break
+                except queue.Full:
+                    with self._lock:
+                        exception = self._upload_exception
+                    if exception is not None:
+                        raise IOError(
+                            f"Background upload failed: {exception}"
+                        ) from exception
 
         return len(data)
 
@@ -221,7 +232,12 @@ class LargeBinaryOutputStream(IOBase):
         try:
             # Signal EOF to upload thread and wait for completion
             if self._upload_thread is not None:
-                self._queue.put(None, block=True)  # EOF marker
+                while not self._upload_complete.is_set():
+                    try:
+                        self._queue.put(None, timeout=_QUEUE_TIMEOUT)
+                        break
+                    except queue.Full:
+                        pass
                 self._upload_thread.join()
                 self._upload_complete.wait()
 

--- a/amber/src/test/python/pytexera/storage/test_large_binary_output_stream.py
+++ b/amber/src/test/python/pytexera/storage/test_large_binary_output_stream.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import queue
+import threading
 import pytest
 import time
 from unittest.mock import patch, MagicMock
@@ -231,6 +232,33 @@ class TestLargeBinaryOutputStream:
                 # doesn't fire against a later test's mocks.
                 with pytest.raises(IOError):
                     stream.close()
+
+    def test_write_unblocks_when_upload_fails_with_full_queue(self, large_binary):
+        with (
+            patch("pytexera.storage.large_binary_output_stream._CHUNK_SIZE", 1),
+            patch.object(large_binary_manager, "_get_s3_client") as get_client,
+            patch.object(large_binary_manager, "_ensure_bucket_exists"),
+        ):
+            get_client.return_value.upload_fileobj.side_effect = RuntimeError(
+                "upload failed"
+            )
+            stream = LargeBinaryOutputStream(large_binary)
+            errors = []
+
+            def write_chunks():
+                try:
+                    stream.write(b"abc")
+                except IOError as error:
+                    errors.append(error)
+
+            writer = threading.Thread(target=write_chunks, daemon=True)
+            writer.start()
+            writer.join(1)
+
+            assert not writer.is_alive()
+            assert str(errors[0]) == "Background upload failed: upload failed"
+            with pytest.raises(IOError, match="Failed to complete upload"):
+                stream.close()
 
     def test_multiple_close_calls(self, large_binary):
         """Test that multiple close() calls are safe."""


### PR DESCRIPTION
### What changes were proposed in this PR?

Use timed queue writes so a producer notices when the background upload has failed. Stop waiting to enqueue the EOF marker once that upload worker has completed.

A regression covers both `write` and `close` with a full queue after an upload failure.

### Any related issues, documentation, discussions?

Closes #8259

### How was this PR tested?

Live reproduction on the untouched base reported `write_still_blocked=True`. The same probe after the fix reported `write_still_blocked=False` and surfaced the upload error.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug66\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/pytexera/storage/test_large_binary_output_stream.py','-q','-p','no:cacheprovider']))"`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/pytexera/storage/large_binary_output_stream.py amber/src/test/python/pytexera/storage/test_large_binary_output_stream.py`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex