### PR TITLE
feat(pyamber): honor output port lookup

### DIFF
--- a/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -168,8 +168,11 @@ class OutputManager:
             self._port_state_writers,
         )
 
-    def get_port(self, port_id=None) -> WorkerPort:
-        return list(self._ports.values())[0]
+    def get_port(self, port_id: typing.Optional[PortIdentity] = None) -> WorkerPort:
+        """Return the requested port, or the first port when no ID is given."""
+        if port_id is None:
+            return list(self._ports.values())[0]
+        return self._ports[port_id]
 
     def get_port_ids(self) -> typing.List[PortIdentity]:
         return list(self._ports.keys())

--- a/amber/src/test/python/core/architecture/packaging/test_output_manager.py
+++ b/amber/src/test/python/core/architecture/packaging/test_output_manager.py
@@ -666,6 +666,30 @@ class TestQueryMethods:
         output_manager.add_output_port(port_b, MagicMock())
         assert output_manager.get_port_ids() == [port_a, port_b]
 
+    def test_get_port_honors_the_requested_port_id(self, output_manager):
+        port_a = PortIdentity(id=0, internal=False)
+        port_b = PortIdentity(id=1, internal=False)
+        schema_a = MagicMock(name="schema_a")
+        schema_b = MagicMock(name="schema_b")
+        output_manager.add_output_port(port_a, schema_a)
+        output_manager.add_output_port(port_b, schema_b)
+        assert output_manager.get_port(port_b).get_schema() is schema_b
+
+    def test_get_port_without_an_id_uses_the_first_port(self, output_manager):
+        schema_a = MagicMock(name="schema_a")
+        output_manager.add_output_port(PortIdentity(id=0), schema_a)
+        output_manager.add_output_port(PortIdentity(id=1), MagicMock(name="schema_b"))
+        assert output_manager.get_port().get_schema() is schema_a
+
+    def test_get_port_without_ports_preserves_index_error(self, output_manager):
+        with pytest.raises(IndexError, match="list index out of range"):
+            output_manager.get_port()
+
+    def test_get_port_rejects_an_unknown_port_id(self, output_manager):
+        output_manager.add_output_port(PortIdentity(id=0), MagicMock())
+        with pytest.raises(KeyError):
+            output_manager.get_port(PortIdentity(id=99))
+
     def test_get_output_channel_ids_lists_channels_from_add_partitioning(
         self, output_manager
     ):


### PR DESCRIPTION
### What changes were proposed in this PR?

Honor an explicit port ID when retrieving an output port. Calls without an ID retain the existing first-port behavior and `IndexError` on an empty port collection, while unknown explicit IDs fail with `KeyError`.

No current production caller passes a port ID, so the multi-output mismatch described in #8274 is not reachable today. This change corrects the method contract before a port-aware caller is added.

### Any related issues, documentation, discussions?

Closes #8274

### How was this PR tested?

- `python -m pytest src/test/python/core/architecture/packaging/test_output_manager.py -k get_port -q`
- `python -m ruff check src/main/python/core/architecture/packaging/output_manager.py src/test/python/core/architecture/packaging/test_output_manager.py`
- `python -m ruff format --check src/main/python/core/architecture/packaging/output_manager.py src/test/python/core/architecture/packaging/test_output_manager.py`

The five focused tests passed. Ruff checks passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex