### PR TITLE
refactor(core): remove unreachable null guards in Attribute.equals

### DIFF
--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/tuple/Attribute.java
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/tuple/Attribute.java
@@ -80,13 +80,6 @@ public class Attribute implements Serializable {
 
         Attribute that = (Attribute) toCompare;
 
-        if (this.attributeName == null) {
-            return that.attributeName == null;
-        }
-        if (this.attributeType == null) {
-            return that.attributeType == null;
-        }
-
         return this.attributeName.equalsIgnoreCase(that.attributeName) && this.attributeType.equals(that.attributeType);
     }
 


### PR DESCRIPTION
### What changes were proposed in this PR?
Removed unreachable null checks in `Attribute.equals()` in `Attribute.java`. Both `attributeName` and `attributeType` are already guaranteed non-null by `checkNotNull` in the constructor.

### Any related issues, documentation, discussions?
Closes #8149

### How was this PR tested?
- Verified `Attribute` constructor enforces non-null fields via `checkNotNull`.
- Ran existing unit tests in `workflow-core` (`sbt test`).

### Was this PR authored or co-authored using generative AI tooling?
N/A