### PR TITLE
feat(pyamber): handle empty list output

### DIFF
--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -88,6 +88,8 @@ def all_output_to_tuple(output) -> Iterator[Tuple]:
     :param output:
     :return:
     """
+    if isinstance(output, list) and not output:
+        return
     yield from match(
         output,
         None,

--- a/amber/src/test/python/core/models/test_table.py
+++ b/amber/src/test/python/core/models/test_table.py
@@ -24,6 +24,15 @@ import re
 from pandas import RangeIndex
 
 from core.models import Table, Tuple
+from core.models.table import all_output_to_tuple
+
+
+def test_empty_list_output_produces_no_tuples():
+    assert list(all_output_to_tuple([])) == []
+
+
+def test_nonempty_list_output_still_produces_tuples():
+    assert list(all_output_to_tuple([{"x": 1}])) == [Tuple({"x": 1})]
 
 
 class TestTable:


### PR DESCRIPTION
### What changes were proposed in this PR?

Treat an empty Python list as no operator output before invoking the generic matcher. Nonempty list output continues through the existing conversion path.

### Any related issues, documentation, discussions?

Closes #8272

### How was this PR tested?

Added negative coverage for empty list output and positive coverage for a nonempty list.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug72\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\models\test_table.py',r'amber\src\test\python\core\models\test_operator.py','-p','no:cacheprovider','-q']))"`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python/core/models/table.py amber/src/test/python/core/models/test_table.py`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/models/table.py amber/src/test/python/core/models/test_table.py`

All 64 tests passed. Ruff checks passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex
