### PR TITLE
refactor(test): extract shared DB provisioning helper

### DIFF
--- a/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
+++ b/amber/src/test/scala/org/apache/texera/amber/engine/e2e/TestUtils.scala
@@ -231,20 +231,10 @@ object TestUtils {
     org.apache.texera.dao.MockTexeraDB.ensureInitialized()
     val embedded = org.apache.texera.dao.MockTexeraDB.getDBInstance
 
-    val dbName = "texera_db_for_test_cases_" + java.util.UUID.randomUUID().toString.replace("-", "")
+    val dbName =
+      "texera_db_for_test_cases_" + java.util.UUID.randomUUID().toString.replace("-", "")
 
-    scala.util.Using.resource(embedded.getPostgresDatabase.getConnection) { conn =>
-      scala.util.Using.resource(conn.createStatement()) { stmt =>
-        stmt.execute(s"CREATE DATABASE $dbName")
-      }
-    }
-
-    scala.util.Using.resource(embedded.getDatabase("postgres", dbName).getConnection) {
-      targetDbConn =>
-        scala.util.Using.resource(targetDbConn.createStatement()) { stmt =>
-          stmt.execute(org.apache.texera.dao.MockTexeraDB.getDDLScript)
-        }
-    }
+    org.apache.texera.dao.MockTexeraDB.createTestDatabase(dbName)
 
     SqlServer.initConnection(
       embedded.getJdbcUrl("postgres", dbName),

--- a/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
+++ b/common/dao/src/test/scala/org/apache/texera/dao/MockTexeraDB.scala
@@ -94,6 +94,23 @@ object MockTexeraDB {
   def getDBInstance: EmbeddedPostgres =
     dbInstance.getOrElse(throw new RuntimeException("DB not initialized"))
   def getDDLScript: String = ddlScript.getOrElse(throw new RuntimeException("DDL not loaded"))
+  def createTestDatabase(dbName: String): Unit = {
+    val embedded = getDBInstance
+
+    Using.resource(embedded.getPostgresDatabase.getConnection) { conn =>
+      Using.resource(conn.createStatement()) { stmt =>
+        stmt.execute(s"CREATE DATABASE $dbName")
+      }
+    }
+
+    // Run the DDL once via a throwaway connection (autoCommit is TRUE by default,
+    // so the schema is permanently committed to this suite's isolated database).
+    Using.resource(embedded.getDatabase(username, dbName).getConnection) { conn =>
+      Using.resource(conn.createStatement()) { stmt =>
+        stmt.execute(getDDLScript)
+      }
+    }
+  }
 }
 
 trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
@@ -114,24 +131,15 @@ trait MockTexeraDB extends TestSuiteMixin { this: TestSuite =>
     synchronized {
       if (dataSource.isEmpty || dataSource.get.isClosed) {
         MockTexeraDB.ensureInitialized()
+
+        uniqueDbName =
+          "texera_db_" + java.util.UUID.randomUUID().toString.replace("-", "")
+
+        MockTexeraDB.createTestDatabase(uniqueDbName)
+
         val embedded = MockTexeraDB.getDBInstance
-
-        uniqueDbName = "texera_db_" + java.util.UUID.randomUUID().toString.replace("-", "")
-        Using.resource(embedded.getPostgresDatabase.getConnection) { defaultConn =>
-          Using.resource(defaultConn.createStatement()) { stmt =>
-            stmt.execute(s"CREATE DATABASE $uniqueDbName")
-          }
-        }
-
-        // Run the DDL once via a throwaway connection (autoCommit is TRUE by default,
-        // so the schema is permanently committed to this suite's isolated database).
-        Using.resource(embedded.getDatabase("postgres", uniqueDbName).getConnection) { conn =>
-          Using.resource(conn.createStatement()) { stmt =>
-            stmt.execute(MockTexeraDB.getDDLScript)
-          }
-        }
-
         val jdbcUrl = embedded.getJdbcUrl("postgres", uniqueDbName)
+
         val ds = new HikariDataSource(createHikariConfig(jbdcUrl = jdbcUrl))
         dataSource = Some(ds)
 


### PR DESCRIPTION
### What changes were proposed in this PR?

Extract the shared test database provisioning logic from `TestUtils.initiateTexeraDBForTestCases` and `MockTexeraDB.initializeDBAndReplaceDSLContext` into a reusable `MockTexeraDB.createTestDatabase` helper.

The helper centralizes the creation of an isolated test database and execution of the cached DDL script, while preserving the existing database naming and connection/resource lifecycle behavior.

### Any related issues, documentation, discussions?

Closes #6421

### How was this PR tested?

- Ran `DAO / test` successfully.
- Ran `PauseSpec` successfully.
- Ran `ReconfigurationSpec` successfully.
- Ran `DataProcessingSpec` successfully.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: ChatGPT (5.5 mini)