### PR TITLE
feat(pyamber): validate large binary URI

### DIFF
--- a/amber/src/main/python/core/models/type/large_binary.py
+++ b/amber/src/main/python/core/models/type/large_binary.py
@@ -69,6 +69,9 @@ class largebinary:
 
         if not uri.startswith("s3://"):
             raise ValueError(f"largebinary URI must start with 's3://', got: {uri}")
+        parsed_uri = urlparse(uri)
+        if not parsed_uri.netloc or not parsed_uri.path.lstrip("/"):
+            raise ValueError("largebinary URI must include a bucket and object key")
 
         self._uri = uri
 

--- a/amber/src/test/python/core/models/type/test_large_binary.py
+++ b/amber/src/test/python/core/models/type/test_large_binary.py
@@ -49,6 +49,10 @@ class TestLargeBinary:
         with pytest.raises(ValueError, match="largebinary URI must start with 's3://'"):
             largebinary("invalid-uri")
 
+        for uri in ("s3://", "s3:///object", "s3://bucket", "s3://bucket/"):
+            with pytest.raises(ValueError, match="bucket and object key"):
+                largebinary(uri)
+
     def test_get_bucket_name(self):
         """Test extracting bucket name from URI."""
         large_binary = largebinary("s3://my-bucket/path/to/object")


### PR DESCRIPTION
### What changes were proposed in this PR?

Validate that a large-binary S3 reference contains both a bucket and an object key during construction, before any stream reaches S3.

### Any related issues, documentation, discussions?

Closes #8279

### How was this PR tested?

Added negative coverage for missing buckets and keys. Existing valid URI, generated URI, equality, hashing, and stream tests remain green.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug75\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\models\type\test_large_binary.py',r'amber\src\test\python\pytexera\storage\test_large_binary_input_stream.py','-p','no:cacheprovider','-q']))"`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python/core/models/type/large_binary.py amber/src/test/python/core/models/type/test_large_binary.py`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/models/type/large_binary.py amber/src/test/python/core/models/type/test_large_binary.py`

All 23 tests passed. Ruff checks passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex
