### PR TITLE
feat(pyamber): preserve pickle-prefixed bytes

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -99,7 +99,7 @@ class ArrowTableTupleProvider:
             if (
                 field_type == pyarrow.binary()
                 and value is not None
-                and value[:6] == b"pickle"
+                and value[:10] == b"pickle    "
             ):
                 value = pickle.loads(value[10:])
 

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -673,11 +673,17 @@ class TestTuple:
             [
                 pyarrow.field("scores", pyarrow.binary()),
                 pyarrow.field("raw", pyarrow.binary()),
+                pyarrow.field("prefixed", pyarrow.binary()),
                 pyarrow.field("empty", pyarrow.binary()),
             ]
         )
         arrow_table = pyarrow.Table.from_pydict(
-            {"scores": [pickled], "raw": [b"plain bytes"], "empty": [None]},
+            {
+                "scores": [pickled],
+                "raw": [b"plain bytes"],
+                "prefixed": [b"picklehello"],
+                "empty": [None],
+            },
             schema=arrow_schema,
         )
 
@@ -691,6 +697,7 @@ class TestTuple:
         # Bytes that were never pickled must survive untouched, and a null
         # binary must not be fed to pickle.loads.
         assert tuples[0]["raw"] == b"plain bytes"
+        assert tuples[0]["prefixed"] == b"picklehello"
         assert tuples[0]["empty"] is None
 
     def test_binary_field_starting_with_pickle_bytes_is_unpickled(self):


### PR DESCRIPTION
### What changes were proposed in this PR?

Require the complete ten-byte Texera pickle header before unpickling an Arrow binary value. Raw bytes that merely begin with `pickle` now remain unchanged.

The existing round-trip test still covers encoded Python objects, ordinary bytes, prefixed bytes, and null values.

### Any related issues, documentation, discussions?

Closes #8268

### How was this PR tested?

The untouched live probe raised `_pickle.UnpicklingError` for `b"picklehello"`. After the fix it reported `decoded=b"picklehello"`.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug70\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-q','-k','not test_hash','-p','no:cacheprovider']))"`

Result: 101 passed and 2 deselected. The excluded upstream Windows timestamp hash tests are covered by PR #8174.

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/models/tuple.py amber/src/test/python/core/models/test_tuple.py`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex