### PR TITLE
chore(amber): remove the unused search-by-operators endpoint

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -42,8 +42,8 @@ import org.apache.texera.web.service.WarehouseReadGuard
 import org.apache.texera.web.resource.dashboard.hub.HubResource.recordCloneAction
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowAccessResource.hasReadAccess
 import org.apache.texera.web.resource.dashboard.user.workflow.WorkflowResource._
-import org.jooq.impl.DSL.{groupConcatDistinct, noCondition, max}
-import org.jooq.{Condition, DSLContext, Record11, Result, SelectOnConditionStep}
+import org.jooq.impl.DSL.{groupConcatDistinct, max}
+import org.jooq.{DSLContext, Record11, Result, SelectOnConditionStep}
 
 import java.sql.Timestamp
 import java.util
@@ -317,59 +317,6 @@ class WorkflowResource extends LazyLogging {
       .on(WORKFLOW_OF_USER.UID.eq(USER.UID))
       .where(WORKFLOW_USER_ACCESS.UID.eq(user.getUid))
       .fetchInto(classOf[String])
-  }
-
-  /**
-    * This method returns workflow IDs, that contain the selected operators, as strings
-    *
-    * @return WorkflowID[]
-    */
-  @GET
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
-  @Path("/search-by-operators")
-  def searchWorkflowByOperator(
-      @QueryParam("operator") operator: String,
-      @Auth sessionUser: SessionUser
-  ): List[String] = {
-    // Example GET url: localhost:8080/workflow/searchOperators?operator=Regex,CSVFileScan
-    val user = sessionUser.getUser
-    val quotes = "\""
-    val operatorArray =
-      operator.replace(" ", "").stripPrefix("[").stripSuffix("]").split(',')
-    var orCondition: Condition = noCondition()
-    for (i <- operatorArray.indices) {
-      val operatorName = operatorArray(i)
-      orCondition = orCondition.or(
-        WORKFLOW.CONTENT
-          .likeIgnoreCase(
-            "%" + quotes + "operatorType" + quotes + ":" + quotes + s"$operatorName" + quotes + "%"
-            //gives error when I try to combine escape character with formatted string
-            //may be due to old scala version bug
-          )
-      )
-
-    }
-
-    val workflowEntries =
-      context
-        .select(
-          WORKFLOW.WID
-        )
-        .from(WORKFLOW)
-        .join(WORKFLOW_USER_ACCESS)
-        .on(WORKFLOW_USER_ACCESS.WID.eq(WORKFLOW.WID))
-        .where(
-          orCondition
-            .and(WORKFLOW_USER_ACCESS.UID.eq(user.getUid))
-        )
-        .fetch()
-
-    workflowEntries
-      .map(workflowRecord => {
-        workflowRecord.into(WORKFLOW).getWid.intValue().toString
-      })
-      .asScala
-      .toList
   }
 
   /**

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -1028,19 +1028,6 @@ class WorkflowResourceSpec
     assertThrows[ForbiddenException](workflowResource.makePublic(wid, sessionUser2))
   }
 
-  "WorkflowResource.searchWorkflowByOperator" should "return only workflows whose content contains the operator" in {
-    val wid = seedWorkflow(
-      sessionUser1,
-      "csv-wf",
-      "d",
-      "{\"operators\":[{\"operatorType\":\"CSVFileScan\"}]}"
-    ).workflow.getWid
-    seedWorkflow(sessionUser1, "filter-wf", "d", "{\"operators\":[{\"operatorType\":\"Filter\"}]}")
-
-    val hits = workflowResource.searchWorkflowByOperator("CSVFileScan", sessionUser1)
-    assert(hits == List(wid.toString))
-  }
-
   "WorkflowResource.duplicateWorkflow" should "create a distinct copy owned by the user" in {
     // duplicateWorkflow reassigns operator ids, so the content must have an operators array.
     val wid = seedWorkflow(


### PR DESCRIPTION
### What changes were proposed in this PR?

Deletes `WorkflowResource.searchWorkflowByOperator` (`GET /workflow/search-by-operators`), which has no client. Pure deletion, no behaviour change: **−66 lines**.

Workflow search in the UI goes to the unified `/dashboard/search` resource — the frontend's search service builds `${API}/dashboard/search`, and no file references this path.

### History

| | |
| --- | --- |
| **Introduced by** | #1611 (2022-08-07) — "Search Workflows Feature" |
| **Usage removed by** | #2038 (2023-07-07) — "Allow users to cascade the sharing" deleted the frontend constant `WORKFLOW_OPERATOR_URL = WORKFLOW_BASE_URL + "/search-by-operators"` when search moved to the dashboard resource |

Dead for about three years; workflow search has gone to `/dashboard/search` ever since.

> Reviewer note: the frontend's `searchByOperators` test in `user-workflow.component.spec.ts` is a name coincidence, not a caller — it drives the filter UI (`component.filters.operators`, `masterFilterList`), which queries `/dashboard/search`. Nothing in the frontend, or anywhere else, builds this URL.

Removing the method also frees `Condition` and `noCondition`, which no other method in `WorkflowResource` uses — scalafix flagged both, and they are the only other lines touched.

### Any related issues, documentation, discussions?

Closes #8328

### How was this PR tested?

Existing tests only — this PR adds none, since it removes an endpoint and the one test that covered it.

Locally, from the repo root with Java 17:

- `sbt "WorkflowExecutionService/Test/compile"` — success.
- `sbt "WorkflowExecutionService/testOnly *WorkflowResourceSpec"` — 80 tests, all pass.
- `sbt scalafmtCheckAll "scalafixAll --check"` — clean.

Verification, re-runnable by a reviewer:

```
git grep -rn "search-by-operators\|searchWorkflowByOperator"   # only the deleted method and its test
git grep -rn "dashboard/search" -- frontend/src                # where search actually goes
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)

