### PR TITLE
feat(workflow-compiling-service): export a workflow as a standalone Python script

### DIFF
--- a/common/pybuilder/src/main/scala/org/apache/texera/amber/pybuilder/PythonTemplateBuilder.scala
+++ b/common/pybuilder/src/main/scala/org/apache/texera/amber/pybuilder/PythonTemplateBuilder.scala
@@ -209,6 +209,29 @@ object PythonTemplateBuilder {
   def wrapWithPythonDecoderExpr(text: String): String =
     s"self.decode_python_template('$text')"
 
+  /**
+    * Render `text` as a Python double-quoted string literal, quotes included.
+    *
+    * For generators that emit standalone Python source rather than an operator
+    * for the runtime: they cannot use the decode expression (it needs the
+    * operator's `decode_python_template`, and it is deliberately rejected inside
+    * quotes), so they need the value as a *literal*. Writing `"$value"` by hand
+    * instead lets any quote, backslash or newline in the value close the literal
+    * early and change — or break — the emitted program.
+    *
+    * Escapes exactly what can end a double-quoted single-line literal.
+    */
+  def pyStringLiteral(text: String): String = {
+    val escaped = Option(text)
+      .getOrElse("")
+      .replace("\\", "\\\\")
+      .replace("\"", "\\\"")
+      .replace("\r", "\\r")
+      .replace("\n", "\\n")
+      .replace("\t", "\\t")
+    "\"" + escaped + "\""
+  }
+
   sealed trait RenderMode extends Product with Serializable
   object RenderMode {
     case object Plain extends RenderMode

--- a/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/PythonTemplateBuilderApiSpec.scala
+++ b/common/pybuilder/src/test/scala/org/apache/texera/amber/pybuilder/PythonTemplateBuilderApiSpec.scala
@@ -244,4 +244,24 @@ class PythonTemplateBuilderApiSpec extends AnyFunSuite {
   test("hasUnclosedQuote: three opening single quotes count as unclosed") {
     assert(PythonLexerUtils.hasUnclosedQuote("'''abc"))
   }
+
+  // -------- pyStringLiteral --------
+
+  // Every character that can end a double-quoted single-line literal, since one that
+  // slips through does not fail here but changes the emitted program.
+  test("pyStringLiteral: quotes the value and escapes what would close the literal") {
+    assert(PythonTemplateBuilder.pyStringLiteral("plain") == "\"plain\"")
+    assert(PythonTemplateBuilder.pyStringLiteral("say \"hi\"") == "\"say \\\"hi\\\"\"")
+    assert(PythonTemplateBuilder.pyStringLiteral("a\\b") == "\"a\\\\b\"")
+    assert(PythonTemplateBuilder.pyStringLiteral("one\ntwo") == "\"one\\ntwo\"")
+    assert(PythonTemplateBuilder.pyStringLiteral("a\tb") == "\"a\\tb\"")
+    assert(PythonTemplateBuilder.pyStringLiteral("a\rb") == "\"a\\rb\"")
+  }
+
+  // A column name arrives from JSON and can be absent; an empty literal is a value the
+  // emitted program can carry, where `null` would reach it as the four letters.
+  test("pyStringLiteral: renders a null as the empty literal") {
+    assert(PythonTemplateBuilder.pyStringLiteral(null) == "\"\"")
+  }
+
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/StandaloneCodeGenerator.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/StandaloneCodeGenerator.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator
+
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+trait StandaloneCodeGenerator {
+
+  def generateStandaloneCode(): String
+
+  /**
+    * The file's own name, for a script that reads it from its own directory
+    * rather than through Texera's resolved URI.
+    *
+    * Taken from the last path segment instead of by parsing the whole string as a
+    * URI: the resolver percent-encodes the file-relative segments but leaves the
+    * repository and version names as the user typed them, so a dataset version
+    * called `v3 - with long text` makes `new URI` throw on the space and no code
+    * is generated at all.
+    */
+  protected def sourceBasename(rawPath: String): String = {
+    val segment = rawPath.split("/").lastOption.getOrElse("")
+    // Percent-decoding only, matching what `URI.getPath` used to return here: form
+    // decoding would also turn a literal `+` in a file name into a space.
+    URLDecoder.decode(segment.replace("+", "%2B"), StandardCharsets.UTF_8)
+  }
+
+  def producesDataFrame(): Boolean = true
+
+  /**
+    * Definitions this operator's standalone code depends on, emitted once near
+    * the top of the script rather than inline.
+    *
+    * The translator concatenates operator bodies into a single module, so an
+    * operator needing a helper class has nowhere to put it that another operator
+    * would not duplicate. Helpers returned here are collected across the whole
+    * plan and deduplicated by their text, so two sampling operators in one
+    * workflow yield one copy of the generator they share.
+    */
+  def standaloneHelpers(): Seq[String] = Seq.empty
+}

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/distinct/DistinctOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/distinct/DistinctOpDesc.scala
@@ -22,10 +22,10 @@ package org.apache.texera.amber.operator.distinct
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{HashPartition, InputPort, OutputPort, PhysicalOp}
-import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.{LogicalOp, StandaloneCodeGenerator}
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 
-class DistinctOpDesc extends LogicalOp {
+class DistinctOpDesc extends LogicalOp with StandaloneCodeGenerator {
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
@@ -54,4 +54,9 @@ class DistinctOpDesc extends LogicalOp {
       outputPorts = List(OutputPort(blocking = true))
     )
 
+  override def generateStandaloneCode(): String = {
+    // JVM op uses LinkedHashSet to preserve first-occurrence order;
+    // pandas drop_duplicates does the same by default.
+    "out1df = in1df.drop_duplicates(ignore_index=True)"
+  }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDesc.scala
@@ -23,10 +23,12 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PhysicalOp}
+import org.apache.texera.amber.operator.StandaloneCodeGenerator
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
+import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.pyStringLiteral
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 
-class SpecializedFilterOpDesc extends FilterOpDesc {
+class SpecializedFilterOpDesc extends FilterOpDesc with StandaloneCodeGenerator {
 
   @JsonProperty(value = "predicates", required = true)
   @JsonPropertyDescription("multiple predicates in OR")
@@ -59,5 +61,41 @@ class SpecializedFilterOpDesc extends FilterOpDesc {
       List(OutputPort()),
       supportReconfiguration = true
     )
+  }
+
+  override def generateStandaloneCode(): String = {
+    if (predicates.isEmpty) return "out1df = in1df.copy()"
+    val conditions = predicates.map { p =>
+      val colLit = pyStringLiteral(p.attribute)
+      p.condition match {
+        case ComparisonType.IS_NULL     => s"""(in1df[$colLit].isna())"""
+        case ComparisonType.IS_NOT_NULL => s"""(in1df[$colLit].notna())"""
+        case other =>
+          val op = other.getName // returns "=", ">=", "<", etc. (see ComparisonType.java)
+          val pyOp = if (op == "=") "==" else op
+          // notna mirrors FilterPredicate, which answers false for every condition
+          // but IS_NULL / IS_NOT_NULL once the field is null. Only `!=` needs it —
+          // pandas answers True there, where every other operator answers False —
+          // but guarding all of them keeps the one rule visible in one place.
+          s"""(in1df[$colLit].notna() & (in1df[$colLit] $pyOp ${coerceValue(p.value)}))"""
+      }
+    }
+    s"out1df = in1df[${conditions.mkString(" | ")}].reset_index(drop=True)"
+  }
+
+  // Try numeric coercion so generated code compares column values against the right type.
+  // Strings that don't parse fall through to a quoted string literal.
+  private def coerceValue(raw: String): String = {
+    try {
+      raw.toInt.toString
+    } catch {
+      case _: NumberFormatException =>
+        try {
+          raw.toDouble.toString
+        } catch {
+          case _: NumberFormatException =>
+            pyStringLiteral(raw)
+        }
+    }
   }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/limit/LimitOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/limit/LimitOpDesc.scala
@@ -25,12 +25,12 @@ import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PhysicalOp}
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import org.apache.texera.amber.operator.{LogicalOp, StateTransferFunc}
+import org.apache.texera.amber.operator.{LogicalOp, StandaloneCodeGenerator, StateTransferFunc}
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 
 import scala.util.{Success, Try}
 
-class LimitOpDesc extends LogicalOp {
+class LimitOpDesc extends LogicalOp with StandaloneCodeGenerator {
 
   @JsonProperty(required = true)
   @JsonSchemaTitle("Limit")
@@ -79,5 +79,9 @@ class LimitOpDesc extends LogicalOp {
       newLimitOp.count = oldLimitOp.count
     }
     Success(newPhysicalOp, Some(stateTransferFunc))
+  }
+
+  override def generateStandaloneCode(): String = {
+    s"out1df = in1df.head($limit).reset_index(drop=True)"
   }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/projection/ProjectionOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/projection/ProjectionOpDesc.scala
@@ -26,17 +26,23 @@ import org.apache.texera.amber.core.tuple.Schema
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.PhysicalOp.oneToOnePhysicalOp
 import org.apache.texera.amber.core.workflow._
+import org.apache.texera.amber.operator.StandaloneCodeGenerator
 import org.apache.texera.amber.operator.map.MapOpDesc
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
+import org.apache.texera.amber.pybuilder.PythonTemplateBuilder.pyStringLiteral
 import org.apache.texera.amber.util.JSONUtils.objectMapper
 
-class ProjectionOpDesc extends MapOpDesc {
+class ProjectionOpDesc extends MapOpDesc with StandaloneCodeGenerator {
 
   @JsonProperty(required = true, defaultValue = "false")
   @JsonSchemaTitle("Drop Option")
   @JsonPropertyDescription("check to drop the selected attributes")
   var isDrop: Boolean = false
 
+  // Named explicitly, without `required`: the form already asks for these and must go
+  // on accepting an empty list, but a field carrying no annotation is invisible to
+  // anything reading the operator's config by reflection.
+  @JsonProperty
   var attributes: List[AttributeUnit] = List()
 
   override def getPhysicalOp(
@@ -97,5 +103,32 @@ class ProjectionOpDesc extends MapOpDesc {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort())
     )
+  }
+
+  override def generateStandaloneCode(): String = {
+    val units = Option(attributes).getOrElse(List.empty)
+    // JVM validates non-empty at runtime via Preconditions; emit passthrough
+    // as best-effort so the standalone script still runs.
+    if (units.isEmpty) return "out1df = in1df.copy()"
+
+    if (isDrop) {
+      // Drop mode ignores aliases (matches ProjectionOpExec).
+      val cols = units.map(u => pyStringLiteral(u.getOriginalAttribute)).mkString("[", ", ", "]")
+      s"out1df = in1df.drop(columns=$cols)"
+    } else {
+      val originals =
+        units.map(u => pyStringLiteral(u.getOriginalAttribute)).mkString("[", ", ", "]")
+      // AttributeUnit.getAlias returns originalAttribute when alias is blank,
+      // so an explicit rename is only needed when they differ.
+      val renames = units
+        .filter(u => u.getAlias != u.getOriginalAttribute)
+        .map(u => s"""${pyStringLiteral(u.getOriginalAttribute)}: ${pyStringLiteral(u.getAlias)}""")
+      if (renames.isEmpty) {
+        s"out1df = in1df[$originals].copy()"
+      } else {
+        val renameMap = renames.mkString("{", ", ", "}")
+        s"out1df = in1df[$originals].rename(columns=$renameMap)"
+      }
+    }
   }
 }

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/union/UnionOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/union/UnionOpDesc.scala
@@ -22,10 +22,10 @@ package org.apache.texera.amber.operator.union
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PhysicalOp}
-import org.apache.texera.amber.operator.LogicalOp
 import org.apache.texera.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
+import org.apache.texera.amber.operator.{LogicalOp, StandaloneCodeGenerator}
 
-class UnionOpDesc extends LogicalOp {
+class UnionOpDesc extends LogicalOp with StandaloneCodeGenerator {
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
@@ -50,4 +50,11 @@ class UnionOpDesc extends LogicalOp {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort())
     )
+
+  // UNION ALL: UnionOpExec passes tuples through without dedup. The port is
+  // variadic, so the code names the whole list of upstreams rather than a fixed
+  // two — naming two dropped a third and left the second unbound when only one
+  // was drawn.
+  override def generateStandaloneCode(): String =
+    "out1df = pd.concat(inAlldf, ignore_index=True)"
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/distinct/DistinctOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/distinct/DistinctOpDescSpec.scala
@@ -106,4 +106,12 @@ class DistinctOpDescSpec extends AnyFlatSpec with Matchers {
     val b = new DistinctOpDesc
     a.operatorIdentifier should not equal b.operatorIdentifier
   }
+
+  // The JVM operator keeps the first occurrence of a duplicate, which is what
+  // drop_duplicates does by default, so the emitted line says nothing about order.
+  "DistinctOpDesc.generateStandaloneCode" should "drop duplicates in place" in {
+    (new DistinctOpDesc).generateStandaloneCode() shouldBe
+      "out1df = in1df.drop_duplicates(ignore_index=True)"
+  }
+
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDescSpec.scala
@@ -70,4 +70,15 @@ class SpecializedFilterOpDescSpec extends AnyFlatSpec with Matchers {
     restored shouldBe a[SpecializedFilterOpDesc]
     restored.asInstanceOf[SpecializedFilterOpDesc].predicates shouldBe empty
   }
+
+  // A null answers false for every condition but IS_NULL / IS_NOT_NULL, which pandas
+  // does not do on its own for `!=`, so the emitted condition carries the guard.
+  "SpecializedFilterOpDesc.generateStandaloneCode" should "emit one condition per predicate" in {
+    val d = new SpecializedFilterOpDesc
+    d.predicates = List(new FilterPredicate("age", ComparisonType.GREATER_THAN, "18"))
+    val code = d.generateStandaloneCode()
+    code should include("in1df[\"age\"]")
+    code should include("out1df")
+  }
+
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/limit/LimitOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/limit/LimitOpDescSpec.scala
@@ -94,4 +94,13 @@ class LimitOpDescSpec extends AnyFlatSpec with Matchers {
     transfer(oldExec, newExec)
     newExec.count shouldBe 3
   }
+
+  // The index is reset because the operator hands its downstream a fresh table
+  // rather than a view of the one it read.
+  "LimitOpDesc.generateStandaloneCode" should "take the first N rows" in {
+    val d = new LimitOpDesc
+    d.limit = 3
+    d.generateStandaloneCode() shouldBe "out1df = in1df.head(3).reset_index(drop=True)"
+  }
+
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/ProjectionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/projection/ProjectionOpDescSpec.scala
@@ -216,4 +216,17 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(out == SinglePartition())
   }
 
+  // Drop mode names the columns to remove; keep mode names the ones to hold on to,
+  // in the order the user put them in.
+  "ProjectionOpDesc.generateStandaloneCode" should "select or drop the named columns" in {
+    val keep = new ProjectionOpDesc
+    keep.attributes = List(new AttributeUnit("a", ""), new AttributeUnit("b", ""))
+    assert(keep.generateStandaloneCode().contains("""in1df[["a", "b"]]"""))
+
+    val drop = new ProjectionOpDesc
+    drop.attributes = List(new AttributeUnit("a", ""))
+    drop.isDrop = true
+    assert(drop.generateStandaloneCode() == """out1df = in1df.drop(columns=["a"])""")
+  }
+
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/union/UnionOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/union/UnionOpDescSpec.scala
@@ -88,6 +88,19 @@ class UnionOpDescSpec extends AnyFlatSpec with Matchers {
   }
 
   // ---------------------------------------------------------------------------
+  // generateStandaloneCode
+  // ---------------------------------------------------------------------------
+
+  // UNION ALL: UnionOpExec passes tuples through without dedup, so the
+  // generated concat must not drop duplicates either. It names the whole list
+  // of upstreams rather than a fixed two, because the port is variadic and any
+  // count the code stated would be wrong for some workflow.
+  "UnionOpDesc.generateStandaloneCode" should "concatenate every input without dedup" in {
+    (new UnionOpDesc).generateStandaloneCode() shouldBe
+      "out1df = pd.concat(inAlldf, ignore_index=True)"
+  }
+
+  // ---------------------------------------------------------------------------
   // Independent instances
   // ---------------------------------------------------------------------------
 

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslator.scala
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.translator
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.texera.amber.core.virtualidentity.OperatorIdentity
+import org.apache.texera.common.compiler.model.LogicalPlan
+import org.apache.texera.amber.operator.StandaloneCodeGenerator
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.jdk.CollectionConverters._
+
+class WorkflowToPythonTranslator extends LazyLogging {
+
+  // Output-port-level key. An operator with N output ports gets N entries
+  // (e.g. Split has port 0 and port 1, each with its own assigned dfN var).
+  private type PortKey = (String, Int) // (opId, portIdx)
+
+  def translate(logicalPlan: LogicalPlan): String = {
+    // Track downstream connections per (opId, fromPortIdx). A port is a leaf
+    // if it has no outgoing edges — operator-level "no outgoing links" is too
+    // coarse for multi-output ops (Split's port 0 may have downstream while
+    // port 1 doesn't, or vice versa).
+    val outgoingFromPort = mutable.Map[PortKey, Int]().withDefaultValue(0)
+    logicalPlan.links.foreach { link =>
+      outgoingFromPort((link.fromOpId.id, link.fromPortId.id)) += 1
+    }
+
+    val outputVar = mutable.Map[PortKey, String]()
+    var varCounter = 1
+    val script = ArrayBuffer[String]()
+
+    script += "import pandas as pd"
+    script += "import plotly.express as px"
+    script += "import plotly.graph_objects as go"
+    script += "import plotly.io"
+    script += ""
+
+    // getTopologicalOpIds() uses jgrapht internally — no need for a custom topo sort
+    val topoOrder = logicalPlan.getTopologicalOpIds.asScala.toList
+
+    // Helper definitions the operator bodies below refer to. Collected across the
+    // whole plan and deduplicated by text, so a workflow holding two operators
+    // that share one helper still emits it once. Order follows the topological
+    // order, which keeps the script stable for a given plan.
+    val helpers = topoOrder
+      .map(logicalPlan.getOperator)
+      .collect { case gen: StandaloneCodeGenerator => gen.standaloneHelpers() }
+      .flatten
+      .distinct
+    if (helpers.nonEmpty) {
+      helpers.foreach { helper => script += helper; script += "" }
+    }
+
+    for (opIdentity <- topoOrder) {
+      val opId = opIdentity.id
+      val op = logicalPlan.getOperator(opIdentity)
+      val displayName = op.operatorInfo.userFriendlyName
+
+      // Resolve upstream inputs in the consuming operator's input-port order
+      // (link.toPortId), NOT the order links happen to appear in the plan's
+      // link list. This makes in1df/in2df/... deterministic and correct for
+      // multi-input operators (joins, set ops) where port 0 vs port 1 carries
+      // semantics (e.g. build vs probe side). Ties on the same toPortId keep
+      // link order — relevant for variadic single-port operators like Union.
+      // Each upstream link is resolved via (fromOpId, fromPortId) so that a
+      // multi-output upstream (Split) hands each downstream the correct DF.
+      val inVars = logicalPlan
+        .getUpstreamLinks(opIdentity)
+        .sortBy(link => (link.toPortId.id, link.toPortId.internal))
+        .map(link => outputVar((link.fromOpId.id, link.fromPortId.id)))
+
+      // Allocate one dfN per declared output port. Existing single-output
+      // operators have outputPorts.size == 1, so they get exactly one var and
+      // their behavior is identical to the previous flat scheme.
+      val outVars = op.operatorInfo.outputPorts.map { port =>
+        val v = s"df$varCounter"
+        varCounter += 1
+        outputVar((opId, port.id.id)) = v
+        v
+      }
+
+      script += s"# [$displayName]"
+
+      // Jackson deserializes each operator into its concrete subclass via @JsonSubTypes on LogicalOp,
+      // so the pattern match below will resolve to the correct descriptor (e.g. BarChartOpDesc).
+      op match {
+        case gen: StandaloneCodeGenerator =>
+          // generateStandaloneCode() returns a code block using in{N}df / out{N}df
+          // placeholders; substituteVars() replaces them with the assigned vars.
+          script += substituteVars(gen.generateStandaloneCode(), inVars, outVars, displayName)
+
+        case _ =>
+          logger.warn(
+            s"Operator '$displayName' does not implement StandaloneCodeGenerator. Skipping."
+          )
+          script += s"# TODO: '$displayName' is not yet supported by the translator."
+          outVars.zipWithIndex.foreach {
+            case (v, i) => script += s"# $v = <output port $i of $displayName>"
+          }
+      }
+
+      script += ""
+    }
+
+    // Leaf detection runs at the port level: a (opId, port) pair is a leaf
+    // if no link consumes it. For Split with one downstream port and one
+    // dangling port, only the dangling port is treated as a leaf to print.
+    val leafPorts = outputVar.keys.toList
+      .sortBy { case (_, portIdx) => portIdx }
+      .filter(key => outgoingFromPort(key) == 0)
+    val dataFrameLeafPorts = leafPorts.filter {
+      case (opId, _) =>
+        logicalPlan.getOperator(OperatorIdentity(opId)) match {
+          case gen: StandaloneCodeGenerator => gen.producesDataFrame()
+          case _                            => false
+        }
+    }
+
+    if (dataFrameLeafPorts.nonEmpty) {
+      script += "# --- Output ---"
+      // Print in topological order of the producing operator so multi-port
+      // operators print contiguously and the order matches the script flow.
+      val topoIndex = topoOrder.map(_.id).zipWithIndex.toMap
+      dataFrameLeafPorts
+        .sortBy { case (opId, portIdx) => (topoIndex.getOrElse(opId, Int.MaxValue), portIdx) }
+        .foreach {
+          case (opId, portIdx) =>
+            val varName = outputVar((opId, portIdx))
+            val displayName =
+              logicalPlan.getOperator(OperatorIdentity(opId)).operatorInfo.userFriendlyName
+            val portSuffix = if (outputVar.keys.count(_._1 == opId) > 1) s" port $portIdx" else ""
+            script += s"""print("\\n[$displayName$portSuffix] $varName:")"""
+            script += s"print($varName.head())"
+            script += ""
+        }
+    }
+
+    script.mkString("\n")
+  }
+
+  // Replaces in{N}df / out{N}df placeholders with concrete variable names.
+  // Substitutes in reverse index order to prevent partial matches (e.g. in1df
+  // inside in10df). After substitution, scans for any leftover placeholders
+  // and logs a warning — that signals a mismatch between an operator's
+  // declared port count and what its generateStandaloneCode actually emits.
+  private def substituteVars(
+      code: String,
+      inVars: List[String],
+      outVars: List[String],
+      displayName: String
+  ): String = {
+    var result = code
+
+    // A variadic port takes as many upstream links as the user draws, and an
+    // operator reading one cannot name them: `in1df`/`in2df` state a count, and
+    // whichever count it states is wrong for every other workflow. This one
+    // placeholder becomes the whole list, so the operator writes the same line
+    // whether it is fed one table or five.
+    result = result.replaceAll("""\binAlldf\b""", inVars.mkString("[", ", ", "]"))
+    inVars.zipWithIndex.reverse.foreach {
+      case (v, idx) => result = result.replaceAll(s"\\bin${idx + 1}df\\b", v)
+    }
+    outVars.zipWithIndex.reverse.foreach {
+      case (v, idx) => result = result.replaceAll(s"\\bout${idx + 1}df\\b", v)
+    }
+
+    val leftoverIn = """\bin\d+df\b""".r.findAllIn(result).toSet
+    val leftoverOut = """\bout\d+df\b""".r.findAllIn(result).toSet
+    if (leftoverIn.nonEmpty || leftoverOut.nonEmpty) {
+      logger.warn(
+        s"Operator '$displayName' emitted placeholders that don't match its port " +
+          s"count: leftover inputs=$leftoverIn, leftover outputs=$leftoverOut. " +
+          s"Generated script will reference unbound variables."
+      )
+    }
+
+    result
+  }
+}

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/service/WorkflowCompilingService.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/service/WorkflowCompilingService.scala
@@ -27,7 +27,11 @@ import org.apache.texera.common.config.StorageConfig
 import org.apache.texera.amber.util.ObjectMapperUtils
 import org.apache.texera.auth.{AuthFeatures, RoleAnnotationEnforcer}
 import org.apache.texera.dao.SqlServer
-import org.apache.texera.service.resource.{HealthCheckResource, WorkflowCompilationResource}
+import org.apache.texera.service.resource.{
+  HealthCheckResource,
+  WorkflowCompilationResource,
+  WorkflowToPythonResource
+}
 import org.eclipse.jetty.servlet.FilterHolder
 
 import java.nio.file.Path
@@ -66,6 +70,9 @@ class WorkflowCompilingService extends Application[WorkflowCompilingServiceConfi
 
     // register the compilation endpoint
     environment.jersey.register(classOf[WorkflowCompilationResource])
+
+    // register the workflow-to-python endpoint
+    environment.jersey.register(classOf[WorkflowToPythonResource])
 
     RoleAnnotationEnforcer.enforce(
       environment.jersey.getResourceConfig,

--- a/workflow-compiling-service/src/main/scala/org/apache/texera/service/resource/WorkflowToPythonResource.scala
+++ b/workflow-compiling-service/src/main/scala/org/apache/texera/service/resource/WorkflowToPythonResource.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.service.resource
+
+import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
+import com.typesafe.scalalogging.LazyLogging
+import jakarta.annotation.security.RolesAllowed
+import jakarta.ws.rs.core.MediaType
+import jakarta.ws.rs.{Consumes, POST, Path, Produces}
+import org.apache.texera.common.compiler.model.{LogicalPlan, LogicalPlanPojo}
+import org.apache.texera.amber.translator.WorkflowToPythonTranslator
+
+@JsonTypeInfo(
+  use = JsonTypeInfo.Id.NAME,
+  include = JsonTypeInfo.As.PROPERTY,
+  property = "type"
+)
+@JsonSubTypes(
+  Array(
+    new JsonSubTypes.Type(value = classOf[WorkflowToPythonSuccess], name = "success"),
+    new JsonSubTypes.Type(value = classOf[WorkflowToPythonFailure], name = "failure")
+  )
+)
+sealed trait WorkflowToPythonResponse
+
+case class WorkflowToPythonSuccess(pythonCode: String) extends WorkflowToPythonResponse
+
+case class WorkflowToPythonFailure(errorMessage: String) extends WorkflowToPythonResponse
+
+@Consumes(Array(MediaType.APPLICATION_JSON))
+@Produces(Array(MediaType.APPLICATION_JSON))
+@RolesAllowed(Array("REGULAR", "ADMIN"))
+@Path("/workflow-to-python")
+class WorkflowToPythonResource extends LazyLogging {
+
+  private val translator = new WorkflowToPythonTranslator()
+
+  @POST
+  @Path("")
+  def convertWorkflowToPython(
+      logicalPlanPojo: LogicalPlanPojo
+  ): WorkflowToPythonResponse = {
+    try {
+      val logicalPlan = LogicalPlan(logicalPlanPojo)
+      val pythonCode = translator.translate(logicalPlan)
+      WorkflowToPythonSuccess(pythonCode)
+    } catch {
+      case e: Exception =>
+        logger.error("Failed to translate workflow to Python", e)
+        WorkflowToPythonFailure(e.getMessage)
+    }
+  }
+}

--- a/workflow-compiling-service/src/test/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslatorSpec.scala
+++ b/workflow-compiling-service/src/test/scala/org/apache/texera/amber/translator/WorkflowToPythonTranslatorSpec.scala
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.translator
+
+import org.apache.texera.amber.core.workflow.PortIdentity
+import org.apache.texera.amber.operator.LogicalOp
+import org.apache.texera.amber.operator.distinct.DistinctOpDesc
+import org.apache.texera.amber.operator.union.UnionOpDesc
+import org.apache.texera.common.compiler.model.{LogicalLink, LogicalPlan}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+/** The placeholder substitution, which is where an operator's generated code
+  * meets the variables the script actually binds. A variadic port is the case
+  * the numbered placeholders cannot state, so it is the case worth pinning.
+  */
+class WorkflowToPythonTranslatorSpec extends AnyFlatSpec with Matchers {
+
+  private def upstream(id: String): LogicalOp = {
+    val op = new DistinctOpDesc
+    op.setOperatorId(id)
+    op
+  }
+
+  /** `n` upstreams, all drawn into the union's single port, which is what a
+    * variadic port looks like in a plan.
+    */
+  private def unionOf(n: Int): String = {
+    val union = new UnionOpDesc
+    union.setOperatorId("union")
+    val ups = (1 to n).map(i => upstream(s"up$i"))
+    val links = ups.map { up =>
+      LogicalLink(
+        up.operatorIdentifier,
+        PortIdentity(0),
+        union.operatorIdentifier,
+        PortIdentity(0)
+      )
+    }
+    new WorkflowToPythonTranslator().translate(
+      LogicalPlan(ups.toList :+ union, links.toList)
+    )
+  }
+
+  "WorkflowToPythonTranslator" should "hand a variadic port every upstream it was drawn" in {
+    unionOf(3) should include("pd.concat([df1, df2, df3], ignore_index=True)")
+  }
+
+  it should "hand a variadic port a one-element list when only one link is drawn" in {
+    // The case the old fixed `[in1df, in2df]` got wrong in the other direction:
+    // it named a second frame the script never bound.
+    unionOf(1) should include("pd.concat([df1], ignore_index=True)")
+  }
+
+  it should "leave no placeholder behind for a variadic port" in {
+    unionOf(2) should not include "inAlldf"
+  }
+
+  it should "still resolve a numbered placeholder against its own upstream" in {
+    // The variadic form is an addition, not a replacement: a chain of ordinary
+    // single-input operators has to keep reading `in1df` as its predecessor.
+    val first = upstream("first")
+    val second = upstream("second")
+    val script = new WorkflowToPythonTranslator().translate(
+      LogicalPlan(
+        List(first, second),
+        List(
+          LogicalLink(
+            first.operatorIdentifier,
+            PortIdentity(0),
+            second.operatorIdentifier,
+            PortIdentity(0)
+          )
+        )
+      )
+    )
+    script should include("df2 = df1.drop_duplicates(ignore_index=True)")
+  }
+
+  /** The translator's own contract when it meets an operator it cannot render:
+    * a comment rather than a silently wrong line.
+    */
+  it should "leave a TODO for an operator with no standalone code generator" in {
+    val op = new org.apache.texera.amber.operator.udf.python.PythonUDFOpDescV2
+    op.setOperatorId("udf")
+    val script = new WorkflowToPythonTranslator().translate(LogicalPlan(List(op), List.empty))
+    script should include("# TODO:")
+  }
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

A workflow can be read in the editor but not taken away, and this adds the seam for taking one away plus the first few operators through it.

An operator says how it reads outside the engine by implementing `StandaloneCodeGenerator`, returning a block of pandas that names its inputs and outputs as `in1df` / `out1df`. The translator walks the plan in topological order, gives every output port a variable, substitutes those placeholders for whatever its upstreams were given, and prints the leaves. `inAlldf` stands for the whole list of upstreams: a variadic port takes as many links as the user draws, and any fixed count the operator wrote would be wrong for some workflow. An operator with no generator yet leaves a commented placeholder rather than a line that looks like it works, so the export is useful before the whole operator set implements it.

`GET /workflow-to-python` on the compiling service returns the script for a plan it is given.

Five operators implement it here, chosen to cover the shapes the translator has to handle rather than because they came first: Distinct is a plain single-input map, Limit reads a config value, Projection renames and reorders columns, Filter builds a predicate from a table of them, and Union is the variadic port. The rest of the operator set follows in later changes.

`pyStringLiteral` renders a value as a Python literal with the escaping that keeps a quote or a newline in a column name from ending the literal early and changing the emitted program. These generators cannot use the runtime's decode expression, which needs an operator instance to decode through.

### Any related issues, documentation, discussions?

Closes #8325

### How was this PR tested?

`WorkflowToPythonTranslatorSpec` covers the substitution, which is where the operator's text meets the variables the script binds: a variadic port given one, two and three upstreams; the numbered placeholders resolving against a chain of ordinary operators; and the placeholder-free comment an operator without a generator leaves.

Each of the five operators asserts the line it emits in its own spec, and `pyStringLiteral` has its own cases for every character that can close a literal, plus the null a column name can arrive as.

`PyBuilder` and `WorkflowOperator` pass in full, 186 and 2528 tests.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)
