### PR TITLE
fix(amber): refresh typing-extensions in LICENSE-binary-python

### DIFF
--- a/amber/LICENSE-binary-python
+++ b/amber/LICENSE-binary-python
@@ -355,7 +355,7 @@ Dependencies under the Python Software Foundation License
 Python packages:
   - aiohappyeyeballs==2.7.1
   - matplotlib==3.11.1
-  - typing-extensions==4.14.1
+  - typing-extensions==4.16.0
 
 --------------------------------------------------------------------------------
 Dependencies under the MIT-CMU License


### PR DESCRIPTION
### What changes were proposed in this PR?

`typing-extensions` is a direct dependency, and the version it resolves to moved to 4.16.0 while `amber/LICENSE-binary-python` still claimed 4.14.1. Direct-dependency drift hard-fails the license check rather than being reported as informational, so `build / pyamber (ubuntu-latest, 3.12)` fails its license step on every pull request and on `main` — the last four `Required Checks` runs on `main` are red — and every later step in that job is skipped. Re-running does not help: the resolver picks up 4.16.0 each time.

The version is the only thing that changed. PyPI reports `license_expression: PSF-2.0` for both 4.14.1 and 4.16.0, so the entry stays in the Python Software Foundation License section it is already listed under.

The transitive entries printed alongside it in the same output are advisory; the nightly exact-match check on `main` refreshes those.

### Any related issues, documentation, discussions?

Closes #8374. Same failure mode as #8293, with a different package. #7285 is the weekly aggregate tracker `license-binary-checker.yml` re-uses; it does not name the offending dependency.

### How was this PR tested?

Verified before editing rather than after: the failing run is [33710669719](https://github.com/apache/texera/actions/runs/33710669719), whose license step prints `~ typing-extensions: LICENSE-binary=4.14.1  bundled=4.16.0` under `DRIFT (direct)`. PyPI's metadata for both versions reports `license_expression: PSF-2.0`, and the entry is already in the Python Software Foundation License section, so no section move is needed.

The check itself runs in CI on this PR — a green `build / pyamber (ubuntu-latest, 3.12)` is the confirmation that the manifest now matches what gets installed.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (claude-opus-5)
