### PR TITLE
chore: add 1.3.0-incubating and 1.4.0-incubating-SNAPSHOT to bug-report options

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-template.yaml
@@ -44,7 +44,8 @@ body:
       label: Version/Branch
       description: Which version/branch did you hit this on?
       options:
-        - 1.3.0-incubating-SNAPSHOT (main)
+        - 1.4.0-incubating-SNAPSHOT (main)
+        - 1.3.0-incubating (release/v1.3)
         - 1.2.0-incubating (release/v1.2)
         - 1.1.0-incubating
       default: 0


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR updates the version dropdown in `.github/ISSUE_TEMPLATE/bug-template.yaml`
so bug reporters can select the current versions:

- `1.4.0-incubating-SNAPSHOT (main)` — current development
- `1.3.0-incubating (release/v1.3)` — release/v1.3 line

### Any related issues, documentation, discussions?

Closes #8308.

### How was this PR tested?

Config-only change to a GitHub issue template.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)
