### PR TITLE
feat(python): give a port that carried no rows its declared columns

### DIFF
--- a/amber/src/main/python/core/models/operator.py
+++ b/amber/src/main/python/core/models/operator.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from typing import Iterator, List, Mapping, Optional, Union, MutableMapping, Protocol
 
-from . import Table, TableLike, Tuple, TupleLike, Batch, BatchLike
+from . import Table, TableLike, Tuple, TupleLike, Batch, BatchLike, Schema
 from .state import State
 from .table import all_output_to_tuple
 
@@ -91,6 +91,23 @@ class Operator(ABC):
     @overrides.final
     def is_source(self, value: bool) -> None:
         self.__internal_is_source = value
+
+    __internal_input_schemas: Optional[MutableMapping[int, Schema]] = None
+
+    @property
+    @overrides.final
+    def input_schemas(self) -> MutableMapping[int, Schema]:
+        """
+        What each input port was declared to carry, keyed by port index and
+        written by the runtime before that port's data is handed over.
+
+        The tuples themselves say this too, so an operator only needs to ask
+        when there are none: a port can finish having carried no rows at all,
+        and its schema is then the only record of what its columns were.
+        """
+        if self.__internal_input_schemas is None:
+            self.__internal_input_schemas = {}
+        return self.__internal_input_schemas
 
     def open(self) -> None:
         """
@@ -276,7 +293,11 @@ class TableOperator(TupleOperatorV2):
         yield
 
     def on_finish(self, port: int) -> Iterator[Optional[TableLike]]:
-        table = Table(self.__table_data[port])
+        rows = self.__table_data[port]
+        schema = self.input_schemas.get(port)
+        # A port that carried no rows has no tuples to read column names off,
+        # and a table of no columns fails every operator that names one.
+        table = Table(rows) if rows or schema is None else Table.empty_of(schema)
         yield from self.process_table(table, port)
 
     @abstractmethod

--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -27,7 +27,7 @@ TableLike = TypeVar("TableLike", pandas.DataFrame, List[TupleLike])
 
 class Table(pandas.DataFrame):
     @staticmethod
-    def empty_of(schema) -> pandas.DataFrame:
+    def empty_of(schema) -> "Table":
         """
         The declared columns with no rows under them.
 
@@ -38,7 +38,9 @@ class Table(pandas.DataFrame):
         table. Building it through Arrow gives each column the dtype it would
         have had with rows in it.
         """
-        return pa.Table.from_pylist([], schema=schema.as_arrow_schema()).to_pandas()
+        return Table(
+            pa.Table.from_pylist([], schema=schema.as_arrow_schema()).to_pandas()
+        )
 
     @staticmethod
     def from_table(table):

--- a/amber/src/main/python/core/models/table.py
+++ b/amber/src/main/python/core/models/table.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import pandas
+import pyarrow as pa
 from pampy import match
 from typing import Iterator, TypeVar, List
 
@@ -25,6 +26,20 @@ TableLike = TypeVar("TableLike", pandas.DataFrame, List[TupleLike])
 
 
 class Table(pandas.DataFrame):
+    @staticmethod
+    def empty_of(schema) -> pandas.DataFrame:
+        """
+        The declared columns with no rows under them.
+
+        ``from_tuple_likes`` reads the column names off the tuples it is given,
+        so with none to read it produces a frame of no columns at all, and an
+        operator naming any of its own columns raises KeyError. A port that
+        carried no rows still has a schema, and this is what it looks like as a
+        table. Building it through Arrow gives each column the dtype it would
+        have had with rows in it.
+        """
+        return pa.Table.from_pylist([], schema=schema.as_arrow_schema()).to_pandas()
+
     @staticmethod
     def from_table(table):
         return table

--- a/amber/src/main/python/core/runnables/data_processor.py
+++ b/amber/src/main/python/core/runnables/data_processor.py
@@ -74,7 +74,21 @@ class DataProcessor(Runnable, Stoppable):
                 # Flush the state to MainLoop before producing tuples so the
                 # state and the tuple stream don't share a single switch.
                 self._switch_context()
+                self._declare_input_schema(executor, port_id)
                 self._set_output_tuple(executor.on_finish(port_id))
+
+    def _declare_input_schema(self, executor, port_id: int) -> None:
+        """
+        Tell the executor what the finishing port was declared to carry, so an
+        operator handed no rows can still say what its columns were. A source
+        has no input port to ask, so it is left alone.
+        """
+        port_identity = self._context.tuple_processing_manager.current_input_port_id
+        if port_identity is None:
+            return
+        executor.input_schemas[port_id] = self._context.input_manager.get_port(
+            port_identity
+        ).get_schema()
 
     def process_state(self, state: State) -> None:
         """

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -22,6 +22,7 @@ import pytest
 
 from core.models import (
     BatchOperator,
+    Schema,
     SourceOperator,
     State,
     Table,
@@ -385,6 +386,21 @@ class TestTableOperator:
         list(op.on_finish(port=0))
         assert len(op.received_tables) == 1
         assert list(op.received_tables[0].as_tuples()) == []
+
+    def test_on_finish_with_no_rows_keeps_the_declared_columns(self):
+        # The column names are read off the tuples, so a port that carried none
+        # left the operator a frame of no columns and every operator naming one
+        # of its own raised KeyError. The port's schema is the only record left.
+        op = _ConcreteTable()
+        op.input_schemas[0] = Schema(raw_schema={"x": "INTEGER", "y": "STRING"})
+
+        list(op.on_finish(port=0))
+
+        table = op.received_tables[0]
+        assert list(table.columns) == ["x", "y"]
+        assert table.empty
+        # The dtype each column would have had with rows under it.
+        assert table["x"].dtype == "int32"
 
     def test_buffers_are_keyed_by_port(self):
         # Each input port has its own tuple buffer; on_finish for one port

--- a/amber/src/test/python/core/models/test_operator.py
+++ b/amber/src/test/python/core/models/test_operator.py
@@ -397,6 +397,9 @@ class TestTableOperator:
         list(op.on_finish(port=0))
 
         table = op.received_tables[0]
+        # Still a Table, so an operator reading it with as_tuples() keeps working.
+        assert isinstance(table, Table)
+        assert list(table.as_tuples()) == []
         assert list(table.columns) == ["x", "y"]
         assert table.empty
         # The dtype each column would have had with rows under it.

--- a/amber/src/test/python/core/runnables/test_main_loop.py
+++ b/amber/src/test/python/core/runnables/test_main_loop.py
@@ -215,6 +215,10 @@ class TestMainLoop:
         # from `produce_state_on_finish` so EndChannel handling can be
         # observed.
         class StateProcessingExecutor:
+            # What Operator gives a real executor, for DataProcessor to record
+            # the finishing port's declared schema in.
+            input_schemas: dict = {}
+
             @staticmethod
             def process_tuple(tuple_, port):
                 yield tuple_


### PR DESCRIPTION
### What changes were proposed in this PR?

The runtime now tells an executor what each input port was declared to carry, and `TableOperator` falls back to that when a port finishes with no rows.

`Operator` gains an `input_schemas` mapping, keyed by port index. `DataProcessor` writes the finishing port's schema into it just before calling `on_finish`, reading it from the input manager's own port; a source has no input port to ask, so it is left alone. `TableOperator.on_finish` uses it only when there are no tuples to read column names off, which is the only case where the tuples do not already say the same thing. `Table.empty_of` builds that frame through Arrow, so each column carries the dtype it would have had with rows in it rather than object.

### Any related issues, documentation, discussions?

Found while building #8325, but not part of it: the bug is in the engine, not in
the export. The export's verification is what surfaced it, by running each
operator on a table with no rows, but it reaches Sort, the visualization
operators and any user-written `UDFTableOperator` in an ordinary run.

Closes #8487, the bug this change is the whole of.

### How was this PR tested?

A new case in `TestTableOperator`, `test_on_finish_with_no_rows_keeps_the_declared_columns`, gives a port an INTEGER and a STRING column, finishes it with no rows, and asserts the operator receives both columns, an empty frame, and `int32` for the integer one. Removing the fallback turns it red on the missing columns.

The rest of `amber/src/test/python/core` passes unchanged, 1107 tests. The one failure is `test_iceberg_rest_catalog_integration`, which needs a running catalog and fails the same way without this change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)




