### PR TITLE
chore: bump version to v1.3.0-incubating

### DIFF
--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -19,7 +19,7 @@ texera:
   # Container image registry and tag for all Texera services
   # Override these to use a different registry or version
   imageRegistry: docker.io/apache
-  imageTag: 1.3.0-incubating-SNAPSHOT
+  imageTag: 1.3.0-incubating
 
 global:
   # Required by Bitnami sub-charts (postgresql, minio) to allow custom images

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 // under the License.
 
 ThisBuild / organization := "org.apache.texera"
-ThisBuild / version      := "1.3.0-incubating-SNAPSHOT"
+ThisBuild / version      := "1.3.0-incubating"
 ThisBuild / scalaVersion := "2.13.18"
 
 // Pull JDK 17+ JVM flags from .jvmopts so every JVM the build launches sees the same list.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui",
-  "version": "1.3.0-incubating-SNAPSHOT",
+  "version": "1.3.0-incubating",
   "engines": {
     "node": ">=24.0.0"
   },


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR bumps the project version from `1.3.0-incubating-SNAPSHOT` to
`1.3.0-incubating` on the `release/v1.3` branch, in preparation for the
v1.3.0-incubating release:

- `build.sbt`: `ThisBuild / version` from `1.3.0-incubating-SNAPSHOT` to `1.3.0-incubating`
- `bin/k8s/values.yaml`: `imageTag` from `1.3.0-incubating-SNAPSHOT` to `1.3.0-incubating`
- `frontend/package.json`: `version` from `1.3.0-incubating-SNAPSHOT` to `1.3.0-incubating`

### Any related issues, documentation, discussions?

Closes #8305.

### How was this PR tested?

Configuration-only change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)
