### PR TITLE
feat(scorer): report the settings the Machine Learning Scorer cannot score

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
@@ -33,6 +33,36 @@ import org.apache.texera.amber.operator.PythonOperatorDescriptor
 import org.apache.texera.amber.operator.metadata.annotations.{AutofillAttributeName, HideAnnotation}
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 
+// Whichever metric list the task shows must hold at least one metric: an empty
+// one renders as `metric_list = ['']` and the metric lookup fails on the empty
+// name. The rule is conditional because only one of the two lists is visible at
+// a time, and a flat `required` on both can never be satisfied.
+@JsonSchemaInject(json = """
+{
+  "allOf": [
+    {
+      "if": {
+        "required": ["isRegression"],
+        "properties": { "isRegression": { "const": false } }
+      },
+      "then": {
+        "required": ["classificationFlag"],
+        "properties": { "classificationFlag": { "minItems": 1 } }
+      }
+    },
+    {
+      "if": {
+        "required": ["isRegression"],
+        "properties": { "isRegression": { "const": true } }
+      },
+      "then": {
+        "required": ["regressionFlag"],
+        "properties": { "regressionFlag": { "minItems": 1 } }
+      }
+    }
+  ]
+}
+""")
 class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(required = true, defaultValue = "false")
   @JsonSchemaTitle("Regression")
@@ -85,9 +115,61 @@ class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort())
     )
+
+  /** The two scored columns hold one quantity measured twice, so they have to be
+    * comparable. Left to sklearn, a mismatched pair either raises `Mix of label
+    * input types` from deep inside a metric or, for Accuracy, quietly scores 0 —
+    * neither of which points back at the two columns the user picked.
+    *
+    * Types only, not values: a DOUBLE label column of 0.0 / 1.0 is a legitimate
+    * classification target even though a continuous one is not, and the schema
+    * cannot tell the two apart.
+    */
+  private def validateScoredColumns(inputSchemas: Map[PortIdentity, Schema]): Unit = {
+    val numeric = Set(AttributeType.INTEGER, AttributeType.LONG, AttributeType.DOUBLE)
+    // Blank names are what the form reports before the user has picked; the
+    // schema's own `required` already says so, and saying it twice would put a
+    // second message on a half-filled operator.
+    if (actualValueColumn.isEmpty || predictValueColumn.isEmpty) return
+    inputSchemas.get(operatorInfo.inputPorts.head.id).foreach { schema =>
+      Seq(("Actual Value", actualValueColumn), ("Predicted Value", predictValueColumn))
+        .foreach {
+          case (label, column) =>
+            if (!schema.containsAttribute(column))
+              throw new RuntimeException(s"$label column '$column' is not in the input table")
+        }
+      val actualType = schema.getAttribute(actualValueColumn).getType
+      val predictType = schema.getAttribute(predictValueColumn).getType
+      if (isRegression) {
+        Seq(
+          ("Actual Value", actualValueColumn, actualType),
+          ("Predicted Value", predictValueColumn, predictType)
+        )
+          .foreach {
+            case (label, column, attributeType) =>
+              if (!numeric.contains(attributeType))
+                throw new RuntimeException(
+                  s"A regression metric needs a numeric $label column, but '$column' is " +
+                    s"${attributeType.getName}"
+                )
+          }
+      } else {
+        val comparable = (numeric.contains(actualType) && numeric.contains(predictType)) ||
+          actualType == predictType
+        if (!comparable)
+          throw new RuntimeException(
+            s"Actual Value '$actualValueColumn' (${actualType.getName}) and Predicted Value " +
+              s"'$predictValueColumn' (${predictType.getName}) hold different kinds of label, " +
+              "so a classification metric cannot compare them"
+          )
+      }
+    }
+  }
+
   override def getOutputSchemas(
       inputSchemas: Map[PortIdentity, Schema]
   ): Map[PortIdentity, Schema] = {
+    validateScoredColumns(inputSchemas)
     val metrics = if (isRegression) {
       regressionMetrics.map(_.getName())
     } else {

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDescSpec.scala
@@ -21,6 +21,7 @@ package org.apache.texera.amber.operator.machineLearning.Scorer
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import org.apache.texera.amber.core.tuple.{Attribute, AttributeType, Schema}
+import org.apache.texera.amber.core.workflow.PortIdentity
 import org.apache.texera.amber.operator.LogicalOp
 import org.apache.texera.amber.operator.metadata.OperatorGroupConstants
 import org.apache.texera.amber.util.JSONUtils.objectMapper
@@ -107,6 +108,67 @@ class MachineLearningScorerOpDescSpec extends AnyFlatSpec with Matchers {
     val port = d.operatorInfo.outputPorts.head.id
     d.getOutputSchemas(Map.empty)(port).getAttributes.map(a => (a.getName, a.getType)) shouldBe
       List(("MSE", AttributeType.DOUBLE), ("R2", AttributeType.DOUBLE))
+  }
+
+  /** An input table holding one column of each type the scored-column check reasons about. */
+  private def inputSchemas(d: MachineLearningScorerOpDesc): Map[PortIdentity, Schema] =
+    Map(
+      d.operatorInfo.inputPorts.head.id -> Schema(
+        List(
+          new Attribute("y_int", AttributeType.INTEGER),
+          new Attribute("pred_long", AttributeType.LONG),
+          new Attribute("label_str", AttributeType.STRING),
+          new Attribute("pred_str", AttributeType.STRING)
+        )
+      )
+    )
+
+  private def scorer(
+      regression: Boolean,
+      actual: String,
+      predict: String
+  ): MachineLearningScorerOpDesc = {
+    val d = new MachineLearningScorerOpDesc
+    d.isRegression = regression
+    d.actualValueColumn = actual
+    d.predictValueColumn = predict
+    d
+  }
+
+  it should "accept a classification pair whose types are both numeric" in {
+    // INTEGER against LONG is one label domain read through two widths, which is
+    // what an upstream predictor emitting a wider column looks like.
+    val d = scorer(regression = false, "y_int", "pred_long")
+    d.classificationMetrics = List(classificationMetricsFnc.accuracy)
+    noException should be thrownBy d.getOutputSchemas(inputSchemas(d))
+  }
+
+  it should "reject a classification pair that mixes a number with a string" in {
+    val d = scorer(regression = false, "y_int", "pred_str")
+    d.classificationMetrics = List(classificationMetricsFnc.accuracy)
+    the[RuntimeException] thrownBy d.getOutputSchemas(inputSchemas(d)) should have message
+      "Actual Value 'y_int' (integer) and Predicted Value 'pred_str' (string) hold different " +
+        "kinds of label, so a classification metric cannot compare them"
+  }
+
+  it should "reject a non-numeric column once the task is regression" in {
+    val d = scorer(regression = true, "label_str", "pred_str")
+    d.regressionMetrics = List(regressionMetricsFnc.mse)
+    the[RuntimeException] thrownBy d.getOutputSchemas(inputSchemas(d)) should have message
+      "A regression metric needs a numeric Actual Value column, but 'label_str' is string"
+  }
+
+  it should "reject a column the input table does not hold" in {
+    val d = scorer(regression = false, "y_int", "absent")
+    the[RuntimeException] thrownBy d.getOutputSchemas(inputSchemas(d)) should have message
+      "Predicted Value column 'absent' is not in the input table"
+  }
+
+  it should "say nothing about the pair while a column is still unpicked" in {
+    // Half-filled is the state every operator passes through on the way to a
+    // valid one; the empty field already carries its own required marker.
+    val d = scorer(regression = false, "y_int", "")
+    noException should be thrownBy d.getOutputSchemas(inputSchemas(d))
   }
 
   "MachineLearningScorerOpDesc.generatePythonCode" should "emit the scorer table operator" in {


### PR DESCRIPTION
### What changes were proposed in this PR?

The Machine Learning Scorer accepts settings it cannot score, and it says so only once the generated Python has already failed. This adds the two checks that report them in the editor instead.

The first is on the schema. The Scorer Functions multi-select starts empty and nothing marks it required, so an untouched operator runs and then fails with `KeyError: ''`. The rule has to be conditional: there are two metric lists, one per branch of the Regression switch, and only one of them is visible at a time, so a flat `required` on both could never be satisfied. Stated as a conditional `required` plus `minItems`, only the visible list is asked for, and the editor already renders the marker for a rule in that form.

The second is on the pair of column settings. Actual Value and Predicted Value hold one label read twice, so they have to be comparable, and `getOutputSchemas` is where both the settings and the upstream schema are in hand. It now reports a column the input table does not hold, a non-numeric column on the regression branch, and a classification pair that mixes a number with a string. That last one is the reason this is worth catching: with Accuracy the mismatched pair does not fail at all, it scores 0.0, which reads as a model that never predicts correctly.

The check reads types, not values. A DOUBLE label column of 0.0 / 1.0 is a legitimate classification target even though a continuous one is not, and a schema cannot tell the two apart, so pinning the columns to a type would refuse configurations that work today.

### Any related issues, documentation, discussions?

Closes #8302

### How was this PR tested?

Five cases were added to `MachineLearningScorerOpDescSpec`, covering each rejection with the message it produces and both cases that have to stay accepted: an INTEGER label against a LONG prediction, and a half-filled operator whose second column is still unpicked, where the existing required marker already speaks for itself.

The schema rule was checked by generating the operator's JSON Schema and running it through the same AJV configuration the editor validates with. A classification config carrying at least one metric is valid; an empty or absent `classificationFlag` is not; the same holds for `regressionFlag` on the other branch; and a leftover empty list on the branch that is hidden does not block the branch in use.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
