### PR TITLE
ci: record the typing-extensions version that is actually installed

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -355,7 +355,7 @@ Dependencies under the Python Software Foundation License
 Python packages:
   - aiohappyeyeballs==2.7.1
   - matplotlib==3.11.1
-  - typing-extensions==4.14.1
+  - typing-extensions==4.16.0
 
 --------------------------------------------------------------------------------
 Dependencies under the MIT-CMU License


### PR DESCRIPTION
### What changes were proposed in this PR?

One line. `amber/LICENSE-binary-python` records typing-extensions at 4.14.1 and 4.16.0 is what gets installed, so the check that compares the two fails.

It is a direct dependency, and a direct dependency whose recorded version has drifted blocks the Python 3.12 leg outright: the step runs first, so lint, the proto bindings and pytest are all skipped behind it. Nothing about the change that happened to run next is involved, which is why this is on its own.

### Any related issues, documentation, discussions?

`typing-extensions` 4.16.0 has been on PyPI since 2 July, so its release is not what changed. anyio 4.15.0 raised its floor to `typing_extensions>=4.16.0`, and the transitive closure of `operator-requirements.txt` is not pinned, so the pass that installs it now has to take the newer version. The 3.12 leg was green at 21:24 on 2 September and red on the next run of it.

Refreshing the record is the remedy each time this surfaces (#7285, #8292). It does not explain why a pinned package drifted at all: `amber/requirements.txt` pins `typing_extensions==4.14.1`, and that pin is not binding on the passes installed after it. #8354 covers that.

### How was this PR tested?

The failing step is `Check installed Python packages against per-module LICENSE-binary files`, which runs on the 3.12 leg and is what this PR's own CI exercises.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Opus 5)




