### PR TITLE
feat(pyamber): stop materialized state replay

### DIFF
--- a/amber/src/main/python/core/storage/runnables/input_port_materialization_reader_runnable.py
+++ b/amber/src/main/python/core/storage/runnables/input_port_materialization_reader_runnable.py
@@ -159,6 +159,8 @@ class InputPortMaterializationReaderRunnable(Runnable, Stoppable):
                 VFSURIFactory.state_uri(self.uri)
             )
             for state_row in state_document.get():
+                if self._stopped:
+                    break
                 self.emit_payload(
                     StateFrame(
                         State.from_tuple(state_row),

--- a/amber/src/test/python/core/storage/runnables/test_input_port_materialization_reader_runnable.py
+++ b/amber/src/test/python/core/storage/runnables/test_input_port_materialization_reader_runnable.py
@@ -219,11 +219,11 @@ class TestRunTupleLoop:
         return ActorVirtualIdentity(name="me")
 
     @staticmethod
-    def _run_with_documents(reader, tuples):
+    def _run_with_documents(reader, tuples, states=()):
         result_doc = MagicMock()
         result_doc.get.return_value = iter(tuples)
         state_doc = MagicMock()
-        state_doc.get.return_value = iter([])  # no materialized states
+        state_doc.get.return_value = iter(states)
         with patch(DOCUMENT_FACTORY) as mock_factory:
             mock_factory.open_document.side_effect = [
                 (result_doc, reader.tuple_schema),
@@ -274,11 +274,16 @@ class TestRunTupleLoop:
         reader = _build_reader(me)
         reader.partitioner.flush.side_effect = lambda receiver, ecm: [ecm]
         reader.partitioner.add_tuple_to_batch.side_effect = lambda tup: [(me, [tup])]
+        state_row = {State.LOOP_COUNTER: 0, State.LOOP_START_ID: ""}
 
         reader.stop()
-        self._run_with_documents(reader, [Tuple({"x": 1}), Tuple({"x": 2})])
+        with patch.object(State, "from_tuple", return_value=State({"i": 1})) as load:
+            self._run_with_documents(
+                reader, [Tuple({"x": 1}), Tuple({"x": 2})], [state_row]
+            )
 
-        # No tuple is replayed once stopped ...
+        # No state or tuple is replayed once stopped ...
+        load.assert_not_called()
         assert _emitted_data_frames(reader) == []
         reader.partitioner.add_tuple_to_batch.assert_not_called()
         # ... but the channel is still closed, so the downstream port


### PR DESCRIPTION
### What changes were proposed in this PR?

Honor the materialized input reader's stop flag while replaying persisted state, matching the existing tuple replay behavior. The reader still sends its end marker so downstream port alignment can finish.

### Any related issues, documentation, discussions?

Closes #8265

### How was this PR tested?

The untouched live probe emitted one state frame after `stop`. After the fix it reported `state_frames_emitted=0` and `finished=True`.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug69\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/storage/runnables/test_input_port_materialization_reader_runnable.py','-q','-p','no:cacheprovider']))"`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/storage/runnables/input_port_materialization_reader_runnable.py amber/src/test/python/core/storage/runnables/test_input_port_materialization_reader_runnable.py`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex