### PR TITLE
feat(workflow-operator): let Filter combine predicates with AND

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/PredicateCombinator.java
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/PredicateCombinator.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.filter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum PredicateCombinator {
+    OR("any (OR)"),
+
+    AND("all (AND)");
+
+    private final String name;
+
+    private PredicateCombinator(String name) {
+        this.name = name;
+    }
+
+    // use the name string instead of enum string in JSON
+    @JsonValue
+    public String getName() {
+        return this.name;
+    }
+
+    // Handle custom deserialization for enum
+    @JsonCreator
+    public static PredicateCombinator fromString(String value) {
+        for (PredicateCombinator combinator : PredicateCombinator.values()) {
+            if (combinator.name.equalsIgnoreCase(value)) {
+                return combinator;
+            }
+        }
+        throw new IllegalArgumentException("Unknown predicate combinator: " + value);
+    }
+}

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDesc.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDesc.scala
@@ -20,6 +20,7 @@
 package org.apache.texera.amber.operator.filter
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import org.apache.texera.amber.core.executor.OpExecWithClassName
 import org.apache.texera.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import org.apache.texera.amber.core.workflow.{InputPort, OutputPort, PhysicalOp}
@@ -29,8 +30,13 @@ import org.apache.texera.amber.util.JSONUtils.objectMapper
 class SpecializedFilterOpDesc extends FilterOpDesc {
 
   @JsonProperty(value = "predicates", required = true)
-  @JsonPropertyDescription("multiple predicates in OR")
+  @JsonPropertyDescription("multiple predicates to be combined")
   var predicates: List[FilterPredicate] = List.empty
+
+  @JsonProperty(required = true, defaultValue = "any (OR)")
+  @JsonSchemaTitle("Combine Predicates With")
+  @JsonPropertyDescription("how to combine multiple predicates")
+  var predicateCombinator: PredicateCombinator = PredicateCombinator.OR
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
@@ -53,7 +59,7 @@ class SpecializedFilterOpDesc extends FilterOpDesc {
   override def operatorInfo: OperatorInfo = {
     OperatorInfo(
       "Filter",
-      "Performs a filter operation using OR between multiple predicates",
+      "Performs a filter operation using AND or OR between multiple predicates",
       OperatorGroupConstants.CLEANING_GROUP,
       List(InputPort()),
       List(OutputPort()),

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpExec.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpExec.scala
@@ -25,5 +25,11 @@ import org.apache.texera.amber.util.JSONUtils.objectMapper
 class SpecializedFilterOpExec(descString: String) extends FilterOpExec {
   private val desc: SpecializedFilterOpDesc =
     objectMapper.readValue(descString, classOf[SpecializedFilterOpDesc])
-  setFilterFunc((tuple: Tuple) => desc.predicates.exists(_.evaluate(tuple)))
+  setFilterFunc((tuple: Tuple) =>
+    desc.predicateCombinator match {
+      case PredicateCombinator.AND =>
+        desc.predicates.nonEmpty && desc.predicates.forall(_.evaluate(tuple))
+      case _ => desc.predicates.exists(_.evaluate(tuple))
+    }
+  )
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/PredicateCombinatorSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/PredicateCombinatorSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.texera.amber.operator.filter
+
+import org.apache.texera.amber.util.JSONUtils.objectMapper
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PredicateCombinatorSpec extends AnyFlatSpec with Matchers {
+
+  "PredicateCombinator" should "map each constant to its wire name via getName" in {
+    PredicateCombinator.OR.getName shouldBe "any (OR)"
+    PredicateCombinator.AND.getName shouldBe "all (AND)"
+    PredicateCombinator.values() should have length 2
+  }
+
+  "PredicateCombinator.fromString" should "resolve names case-insensitively" in {
+    PredicateCombinator.fromString("any (OR)") shouldBe PredicateCombinator.OR
+    PredicateCombinator.fromString("ALL (AND)") shouldBe PredicateCombinator.AND
+  }
+
+  it should "reject an unknown name" in {
+    intercept[IllegalArgumentException](PredicateCombinator.fromString("xor"))
+  }
+
+  "PredicateCombinator" should "round-trip through Jackson using its name" in {
+    objectMapper.writeValueAsString(PredicateCombinator.AND) shouldBe "\"all (AND)\""
+    objectMapper.readValue(
+      "\"any (OR)\"",
+      classOf[PredicateCombinator]
+    ) shouldBe PredicateCombinator.OR
+  }
+}

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDescSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpDescSpec.scala
@@ -36,6 +36,7 @@ class SpecializedFilterOpDescSpec extends AnyFlatSpec with Matchers {
     "advertise the name, Cleaning group, and reconfiguration support" in {
     val info = (new SpecializedFilterOpDesc).operatorInfo
     info.userFriendlyName shouldBe "Filter"
+    info.operatorDescription should include("AND or OR")
     info.operatorGroupName shouldBe OperatorGroupConstants.CLEANING_GROUP
     info.inputPorts should have length 1
     info.outputPorts should have length 1
@@ -44,6 +45,10 @@ class SpecializedFilterOpDescSpec extends AnyFlatSpec with Matchers {
 
   "SpecializedFilterOpDesc.predicates" should "default to an empty list" in {
     (new SpecializedFilterOpDesc).predicates shouldBe empty
+  }
+
+  "SpecializedFilterOpDesc.predicateCombinator" should "default to OR" in {
+    (new SpecializedFilterOpDesc).predicateCombinator shouldBe PredicateCombinator.OR
   }
 
   "SpecializedFilterOpDesc.getPhysicalOp" should
@@ -69,5 +74,28 @@ class SpecializedFilterOpDescSpec extends AnyFlatSpec with Matchers {
       )
     restored shouldBe a[SpecializedFilterOpDesc]
     restored.asInstanceOf[SpecializedFilterOpDesc].predicates shouldBe empty
+  }
+
+  "SpecializedFilterOpDesc" should
+    "deserialize to OR when predicateCombinator is absent" in {
+    val restored =
+      objectMapper.readValue(
+        """{"operatorType":"Filter","predicates":[]}""",
+        classOf[LogicalOp]
+      )
+    restored
+      .asInstanceOf[SpecializedFilterOpDesc]
+      .predicateCombinator shouldBe PredicateCombinator.OR
+  }
+
+  "SpecializedFilterOpDesc" should
+    "round-trip an explicit AND combinator through the polymorphic base" in {
+    val op = new SpecializedFilterOpDesc
+    op.predicateCombinator = PredicateCombinator.AND
+    val restored =
+      objectMapper.readValue(objectMapper.writeValueAsString(op), classOf[LogicalOp])
+    restored
+      .asInstanceOf[SpecializedFilterOpDesc]
+      .predicateCombinator shouldBe PredicateCombinator.AND
   }
 }

--- a/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpExecSpec.scala
+++ b/common/workflow-operator/src/test/scala/org/apache/texera/amber/operator/filter/SpecializedFilterOpExecSpec.scala
@@ -61,6 +61,10 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     .add(new Attribute("long", AttributeType.LONG), Long.MaxValue)
     .build()
 
+  before {
+    opDesc.predicateCombinator = PredicateCombinator.OR
+  }
+
   it should "open and close" in {
     opDesc.predicates = List()
     val opExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
@@ -134,5 +138,66 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
         assert(opExec.processTuple(nullTuple, inputPort).isEmpty)
         opExec.close()
       })
+  }
+
+  it should "keep a tuple under OR when only one predicate matches" in {
+    opDesc.predicates = List(
+      new FilterPredicate("int", ComparisonType.EQUAL_TO, "0"),
+      new FilterPredicate("string", ComparisonType.EQUAL_TO, "world")
+    )
+    opDesc.predicateCombinator = PredicateCombinator.OR
+    val opExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
+    opExec.open()
+    assert(opExec.processTuple(nonNullTuple, inputPort).nonEmpty)
+    opExec.close()
+  }
+
+  it should "drop a tuple under AND when only one predicate matches" in {
+    opDesc.predicates = List(
+      new FilterPredicate("int", ComparisonType.EQUAL_TO, "0"),
+      new FilterPredicate("string", ComparisonType.EQUAL_TO, "world")
+    )
+    opDesc.predicateCombinator = PredicateCombinator.AND
+    val opExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
+    opExec.open()
+    assert(opExec.processTuple(nonNullTuple, inputPort).isEmpty)
+    opExec.close()
+  }
+
+  it should "keep a tuple under AND when every predicate matches" in {
+    opDesc.predicates = List(
+      new FilterPredicate("int", ComparisonType.EQUAL_TO, "0"),
+      new FilterPredicate("string", ComparisonType.EQUAL_TO, "hello")
+    )
+    opDesc.predicateCombinator = PredicateCombinator.AND
+    val opExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
+    opExec.open()
+    assert(opExec.processTuple(nonNullTuple, inputPort).nonEmpty)
+    opExec.close()
+  }
+
+  it should "do nothing under AND when predicates is an empty list" in {
+    opDesc.predicates = List()
+    opDesc.predicateCombinator = PredicateCombinator.AND
+    val opExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
+    opExec.open()
+    assert(opExec.processTuple(allNullTuple, inputPort).isEmpty)
+    assert(opExec.processTuple(nonNullTuple, inputPort).isEmpty)
+    opExec.close()
+  }
+
+  it should "agree with OR on a single predicate under AND" in {
+    opDesc.predicates = List(new FilterPredicate("string", ComparisonType.EQUAL_TO, "hello"))
+    opDesc.predicateCombinator = PredicateCombinator.AND
+    val andExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
+    andExec.open()
+    assert(andExec.processTuple(nonNullTuple, inputPort).nonEmpty)
+    andExec.close()
+
+    opDesc.predicateCombinator = PredicateCombinator.OR
+    val orExec = new SpecializedFilterOpExec(objectMapper.writeValueAsString(opDesc))
+    orExec.open()
+    assert(orExec.processTuple(nonNullTuple, inputPort).nonEmpty)
+    orExec.close()
   }
 }

--- a/docs/reference/operators/data-cleaning/filter.md
+++ b/docs/reference/operators/data-cleaning/filter.md
@@ -19,7 +19,7 @@
 
 ---
 title: "Filter"
-description: "Performs a filter operation using OR between multiple predicates"
+description: "Performs a filter operation using AND or OR between multiple predicates"
 category: "Data Cleaning"
 operator_type: "Filter"
 tags: [data-cleaning]
@@ -31,10 +31,11 @@ tags: [data-cleaning]
 
 | Property | Requirement | Type | Default | Description |
 |----------|-------------|------|---------|-------------|
-| Predicates | ✓ | List<Filter Predicate> | - | Multiple predicates in OR |
+| Predicates | ✓ | List<Filter Predicate> | - | Multiple predicates to be combined |
 | ↳ Attribute | ✓ | String | - |  |
 | ↳ Condition | ✓ | =, >, >=, <, <=, !=, is null,<br>is not null | - |  |
 | ↳ Value |  | String | - |  |
+| Combine Predicates With | ✓ | any (OR), all (AND) | any (OR) | How to combine multiple predicates |
 
 ### Output Ports
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request (PR)! Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: 
     [Contributing to Texera](https://github.com/apache/texera/blob/main/CONTRIBUTING.md)
  2. Ensure you have added or run the appropriate tests for your PR
  3. If the PR is work in progress, mark it a draft on GitHub.
  4. Please write your PR title to summarize what this PR proposes, we
    are following Conventional Commits style for PR titles as well:
      - `fix` is for behavior that worked before and no longer does; adding or
        removing a functionality, or reworking one so that user-facing behavior
        intentionally changes, is a `feat`; a change that leaves the user-facing
        behavior unchanged is a `refactor`.
      - A test-only PR is `test(<module>): ...`; repairing a broken test is
        `fix(test, <module>): ...`.
      - A dependency bump is `fix(deps, <module>): ...` when it patches a CVE
        and `chore(deps, <module>): ...` otherwise; GitHub Actions bumps take
        `ci` as their module, e.g. `chore(deps, ci): ...`.
      - A PR targeting a release branch appends the version as the last scope
        component, e.g. `fix(deps, frontend, v1.2): ...`.
    See CONTRIBUTING.md for the full convention.
  5. Be sure to keep the PR description updated to reflect all changes.
-->

### What changes were proposed in this PR?
The `Filter` operator hard-codes OR semantics — a tuple passes as soon as any one
predicate matches. Users who need AND (e.g. `age > 30 AND country = "US"`) have to
chain multiple `Filter` operators, which adds workflow clutter and an extra hop per
condition.

This PR makes the combination configurable:

- **New `PredicateCombinator` enum** (`OR` → `"any (OR)"`, `AND` → `"all (AND)"`),
  following the `@JsonValue` / `@JsonCreator` pattern already used by
  `ComparisonType` in the same package.
- **New `predicateCombinator` property** on `SpecializedFilterOpDesc`, defaulting to
  `OR`. The UI dropdown renders automatically from the JSON schema, so there are no
  frontend changes.
- **`SpecializedFilterOpExec`** now selects `forall` for AND and `exists` for OR.
- **Docs and descriptions** updated to stop claiming OR-only behavior.

**Backward compatibility:** the default is `OR`, and a stored descriptor without the
field deserializes to `OR`, so existing workflows behave exactly as before and no
migration is needed.

**One behavioral note for reviewers:** an empty predicate list continues to drop every
tuple in *both* modes. A bare `forall` returns `true` on an empty list, which would
have silently flipped an empty Filter from "drop everything" to "pass everything", so
the AND branch is guarded with `predicates.nonEmpty &&`. There is a test covering this.

Nested predicate trees (e.g. `(A AND B) OR C`) are intentionally out of scope — they
need more extensive UI work and are noted as a follow-up in the issue.
<!--
Please clarify what changes you are proposing. The purpose of this section 
is to outline the changes. Here are some tips for you:
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
  3. If it is a refactoring, clarify what has been changed.
  3. It would be helpful to include a before-and-after comparison using 
     screenshots or GIFs.
  4. Please consider writing useful notes for better and faster reviews.
-->


### Any related issues, documentation, discussions?
Closes #6939

Operator documentation updated in the same PR:
`docs/reference/operators/data-cleaning/filter.md`.
<!--
Please use this section to link other resources if not mentioned already.
  1. If this PR fixes an issue, please include `Fixes #1234`, `Resolves #1234`
     or `Closes #1234`. If it is only related, simply mention the issue number.
  2. If there is design documentation, please add the link.
  3. If there is a discussion in the mailing list, please add the link.
-->


### How was this PR tested?
New and updated unit tests, all run locally via
`sbt "WorkflowOperator/testOnly *filter*"` — 67 tests across 7 suites, all passing.

- **`PredicateCombinatorSpec`** (new): wire names via `getName`, case-insensitive
  `fromString`, rejection of an unknown name, and the Jackson round-trip.
- **`SpecializedFilterOpDescSpec`**: the property defaults to `OR`; a hand-written
  descriptor JSON with **no** `predicateCombinator` field deserializes to `OR`
  (this is the backward-compatibility claim above); an explicit `AND` survives the
  round-trip through the polymorphic `LogicalOp` base; `operatorInfo` advertises the
  new behavior.
- **`SpecializedFilterOpExecSpec`**: with two predicates where only one matches, OR
  keeps the tuple and AND drops it; AND keeps it when both match; AND with an empty
  predicate list drops everything; AND and OR agree on a single predicate. A
  `before` block resets the shared descriptor between tests so a mode set in one
  test cannot leak into the ones after it.

The empty-list guard was additionally verified by mutation: removing
`predicates.nonEmpty &&` from the executor makes exactly one test fail, confirming
the case is genuinely covered rather than incidentally passing.
<!--
If tests were added, say they were added here. Or simply mention that if the PR 
is tested with existing test cases.  Make sure to include/update test cases that
check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how
you tested step by step, ideally copy and paste-able, so that other reviewers can
test and check, and descendants can verify in the future. If tests were not added, 
please describe why they were not added and/or why it was difficult to add. 
-->


### Was this PR authored or co-authored using generative AI tooling?
Generated-by: Claude Code (Claude Opus 5)
<!--
If generative AI tooling has been used in the process of authoring this PR, 
please include the phrase: 'Generated-by: ' followed by the name of the tool 
and its version. If no, write 'No'. 
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
