### PR TITLE
feat(visualization): require the Filled Area Plot line group under its switch

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -20,7 +20,7 @@
 package org.apache.texera.amber.operator.visualization.filledAreaPlot
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.PythonTemplateBuilderStringContext
 import org.apache.texera.amber.pybuilder.PyStringTypes.EncodableString
@@ -32,6 +32,27 @@ import org.apache.texera.amber.pybuilder.PythonTemplateBuilder
 
 import javax.validation.constraints.NotNull
 
+// `lineGroup` names the column the plot is split on, so it is required exactly when
+// that switch is on: with the switch off nothing reads it, and with the switch on
+// code generation asserts it and the run ends. Conditional rather than a plain
+// required, so a freshly dropped operator is not flagged for a field it has no use
+// for.
+@JsonSchemaInject(json = """
+{
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "facetColumn": { "const": true }
+        }
+      },
+      "then": {
+        "required": ["lineGroup"]
+      }
+    }
+  ]
+}
+""")
 class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(required = true)

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDescSpec.scala
@@ -22,6 +22,7 @@ package org.apache.texera.amber.operator.visualization.filledAreaPlot
 import com.typesafe.config.ConfigFactory
 import org.apache.texera.amber.core.tuple.{AttributeType, Schema}
 import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.metadata.OperatorMetadataGenerator
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -30,6 +31,7 @@ import org.scalatest.matchers.should.Matchers
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 class FilledAreaPlotOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matchers {
@@ -369,5 +371,29 @@ class FilledAreaPlotOpDescSpec extends AnyFlatSpec with BeforeAndAfter with Matc
     fp.color shouldBe "c"
     fp.facetColumn shouldBe true
     fp.pattern shouldBe "p"
+  }
+
+  // The assertion tested above is the last line of defence, reached only once the
+  // user has hit run. The schema is what refuses the configuration while it is
+  // still being written, and only under the switch: with it off nothing reads the
+  // field, so a freshly dropped operator is not flagged for it.
+  "FilledAreaPlotOpDesc JSON schema" should
+    "require the line group only when the plot is split by it" in {
+    val schema =
+      OperatorMetadataGenerator.generateOperatorJsonSchema(classOf[FilledAreaPlotOpDesc])
+
+    val baseRequired = schema.get("required").elements().asScala.map(_.asText()).toSet
+    baseRequired should contain("x")
+    baseRequired should not contain "lineGroup"
+
+    val rule = schema
+      .get("allOf")
+      .elements()
+      .asScala
+      .find(node => node.has("if") && node.has("then"))
+      .getOrElse(fail("expected a conditional if/then rule in the FilledAreaPlot schema"))
+    rule.get("if").get("properties").get("facetColumn").get("const").asBoolean() shouldBe true
+    val thenRequired = rule.get("then").get("required").elements().asScala.map(_.asText()).toList
+    thenRequired should contain("lineGroup")
   }
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Turning on `Split Plot by Line Group` makes `Line Group` required, because code generation asserts it and the run ends on `Line Group cannot be empty`. The field is declared `@JsonProperty(required = false)` and carried no conditional constraint, so the property panel accepted the configuration and the error waited for the run. A field that is optional is exactly the one a user leaves behind.

The schema states the rule instead, in the conditional form the Sklearn text columns already use (#7643): `required: ["lineGroup"]` under `facetColumn`, so the panel refuses the configuration while it is being written. Conditional rather than a plain required, so a freshly dropped operator, whose switch is off, is not flagged for a field it has no use for.

The assertion stays as the last line of defence, and the two tests that pin it stay with it. Nothing about the generated Python changes.

One thing worth noting beyond the panel: a rule stated in the schema is one the tooling can read. Our translator's configuration generator fills a conditionally-required field from exactly this shape, which is how it fills the Sklearn text columns under Count Vectorizer; the assertion in Scala was invisible to it.

### Any related issues, documentation, discussions?

Closes #8283. Same shape as #7643, which stated the Sklearn rule.

### How was this PR tested?

`FilledAreaPlotOpDescSpec` gains an assertion on the generated schema: the line group is not unconditionally required, and the conditional rule requires it under the switch. Removing the annotation turns that test red. `WorkflowOperator/test` passes: 2517 tests.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
