### PR TITLE
feat(pyamber): preserve overlapping channel pauses

### DIFF
--- a/amber/src/main/python/core/architecture/managers/pause_manager.py
+++ b/amber/src/main/python/core/architecture/managers/pause_manager.py
@@ -70,11 +70,13 @@ class PauseManager:
     def resume(self, pause_type: PauseType, change_state=True) -> None:
         if pause_type in self._global_pauses:
             self._global_pauses.remove(pause_type)
-        if pause_type in self._specific_input_pauses:
-            # need to resume specific input channels
-            for channel_id in self._specific_input_pauses[pause_type]:
+        paused_channels = self._specific_input_pauses.pop(pause_type, set())
+        for channel_id in paused_channels:
+            if not any(
+                channel_id in channels
+                for channels in self._specific_input_pauses.values()
+            ):
                 self._input_queue.enable(channel_id)
-            del self._specific_input_pauses[pause_type]
 
         # still globally paused no action, don't need to resume anything
         if self._global_pauses:

--- a/amber/src/test/python/core/architecture/managers/test_pause_manager.py
+++ b/amber/src/test/python/core/architecture/managers/test_pause_manager.py
@@ -180,6 +180,19 @@ class TestPauseManager:
         assert input_queue._queue.is_enabled(first)
         assert not input_queue._queue.is_enabled(second)
 
+    def test_releasing_one_of_two_holds_keeps_the_channel_paused(
+        self, pause_manager, input_queue
+    ):
+        channel = self._register_channel(input_queue, "shared")
+        pause_manager.pause_input_channel(PauseType.DEBUG_PAUSE, channel)
+        pause_manager.pause_input_channel(PauseType.ECM_PAUSE, channel)
+
+        pause_manager.resume(PauseType.DEBUG_PAUSE)
+        assert not input_queue._queue.is_enabled(channel)
+
+        pause_manager.resume(PauseType.ECM_PAUSE)
+        assert input_queue._queue.is_enabled(channel)
+
     def test_pause_with_change_state_false_leaves_the_state_alone(
         self, pause_manager, state_manager
     ):


### PR DESCRIPTION
### What changes were proposed in this PR?

Release a specifically paused input channel only when no other pause type still holds it.

### Any related issues, documentation, discussions?

Closes #8284

### How was this PR tested?

Added real-queue coverage for two pause types holding the same channel, including the intermediate disabled state and final release.

`C:\Users\carlo\texera\texera\.venv312\Scripts\python.exe -c "import sys,pytest; sys.path[:0]=[r'C:\Users\carlo\texera\texera-worktrees\investigate-bug77\amber\src\main\python',r'C:\Users\carlo\texera\texera\amber\src\main\python']; raise SystemExit(pytest.main([r'amber\src\test\python\core\architecture\managers\test_pause_manager.py','-p','no:cacheprovider','-q']))"`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe check amber/src/main/python/core/architecture/managers/pause_manager.py amber/src/test/python/core/architecture/managers/test_pause_manager.py`

`C:\Users\carlo\texera\texera\.venv312\Scripts\ruff.exe format --check amber/src/main/python/core/architecture/managers/pause_manager.py amber/src/test/python/core/architecture/managers/test_pause_manager.py`

All 12 tests passed. Ruff checks passed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex
