### PR TITLE
fix(workflow): return 404 for missing workflow type

### DIFF
--- a/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/amber/src/main/scala/org/apache/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -848,6 +848,9 @@ class WorkflowResource extends LazyLogging {
   @Path("/type/{wid}")
   def getWorkflowType(@PathParam("wid") wid: Integer): String = {
     val workflow: Workflow = workflowDao.fetchOneByWid(wid)
+    if (workflow == null) {
+      throw new NotFoundException(s"Workflow with id $wid not found")
+    }
     if (workflow.getIsPublic) {
       "Public"
     } else {

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -947,7 +947,7 @@ class WorkflowResourceSpec
     assert(sizes.get(wid) == content.length)
   }
 
-  it should "return NotFoundException for a missing workflow type" in {
+  it should "throw NotFoundException for a missing workflow type" in {
     assertThrows[NotFoundException] {
       workflowResource.getWorkflowType(Integer.valueOf(2147483647))
     }

--- a/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/amber/src/test/scala/org/apache/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -947,6 +947,12 @@ class WorkflowResourceSpec
     assert(sizes.get(wid) == content.length)
   }
 
+  it should "return NotFoundException for a missing workflow type" in {
+    assertThrows[NotFoundException] {
+      workflowResource.getWorkflowType(Integer.valueOf(2147483647))
+    }
+  }
+
   "WorkflowResource.getSize" should "return an empty map for a null or empty id list" in {
     assert(workflowResource.getSize(null).isEmpty)
     assert(workflowResource.getSize(Collections.emptyList()).isEmpty)


### PR DESCRIPTION
### What changes were proposed in this PR?

Return `404 Not Found` when the workflow type endpoint is requested for a workflow that does not exist. Previously, `getWorkflowType` dereferenced a null DAO result and returned `500 Internal Server Error`.

Before:
<img width="2690" height="202" alt="image" src="https://github.com/user-attachments/assets/23e711f9-47a4-43f3-8b83-2d8e8d18e375" />

After:
<img width="2690" height="230" alt="image" src="https://github.com/user-attachments/assets/189d5398-4fa6-4112-95d2-c26c59b0f2de" />

### Any related issues, documentation, discussions?

Closes #8300

### How was this PR tested?

- Ran `WorkflowResourceSpec`
- Verified `GET /api/workflow/type/2147483647` returns `404` instead of `500`
- Added regression coverage for a missing workflow type

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: ChatGPT (5.5 mini)
