### PR TITLE
feat(pyamber): resolve unset input port zero

### DIFF
--- a/amber/src/main/python/core/architecture/packaging/input_manager.py
+++ b/amber/src/main/python/core/architecture/packaging/input_manager.py
@@ -139,7 +139,14 @@ class InputManager:
         return self._channels[channel_id].port_id
 
     def get_port(self, port_id: PortIdentity) -> WorkerPort:
-        return self._ports[port_id]
+        if port_id.id is None:
+            port_id.id = 0
+        if port_id.internal is None:
+            port_id.internal = False
+        try:
+            return self._ports[port_id]
+        except KeyError as error:
+            raise KeyError(f"unknown input port {port_id}") from error
 
     def register_input(
         self, channel_id: ChannelIdentity, port_id: PortIdentity

--- a/amber/src/test/python/core/architecture/packaging/test_input_manager.py
+++ b/amber/src/test/python/core/architecture/packaging/test_input_manager.py
@@ -73,6 +73,14 @@ class TestPortIdentityDefaults:
         # PortIdentity(0, False) resolves to the very same port.
         assert manager.get_port(PortIdentity(0, False)).get_schema() == schema
 
+    def test_get_port_resolves_unset_zero_identity(self, manager):
+        schema = Schema(raw_schema={"x": "INTEGER"})
+        manager.add_input_port(PortIdentity(0, False), schema, [], [])
+
+        assert manager.get_port(PortIdentity()).get_schema() == schema
+        with pytest.raises(KeyError, match="unknown input port"):
+            manager.get_port(PortIdentity(1, False))
+
     def test_register_input_defaults_unset_fields(self, manager):
         canonical = PortIdentity(0, False)
         manager.add_input_port(canonical, Schema(raw_schema={"x": "INTEGER"}), [], [])


### PR DESCRIPTION
### What changes were proposed in this PR?

Normalize unset protobuf port fields before the dictionary lookup, keeping lookup O(1). This lets an unset port-zero identity find the registered port and preserves a clear KeyError for unknown ports.

### Any related issues, documentation, discussions?

Closes #8263

### How was this PR tested?

The untouched live probe showed equal port-zero identities with different hashes and raised `KeyError`. After the fix it reported `lookup_succeeded=True` with the hashes still different.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug68\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/architecture/packaging/test_input_manager.py','-q','-p','no:cacheprovider']))"`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/architecture/packaging/input_manager.py amber/src/test/python/core/architecture/packaging/test_input_manager.py`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex