### PR TITLE
fix(frontend): remove the clear button from the dataset version picker

### DIFF
--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -395,7 +395,6 @@
                   <div class="select-and-button-container">
                     <nz-select
                       nzShowSearch
-                      nzAllowClear
                       nzPlaceHolder="Select a version"
                       (ngModelChange)="onVersionSelected($event)"
                       [(ngModel)]="selectedVersion">

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
@@ -704,6 +704,16 @@ describe("DatasetDetailComponent behavior", () => {
       expect(component.selectedVersionCreationTime).toMatch(/^\d{2}\/\d{2}\/\d{4} \d{2}:\d{2}:\d{2}$/);
     });
 
+    it("survives the version select being emptied", () => {
+      createComponent();
+      component.did = 5;
+
+      expect(() => component.onVersionSelected(undefined)).not.toThrow();
+
+      expect(component.selectedVersion).toBeUndefined();
+      expect(datasetServiceStub.retrieveDatasetVersionFileTree).not.toHaveBeenCalled();
+    });
+
     it("does not fetch a file tree for a version without a dvid", () => {
       createComponent();
       component.did = 5;
@@ -2420,6 +2430,11 @@ describe("DatasetDetailComponent rendered template", () => {
       // authenticated or the anonymous endpoint, so it has to be the real flag.
       expect(datasetService.retrieveDatasetVersionFileTree).toHaveBeenCalledWith(5, 12, true);
       expect(datasetService.retrieveDatasetVersionFileTree).toHaveBeenCalledWith(5, 13, true);
+    });
+
+    it("offers no way to empty the selection", () => {
+      // Clearing it used to reach onVersionSelected as null and throw.
+      expect(fixture.nativeElement.querySelector("nz-select-clear, .ant-select-clear")).toBeNull();
     });
 
     it("loads a picked version over the anonymous endpoint when nobody is signed in", () => {

--- a/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/frontend/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -424,11 +424,11 @@ export class DatasetDetailComponent implements OnInit {
     this.isRightBarCollapsed = !this.isRightBarCollapsed;
   }
 
-  onVersionSelected(version: DatasetVersion): void {
+  onVersionSelected(version: DatasetVersion | undefined): void {
     this.selectedVersion = version;
-    if (this.did && this.selectedVersion.dvid)
+    if (this.did && version?.dvid)
       this.datasetService
-        .retrieveDatasetVersionFileTree(this.did, this.selectedVersion.dvid, this.isLogin)
+        .retrieveDatasetVersionFileTree(this.did, version.dvid, this.isLogin)
         .pipe(untilDestroyed(this))
         .subscribe(data => {
           this.fileTreeNodeList = data.fileNodes;


### PR DESCRIPTION
### What changes were proposed in this PR?
 
The version dropdown on a dataset's detail page carried nzAllowClear, so clicking the × emitted null into onVersionSelected(version: DatasetVersion), which read this.selectedVersion.dvid and threw an uncaught TypeError. The page was left half-cleared: the main pane said "No version is selected" while the header still showed the cleared version's file path and the file tree still listed its files.

Clearing the selection is not a meaningful action on a page whose entire content is one version, so the button goes away. The model detail page already works this way.

dataset-detail.component.html — drop nzAllowClear from the version nz-select.
dataset-detail.component.ts — onVersionSelected takes DatasetVersion | undefined and skips the fetch when there is no dvid, so an empty selection cannot throw even if the control pushes one (an empty version list, for instance). Mirrors model-detail.component.ts.
Picking a version behaves exactly as before: same request, same arguments.

Before — the × in the dropdown, and the page after clicking it (console output overlaid so it fits in one screenshot):

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/8780a9e5-e135-4281-9120-9cbe898639c4" />

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/3edcf630-fc06-4c5f-9bab-e916f10e03c7" />


After — same dropdown hovered, no clear button:

<img width="1440" height="900" alt="image" src="https://github.com/user-attachments/assets/a837ab1e-06b8-4d8c-a43e-540c4142b51f" />


### Any related issues, documentation, discussions?
Closes #8342 

### How was this PR tested?

Two cases added to dataset-detail.component.spec.ts:

survives the version select being emptied — onVersionSelected(undefined) neither throws nor fetches. Without the signature change it does not compile.
offers no way to empty the selection — the rendered picker has no clear control.

```
cd frontend
npx ng test --include src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.spec.ts
# Tests  144 passed (144)
```
Also checked by hand against a local stack: hovering the version dropdown on a dataset with two versions no longer offers a ×, switching versions still reloads the file tree and preview, and the console stays clean.



### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Opus 5)
