### PR TITLE
fix(file-service): 400 on revoke of an unknown email

### DIFF
--- a/file-service/src/main/scala/org/apache/texera/service/resource/ResourceAccess.scala
+++ b/file-service/src/main/scala/org/apache/texera/service/resource/ResourceAccess.scala
@@ -252,11 +252,7 @@ object ResourceAccess {
       requesterUid: Integer
   ): Response = {
     requireWriteAccess(ctx, resource, id, requesterUid)
-    val grantee = new UserDao(ctx.configuration()).fetchOneByEmail(email)
-    if (grantee == null || grantee.getIsPlaceholder) {
-      throw new BadRequestException(s"No registered user with email $email")
-    }
-    val granteeUid = grantee.getUid
+    val granteeUid = resolveUidByEmail(ctx, email)
     val granted = PrivilegeEnum.valueOf(privilege)
 
     ctx
@@ -276,6 +272,7 @@ object ResourceAccess {
     * Removes the user's explicit grant; a no-op when they hold none.
     *
     * @throws jakarta.ws.rs.ForbiddenException if the caller cannot modify the resource.
+    * @throws jakarta.ws.rs.BadRequestException if the email does not match a registered user.
     */
   def revoke[R <: Record, A <: Record](
       ctx: DSLContext,
@@ -285,7 +282,7 @@ object ResourceAccess {
       requesterUid: Integer
   ): Response = {
     requireWriteAccess(ctx, resource, id, requesterUid)
-    val granteeUid = new UserDao(ctx.configuration()).fetchOneByEmail(email).getUid
+    val granteeUid = resolveUidByEmail(ctx, email)
 
     ctx
       .delete(resource.accessTable)
@@ -322,6 +319,19 @@ object ResourceAccess {
         s"You do not have access to ${resource.label} $id"
       )
     }
+
+  /**
+    * Resolves an email to its user id, throwing BadRequestException (400) when no registered
+    * account matches — the service registers no ExceptionMapper for NullPointerException, so a
+    * bare dereference surfaces as an opaque HTTP 500. Shared by grant/revoke.
+    */
+  private def resolveUidByEmail(ctx: DSLContext, email: String): Integer = {
+    val user = new UserDao(ctx.configuration()).fetchOneByEmail(email)
+    if (user == null || user.getIsPlaceholder) {
+      throw new BadRequestException(s"No registered user with email $email")
+    }
+    user.getUid
+  }
 
   /**
     * Emails of the owners of every resource the caller has an explicit grant on, for the

--- a/file-service/src/test/scala/org/apache/texera/service/resource/DatasetAccessResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/DatasetAccessResourceSpec.scala
@@ -422,6 +422,12 @@ class DatasetAccessResourceSpec
     accessList(privateDataset.getDid) shouldBe empty
   }
 
+  it should "reject a revoke for an email with no account" in {
+    assertThrows[BadRequestException] {
+      accessResource.revokeAccess(privateDataset.getDid, "nobody@example.com", ownerSession)
+    }
+  }
+
   it should "be forbidden for a user without write access" in {
     grantDirectly(privateDataset.getDid, readGranteeUser.getUid, PrivilegeEnum.READ)
 

--- a/file-service/src/test/scala/org/apache/texera/service/resource/ModelAccessResourceSpec.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/resource/ModelAccessResourceSpec.scala
@@ -412,6 +412,12 @@ class ModelAccessResourceSpec
     userHasReadAccess(getDSLContext, privateModel.getMid, readGranteeUser.getUid) shouldBe false
   }
 
+  it should "reject a revoke for an email with no account" in {
+    assertThrows[BadRequestException] {
+      accessResource.revokeAccess(privateModel.getMid, "nobody@example.com", ownerSession)
+    }
+  }
+
   it should "allow a WRITE grantee to revoke another user's access" in {
     grantDirectly(privateModel.getMid, writeGranteeUser.getUid, PrivilegeEnum.WRITE)
     grantDirectly(privateModel.getMid, readGranteeUser.getUid, PrivilegeEnum.READ)


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we
    are following Conventional Commits style for PR titles as well:
      - `fix` is for behavior that worked before and no longer does; adding or
        removing a functionality, or reworking one so that user-facing behavior
        intentionally changes, is a `feat`; a change that leaves the user-facing
        behavior unchanged is a `refactor`.
      - A test-only PR is `test(<module>): ...`; repairing a broken test is
        `fix(test, <module>): ...`.
      - A dependency bump is `fix(deps, <module>): ...` when it patches a CVE
        and `chore(deps, <module>): ...` otherwise; GitHub Actions bumps take
        `ci` as their module, e.g. `chore(deps, ci): ...`.
      - A PR targeting a release branch appends the version as the last scope
        component, e.g. `fix(deps, frontend, v1.2): ...`.
    See CONTRIBUTING.md for the full convention.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?

`ResourceAccess.revoke` dereferenced the result of `UserDao.fetchOneByEmail(email)` without a null check:

```scala
val granteeUid = new UserDao(ctx.configuration()).fetchOneByEmail(email).getUid
```

`fetchOneByEmail` returns `null` for an address with no account, so revoking a dataset or model share for an unregistered email threw a `NullPointerException`. The service registers no `ExceptionMapper` for it, so it surfaced as an opaque HTTP 500 rather than an actionable 400.

`grant`, in the same object, already performed the correct check. This PR extracts that check into a private `resolveUidByEmail` helper and routes both `grant` and `revoke` through it, mirroring `ComputingUnitAccessResource.resolveUidByEmail` added in #6446 for the same defect.

Affected endpoints:

- `DELETE /api/access/dataset/revoke/{did}/{email}`
- `DELETE /api/access/model/revoke/{mid}/{email}`

Behaviour note: `revoke` now also rejects placeholder accounts, matching `grant` and `ComputingUnitAccessResource`.

<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->


### Any related issues, documentation, discussions?
Closes #8353.

Same defect as #6445, fixed in #6446 for `ComputingUnitAccessResource` only. That fix's rationale assumed the dataset/model/project resources already behaved correctly — true of their `grant` paths, but not their `revoke` paths.
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->


### How was this PR tested?
Added `"reject a revoke for an email with no account"` to `DatasetAccessResourceSpec` and `ModelAccessResourceSpec`.

```
sbt "FileService/testOnly *DatasetAccessResourceSpec *ModelAccessResourceSpec"

[info] Tests: succeeded 71, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
```

Originally found on a local `bin/local-dev.sh` stack, where `DELETE /api/access/dataset/revoke/2/nobody@example.com` returned HTTP 500 with:

```
java.lang.NullPointerException: Cannot invoke "...pojos.User.getUid()" because the return value of "...daos.UserDao.fetchOneByEmail(String)" is null
    at org.apache.texera.service.resource.ResourceAccess$.revoke(ResourceAccess.scala:288)
    at org.apache.texera.service.resource.DatasetAccessResource.$anonfun$revokeAccess$1(DatasetAccessResource.scala:138)
```
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->


### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
