### PR TITLE
fix(amber): declare cloudpickle in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -291,6 +291,7 @@ Dependencies under the BSD 3-Clause License
 Python packages:
   - cached-property==2.0.1
   - click==8.4.2
+  - cloudpickle==3.1.2
   - contourpy==1.3.3
   - cycler==0.12.1
   - fsspec==2026.6.0


### PR DESCRIPTION
### What changes were proposed in this PR?

One bullet in `amber/LICENSE-binary-python`, in the BSD 3-Clause section:

```
  - click==8.4.2
+ - cloudpickle==3.1.2
  - contourpy==1.3.3
```

**Why it is a bug.** `build / pyamber (ubuntu-latest, 3.12)` has been red
repo-wide since ~09:00-13:00 UTC on 2026-08-31, on every open PR regardless of
what the PR touches, because **joblib 1.6.0 stopped vendoring cloudpickle**:

| | joblib 1.5.3 | joblib 1.6.0 |
| --- | --- | --- |
| `joblib/externals/cloudpickle/` in the wheel | present (vendored) | **gone** |
| `Requires-Dist` | *(none)* | `cloudpickle>=3.0` |
| visible to `pip-licenses` | no | **yes** |

`amber/operator-requirements.txt` reaches joblib transitively, so pip now
installs cloudpickle as its own distribution and the manifest no longer
describes what the image bundles:

```
operator-requirements.txt -> scikit-learn==1.7.2 -> joblib>=1.2.0 -> cloudpickle>=3.0
```

```
Before:  any PR -> pyamber 3.12 -> "+ cloudpickle==3.1.2"                -> red
After:   any PR -> pyamber 3.12 -> "OK: 110 Python packages match ..."   -> green
```

Note that the code was always in the distribution -- it shipped inside the
joblib wheel. What changed is that it became a separate distribution, and so
became visible to the license scanner.

**License clearance.** cloudpickle 3.1.2's wheel METADATA says
`License: BSD-3-Clause` (PyPI's classifier reports only the generic
`BSD License`, which is what the CI line quotes), and the bundled `LICENSE` is
the canonical three-clause text. That is **ASF Category A**. The wheel ships no
`NOTICE`, and `licenses/LICENSE-BSD-3-Clause.txt` already carries the text that
the section references, so no `NOTICE-binary` / `NOTICE-binary-python` change is
needed and the one bullet is the entire fix.

**Deliberately out of scope.** The same step prints a long
`DRIFT (transitive, informational)` list (`charset-normalizer`, `click`,
`joblib`, `regex`, `scipy`, ...). PR runs pass `--ignore-transitive-version`, so
none of it is fatal, and the nightly exact-match check on `main` owns refreshing
those pins -- bulk-bumping 22 moving targets here would just add churn. That is
why `joblib` stays at `1.5.3` in the manifest even though `1.6.0` is what
introduced the coupling.

This unblocks every open PR's `build / pyamber (ubuntu-latest, 3.12)` job.

### Any related issues, documentation, discussions?

Closes #8292

Related: #8294

### How was this PR tested?

Reproduced the CI check locally, byte-for-byte, without a full `pip install`.
CI's own report is a complete description of the diff between the manifest and
reality (1 `+`, 0 stale, 0 direct drift, 22 transitive drifts), so the installed
set was rebuilt as "every claimed bullet at its bundled version, plus
cloudpickle==3.1.2" and fed to the checker exactly as `build.yml` invokes it:

```bash
python bin/licensing/check_binary_deps.py --ignore-transitive-version python /tmp/pip-licenses.csv
```

| | exit | output |
| --- | --- | --- |
| before (main) | 1 | `+ cloudpickle==3.1.2  (license: BSD License)` -- identical to run 33394216939 |
| after (this PR) | 0 | `OK: 110 Python packages match LICENSE-binary.` |

The `--ignore-transitive-version`-less (nightly) mode still exits 1 on the 22
transitive drifts both before and after this change, so the behavior there is
unchanged -- that is the nightly refresh's job, not this PR's.

Upstream cause confirmed straight from the published wheels:

```bash
pip download joblib==1.5.3 --no-deps -d . && pip download joblib==1.6.0 --no-deps -d .
# 1.6.0 METADATA: Requires-Dist: cloudpickle>=3.0, and no joblib/externals/cloudpickle/
# 1.5.3 METADATA: no Requires-Dist,           and joblib/externals/cloudpickle/ present
pip download cloudpickle==3.1.2 --no-deps -d .
# METADATA: License: BSD-3-Clause; licenses/LICENSE is the 3-clause text; no NOTICE
```

The failure was verified as repo-wide rather than PR-specific on two unrelated
branches -- `chore/remove-superseded-sql-updates` (run 33394216939, 12:55 UTC)
and `ci/8084-backport-manager-approval-gate` (run 33392828233, 12:39 UTC) -- both
failing on the same `+ cloudpickle==3.1.2` line, against green license steps at
08:39 UTC (#8282) and 08:49 UTC (#8286).

One wrinkle worth flagging for the reviewer: `build` was **skipped** on this
PR's first runs. `amber/LICENSE-binary-python` matches no glob in
`.github/labeler.yml`, so no stack label was applied, `precheck` selected no
stacks, and the aggregate gate accepts `build: skipped` as passing -- i.e. a
change to this manifest is not normally gated by the check that validates it.
The `pyamber` label was applied by hand here so the license check actually runs
against the fix. That gap is filed separately as #8294 and left out of this
diff to keep the hotfix a one-liner.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
