### PR TITLE
feat(pyamber): isolate tuple copy storage

### DIFF
--- a/amber/src/main/python/core/models/tuple.py
+++ b/amber/src/main/python/core/models/tuple.py
@@ -192,7 +192,7 @@ class Tuple:
         assert len(tuple_like) != 0
         self._field_data: "OrderedDict[str, Field]"
         if isinstance(tuple_like, Tuple):
-            self._field_data = tuple_like._field_data
+            self._field_data = tuple_like._field_data.copy()
         elif isinstance(tuple_like, pandas.Series):
             self._field_data = OrderedDict(tuple_like.to_dict())
         else:

--- a/amber/src/test/python/core/models/test_tuple.py
+++ b/amber/src/test/python/core/models/test_tuple.py
@@ -42,6 +42,16 @@ class TestTuple:
     def test_tuple_from_series(self, target_tuple):
         assert Tuple(pandas.Series({"x": 1, "y": "a"})) == target_tuple
 
+    def test_tuple_copy_has_independent_field_storage(self, target_tuple):
+        copied = Tuple(target_tuple)
+        assert copied == target_tuple
+
+        copied["x"] = 2
+        target_tuple["y"] = "b"
+
+        assert target_tuple["x"] == 1
+        assert copied["y"] == "a"
+
     def test_tuple_as_key_value_pairs(self, target_tuple):
         assert target_tuple.as_key_value_pairs() == [("x", 1), ("y", "a")]
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Give a tuple constructed from another tuple its own shallow field mapping. The initial field values remain the same, but later assignments no longer mutate the other tuple.

### Any related issues, documentation, discussions?

Closes #8270

### How was this PR tested?

The untouched live probe reported `original_x=2`, `derived_x=2`, and `same_storage=True` after editing only the derived tuple. After the fix, independent edits remain isolated and `same_storage=False`.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug71\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber/src/test/python/core/models/test_tuple.py','-q','-k','not test_hash','-p','no:cacheprovider']))"`

Result: 102 passed and 2 deselected. The excluded upstream Windows timestamp hash tests are covered by PR #8174.

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python amber/src/test/python`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/models/tuple.py amber/src/test/python/core/models/test_tuple.py`

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex