### PR TITLE
chore(ci): add release/v1.3 to the merge-queue ruleset

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -82,6 +82,7 @@ github:
             # Add each release line here as it is cut.
             - "refs/heads/release/v1.1"
             - "refs/heads/release/v1.2"
+            - "refs/heads/release/v1.3"
       rules:
         - type: deletion
         - type: non_fast_forward


### PR DESCRIPTION
### What changes were proposed in this PR?

Add `refs/heads/release/v1.3` to the `Merge Queue` ruleset in `.asf.yaml`,
following the ruleset's own instruction ("Add each release line here as it is
cut"). Merge-queue rules do not support wildcard ref patterns (#7121), so each
release branch must be listed explicitly.

release/v1.3 was cut from main today. Until this lands, PRs targeting
release/v1.3 carry no required review, no required status checks, and no merge
queue; once ASF Infra applies the updated ruleset, the branch gets the same
protections as main and the other release branches.

### Any related issues, documentation, discussions?

Closes #8311. Related: #8310 (v1.3.0-incubating release tracking).
See #7121 for the wildcard limitation.

### How was this PR tested?

Config-only change; `.asf.yaml` is applied by ASF Infra from the default
branch. The new entry mirrors the existing `release/v1.1` / `release/v1.2`
lines.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-fable-5)
