### PR TITLE
feat(computing-unit): name the configuration a unit cannot start without

### DIFF
--- a/common/config/src/main/resources/kubernetes.conf
+++ b/common/config/src/main/resources/kubernetes.conf
@@ -34,7 +34,8 @@ kubernetes {
   compute-unit-pod-name-prefix = "computing-unit"
   compute-unit-pod-name-prefix = ${?KUBERNETES_COMPUTE_UNIT_POD_NAME_PREFIX}
 
-  image-name = "bobbai/texera-workflow-computing-unit:dev"
+  # What this repository publishes; the helm chart sets the same.
+  image-name = "ghcr.io/apache/texera-workflow-execution-coordinator:latest"
   image-name = ${?KUBERNETES_IMAGE_NAME}
 
   image-pull-policy = "Always"

--- a/common/config/src/main/resources/kubernetes.conf
+++ b/common/config/src/main/resources/kubernetes.conf
@@ -34,7 +34,9 @@ kubernetes {
   compute-unit-pod-name-prefix = "computing-unit"
   compute-unit-pod-name-prefix = ${?KUBERNETES_COMPUTE_UNIT_POD_NAME_PREFIX}
 
-  # What this repository publishes; the helm chart sets the same.
+  # The nightly image this repository publishes, reached only by a service run outside the
+  # helm chart -- the chart always sets KUBERNETES_IMAGE_NAME, to its own registry and
+  # release tag. This one tracks main, so pin it to match a manager built from a release.
   image-name = "ghcr.io/apache/texera-workflow-execution-coordinator:latest"
   image-name = ${?KUBERNETES_IMAGE_NAME}
 

--- a/common/config/src/main/resources/kubernetes.conf
+++ b/common/config/src/main/resources/kubernetes.conf
@@ -34,9 +34,8 @@ kubernetes {
   compute-unit-pod-name-prefix = "computing-unit"
   compute-unit-pod-name-prefix = ${?KUBERNETES_COMPUTE_UNIT_POD_NAME_PREFIX}
 
-  # The nightly image this repository publishes, reached only by a service run outside the
-  # helm chart -- the chart always sets KUBERNETES_IMAGE_NAME, to its own registry and
-  # release tag. This one tracks main, so pin it to match a manager built from a release.
+  # Nightly image, tracking main. The chart always sets KUBERNETES_IMAGE_NAME to its own
+  # registry and tag, so only a service run outside the chart reaches this default.
   image-name = "ghcr.io/apache/texera-workflow-execution-coordinator:latest"
   image-name = ${?KUBERNETES_IMAGE_NAME}
 

--- a/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
@@ -48,7 +48,6 @@ class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
     ifUnset("KUBERNETES_COMPUTE_UNIT_POOL_NAMESPACE")(
       KubernetesConfig.computeUnitPoolNamespace shouldBe "texera-workflow-computing-unit-pool"
     )
-    // The published image, not the personal repository the default used to name.
     ifUnset("KUBERNETES_IMAGE_NAME")(
       KubernetesConfig.computeUnitImageName shouldBe
         "ghcr.io/apache/texera-workflow-execution-coordinator:latest"

--- a/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
+++ b/common/config/src/test/scala/org/apache/texera/common/config/KubernetesConfigSpec.scala
@@ -48,8 +48,10 @@ class KubernetesConfigSpec extends AnyFlatSpec with Matchers {
     ifUnset("KUBERNETES_COMPUTE_UNIT_POOL_NAMESPACE")(
       KubernetesConfig.computeUnitPoolNamespace shouldBe "texera-workflow-computing-unit-pool"
     )
+    // The published image, not the personal repository the default used to name.
     ifUnset("KUBERNETES_IMAGE_NAME")(
-      KubernetesConfig.computeUnitImageName shouldBe "bobbai/texera-workflow-computing-unit:dev"
+      KubernetesConfig.computeUnitImageName shouldBe
+        "ghcr.io/apache/texera-workflow-execution-coordinator:latest"
     )
     ifUnset("KUBERNETES_IMAGE_PULL_POLICY")(
       KubernetesConfig.computingUnitImagePullPolicy shouldBe "Always"

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -115,14 +115,18 @@ object ComputingUnitManagingResource {
       lookup: String => Option[String]
   ): Map[String, String] = {
     // Blank counts as missing, as elsewhere in config: the chart renders every value as
-    // "{{ .value }}", so an unset one arrives as "" rather than absent.
+    // "{{ .value }}", so an unset one arrives as "" rather than absent. The trimmed value is
+    // what is kept, too -- LakeFSFileDocument trims these on the way back out, and a padded
+    // boolean or int is a value HOCON refuses to parse in the pod.
     val looked =
-      requiredComputingUnitEnvNames.map(name => name -> lookup(name).filter(_.trim.nonEmpty))
+      requiredComputingUnitEnvNames.map(name => name -> lookup(name).map(_.trim).filter(_.nonEmpty))
     val missing = looked.collect { case (name, None) => name }
     if (missing.nonEmpty) {
+      // "unset or blank", because a variable set to whitespace is reported here as well, and
+      // telling someone a variable they can see in the pod is "missing" strands them.
       throw new ServiceUnavailableException(
-        "This deployment cannot create a computing unit: required configuration is not " +
-          s"set. Missing environment variable(s): ${missing.mkString(", ")}."
+        "This deployment cannot create a computing unit. Unset or blank environment " +
+          s"variable(s): ${missing.mkString(", ")}."
       )
     }
     looked.collect { case (name, Some(value)) => name -> value }.toMap

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -93,60 +93,45 @@ object ComputingUnitManagingResource {
     }
   }
 
-  /**
-    * Variables only the deployment knows, each one read inside the unit: the two endpoints
-    * by LakeFSFileDocument and ResultExportService, the payload size by ApplicationConfig,
-    * the secret by AuthConfig. The helm chart supplies every one.
-    *
-    * USER_SYS_ENABLED and SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR are not
-    * here: their conf keys went away with #3831 and #3542, so nothing reads them and
-    * requiring one would refuse a unit over a variable that changes nothing.
-    */
+  // Required by the unit: the endpoints by LakeFSFileDocument and ResultExportService, the
+  // payload size by ApplicationConfig, the secret by AuthConfig. USER_SYS_ENABLED and
+  // SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR lost their conf keys in #3831
+  // and #3542, so nothing reads them.
   private val requiredComputingUnitEnvNames: Seq[String] = Seq(
     EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
     EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
-    // TODO: use AmberConfig for the payload size. Currently AmberConfig is only accessible
-    // in workflow-executing-service
+    // TODO: use AmberConfig here; it is only accessible in workflow-executing-service
     EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
 
-  /**
-    * Forwarded byte-for-byte rather than trimmed. This service signs the unit's token with
-    * AUTH_JWT_SECRET as AuthConfig read it, and AuthConfig does not trim, so a trimmed copy
-    * would leave the two verifying against different keys -- a silent auth failure.
-    */
+  // Forwarded raw. AuthConfig does not trim, so a trimmed copy would leave the unit and this
+  // service verifying the token against different keys.
   private val untrimmedComputingUnitEnvNames: Set[String] = Set(
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
 
   /**
-    * Returns the variables, or fails with a 503 listing every one that is missing.
+    * Returns the variables, or fails with a 503 listing every one that is unset or blank.
     *
-    * All of them at once, because when these are missing they are usually all missing.
-    * A WebApplicationException so the message reaches the caller: None.get was not one,
-    * and dropwizard replaced it with generic text. 503 because it is the deployment that
-    * is not ready, not the request that is wrong.
+    * A WebApplicationException so the message survives: dropwizard replaces a plain 500's
+    * with generic text. 503 because the deployment is not ready, not the request wrong.
     */
   private[resource] def requiredComputingUnitEnv(
       lookup: String => Option[String]
   ): Map[String, String] = {
-    // Blank counts as missing, as elsewhere in config: the chart renders every value as
-    // "{{ .value }}", so an unset one arrives as "" rather than absent.
+    // Blank counts as missing: the chart renders every value as "{{ .value }}", so an unset
+    // one arrives as "" rather than absent.
     val looked =
       requiredComputingUnitEnvNames.map(name => name -> lookup(name).filter(_.trim.nonEmpty))
     val missing = looked.collect { case (name, None) => name }
     if (missing.nonEmpty) {
-      // "unset or blank", because a variable set to whitespace is reported here as well, and
-      // telling someone a variable they can see in the pod is "missing" strands them.
       throw new ServiceUnavailableException(
         "This deployment cannot create a computing unit. Unset or blank environment " +
           s"variable(s): ${missing.mkString(", ")}."
       )
     }
-    // A padded value passes the blank check, so what is forwarded is trimmed: HOCON reads
-    // " 1024" as a string and refuses it as an int, and the unit dies at startup naming no
-    // variable. The secret is the exception -- see untrimmedComputingUnitEnvNames.
+    // Trimmed, because HOCON refuses " 1024" as an int and the unit then dies naming nothing.
     looked.collect {
       case (name, Some(raw)) =>
         name -> (if (untrimmedComputingUnitEnvNames(name)) raw else raw.trim)

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -93,6 +93,41 @@ object ComputingUnitManagingResource {
     }
   }
 
+  /** Variables only the deployment knows. The helm chart supplies every one. */
+  private val requiredComputingUnitEnvNames: Seq[String] = Seq(
+    EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
+    EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
+    EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
+    EnvironmentalVariable.ENV_USER_SYS_ENABLED,
+    EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
+    EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+  )
+
+  /**
+    * Returns the variables, or fails with a 503 listing every one that is missing.
+    *
+    * All of them at once, because when these are missing they are usually all missing.
+    * A WebApplicationException so the message reaches the caller: None.get was not one,
+    * and dropwizard replaced it with generic text. 503 because it is the deployment that
+    * is not ready, not the request that is wrong.
+    */
+  private[resource] def requiredComputingUnitEnv(
+      lookup: String => Option[String]
+  ): Map[String, String] = {
+    // Blank counts as missing, as elsewhere in config: the chart renders every value as
+    // "{{ .value }}", so an unset one arrives as "" rather than absent.
+    val looked =
+      requiredComputingUnitEnvNames.map(name => name -> lookup(name).filter(_.trim.nonEmpty))
+    val missing = looked.collect { case (name, None) => name }
+    if (missing.nonEmpty) {
+      throw new ServiceUnavailableException(
+        "This deployment cannot create a computing unit: required configuration is not " +
+          s"set. Missing environment variable(s): ${missing.mkString(", ")}."
+      )
+    }
+    looked.collect { case (name, Some(value)) => name -> value }.toMap
+  }
+
   // Environment variables passed to the created computing unit(pod)
   private lazy val computingUnitEnvironmentVariables: Map[String, Any] =
     icebergEnvironmentVariables ++ Map(
@@ -108,28 +143,10 @@ object ComputingUnitManagingResource {
       EnvironmentalVariable.ENV_S3_ENDPOINT -> StorageConfig.s3Endpoint,
       EnvironmentalVariable.ENV_S3_REGION -> StorageConfig.s3Region,
       EnvironmentalVariable.ENV_S3_AUTH_USERNAME -> StorageConfig.s3Username,
-      EnvironmentalVariable.ENV_S3_AUTH_PASSWORD -> StorageConfig.s3Password,
-      EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT -> EnvironmentalVariable
-        .get(EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT)
-        .get,
-      EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT -> EnvironmentalVariable
-        .get(EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT)
-        .get,
-      // Variables for amber setting
-      // TODO: use AmberConfig for the following items. Currently AmberConfig is only accessible in workflow-executing-service
-      EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR -> EnvironmentalVariable
-        .get(EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR)
-        .get,
-      EnvironmentalVariable.ENV_USER_SYS_ENABLED -> EnvironmentalVariable
-        .get(EnvironmentalVariable.ENV_USER_SYS_ENABLED)
-        .get,
-      EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB -> EnvironmentalVariable
-        .get(EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB)
-        .get,
-      EnvironmentalVariable.ENV_AUTH_JWT_SECRET -> EnvironmentalVariable
-        .get(EnvironmentalVariable.ENV_AUTH_JWT_SECRET)
-        .get
-    )
+      EnvironmentalVariable.ENV_S3_AUTH_PASSWORD -> StorageConfig.s3Password
+    ) ++
+      // TODO: use AmberConfig for the amber items. Currently AmberConfig is only accessible in workflow-executing-service
+      requiredComputingUnitEnv(EnvironmentalVariable.get)
 
   case class WorkflowComputingUnitCreationParams(
       name: String,

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -93,22 +93,24 @@ object ComputingUnitManagingResource {
     }
   }
 
-  // Required by the unit: the endpoints by LakeFSFileDocument and ResultExportService, the
-  // payload size by ApplicationConfig, the secret by AuthConfig. USER_SYS_ENABLED and
-  // SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR lost their conf keys in #3831
-  // and #3542, so nothing reads them.
+  // Required: the endpoints default to localhost:9092 (LakeFSFileDocument,
+  // ResultExportService) and the secret to a published literal (auth.conf), none of which
+  // suits a real deployment. Forwarded raw -- the endpoints are trimmed by their own readers,
+  // and trimming the secret would leave the unit and this service verifying the token against
+  // different keys, since AuthConfig does not trim.
   private val requiredComputingUnitEnvNames: Seq[String] = Seq(
     EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
     EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
-    // TODO: use AmberConfig here; it is only accessible in workflow-executing-service
-    EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
 
-  // Forwarded raw. AuthConfig does not trim, so a trimmed copy would leave the unit and this
-  // service verifying the token against different keys.
-  private val untrimmedComputingUnitEnvNames: Set[String] = Set(
-    EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+  // Overrides, forwarded only when set: application.conf defaults the payload size to 1024,
+  // so its absence is not an error. USER_SYS_ENABLED and
+  // SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR are absent from both lists --
+  // their conf keys went away with #3831 and #3542, so nothing reads them.
+  // TODO: use AmberConfig here; it is only accessible in workflow-executing-service
+  private val optionalComputingUnitEnvNames: Seq[String] = Seq(
+    EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
   )
 
   /**
@@ -131,12 +133,20 @@ object ComputingUnitManagingResource {
           s"variable(s): ${missing.mkString(", ")}."
       )
     }
-    // Trimmed, because HOCON refuses " 1024" as an int and the unit then dies naming nothing.
-    looked.collect {
-      case (name, Some(raw)) =>
-        name -> (if (untrimmedComputingUnitEnvNames(name)) raw else raw.trim)
-    }.toMap
+    looked.collect { case (name, Some(value)) => name -> value }.toMap
   }
+
+  /**
+    * The overrides that are set, trimmed. A blank one is dropped rather than forwarded, and
+    * a padded one is trimmed, because HOCON reads " 1024" as a string and refuses it as an
+    * int -- the unit then dies at startup naming nothing.
+    */
+  private[resource] def optionalComputingUnitEnv(
+      lookup: String => Option[String]
+  ): Map[String, String] =
+    optionalComputingUnitEnvNames.flatMap { name =>
+      lookup(name).map(_.trim).filter(_.nonEmpty).map(name -> _)
+    }.toMap
 
   // Environment variables passed to the created computing unit(pod)
   private lazy val computingUnitEnvironmentVariables: Map[String, Any] =
@@ -154,7 +164,8 @@ object ComputingUnitManagingResource {
       EnvironmentalVariable.ENV_S3_REGION -> StorageConfig.s3Region,
       EnvironmentalVariable.ENV_S3_AUTH_USERNAME -> StorageConfig.s3Username,
       EnvironmentalVariable.ENV_S3_AUTH_PASSWORD -> StorageConfig.s3Password
-    ) ++ requiredComputingUnitEnv(EnvironmentalVariable.get)
+    ) ++ requiredComputingUnitEnv(EnvironmentalVariable.get) ++
+      optionalComputingUnitEnv(EnvironmentalVariable.get)
 
   case class WorkflowComputingUnitCreationParams(
       name: String,

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -115,11 +115,11 @@ object ComputingUnitManagingResource {
       lookup: String => Option[String]
   ): Map[String, String] = {
     // Blank counts as missing, as elsewhere in config: the chart renders every value as
-    // "{{ .value }}", so an unset one arrives as "" rather than absent. The trimmed value is
-    // what is kept, too -- LakeFSFileDocument trims these on the way back out, and a padded
-    // boolean or int is a value HOCON refuses to parse in the pod.
+    // "{{ .value }}", so an unset one arrives as "" rather than absent. Only the decision
+    // trims -- the value goes on raw, because AUTH_JWT_SECRET has to stay byte-identical to
+    // the one this service signs the unit's token with, and AuthConfig does not trim either.
     val looked =
-      requiredComputingUnitEnvNames.map(name => name -> lookup(name).map(_.trim).filter(_.nonEmpty))
+      requiredComputingUnitEnvNames.map(name => name -> lookup(name).filter(_.trim.nonEmpty))
     val missing = looked.collect { case (name, None) => name }
     if (missing.nonEmpty) {
       // "unset or blank", because a variable set to whitespace is reported here as well, and

--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/resource/ComputingUnitManagingResource.scala
@@ -93,13 +93,30 @@ object ComputingUnitManagingResource {
     }
   }
 
-  /** Variables only the deployment knows. The helm chart supplies every one. */
+  /**
+    * Variables only the deployment knows, each one read inside the unit: the two endpoints
+    * by LakeFSFileDocument and ResultExportService, the payload size by ApplicationConfig,
+    * the secret by AuthConfig. The helm chart supplies every one.
+    *
+    * USER_SYS_ENABLED and SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR are not
+    * here: their conf keys went away with #3831 and #3542, so nothing reads them and
+    * requiring one would refuse a unit over a variable that changes nothing.
+    */
   private val requiredComputingUnitEnvNames: Seq[String] = Seq(
     EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
     EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
-    EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
-    EnvironmentalVariable.ENV_USER_SYS_ENABLED,
+    // TODO: use AmberConfig for the payload size. Currently AmberConfig is only accessible
+    // in workflow-executing-service
     EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
+    EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+  )
+
+  /**
+    * Forwarded byte-for-byte rather than trimmed. This service signs the unit's token with
+    * AUTH_JWT_SECRET as AuthConfig read it, and AuthConfig does not trim, so a trimmed copy
+    * would leave the two verifying against different keys -- a silent auth failure.
+    */
+  private val untrimmedComputingUnitEnvNames: Set[String] = Set(
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
 
@@ -115,9 +132,7 @@ object ComputingUnitManagingResource {
       lookup: String => Option[String]
   ): Map[String, String] = {
     // Blank counts as missing, as elsewhere in config: the chart renders every value as
-    // "{{ .value }}", so an unset one arrives as "" rather than absent. Only the decision
-    // trims -- the value goes on raw, because AUTH_JWT_SECRET has to stay byte-identical to
-    // the one this service signs the unit's token with, and AuthConfig does not trim either.
+    // "{{ .value }}", so an unset one arrives as "" rather than absent.
     val looked =
       requiredComputingUnitEnvNames.map(name => name -> lookup(name).filter(_.trim.nonEmpty))
     val missing = looked.collect { case (name, None) => name }
@@ -129,7 +144,13 @@ object ComputingUnitManagingResource {
           s"variable(s): ${missing.mkString(", ")}."
       )
     }
-    looked.collect { case (name, Some(value)) => name -> value }.toMap
+    // A padded value passes the blank check, so what is forwarded is trimmed: HOCON reads
+    // " 1024" as a string and refuses it as an int, and the unit dies at startup naming no
+    // variable. The secret is the exception -- see untrimmedComputingUnitEnvNames.
+    looked.collect {
+      case (name, Some(raw)) =>
+        name -> (if (untrimmedComputingUnitEnvNames(name)) raw else raw.trim)
+    }.toMap
   }
 
   // Environment variables passed to the created computing unit(pod)
@@ -148,9 +169,7 @@ object ComputingUnitManagingResource {
       EnvironmentalVariable.ENV_S3_REGION -> StorageConfig.s3Region,
       EnvironmentalVariable.ENV_S3_AUTH_USERNAME -> StorageConfig.s3Username,
       EnvironmentalVariable.ENV_S3_AUTH_PASSWORD -> StorageConfig.s3Password
-    ) ++
-      // TODO: use AmberConfig for the amber items. Currently AmberConfig is only accessible in workflow-executing-service
-      requiredComputingUnitEnv(EnvironmentalVariable.get)
+    ) ++ requiredComputingUnitEnv(EnvironmentalVariable.get)
 
   case class WorkflowComputingUnitCreationParams(
       name: String,

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -497,14 +497,15 @@ class ComputingUnitManagingResourceSpec
     thrown.getMessage should include(blank)
   }
 
-  // Padding is judged, so it is also removed: HOCON in the pod refuses to read " 1024" as an
-  // int or " true" as a boolean, and the pod would crashloop naming neither.
-  it should "hand on the trimmed value, not the padded one" in {
-    val padded = EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
+  // Only the blank decision trims. The value itself goes on untouched: this service signs the
+  // unit's token with AUTH_JWT_SECRET as AuthConfig read it, and AuthConfig does not trim, so
+  // handing the unit a trimmed copy would leave the two verifying against different keys.
+  it should "hand on the value untrimmed" in {
+    val padded = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
-      if (name == padded) Some(" 1024\n") else Some("set")
+      if (name == padded) Some(" s3cret ") else Some("set")
     )
-    env(padded) shouldBe "1024"
+    env(padded) shouldBe " s3cret "
   }
 
   // The variable is there in the pod's env, so calling it "missing" would send whoever reads

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -467,13 +467,13 @@ class ComputingUnitManagingResourceSpec
       resource.getComputingUnitResourceLimit("99999", user)
   }
 
-  // The six variables requiredComputingUnitEnv looks up. Kept here because the production
-  // list is private, so a name added there without a test here shows up as a size mismatch.
+  // The variables requiredComputingUnitEnv looks up. Kept here because the production list
+  // is private, so a name added or dropped there without a test here fails the all-set case.
+  // Each one is read inside the unit: the two endpoints by LakeFSFileDocument and
+  // ResultExportService, the payload size by ApplicationConfig, the secret by AuthConfig.
   private val requiredEnvNames = Seq(
     EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
     EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
-    EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
-    EnvironmentalVariable.ENV_USER_SYS_ENABLED,
     EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
@@ -486,6 +486,20 @@ class ComputingUnitManagingResourceSpec
     env.values.foreach(_ should startWith("value-"))
   }
 
+  // USER_SYS_ENABLED and SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR lost their
+  // conf keys in #3831 and #3542, so nothing reads them in the unit. Requiring them would
+  // refuse to start a unit over a variable that changes nothing whatever it is set to.
+  it should "not require a variable no longer read anywhere" in {
+    val retired = Seq(
+      EnvironmentalVariable.ENV_USER_SYS_ENABLED,
+      EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR
+    )
+    val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
+      if (retired.contains(name)) None else Some("set")
+    )
+    retired.foreach(name => env.keySet should not contain name)
+  }
+
   it should "name the missing variable and leave the ones that are set out of it" in {
     val absent = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
     val thrown = intercept[ServiceUnavailableException] {
@@ -495,7 +509,7 @@ class ComputingUnitManagingResourceSpec
     }
     thrown.getMessage should include(absent)
     // Naming a variable that is set sends whoever reads this off to check it for nothing --
-    // the search the message exists to end. So the five that are set stay out of it.
+    // the search the message exists to end. So the ones that are set stay out of it.
     requiredEnvNames
       .filterNot(_ == absent)
       .foreach(name => thrown.getMessage should not include name)
@@ -513,10 +527,21 @@ class ComputingUnitManagingResourceSpec
     thrown.getMessage should include(blank)
   }
 
-  // Only the blank decision trims. The value itself goes on untouched: this service signs the
-  // unit's token with AUTH_JWT_SECRET as AuthConfig read it, and AuthConfig does not trim, so
-  // handing the unit a trimmed copy would leave the two verifying against different keys.
-  it should "hand on the value untrimmed" in {
+  // A padded value passes the blank check, so trimming it is what keeps it from reaching the
+  // pod intact: HOCON reads " 1024" as a string and refuses it as an int, and the unit dies
+  // at startup naming no variable -- the failure this whole guard exists to replace.
+  it should "trim the value it forwards" in {
+    val padded = EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
+    val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
+      if (name == padded) Some(" 1024\n") else Some("set")
+    )
+    env(padded) shouldBe "1024"
+  }
+
+  // The secret is the exception. This service signs the unit's token with AUTH_JWT_SECRET as
+  // AuthConfig read it, and AuthConfig does not trim, so handing the unit a trimmed copy
+  // would leave the two verifying against different keys -- a silent auth failure.
+  it should "hand on the secret untrimmed" in {
     val padded = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
       if (name == padded) Some(" s3cret ") else Some("set")

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -467,15 +467,26 @@ class ComputingUnitManagingResourceSpec
       resource.getComputingUnitResourceLimit("99999", user)
   }
 
+  // The six variables requiredComputingUnitEnv looks up. Kept here because the production
+  // list is private, so a name added there without a test here shows up as a size mismatch.
+  private val requiredEnvNames = Seq(
+    EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
+    EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
+    EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
+    EnvironmentalVariable.ENV_USER_SYS_ENABLED,
+    EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
+    EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+  )
+
   // A missing variable used to fail with None.get, which the caller saw as "There was an
   // error processing your request" -- no variable named, no cause.
   "requiredComputingUnitEnv" should "return every variable when all are set" in {
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name => Some(s"value-$name"))
-    env should have size 6
+    env.keySet shouldBe requiredEnvNames.toSet
     env.values.foreach(_ should startWith("value-"))
   }
 
-  it should "name the single missing variable" in {
+  it should "name the missing variable and leave the ones that are set out of it" in {
     val absent = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
     val thrown = intercept[ServiceUnavailableException] {
       ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
@@ -483,6 +494,11 @@ class ComputingUnitManagingResourceSpec
       )
     }
     thrown.getMessage should include(absent)
+    // Naming a variable that is set sends whoever reads this off to check it for nothing --
+    // the search the message exists to end. So the five that are set stay out of it.
+    requiredEnvNames
+      .filterNot(_ == absent)
+      .foreach(name => thrown.getMessage should not include name)
   }
 
   // The chart renders every value as "{{ .value }}", so an unset variable arrives as ""
@@ -521,14 +537,7 @@ class ComputingUnitManagingResourceSpec
     val thrown = intercept[ServiceUnavailableException] {
       ComputingUnitManagingResource.requiredComputingUnitEnv(_ => None)
     }
-    Seq(
-      EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
-      EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
-      EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
-      EnvironmentalVariable.ENV_USER_SYS_ENABLED,
-      EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
-      EnvironmentalVariable.ENV_AUTH_JWT_SECRET
-    ).foreach(name => thrown.getMessage should include(name))
+    requiredEnvNames.foreach(name => thrown.getMessage should include(name))
   }
 
 }

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -497,6 +497,25 @@ class ComputingUnitManagingResourceSpec
     thrown.getMessage should include(blank)
   }
 
+  // Padding is judged, so it is also removed: HOCON in the pod refuses to read " 1024" as an
+  // int or " true" as a boolean, and the pod would crashloop naming neither.
+  it should "hand on the trimmed value, not the padded one" in {
+    val padded = EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
+    val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
+      if (name == padded) Some(" 1024\n") else Some("set")
+    )
+    env(padded) shouldBe "1024"
+  }
+
+  // The variable is there in the pod's env, so calling it "missing" would send whoever reads
+  // this to check, find it, and conclude the message is wrong.
+  it should "say unset or blank rather than missing" in {
+    val thrown = intercept[ServiceUnavailableException] {
+      ComputingUnitManagingResource.requiredComputingUnitEnv(_ => Some(" "))
+    }
+    thrown.getMessage should include("Unset or blank environment variable(s)")
+  }
+
   it should "name every missing variable at once" in {
     val thrown = intercept[ServiceUnavailableException] {
       ComputingUnitManagingResource.requiredComputingUnitEnv(_ => None)

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -19,7 +19,13 @@
 
 package org.apache.texera.service.resource
 
-import jakarta.ws.rs.{BadRequestException, ForbiddenException, NotFoundException}
+import jakarta.ws.rs.{
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  ServiceUnavailableException
+}
+import org.apache.texera.common.config.EnvironmentalVariable
 import org.apache.texera.auth.SessionUser
 import org.apache.texera.common.config.KubernetesConfig.maxNumOfRunningComputingUnitsPerUser
 import org.apache.texera.dao.MockTexeraDB
@@ -460,4 +466,49 @@ class ComputingUnitManagingResourceSpec
     a[NotFoundException] should be thrownBy
       resource.getComputingUnitResourceLimit("99999", user)
   }
+
+  // A missing variable used to fail with None.get, which the caller saw as "There was an
+  // error processing your request" -- no variable named, no cause.
+  "requiredComputingUnitEnv" should "return every variable when all are set" in {
+    val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name => Some(s"value-$name"))
+    env should have size 6
+    env.values.foreach(_ should startWith("value-"))
+  }
+
+  it should "name the single missing variable" in {
+    val absent = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+    val thrown = intercept[ServiceUnavailableException] {
+      ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
+        if (name == absent) None else Some("set")
+      )
+    }
+    thrown.getMessage should include(absent)
+  }
+
+  // The chart renders every value as "{{ .value }}", so an unset variable arrives as ""
+  // rather than absent -- which would otherwise start a unit with, say, no JWT secret.
+  it should "treat a blank variable as missing" in {
+    val blank = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+    val thrown = intercept[ServiceUnavailableException] {
+      ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
+        if (name == blank) Some("   ") else Some("set")
+      )
+    }
+    thrown.getMessage should include(blank)
+  }
+
+  it should "name every missing variable at once" in {
+    val thrown = intercept[ServiceUnavailableException] {
+      ComputingUnitManagingResource.requiredComputingUnitEnv(_ => None)
+    }
+    Seq(
+      EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
+      EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
+      EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
+      EnvironmentalVariable.ENV_USER_SYS_ENABLED,
+      EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
+      EnvironmentalVariable.ENV_AUTH_JWT_SECRET
+    ).foreach(name => thrown.getMessage should include(name))
+  }
+
 }

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -467,10 +467,8 @@ class ComputingUnitManagingResourceSpec
       resource.getComputingUnitResourceLimit("99999", user)
   }
 
-  // The variables requiredComputingUnitEnv looks up. Kept here because the production list
-  // is private, so a name added or dropped there without a test here fails the all-set case.
-  // Each one is read inside the unit: the two endpoints by LakeFSFileDocument and
-  // ResultExportService, the payload size by ApplicationConfig, the secret by AuthConfig.
+  // Mirrors the private production list, so a name added or dropped there fails the all-set
+  // case.
   private val requiredEnvNames = Seq(
     EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
     EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
@@ -478,17 +476,13 @@ class ComputingUnitManagingResourceSpec
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
 
-  // A missing variable used to fail with None.get, which the caller saw as "There was an
-  // error processing your request" -- no variable named, no cause.
   "requiredComputingUnitEnv" should "return every variable when all are set" in {
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name => Some(s"value-$name"))
     env.keySet shouldBe requiredEnvNames.toSet
     env.values.foreach(_ should startWith("value-"))
   }
 
-  // USER_SYS_ENABLED and SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR lost their
-  // conf keys in #3831 and #3542, so nothing reads them in the unit. Requiring them would
-  // refuse to start a unit over a variable that changes nothing whatever it is set to.
+  // Both lost their conf keys (#3831, #3542), so nothing in the unit reads them.
   it should "not require a variable no longer read anywhere" in {
     val retired = Seq(
       EnvironmentalVariable.ENV_USER_SYS_ENABLED,
@@ -508,15 +502,12 @@ class ComputingUnitManagingResourceSpec
       )
     }
     thrown.getMessage should include(absent)
-    // Naming a variable that is set sends whoever reads this off to check it for nothing --
-    // the search the message exists to end. So the ones that are set stay out of it.
     requiredEnvNames
       .filterNot(_ == absent)
       .foreach(name => thrown.getMessage should not include name)
   }
 
-  // The chart renders every value as "{{ .value }}", so an unset variable arrives as ""
-  // rather than absent -- which would otherwise start a unit with, say, no JWT secret.
+  // The chart renders every value as "{{ .value }}", so an unset one arrives as "".
   it should "treat a blank variable as missing" in {
     val blank = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
     val thrown = intercept[ServiceUnavailableException] {
@@ -527,9 +518,7 @@ class ComputingUnitManagingResourceSpec
     thrown.getMessage should include(blank)
   }
 
-  // A padded value passes the blank check, so trimming it is what keeps it from reaching the
-  // pod intact: HOCON reads " 1024" as a string and refuses it as an int, and the unit dies
-  // at startup naming no variable -- the failure this whole guard exists to replace.
+  // HOCON refuses " 1024" as an int, and the unit then dies at startup naming nothing.
   it should "trim the value it forwards" in {
     val padded = EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
@@ -538,9 +527,7 @@ class ComputingUnitManagingResourceSpec
     env(padded) shouldBe "1024"
   }
 
-  // The secret is the exception. This service signs the unit's token with AUTH_JWT_SECRET as
-  // AuthConfig read it, and AuthConfig does not trim, so handing the unit a trimmed copy
-  // would leave the two verifying against different keys -- a silent auth failure.
+  // AuthConfig does not trim, so a trimmed copy would verify against a different key.
   it should "hand on the secret untrimmed" in {
     val padded = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
@@ -549,8 +536,7 @@ class ComputingUnitManagingResourceSpec
     env(padded) shouldBe " s3cret "
   }
 
-  // The variable is there in the pod's env, so calling it "missing" would send whoever reads
-  // this to check, find it, and conclude the message is wrong.
+  // The variable is there in the pod's env, so calling it "missing" would read as wrong.
   it should "say unset or blank rather than missing" in {
     val thrown = intercept[ServiceUnavailableException] {
       ComputingUnitManagingResource.requiredComputingUnitEnv(_ => Some(" "))

--- a/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
+++ b/computing-unit-managing-service/src/test/scala/org/apache/texera/service/resource/ComputingUnitManagingResourceSpec.scala
@@ -472,9 +472,10 @@ class ComputingUnitManagingResourceSpec
   private val requiredEnvNames = Seq(
     EnvironmentalVariable.ENV_FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT,
     EnvironmentalVariable.ENV_FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT,
-    EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB,
     EnvironmentalVariable.ENV_AUTH_JWT_SECRET
   )
+
+  private val payloadSize = EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
 
   "requiredComputingUnitEnv" should "return every variable when all are set" in {
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name => Some(s"value-$name"))
@@ -482,16 +483,19 @@ class ComputingUnitManagingResourceSpec
     env.values.foreach(_ should startWith("value-"))
   }
 
-  // Both lost their conf keys (#3831, #3542), so nothing in the unit reads them.
-  it should "not require a variable no longer read anywhere" in {
-    val retired = Seq(
+  // USER_SYS_ENABLED and SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR lost their
+  // conf keys (#3831, #3542); the payload size defaults to 1024 in application.conf. None of
+  // the three stops a unit from starting, so none may refuse to create one.
+  it should "not require a variable the unit does not need" in {
+    val notNeeded = Seq(
       EnvironmentalVariable.ENV_USER_SYS_ENABLED,
-      EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR
+      EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR,
+      payloadSize
     )
     val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
-      if (retired.contains(name)) None else Some("set")
+      if (notNeeded.contains(name)) None else Some("set")
     )
-    retired.foreach(name => env.keySet should not contain name)
+    notNeeded.foreach(name => env.keySet should not contain name)
   }
 
   it should "name the missing variable and leave the ones that are set out of it" in {
@@ -518,22 +522,12 @@ class ComputingUnitManagingResourceSpec
     thrown.getMessage should include(blank)
   }
 
-  // HOCON refuses " 1024" as an int, and the unit then dies at startup naming nothing.
-  it should "trim the value it forwards" in {
-    val padded = EnvironmentalVariable.ENV_MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB
-    val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
-      if (name == padded) Some(" 1024\n") else Some("set")
-    )
-    env(padded) shouldBe "1024"
-  }
-
-  // AuthConfig does not trim, so a trimmed copy would verify against a different key.
-  it should "hand on the secret untrimmed" in {
-    val padded = EnvironmentalVariable.ENV_AUTH_JWT_SECRET
-    val env = ComputingUnitManagingResource.requiredComputingUnitEnv(name =>
-      if (name == padded) Some(" s3cret ") else Some("set")
-    )
-    env(padded) shouldBe " s3cret "
+  // AuthConfig does not trim, so a trimmed copy would verify against a different key. The
+  // endpoints are trimmed by their own readers, so they need nothing here either.
+  it should "hand on the value untrimmed" in {
+    val env =
+      ComputingUnitManagingResource.requiredComputingUnitEnv(_ => Some(" s3cret "))
+    env(EnvironmentalVariable.ENV_AUTH_JWT_SECRET) shouldBe " s3cret "
   }
 
   // The variable is there in the pod's env, so calling it "missing" would read as wrong.
@@ -549,6 +543,24 @@ class ComputingUnitManagingResourceSpec
       ComputingUnitManagingResource.requiredComputingUnitEnv(_ => None)
     }
     requiredEnvNames.foreach(name => thrown.getMessage should include(name))
+  }
+
+  "optionalComputingUnitEnv" should "forward an override that is set" in {
+    ComputingUnitManagingResource.optionalComputingUnitEnv(_ => Some("2048")) shouldBe
+      Map(payloadSize -> "2048")
+  }
+
+  // HOCON refuses " 2048" as an int, and the unit then dies at startup naming nothing.
+  it should "trim what it forwards" in {
+    ComputingUnitManagingResource.optionalComputingUnitEnv(_ => Some(" 2048\n")) shouldBe
+      Map(payloadSize -> "2048")
+  }
+
+  // application.conf already defaults this to 1024; forwarding "" would override the default
+  // with a value HOCON cannot read as an int.
+  it should "forward nothing when unset or blank" in {
+    ComputingUnitManagingResource.optionalComputingUnitEnv(_ => None) shouldBe empty
+    ComputingUnitManagingResource.optionalComputingUnitEnv(_ => Some("  ")) shouldBe empty
   }
 
 }


### PR DESCRIPTION
### What changes were proposed in this PR?

Six environment variables were read with `Option.get`, so a deployment missing any of them failed with `None.get`. Dropwizard shows that as "There was an error processing your request" — no variable named, no cause, and six candidates to check.

Every missing variable is now listed at once, as a 503. All at once because when these are missing they are usually all missing: the helm chart supplies them, so they are present together or absent together.

Reviewing what each one is for shrank the list. A variable belongs in it only if the unit has no usable default without it:

| Variable | Without it, the unit | Verdict |
| --- | --- | --- |
| `FILE_SERVICE_GET_DATASET_PRESIGNED_URL_ENDPOINT` | falls back to `localhost:9092` | required |
| `FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT` | falls back to `localhost:9092` | required |
| `AUTH_JWT_SECRET` | falls back to the published literal in `auth.conf` | required |
| `MAX_WORKFLOW_WEBSOCKET_REQUEST_PAYLOAD_SIZE_KB` | uses `application.conf`'s 1024 | optional, forwarded when set |
| `USER_SYS_ENABLED` | ignores it — conf key removed in #3831 | dropped |
| `SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR` | ignores it — conf key removed in #3542 | dropped |

Required values are forwarded raw: `LakeFSFileDocument` and `ResultExportService` trim the endpoints themselves, and the secret has to stay byte-identical to what `AuthConfig` read or the unit and this service verify the token against different keys. The optional override is trimmed, because HOCON reads `" 1024"` as a string and refuses it as an int — the unit then dies at startup naming nothing.

**No change for any working deployment.** A chart deployment sets all of these, unpadded, so every forwarded value is byte-identical to today's; the only difference in the pod's environment is the two dropped variables, which nothing there read. A deployment that omits the payload size is no longer refused.

### Any related issues, documentation, discussions?

Closes #8467
Part of #8466

### How was this PR tested?

Ten new tests for `requiredComputingUnitEnv`, and the existing default-image assertion updated.

| Case | What it pins |
| --- | --- |
| all set | exactly the three keys come back, values untouched |
| not needed | none of the three defaulted/dead variables is required, nor forwarded |
| one missing | that one is named — **and the ones that are set are not** |
| blank | a whitespace-only value counts as missing |
| padded | forwarded raw, so unit and manager verify against the same key |
| wording | "Unset or blank environment variable(s)", not "missing" |
| all missing | every name in one message |
| override set | the payload size is forwarded, trimmed |
| override unset/blank | nothing forwarded, so `application.conf`'s 1024 stands |

The negative half of the one-missing case was verified by mutation: computing `missing` as every name whenever one is absent leaves the suite green without it, and fails only that test with it.

```
sbt "ComputingUnitManagingService/testOnly org.apache.texera.service.resource.ComputingUnitManagingResourceSpec" \
    "Config/testOnly org.apache.texera.common.config.KubernetesConfigSpec"

ComputingUnitManagingResourceSpec 41 passed, 0 failed
KubernetesConfigSpec               6 passed, 0 failed
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)
