### PR TITLE
fix(k8s): stop the gateway timeout from silently truncating large downloads

### DIFF
--- a/bin/k8s/templates/base/gateway/gateway-routes.yaml
+++ b/bin/k8s/templates/base/gateway/gateway-routes.yaml
@@ -15,6 +15,10 @@
 # specific language governing permissions and limitations
 # under the License.
 
+{{- $objectStreamTimeout := "0s" }}
+{{- if and .Values.gatewayConfig .Values.gatewayConfig.objectStreamTimeout }}
+{{- $objectStreamTimeout = .Values.gatewayConfig.objectStreamTimeout }}
+{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -57,6 +61,9 @@ spec:
         - path:
             type: PathPrefix
             value: /api/access/model
+      timeouts:
+        request: {{ $objectStreamTimeout | quote }}
+        backendRequest: {{ $objectStreamTimeout | quote }}
       backendRefs:
         - name: file-service-svc
           port: 9092
@@ -184,6 +191,9 @@ spec:
         - path:
             type: PathPrefix
             value: /
+      timeouts:
+        request: {{ $objectStreamTimeout | quote }}
+        backendRequest: {{ $objectStreamTimeout | quote }}
       backendRefs:
         - name: {{ .Release.Name }}-minio
           port: 9000

--- a/bin/k8s/values-development.yaml
+++ b/bin/k8s/values-development.yaml
@@ -417,7 +417,9 @@ metrics-server:
   priorityClassName: system-cluster-critical
 
 gatewayConfig:
-  # Routes are available at bin/k8s/templates/gateway-routes.yaml
+  # Routes are available at bin/k8s/templates/base/gateway/gateway-routes.yaml
+
+  objectStreamTimeout: "0s"
 
   # The hostname for the Gateway listener (HTTP/HTTPS).
   # e.g., "texera.example.com"

--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -448,7 +448,9 @@ metrics-server:
   priorityClassName: system-cluster-critical
 
 gatewayConfig:
-  # Routes are available at bin/k8s/templates/gateway-routes.yaml
+  # Routes are available at bin/k8s/templates/base/gateway/gateway-routes.yaml
+
+  objectStreamTimeout: "0s"
 
   # The hostname for the Gateway listener (HTTP/HTTPS).
   # e.g., "texera.example.com"

--- a/frontend/src/app/common/util/download-integrity.util.spec.ts
+++ b/frontend/src/app/common/util/download-integrity.util.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpHeaders, HttpResponse } from "@angular/common/http";
+import { firstValueFrom, of } from "rxjs";
+
+import { TruncatedDownloadError, verifyCompleteDownload } from "./download-integrity.util";
+
+function blobResponse(body: Blob | null, headers: Record<string, string> = {}): HttpResponse<Blob> {
+  return new HttpResponse({ body, headers: new HttpHeaders(headers) });
+}
+
+function verify(response: HttpResponse<Blob>): Promise<Blob> {
+  return firstValueFrom(of(response).pipe(verifyCompleteDownload()));
+}
+
+describe("verifyCompleteDownload", () => {
+  it("passes a body whose size matches the declared Content-Length", async () => {
+    const blob = new Blob(["12345"]);
+    expect(await verify(blobResponse(blob, { "Content-Length": "5" }))).toBe(blob);
+  });
+
+  it("rejects a body shorter than the declared Content-Length", async () => {
+    const pending = verify(blobResponse(new Blob(["12345"]), { "Content-Length": "2048" }));
+
+    await expect(pending).rejects.toBeInstanceOf(TruncatedDownloadError);
+    await expect(pending).rejects.toThrow("Download truncated: expected 2048 bytes but received 5.");
+  });
+
+  it("passes a chunked response, which declares no Content-Length", async () => {
+    const blob = new Blob(["12345"]);
+    expect(await verify(blobResponse(blob))).toBe(blob);
+  });
+
+  it("passes a body longer than Content-Length, which means decoding rather than truncation", async () => {
+    const blob = new Blob(["1234567890"]);
+    expect(await verify(blobResponse(blob, { "Content-Length": "4" }))).toBe(blob);
+  });
+
+  it("substitutes an empty blob for a body-less response", async () => {
+    expect((await verify(blobResponse(null))).size).toBe(0);
+  });
+});

--- a/frontend/src/app/common/util/download-integrity.util.ts
+++ b/frontend/src/app/common/util/download-integrity.util.ts
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { HttpResponse } from "@angular/common/http";
+import { OperatorFunction } from "rxjs";
+import { map } from "rxjs/operators";
+
+export class TruncatedDownloadError extends Error {
+  constructor(
+    readonly expectedBytes: number,
+    readonly receivedBytes: number
+  ) {
+    super(`Download truncated: expected ${expectedBytes} bytes but received ${receivedBytes}.`);
+    this.name = "TruncatedDownloadError";
+  }
+}
+
+export function verifyCompleteDownload(): OperatorFunction<HttpResponse<Blob>, Blob> {
+  return map(response => {
+    const blob = response.body ?? new Blob([]);
+    const declaredLength = Number(response.headers.get("Content-Length"));
+    if (Number.isFinite(declaredLength) && declaredLength > blob.size) {
+      throw new TruncatedDownloadError(declaredLength, blob.size);
+    }
+    return blob;
+  });
+}

--- a/frontend/src/app/dashboard/service/user/dataset/dataset.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/dataset/dataset.service.spec.ts
@@ -30,6 +30,7 @@ import { Contributor, Dataset, DatasetVersion } from "../../../../common/type/da
 import { DashboardDataset } from "../../../type/dashboard-dataset.interface";
 import { DatasetFileNode } from "../../../../common/type/datasetVersionFileTree";
 import { DatasetStagedObject } from "../../../../common/type/dataset-staged-object";
+import { TruncatedDownloadError } from "../../../../common/util/download-integrity.util";
 
 const API = "api";
 
@@ -254,6 +255,19 @@ describe("DatasetService", () => {
     expect(await pending).toBe(blob);
   });
 
+  it("retrieveDatasetVersionSingleFile rejects a body shorter than the declared Content-Length", async () => {
+    const pending = firstValueFrom(service.retrieveDatasetVersionSingleFile("big.czi"));
+
+    http
+      .expectOne(`${API}/${DATASET_BASE_URL}/presign-download?filePath=${encodeURIComponent("big.czi")}`)
+      .flush({ presignedUrl: "https://s3.example/big.czi" });
+    http.expectOne("https://s3.example/big.czi").flush(new Blob(["partial"]), {
+      headers: { "Content-Length": "1416092224" },
+    });
+
+    await expect(pending).rejects.toBeInstanceOf(TruncatedDownloadError);
+  });
+
   it("retrieveDatasetVersionSingleFile uses the public presign endpoint when anonymous", () => {
     const filePath = "f.txt";
     service.retrieveDatasetVersionSingleFile(filePath, false).subscribe();
@@ -273,6 +287,16 @@ describe("DatasetService", () => {
     expect(req.request.params.get("latest")).toBeNull();
     expect(req.request.responseType).toBe("blob");
     req.flush(new Blob());
+  });
+
+  it("retrieveDatasetVersionZip rejects a zip shorter than the declared Content-Length", async () => {
+    const pending = firstValueFrom(service.retrieveDatasetVersionZip(3, 99));
+
+    http
+      .expectOne(r => r.url === `${API}/dataset/3/versionZip`)
+      .flush(new Blob(["PK-truncated"]), { headers: { "Content-Length": "9999999" } });
+
+    await expect(pending).rejects.toBeInstanceOf(TruncatedDownloadError);
   });
 
   it("retrieveDatasetVersionZip sets latest=true when dvid is omitted", () => {

--- a/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/frontend/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -30,6 +30,7 @@ import { GuiConfigService } from "../../../../common/service/gui-config.service"
 import { MultipartUploadProgress, MultipartUploadService } from "../file-resource/multipart-upload.service";
 import { StagedFileService } from "../file-resource/staged-file.service";
 import { DATASET_FILE_RESOURCE_ENDPOINT } from "../file-resource/file-resource-endpoint";
+import { verifyCompleteDownload } from "../../../../common/util/download-integrity.util";
 
 export const DATASET_BASE_URL = "dataset";
 export const DATASET_CREATE_URL = DATASET_BASE_URL + "/create";
@@ -113,9 +114,10 @@ export class DatasetService {
     const endpointSegment = isLogin ? "presign-download" : "public-presign-download";
     const endpoint = `${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/${endpointSegment}?filePath=${encodeURIComponent(filePath)}`;
 
-    return this.http
-      .get<{ presignedUrl: string }>(endpoint)
-      .pipe(switchMap(({ presignedUrl }) => this.http.get(presignedUrl, { responseType: "blob" })));
+    return this.http.get<{ presignedUrl: string }>(endpoint).pipe(
+      switchMap(({ presignedUrl }) => this.http.get(presignedUrl, { responseType: "blob", observe: "response" })),
+      verifyCompleteDownload()
+    );
   }
 
   /**
@@ -133,10 +135,13 @@ export class DatasetService {
       params = params.set("latest", "true");
     }
 
-    return this.http.get(`${AppSettings.getApiEndpoint()}/dataset/${did}/versionZip`, {
-      params,
-      responseType: "blob",
-    });
+    return this.http
+      .get(`${AppSettings.getApiEndpoint()}/dataset/${did}/versionZip`, {
+        params,
+        responseType: "blob",
+        observe: "response",
+      })
+      .pipe(verifyCompleteDownload());
   }
 
   public retrieveAccessibleDatasets(): Observable<DashboardDataset[]> {

--- a/frontend/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/frontend/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -31,6 +31,7 @@ import type { Mocked } from "vitest";
 import { WORKFLOW_EXECUTIONS_API_BASE_URL } from "../workflow-executions/workflow-executions.service";
 import { DashboardWorkflowComputingUnit } from "../../../../common/type/workflow-computing-unit";
 import JSZip from "jszip";
+import { TruncatedDownloadError } from "../../../../common/util/download-integrity.util";
 
 function computingUnit(type: string, cuid: number): DashboardWorkflowComputingUnit {
   return { computingUnit: { cuid, type } } as unknown as DashboardWorkflowComputingUnit;
@@ -114,6 +115,20 @@ describe("DownloadService", () => {
     expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download file test/file.txt");
     expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
     expect(notificationServiceSpy.error).toHaveBeenCalledWith("Error downloading file 'test/file.txt'");
+  });
+
+  it("names the truncation in the error notification when a download ends early", async () => {
+    datasetServiceSpy.retrieveDatasetVersionSingleFile.mockReturnValue(
+      throwError(() => new TruncatedDownloadError(1416092224, 106168320))
+    );
+
+    await expect(firstValueFrom(downloadService.downloadSingleFile("big.czi", true))).rejects.toBeInstanceOf(
+      TruncatedDownloadError
+    );
+
+    expect(notificationServiceSpy.error).toHaveBeenCalledWith(
+      "Error downloading file 'big.czi'. Download truncated: expected 1416092224 bytes but received 106168320."
+    );
   });
 
   it("passes isLogin=false through to retrieveDatasetVersionSingleFile", async () => {

--- a/frontend/src/app/dashboard/service/user/download/download.service.ts
+++ b/frontend/src/app/dashboard/service/user/download/download.service.ts
@@ -31,6 +31,7 @@ import { HttpClient, HttpResponse } from "@angular/common/http";
 import { WORKFLOW_EXECUTIONS_API_BASE_URL } from "../workflow-executions/workflow-executions.service";
 import { DashboardWorkflowComputingUnit } from "../../../../common/type/workflow-computing-unit";
 import { TOKEN_KEY } from "../../../../common/service/user/auth.service";
+import { TruncatedDownloadError } from "../../../../common/util/download-integrity.util";
 
 export const EXPORT_BASE_URL = "result/export";
 const IFRAME_TIMEOUT_MS = 10000;
@@ -360,7 +361,9 @@ export class DownloadService {
         this.notificationService.success(successMessage);
       }),
       catchError((error: unknown) => {
-        this.notificationService.error(errorMessage);
+        this.notificationService.error(
+          error instanceof TruncatedDownloadError ? `${errorMessage}. ${error.message}` : errorMessage
+        );
         return throwError(() => error);
       })
     );

--- a/frontend/src/app/dashboard/service/user/model/model.service.ts
+++ b/frontend/src/app/dashboard/service/user/model/model.service.ts
@@ -25,6 +25,7 @@ import { AppSettings } from "../../../../common/app-setting";
 import { Model, ModelVersion } from "../../../../common/type/model";
 import { DashboardModel } from "../../../type/dashboard-model.interface";
 import { DatasetFileNode } from "../../../../common/type/datasetVersionFileTree";
+import { verifyCompleteDownload } from "../../../../common/util/download-integrity.util";
 
 export const MODEL_BASE_URL = "model";
 export const MODEL_CREATE_URL = MODEL_BASE_URL + "/create";
@@ -168,10 +169,13 @@ export class ModelService {
         ? new HttpParams().set("mvid", mvid.toString())
         : new HttpParams().set("latest", "true");
 
-    return this.http.get(`${AppSettings.getApiEndpoint()}/${MODEL_BASE_URL}/${mid}/versionZip`, {
-      params,
-      responseType: "blob",
-    });
+    return this.http
+      .get(`${AppSettings.getApiEndpoint()}/${MODEL_BASE_URL}/${mid}/versionZip`, {
+        params,
+        responseType: "blob",
+        observe: "response",
+      })
+      .pipe(verifyCompleteDownload());
   }
 
   /**
@@ -183,9 +187,10 @@ export class ModelService {
     const endpointSegment = isLogin ? "presign-download" : "public-presign-download";
     const endpoint = `${AppSettings.getApiEndpoint()}/${MODEL_BASE_URL}/${endpointSegment}?filePath=${encodeURIComponent(filePath)}`;
 
-    return this.http
-      .get<{ presignedUrl: string }>(endpoint)
-      .pipe(switchMap(({ presignedUrl }) => this.http.get(presignedUrl, { responseType: "blob" })));
+    return this.http.get<{ presignedUrl: string }>(endpoint).pipe(
+      switchMap(({ presignedUrl }) => this.http.get(presignedUrl, { responseType: "blob", observe: "response" })),
+      verifyCompleteDownload()
+    );
   }
 
   /** Flips the model between public and private; the endpoint toggles rather than taking a value. */


### PR DESCRIPTION
### What changes were proposed in this PR?

Large dataset and model downloads were silently truncated after ~15s of transfer: no browser error, no error toast, nothing in the server log — just a partial file on disk.

Envoy Gateway applies a default 15s request timeout to any `HTTPRoute` rule that declares no `timeouts` block, and the two rules that stream whole objects — the MinIO route serving presigned URLs, and the file-service route serving version zips — declared none. When the timeout fires, Envoy closes the connection *cleanly*, so the browser records a completed download and writes the partial body. That is why truncation landed at a constant wall-clock window rather than a constant byte count, and why it surfaced as silent data corruption instead of a visible failure.

Two changes:

1. **Helm chart (the fix).** Both object-streaming rules now set `timeouts.request` / `timeouts.backendRequest` explicitly, defaulting to `"0s"` — Gateway API treats zero as no timeout — and configurable through a new `gatewayConfig.objectStreamTimeout` for deployments that prefer a finite bound.

2. **Frontend (defense in depth).** Blob downloads now fail with `TruncatedDownloadError` when the body is shorter than the declared `Content-Length`, and the error notification names the shortfall. This covers presigned-URL file downloads and version zips, for datasets and models. `Content-Length` is CORS-safelisted, so the check works on the cross-origin presigned responses too; a chunked response declares no length and still passes through unverified.

Observed before the fix on multi-GB Zeiss `.czi` files: 1.42 GB arrived as 106 MB (7.5%), 2.42 GB as 93 MB (3.8%), and a 9.39 GB version zip as 51 MB (0.5%) with no central directory, so it could not be opened at all.

### Any related issues, documentation, discussions?

Fixes #8445

### How was this PR tested?

**Helm.** Rendered the chart and confirmed both object-streaming rules emit `request: "0s"` / `backendRequest: "0s"` by default, `"1h"` when `gatewayConfig.objectStreamTimeout` is overridden, and the same defaults under the development values. `backendRequest` may equal `request` here because Gateway API's "backendRequest must not exceed request" validation exempts a zero `request`.

**Frontend.** `ng test` over the four affected specs: 116 tests pass. New cases cover a matching `Content-Length` passing, a short body being rejected, a chunked response with no `Content-Length` passing, a body *longer* than the declared length passing (that means decoding, not truncation), and the notification reading `Error downloading file 'big.czi'. Download truncated: expected 1416092224 bytes but received 106168320.` Existing notification text is unchanged for every other error. `eslint` and `prettier-eslint --list-different` are clean on the touched files.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Opus 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wpLu1zHRyP3aLsvCnoPH8
