### PR TITLE
fix(test): seed random in IntervalOpExecSpec

### DIFF
--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/intervalJoin/IntervalOpExecSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/intervalJoin/IntervalOpExecSpec.scala
@@ -28,8 +28,10 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 import java.sql.Timestamp
 import scala.collection.mutable.ArrayBuffer
-import scala.util.Random.{nextInt, nextLong}
+
 class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
+  private val rng = new scala.util.Random(42)
+
   val left: Int = 0
   val right: Int = 1
 
@@ -97,14 +99,14 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   def bruteForceJoin[T](
-      leftInput: Array[T],
-      rightInput: Array[T],
-      includeLeftBound: Boolean,
-      includeRightBound: Boolean,
-      constant: Long,
-      dataType: AttributeType,
-      timeIntervalType: TimeIntervalType = TimeIntervalType.DAY
-  ): Int = {
+                         leftInput: Array[T],
+                         rightInput: Array[T],
+                         includeLeftBound: Boolean,
+                         includeRightBound: Boolean,
+                         constant: Long,
+                         dataType: AttributeType,
+                         timeIntervalType: TimeIntervalType = TimeIntervalType.DAY
+                       ): Int = {
     var resultSize: Int = 0
     for (k <- leftInput.indices) {
       for (i <- rightInput.indices) {
@@ -193,12 +195,12 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   def compare(
-      input1: Long,
-      leftBound: Long,
-      rightBound: Long,
-      includeLeftBound: Boolean,
-      includeRightBound: Boolean
-  ): Boolean = {
+               input1: Long,
+               leftBound: Long,
+               rightBound: Long,
+               includeLeftBound: Boolean,
+               includeRightBound: Boolean
+             ): Boolean = {
     if (includeLeftBound && includeRightBound) {
       input1 >= leftBound && input1 <= rightBound
     } else if (includeLeftBound && !includeRightBound) {
@@ -211,16 +213,16 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   def testJoin[T](
-      leftKey: String,
-      rightKey: String,
-      includeLeftBound: Boolean,
-      includeRightBound: Boolean,
-      dataType: AttributeType,
-      timeIntervalType: TimeIntervalType,
-      intervalConstant: Long,
-      leftInput: Array[T],
-      rightInput: Array[T]
-  ): Unit = {
+                   leftKey: String,
+                   rightKey: String,
+                   includeLeftBound: Boolean,
+                   includeRightBound: Boolean,
+                   dataType: AttributeType,
+                   timeIntervalType: TimeIntervalType,
+                   intervalConstant: Long,
+                   leftInput: Array[T],
+                   rightInput: Array[T]
+                 ): Unit = {
     val inputSchemas =
       Map(
         PortIdentity() -> schema(leftKey, dataType),
@@ -240,8 +242,8 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     counter = 0
     var leftIndex: Int = 0
     var rightIndex: Int = 0
-    val leftOrder = LazyList.continually(nextInt(10)).take(leftInput.length).toList
-    val rightOrder = LazyList.continually(nextInt(10)).take(rightInput.length).toList
+    val leftOrder = LazyList.continually(rng.nextInt(10)).take(leftInput.length).toList
+    val rightOrder = LazyList.continually(rng.nextInt(10)).take(rightInput.length).toList
     val outputTuples: ArrayBuffer[Tuple] = new ArrayBuffer[Tuple]
 
     while (leftIndex < leftOrder.size || rightIndex < rightOrder.size) {
@@ -483,8 +485,8 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "test larger dataset(1k)" in {
-    val pointList: Array[Long] = LazyList.continually(nextLong()).take(1000).toArray
-    val rangeList: Array[Long] = LazyList.continually(nextLong()).take(1000).toArray
+    val pointList: Array[Long] = LazyList.continually(rng.nextLong()).take(1000).toArray
+    val rangeList: Array[Long] = LazyList.continually(rng.nextLong()).take(1000).toArray
     testJoin[Long](
       "point",
       "range",
@@ -492,7 +494,7 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       includeRightBound = true,
       AttributeType.LONG,
       TimeIntervalType.DAY,
-      nextInt(1000).toLong,
+      rng.nextInt(1000).toLong,
       pointList,
       rangeList
     )

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/intervalJoin/IntervalOpExecSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/intervalJoin/IntervalOpExecSpec.scala
@@ -99,14 +99,14 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   def bruteForceJoin[T](
-                         leftInput: Array[T],
-                         rightInput: Array[T],
-                         includeLeftBound: Boolean,
-                         includeRightBound: Boolean,
-                         constant: Long,
-                         dataType: AttributeType,
-                         timeIntervalType: TimeIntervalType = TimeIntervalType.DAY
-                       ): Int = {
+      leftInput: Array[T],
+      rightInput: Array[T],
+      includeLeftBound: Boolean,
+      includeRightBound: Boolean,
+      constant: Long,
+      dataType: AttributeType,
+      timeIntervalType: TimeIntervalType = TimeIntervalType.DAY
+  ): Int = {
     var resultSize: Int = 0
     for (k <- leftInput.indices) {
       for (i <- rightInput.indices) {
@@ -195,12 +195,12 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   def compare(
-               input1: Long,
-               leftBound: Long,
-               rightBound: Long,
-               includeLeftBound: Boolean,
-               includeRightBound: Boolean
-             ): Boolean = {
+      input1: Long,
+      leftBound: Long,
+      rightBound: Long,
+      includeLeftBound: Boolean,
+      includeRightBound: Boolean
+  ): Boolean = {
     if (includeLeftBound && includeRightBound) {
       input1 >= leftBound && input1 <= rightBound
     } else if (includeLeftBound && !includeRightBound) {
@@ -213,16 +213,16 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   def testJoin[T](
-                   leftKey: String,
-                   rightKey: String,
-                   includeLeftBound: Boolean,
-                   includeRightBound: Boolean,
-                   dataType: AttributeType,
-                   timeIntervalType: TimeIntervalType,
-                   intervalConstant: Long,
-                   leftInput: Array[T],
-                   rightInput: Array[T]
-                 ): Unit = {
+      leftKey: String,
+      rightKey: String,
+      includeLeftBound: Boolean,
+      includeRightBound: Boolean,
+      dataType: AttributeType,
+      timeIntervalType: TimeIntervalType,
+      intervalConstant: Long,
+      leftInput: Array[T],
+      rightInput: Array[T]
+  ): Unit = {
     val inputSchemas =
       Map(
         PortIdentity() -> schema(leftKey, dataType),


### PR DESCRIPTION
### What changes were proposed in this PR?

Replace the unseeded global `scala.util.Random` usage in `IntervalOpExecSpec` with a local seeded random generator (`Random(42)`). This makes the test inputs deterministic and ensures test execution paths and JaCoCo branch coverage are reproducible across runs.

Before:
First Run:
<img width="1345" height="62" alt="Screenshot 2026-09-06 at 3 09 28 AM" src="https://github.com/user-attachments/assets/104e9c24-0546-4127-adf7-33ad60b1e979" />

Second Run:
<img width="1345" height="60" alt="Screenshot 2026-09-06 at 3 10 29 AM" src="https://github.com/user-attachments/assets/cf28ce98-5fec-40d6-bddf-2f49c96330d8" />

After:
First Run:
<img width="1345" height="60" alt="Screenshot 2026-09-06 at 3 14 59 AM" src="https://github.com/user-attachments/assets/9030d6f3-6777-4c5c-beaa-f0480acfd833" />

Second Run:
<img width="1345" height="60" alt="Screenshot 2026-09-06 at 3 15 07 AM" src="https://github.com/user-attachments/assets/bbd837e1-ad21-49fd-8e6d-8fa888be9091" />

### Any related issues, documentation, discussions?

Closes #8150

### How was this PR tested?

- Ran `IntervalOpExecSpec` successfully.
- Reproduced the issue before the fix: `IntervalJoinOpExec.scala` branch coverage changed between runs (20 missed / 78 covered vs. 21 missed / 77 covered).
- Verified the test now uses a seeded local random generator for all random inputs.
- Ran the JaCoCo coverage report multiple times and verified the branch coverage is consistent across runs.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: ChatGPT (5.5 mini)