### PR TITLE
chore: bump main version to 1.4.0-incubating-SNAPSHOT

### DIFF
--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -19,7 +19,7 @@ texera:
   # Container image registry and tag for all Texera services
   # Override these to use a different registry or version
   imageRegistry: docker.io/apache
-  imageTag: 1.3.0-incubating-SNAPSHOT
+  imageTag: 1.4.0-incubating-SNAPSHOT
 
 global:
   # Required by Bitnami sub-charts (postgresql, minio) to allow custom images

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 // under the License.
 
 ThisBuild / organization := "org.apache.texera"
-ThisBuild / version      := "1.3.0-incubating-SNAPSHOT"
+ThisBuild / version      := "1.4.0-incubating-SNAPSHOT"
 ThisBuild / scalaVersion := "2.13.18"
 
 // Pull JDK 17+ JVM flags from .jvmopts so every JVM the build launches sees the same list.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gui",
-  "version": "1.3.0-incubating-SNAPSHOT",
+  "version": "1.4.0-incubating-SNAPSHOT",
   "engines": {
     "node": ">=24.0.0"
   },


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR bumps the project version on main from `1.3.0-incubating-SNAPSHOT` to
`1.4.0-incubating-SNAPSHOT`. Since release/v1.3 has been cut from main, main
should now advance to the next version line.

Updated version references:
- `build.sbt`: `ThisBuild / version` → 1.4.0-incubating-SNAPSHOT
- `bin/k8s/values.yaml`: `imageTag` → 1.4.0-incubating-SNAPSHOT
- `frontend/package.json`: `version` → 1.4.0-incubating-SNAPSHOT

### Any related issues, documentation, or discussions?

release/v1.3 is already at `1.3.0-incubating` via #8306, so main now moves to
`1.4.0-incubating-SNAPSHOT`.

Closes #8305.

### How was this PR tested?

Version-string-only change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)
