### PR TITLE
feat(frontend): add a panel that opens a workflow's own record (Hackathon UP)

### DIFF
--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -138,6 +138,35 @@
             nzType="info-circle"></i>
         </button>
         <button
+          (click)="onClickSpy()"
+          [disabled]="!workflowId"
+          nz-button
+          title="spy: how this workflow was built, and which edit changed the results">
+          <svg
+            class="spy-boton-insignia"
+            viewBox="0 0 24 24"
+            width="15"
+            height="15"
+            fill="currentColor"
+            aria-hidden="true">
+            <path
+              d="M12 2.2c3.7 0 5.7 2 6.3 6.2 2 .3 3.2.9 3.2 1.6 0 1.1-4.3 2-9.5 2s-9.5-.9-9.5-2c0-.7 1.2-1.3 3.2-1.6C6.3 4.2 8.3 2.2 12 2.2z" />
+            <rect
+              x="2.4"
+              y="13.1"
+              width="8.3"
+              height="5.2"
+              rx="2.2" />
+            <rect
+              x="13.3"
+              y="13.1"
+              width="8.3"
+              height="5.2"
+              rx="2.2" />
+            <path d="M10.4 15.2h3.2v1.2h-3.2z" />
+          </svg>
+        </button>
+        <button
           *ngIf="pythonNotebookMigrationEnabled && (jupyterNotebookExists$ | async)"
           nz-button
           (click)="onClickExpandJupyterNotebookPanel()"

--- a/frontend/src/app/workspace/component/menu/menu.component.scss
+++ b/frontend/src/app/workspace/component/menu/menu.component.scss
@@ -215,3 +215,9 @@ texera-coeditor-user-icon {
   width: auto;
   vertical-align: -0.2em;
 }
+
+// The spy button carries its own inline SVG emblem rather than a library icon:
+// a fedora and a pair of dark glasses.
+.spy-boton-insignia {
+  vertical-align: -2px;
+}

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -71,6 +71,7 @@ import { NzSwitchComponent } from "ng-zorro-antd/switch";
 import { NzBadgeComponent } from "ng-zorro-antd/badge";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { JupyterPanelService } from "../../service/jupyter-panel/jupyter-panel.service";
+import { SpyComponent } from "../spy/spy.component";
 
 /**
  * MenuComponent is the top level menu bar that shows
@@ -624,6 +625,26 @@ export class MenuComponent implements OnInit, OnDestroy {
     // with TestBed instead of module-mocking the CommonJS file-saver package, which the unit-test
     // builder cannot hoist reliably.
     this.fileSaverService.saveAs(new Blob([workflowContentJson], { type: "text/plain;charset=utf-8" }), fileName);
+  }
+
+  /**
+   * Opens the spy case file: the footage of how this workflow was built, and
+   * the autopsy of which edit changed the results. The data is served by
+   * spy/server.py, which reads what Texera records without showing it.
+   */
+  public onClickSpy(): void {
+    this.modalService.create({
+      nzContent: SpyComponent,
+      nzData: { wid: this.workflowId },
+      nzWidth: "min(1400px, 94vw)",
+      // The panel owns the whole sheet: it draws its own rail, title bar and
+      // scrolling stage, so the modal gives it the surface and gets out of it.
+      nzBodyStyle: { padding: "0", borderRadius: "18px", overflow: "hidden" },
+      nzMaskClosable: true,
+      nzKeyboard: true,
+      nzClosable: true,
+      nzFooter: null,
+    });
   }
 
   /**

--- a/frontend/src/app/workspace/component/spy/spy.component.html
+++ b/frontend/src/app/workspace/component/spy/spy.component.html
@@ -1,0 +1,1723 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="spy">
+  <!-- The rail. Short nouns only; the question each view answers is its title. -->
+  <aside
+    class="spy-rail"
+    [class.folded]="!railOpen">
+    <div class="spy-mark">
+      <svg
+        class="spy-emblem"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true">
+        <path
+          d="M12 2.2c3.7 0 5.7 2 6.3 6.2 2 .3 3.2.9 3.2 1.6 0 1.1-4.3 2-9.5 2s-9.5-.9-9.5-2c0-.7 1.2-1.3 3.2-1.6C6.3 4.2 8.3 2.2 12 2.2z" />
+        <rect
+          x="2.4"
+          y="13.1"
+          width="8.3"
+          height="5.2"
+          rx="2.2" />
+        <rect
+          x="13.3"
+          y="13.1"
+          width="8.3"
+          height="5.2"
+          rx="2.2" />
+        <path d="M10.4 15.2h3.2v1.2h-3.2z" />
+      </svg>
+      <span class="spy-mark-name">Spy</span>
+      <button
+        type="button"
+        class="spy-fold"
+        [title]="railOpen ? 'Hide the sidebar' : 'Show the sidebar'"
+        [attr.aria-label]="railOpen ? 'Hide the sidebar' : 'Show the sidebar'"
+        [attr.aria-expanded]="railOpen"
+        (click)="toggleRail()">
+        <svg
+          viewBox="0 0 20 20"
+          fill="none"
+          aria-hidden="true">
+          <rect
+            x="2.5"
+            y="3.5"
+            width="15"
+            height="13"
+            rx="3" />
+          <path d="M8 3.5v13" />
+        </svg>
+      </button>
+    </div>
+
+    <nav class="spy-nav">
+      <ng-container *ngFor="let group of rail">
+        <p
+          class="spy-nav-group"
+          *ngIf="railOpen">
+          {{ group.group }}
+        </p>
+        <hr
+          class="spy-nav-split"
+          *ngIf="!railOpen" />
+        <button
+          type="button"
+          *ngFor="let item of group.items"
+          [class.on]="tab === item.id"
+          [title]="item.label"
+          (click)="show(item.id)">
+          <svg
+            class="spy-nav-icon"
+            viewBox="0 0 20 20"
+            fill="none"
+            aria-hidden="true">
+            <path
+              *ngFor="let d of item.icon"
+              [attr.d]="d" />
+          </svg>
+          <span *ngIf="railOpen">{{ item.label }}</span>
+        </button>
+      </ng-container>
+    </nav>
+
+    <p
+      class="spy-rail-foot"
+      *ngIf="railOpen">
+      Texera writes down every save and every run, and shows you neither. This opens both.
+    </p>
+  </aside>
+
+  <div class="spy-main">
+    <header class="spy-topbar">
+      <div class="spy-topbar-name">
+        <h3>{{ history?.name || "No workflow open" }}</h3>
+        <span
+          class="spy-state"
+          [ngClass]="'is-' + stateKind">
+          <i></i>{{ state }}
+        </span>
+      </div>
+
+      <dl class="spy-topbar-meta">
+        <div *ngIf="lastRun as r">
+          <dt>Last run</dt>
+          <dd>{{ r.name || "run " + r.eid }}</dd>
+        </div>
+        <div *ngIf="lastRun">
+          <dt>Took</dt>
+          <dd>{{ lastRunTook }}</dd>
+        </div>
+        <div *ngIf="history as h">
+          <dt>Runs</dt>
+          <dd>{{ runs.length }}</dd>
+        </div>
+        <div *ngIf="history as h">
+          <dt>Saves</dt>
+          <dd>{{ h.total }}</dd>
+        </div>
+      </dl>
+
+      <div class="spy-topbar-actions">
+        <label
+          class="spy-version"
+          *ngIf="frames.length">
+          <span>Version</span>
+          <select (change)="show('footage'); goTo(+$any($event.target).value)">
+            <option
+              *ngFor="let f of frames; index as i"
+              [value]="i"
+              [selected]="i === index">
+              {{ when(f.time) }}
+            </option>
+          </select>
+        </label>
+        <!-- The one button in the panel that does something instead of
+             reporting something, so it is the only filled one. -->
+        <button
+          type="button"
+          class="spy-run"
+          [disabled]="keeping"
+          (click)="show('autopsy'); runAndKeep()"
+          title="Runs the workflow and writes down every step's rows, which Texera would otherwise throw away 30 seconds later. Slower than the editor's Run button, because every step's output is kept, not just the last one.">
+          <span
+            class="spy-run-dot"
+            *ngIf="keeping"></span>
+          {{ keeping ? "Running" : "Run and keep rows" }}
+        </button>
+      </div>
+    </header>
+
+    <div class="spy-scroll">
+      <div
+        *ngIf="error"
+        class="spy-error">
+        {{ error }}
+      </div>
+
+      <h2 class="spy-title">{{ titles[tab] }}</h2>
+
+      <!-- ======================= how this workflow works ======================= -->
+      <section
+        class="spy-panel"
+        *ngIf="tab === 'brief'">
+        <p
+          *ngIf="loadingBrief"
+          class="spy-loading">
+          Reading the workflow…
+        </p>
+
+        <div *ngIf="brief as b">
+          <p
+            class="spy-headline"
+            *ngIf="tour.headline">
+            {{ tour.headline }}
+          </p>
+          <p
+            class="spy-headline-wait"
+            *ngIf="tourPending && !tour.headline">
+            Working out what this does…
+          </p>
+
+          <p
+            *ngIf="briefEmpty"
+            class="spy-note">
+            There is nothing on this canvas yet. Once it has a step or two, this is where what they do will be spelled
+            out.
+          </p>
+
+          <!-- The whole workflow as one picture: boxes for steps, pipes for data,
+           and every pipe as thick as the rows that run through it. -->
+          <!-- The stage: the drawing on bare paper, its inspector beside it. -->
+          <div class="spy-stage">
+            <div class="spy-stage-main">
+              <figure
+                class="spy-flowmap"
+                *ngIf="flowNodes.length">
+                <svg
+                  [attr.viewBox]="flowViewBox"
+                  preserveAspectRatio="xMidYMid meet">
+                  <path
+                    *ngFor="let pipe of flowPipes"
+                    [attr.d]="pipe.path"
+                    [attr.stroke-width]="pipe.width"
+                    class="spy-pipe" />
+                  <text
+                    *ngFor="let pipe of flowPipes"
+                    [attr.x]="pipe.midX"
+                    [attr.y]="pipe.midY"
+                    text-anchor="middle"
+                    class="spy-pipe-n">
+                    {{ count(pipe.rows) }}
+                  </text>
+                  <g
+                    *ngFor="let node of flowNodes"
+                    [ngClass]="['spy-map-node', 'spy-map-' + node.step.role, picked === node.step.id ? 'here' : '']"
+                    (click)="pickStep(node.step.id)">
+                    <title>{{ node.step.name }} · {{ node.step.type }}</title>
+                    <rect
+                      [attr.x]="node.x"
+                      [attr.y]="node.y"
+                      [attr.width]="nodeWidth"
+                      [attr.height]="nodeHeight"
+                      rx="3"
+                      class="spy-map-box"
+                      [attr.opacity]="node.step.disabled ? 0.45 : 1" />
+                    <svg
+                      [attr.x]="node.x + 12"
+                      [attr.y]="node.y + 12"
+                      width="22"
+                      height="22"
+                      viewBox="0 0 24 24">
+                      <path
+                        [attr.d]="node.glyph"
+                        class="spy-map-glyph" />
+                    </svg>
+                    <text
+                      [attr.x]="node.x + 44"
+                      [attr.y]="node.y + 26"
+                      class="spy-map-name">
+                      {{ node.step.name }}
+                    </text>
+                    <text
+                      [attr.x]="node.x + 44"
+                      [attr.y]="node.y + 48"
+                      class="spy-map-rows">
+                      {{ node.rows === null || node.rows === undefined ? "not measured" : count(node.rows) + " rows out"
+                      }}
+                    </text>
+                    <text
+                      *ngIf="node.drop"
+                      [attr.x]="node.x + nodeWidth - 10"
+                      [attr.y]="node.y + 48"
+                      text-anchor="end"
+                      class="spy-map-drop">
+                      −{{ count(node.drop) }}
+                    </text>
+                  </g>
+                </svg>
+                <figcaption>
+                  <span class="spy-key added">where data comes in</span>
+                  <span class="spy-key edited">where it ends up</span>
+                  <span class="spy-map-legend">
+                    <i class="thin"></i>
+                    <i class="thick"></i>
+                    the thicker the pipe, the more rows run through it
+                  </span>
+                </figcaption>
+              </figure>
+
+              <!-- The dials: what people in this workflow actually turn. -->
+              <div
+                class="spy-knobs"
+                *ngIf="b.knobs.length">
+                <h4>What people keep changing here</h4>
+                <ul>
+                  <li *ngFor="let knob of b.knobs">
+                    <button
+                      type="button"
+                      class="spy-knob-where"
+                      (click)="pickStep(knob.stepId)">
+                      <b>{{ knob.step }}</b>
+                      <span class="spy-muted">{{ knobLabel(knob) }}</span>
+                    </button>
+                    <span class="spy-chip-now">{{ knobValue(knob) || "—" }}</span>
+                    <span class="spy-knob-dots">
+                      <i
+                        *ngFor="let i of range(knob.times)"
+                        [class.tried]="knob.tried"></i>
+                    </span>
+                    <span class="spy-muted">{{ knob.times }} {{ knob.times === 1 ? "change" : "changes" }}</span>
+                  </li>
+                </ul>
+                <p class="spy-flow-lead">
+                  Every other setting has been left alone since it was written. A filled dot means that value was run,
+                  not only saved.
+                </p>
+              </div>
+            </div>
+
+            <!-- One step at a time: the flow is walked, not read all at once. -->
+            <div
+              class="spy-picked"
+              *ngIf="pickedStep as step">
+              <p class="spy-picked-kicker">Step inspector</p>
+              <div class="spy-picked-head">
+                <svg
+                  class="spy-picked-glyph"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true">
+                  <path [attr.d]="glyphForKind(kindOfStep(step))" />
+                </svg>
+                <div>
+                  <h4>{{ step.name }}</h4>
+                  <span class="spy-muted"
+                    >{{ roleWord(step) }}<span *ngIf="feedersOf(step)"> · {{ feedersOf(step) }}</span></span
+                  >
+                </div>
+                <div class="spy-picked-walk">
+                  <button
+                    type="button"
+                    class="spy-transport"
+                    title="the step before"
+                    [disabled]="pickedAt <= 0"
+                    (click)="stepAlong(-1)">
+                    <svg
+                      class="spy-glyph"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      aria-hidden="true">
+                      <path d="M15 5v14l-9-7z" />
+                    </svg>
+                  </button>
+                  <span class="spy-muted">{{ pickedAt + 1 }} of {{ steps.length }}</span>
+                  <button
+                    type="button"
+                    class="spy-transport"
+                    title="the next step"
+                    [disabled]="pickedAt >= steps.length - 1"
+                    (click)="stepAlong(1)">
+                    <svg
+                      class="spy-glyph"
+                      viewBox="0 0 24 24"
+                      fill="currentColor"
+                      aria-hidden="true">
+                      <path d="M9 5v14l9-7z" />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+
+              <p
+                class="spy-picked-said"
+                *ngIf="stepTold(step.id)">
+                {{ stepTold(step.id) }}
+              </p>
+
+              <!-- What it did to the data, drawn: in on top, out underneath. -->
+              <div
+                class="spy-picked-volume"
+                *ngIf="step.rowsOut !== null && step.rowsOut !== undefined">
+                <span
+                  class="spy-bar earlier"
+                  *ngIf="hasInput(step)">
+                  <span
+                    class="spy-fill"
+                    [style.width.%]="inBar(step)"></span>
+                  <span class="spy-bar-n">{{ count(step.rowsIn || 0) }} in</span>
+                </span>
+                <span class="spy-bar later">
+                  <span
+                    class="spy-fill"
+                    [style.width.%]="outBar(step)"></span>
+                  <span class="spy-bar-n">{{ count(step.rowsOut) }} out</span>
+                </span>
+                <span class="spy-picked-keeps">{{ keepsOf(step) }}</span>
+              </div>
+
+              <ul class="spy-setting-list">
+                <li *ngFor="let setting of settingsOf(step)">
+                  <span class="spy-setting-label">{{ setting.label }}</span>
+                  <span [ngClass]="setting.big ? 'spy-setting-big' : 'spy-setting-value'">{{ setting.text }}</span>
+                </li>
+                <li
+                  *ngIf="settingsOf(step).length === 0"
+                  class="spy-muted">
+                  nothing set: it does the same thing every time
+                </li>
+              </ul>
+
+              <div
+                class="spy-picked-rows"
+                *ngIf="step.sample.length">
+                <table class="spy-grid">
+                  <thead>
+                    <tr>
+                      <th *ngFor="let col of columns(step.sample)">{{ col }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr *ngFor="let row of step.sample">
+                      <td *ngFor="let col of columns(step.sample)">{{ cell(row, col) }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <p
+                  class="spy-muted"
+                  *ngIf="b.sampleFrom as from">
+                  A few of its rows, kept from the run {{ from.name || "number " + from.eid }}.
+                  <span *ngIf="!from.current">That run did not use the settings the workflow has today.</span>
+                </p>
+              </div>
+
+              <p class="spy-picked-foot">
+                <span *ngIf="step.edits"
+                  >changed {{ step.edits }} {{ step.edits === 1 ? "time" : "times" }}<span *ngIf="step.lastEdited"
+                    >, last {{ when(step.lastEdited) }}</span
+                  ></span
+                >
+                <span *ngIf="!step.edits">never changed since it was added</span>
+                <button
+                  type="button"
+                  class="spy-quiet"
+                  (click)="rewindTo(step.id); show('footage')">
+                  see what was changed
+                </button>
+                <span
+                  class="spy-off-tag"
+                  *ngIf="step.disabled"
+                  >switched off</span
+                >
+              </p>
+            </div>
+
+            <p
+              class="spy-stage-hint"
+              *ngIf="!pickedStep && flowNodes.length">
+              Pick a step in the drawing to open it here.
+            </p>
+          </div>
+
+          <!-- The numbers, and then the prose, in that order and folded. -->
+          <div class="spy-band">
+            <div
+              class="spy-figures"
+              *ngIf="briefFigures.length">
+              <div
+                class="spy-figure"
+                *ngFor="let f of briefFigures"
+                [ngClass]="'spy-figure-' + f.tone">
+                <span class="spy-figure-value">{{ f.value }}</span>
+                <span class="spy-figure-label">{{ f.label }}</span>
+              </div>
+            </div>
+          </div>
+
+          <p
+            class="spy-note spy-caution"
+            *ngIf="tour.watchOut">
+            <b>Before you touch anything:</b>&ngsp;{{ tour.watchOut }}
+          </p>
+
+          <p class="spy-disclosure">
+            <button
+              type="button"
+              (click)="unfold('purpose')">
+              {{ isUnfolded("purpose") ? "Hide the written version" : "Read it in words instead" }}
+            </button>
+          </p>
+          <div
+            class="spy-reading"
+            *ngIf="isUnfolded('purpose')">
+            <p *ngIf="tour.purpose">{{ tour.purpose }}</p>
+            <p class="spy-muted">{{ pulseLine }} {{ whoLine }}</p>
+            <p
+              class="spy-warn"
+              *ngIf="b.record.broken">
+              Part of the record cannot be read back: {{ b.record.unreadable }} of the {{ b.record.saves }} saved
+              versions are lost, so how this workflow started is not recoverable.
+            </p>
+            <p class="spy-source">
+              The steps, their settings and their row counts were read from Texera's own record: the saved versions of
+              the canvas and the statistics it keeps for every run. The sentences are written from those facts and
+              nothing else.
+            </p>
+          </div>
+
+          <ng-container *ngTemplateOutlet="askBox"></ng-container>
+        </div>
+      </section>
+
+      <!-- ======================= edit history ======================= -->
+      <section
+        class="spy-panel"
+        *ngIf="tab === 'footage'">
+        <p
+          *ngIf="loadingHistory"
+          class="spy-loading">
+          Loading version history…
+        </p>
+
+        <div *ngIf="history as h">
+          <div class="spy-band">
+            <div
+              class="spy-figures"
+              *ngIf="recordFigures.length">
+              <div
+                class="spy-figure"
+                *ngFor="let h of recordFigures"
+                [ngClass]="'spy-figure-' + h.tone">
+                <span class="spy-figure-value">{{ h.value }}</span>
+                <span class="spy-figure-label">{{ h.label }}</span>
+              </div>
+            </div>
+
+            <!-- The workflow's shape as boxes, so its size is seen and not read. -->
+            <div
+              class="spy-shape"
+              *ngIf="shapeCounts as s">
+              <div class="spy-shape-group">
+                <span class="spy-boxes">
+                  <i *ngFor="let i of range(s.sources)"></i>
+                </span>
+                <span class="spy-shape-label">{{ s.sources }} {{ s.sources === 1 ? "source" : "sources" }}</span>
+              </div>
+              <svg
+                class="spy-shape-arrow"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true">
+                <path d="M4 11h11V7.2L20 12l-5 4.8V13H4z" />
+              </svg>
+              <div
+                class="spy-shape-group"
+                *ngIf="s.middle > 0">
+                <span class="spy-boxes">
+                  <i *ngFor="let i of range(s.middle)"></i>
+                </span>
+                <span class="spy-shape-label">{{ s.middle }} {{ s.middle === 1 ? "step" : "steps" }} in between</span>
+              </div>
+              <svg
+                class="spy-shape-arrow"
+                *ngIf="s.middle > 0"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true">
+                <path d="M4 11h11V7.2L20 12l-5 4.8V13H4z" />
+              </svg>
+              <div class="spy-shape-group">
+                <span class="spy-boxes">
+                  <i *ngFor="let i of range(s.outputs)"></i>
+                </span>
+                <span class="spy-shape-label">{{ s.outputs }} {{ s.outputs === 1 ? "output" : "outputs" }}</span>
+              </div>
+            </div>
+          </div>
+
+          <p class="spy-story">{{ story }}</p>
+
+          <div
+            class="spy-reading"
+            *ngIf="reading.footage">
+            <h4>How this workflow came to be</h4>
+            <div class="spy-reading-body">
+              <p *ngFor="let part of paragraphs(reading.footage)">{{ part }}</p>
+            </div>
+
+            <p class="spy-source">
+              Written from the edits listed below. Every edit it names was rebuilt from Texera's own saved patches.
+            </p>
+          </div>
+          <p
+            class="spy-reading-wait"
+            *ngIf="readingPending.footage">
+            Reading the record…
+          </p>
+
+          <p
+            *ngIf="h.tolerated"
+            class="spy-method">
+            Texera's own record asks {{ h.tolerated === 1 ? "once" : h.tolerated + " times" }} to undo something that
+            was no longer there. Those moments were rebuilt anyway: taking away what is already gone leaves the very
+            same canvas, and every version here still matches what Texera itself returns.
+          </p>
+
+          <p
+            *ngIf="h.broken"
+            class="spy-warn spy-method">
+            Part of the record is unreadable: {{ h.recovered }} of the {{ h.total }} saved versions could be rebuilt,
+            and everything before {{ when(brokenTime) }} is lost. Texera's own "restore this version" cannot reach it
+            either.
+          </p>
+
+          <p class="spy-disclosure">
+            <button
+              type="button"
+              (click)="showMethod = !showMethod">
+              {{ showMethod ? "Hide how this is worked out" : "How is this worked out?" }}
+            </button>
+          </p>
+          <p
+            *ngIf="showMethod"
+            class="spy-method">
+            Texera never stores what a version looked like. It stores the difference between each version and the next
+            one, backwards. To show you a moment, this panel starts from today's canvas and undoes those differences one
+            at a time, which is the same thing the product does when you restore an old version.
+          </p>
+
+          <div class="spy-controls">
+            <div class="spy-transport-group">
+              <button
+                type="button"
+                class="spy-transport"
+                title="previous version (←)"
+                [disabled]="index === 0"
+                (click)="previous()">
+                <svg
+                  class="spy-glyph"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true">
+                  <path d="M11 5v14l-9-7zM22 5v14l-9-7z" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="spy-transport"
+                [title]="playing ? 'pause (space)' : 'play through every version (space)'"
+                (click)="play()">
+                <svg
+                  class="spy-glyph"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true">
+                  <path
+                    *ngIf="!playing"
+                    d="M6 4l14 8-14 8z" />
+                  <path
+                    *ngIf="playing"
+                    d="M6 4h4v16H6zM14 4h4v16h-4z" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                class="spy-transport"
+                title="next version (→)"
+                [disabled]="index === last"
+                (click)="next()">
+                <svg
+                  class="spy-glyph"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true">
+                  <path d="M2 5v14l9-7zM13 5v14l9-7z" />
+                </svg>
+              </button>
+            </div>
+
+            <div class="spy-tape">
+              <button
+                type="button"
+                *ngFor="let b of tape"
+                class="spy-block"
+                [ngClass]="[b.tone, b.index === index ? 'here' : '']"
+                [title]="b.label"
+                (click)="onScrub(b.index)">
+                <span
+                  class="spy-ran"
+                  *ngIf="b.ran"></span>
+              </button>
+            </div>
+
+            <div
+              class="spy-position"
+              *ngIf="frame as f">
+              <span class="spy-vid">{{ when(f.time) }}</span>
+              <span class="spy-count">{{ index + 1 }} of {{ frames.length }}</span>
+            </div>
+          </div>
+
+          <p class="spy-legend">
+            <span class="spy-key-word">Each block is one save:</span>
+            <span class="spy-swatch added">a step appeared</span>
+            <span class="spy-swatch removed">a step went away</span>
+            <span class="spy-swatch edited">a setting changed</span>
+            <span class="spy-swatch quiet">nothing changed</span>
+            <span class="spy-swatch ran">you ran it here</span>
+          </p>
+
+          <p
+            class="spy-caption"
+            *ngIf="frame as f">
+            <b>{{ headline }}</b>
+            <span class="spy-muted">{{ sincePrevious }}</span>
+            <span
+              class="spy-muted"
+              *ngIf="f.runs.length">
+              · you ran the workflow from here
+            </span>
+            <button
+              type="button"
+              class="spy-quiet"
+              *ngIf="hiddenCount > 0 || showEverySave"
+              (click)="toggleEverySave()">
+              {{ showEverySave ? "hide saves that changed nothing" : hiddenCount === 1 ? "1 save that changed nothing is
+              hidden" : hiddenCount + " saves that changed nothing are hidden" }}
+            </button>
+          </p>
+
+          <div class="spy-columns">
+            <figure class="spy-canvas">
+              <div class="spy-canvas-head">
+                <span>The canvas at that moment</span>
+                <span class="spy-muted"
+                  >{{ boxes.length }} {{ boxes.length === 1 ? "operator" : "operators" }} · {{ arrows.length }} {{
+                  arrows.length === 1 ? "link" : "links" }}</span
+                >
+              </div>
+              <svg
+                [attr.viewBox]="viewBox"
+                preserveAspectRatio="xMidYMid meet">
+                <defs>
+                  <marker
+                    id="spy-arrowhead"
+                    markerWidth="7"
+                    markerHeight="7"
+                    refX="6.5"
+                    refY="2.5"
+                    orient="auto">
+                    <path
+                      d="M0,0 L6.5,2.5 L0,5 z"
+                      fill="#8c8c8c" />
+                  </marker>
+                </defs>
+                <rect
+                  *ngFor="let g of ghosts"
+                  [attr.x]="g.x"
+                  [attr.y]="g.y"
+                  [attr.width]="boxWidth"
+                  [attr.height]="boxHeight"
+                  rx="2"
+                  class="spy-ghost" />
+                <line
+                  *ngFor="let a of arrows"
+                  [attr.x1]="a.x1"
+                  [attr.y1]="a.y1"
+                  [attr.x2]="a.x2"
+                  [attr.y2]="a.y2"
+                  class="spy-edge"
+                  marker-end="url(#spy-arrowhead)" />
+                <g
+                  *ngFor="let b of boxes"
+                  class="spy-node"
+                  (click)="focus(b.op.id)">
+                  <title>{{ b.note }}</title>
+                  <rect
+                    [attr.x]="b.x"
+                    [attr.y]="b.y"
+                    [attr.width]="boxWidth"
+                    [attr.height]="boxHeight"
+                    rx="2"
+                    [attr.class]="'spy-box spy-box-' + b.mark + (focused === b.op.id ? ' spy-box-focused' : '')"
+                    [attr.opacity]="b.op.disabled ? 0.4 : 1" />
+                  <text
+                    [attr.x]="b.x + 10"
+                    [attr.y]="b.y + 20"
+                    class="spy-box-name">
+                    {{ b.op.name }}
+                  </text>
+                  <text
+                    [attr.x]="b.x + 10"
+                    [attr.y]="b.y + 34"
+                    class="spy-box-id">
+                    {{ b.op.id }}
+                  </text>
+                </g>
+              </svg>
+              <figcaption>
+                <span class="spy-key added">added at this point</span>
+                <span class="spy-key edited">edited at this point</span>
+                <span class="spy-key plain">unchanged</span>
+                <span class="spy-key ghost">not built yet</span>
+              </figcaption>
+            </figure>
+
+            <aside
+              class="spy-log"
+              *ngIf="frame as f">
+              <h4>What you did</h4>
+
+              <p
+                class="spy-filter"
+                *ngIf="focused">
+                <span>Only what you did to <b>{{ nameOf(focused) }}</b></span>
+                <button
+                  type="button"
+                  (click)="focus(focused)">
+                  show all
+                </button>
+              </p>
+
+              <p
+                *ngIf="!f.recoverable"
+                class="spy-warn">
+                This moment is lost. Texera saved it in a way that can no longer be read back, and its own restore
+                cannot reach it either.
+              </p>
+              <p
+                *ngIf="f.recoverable && f.changes.length === 0 && index > 0"
+                class="spy-muted">
+                Nothing changed on the canvas here. Texera saves by itself every so often, even when you have not
+                touched anything.
+              </p>
+              <p
+                *ngIf="f.recoverable && index === 0"
+                class="spy-muted">
+                The empty canvas you started from.
+              </p>
+              <p
+                *ngIf="focused && log.length === 0 && f.changes.length > 0"
+                class="spy-muted">
+                You did not touch {{ nameOf(focused) }} at this moment.
+              </p>
+
+              <ul>
+                <li
+                  *ngFor="let entry of toldLog"
+                  [ngClass]="['spy-c-' + entry.change.kind, toneOf(entry.change.kind)]"
+                  [title]="entry.told.detail">
+                  <svg
+                    class="spy-chip"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    aria-hidden="true">
+                    <path [attr.d]="glyphOf(entry.change.kind)" />
+                  </svg>
+                  <span class="spy-said">
+                    {{ entry.told.lead }}
+                    <span
+                      class="spy-was"
+                      *ngIf="entry.told.before !== undefined"
+                      >{{ entry.told.before }}</span
+                    >&ngsp;<span *ngIf="entry.told.join">{{ entry.told.join }}</span>&ngsp;<span
+                      class="spy-now"
+                      *ngIf="entry.told.after !== undefined"
+                      >{{ entry.told.after }}</span
+                    >
+                  </span>
+                </li>
+              </ul>
+
+              <div
+                class="spy-runs"
+                *ngIf="f.runs.length">
+                <h4>You ran it from here</h4>
+                <ul>
+                  <li *ngFor="let r of f.runs">{{ when(r.started) }} · {{ r.status }}</li>
+                </ul>
+              </div>
+            </aside>
+          </div>
+
+          <p class="spy-help">
+            Click an operator to follow only that one. The arrow keys move through time, space plays it back, and the
+            blue marks under the timeline are the moments you ran the workflow.
+          </p>
+
+          <ng-container *ngTemplateOutlet="askBox"></ng-container>
+        </div>
+      </section>
+
+      <!-- ======================= what has been tried ======================= -->
+      <section
+        class="spy-panel"
+        *ngIf="tab === 'experiments'">
+        <p class="spy-lead">
+          Every run of this workflow, with the settings it was run at. Texera throws the results away, but it keeps the
+          counts, so runs from weeks ago can still be read.
+        </p>
+
+        <p
+          *ngIf="loadingExperiments"
+          class="spy-loading">
+          Reading every run…
+        </p>
+
+        <div *ngIf="experiments as e">
+          <div
+            class="spy-figures"
+            *ngIf="e.runs.length">
+            <div class="spy-figure spy-figure-flat">
+              <span class="spy-figure-value">{{ count(e.runs.length) }}</span>
+              <span class="spy-figure-label">{{ e.runs.length === 1 ? "run" : "runs" }} on record</span>
+            </div>
+            <div class="spy-figure spy-figure-flat">
+              <span class="spy-figure-value">{{ count(distinctRuns) }}</span>
+              <span class="spy-figure-label">of them different from each other</span>
+            </div>
+            <div class="spy-figure spy-figure-flat">
+              <span class="spy-figure-value">{{ count(knobs.length) }}</span>
+              <span class="spy-figure-label"
+                >{{ knobs.length === 1 ? "setting" : "settings" }} tried at more than one value</span
+              >
+            </div>
+          </div>
+
+          <!-- How the runs moved, run after run. A run that produced nothing is
+           not a low point on the line: the line stops, and picks up after. -->
+          <div
+            class="spy-trends"
+            *ngIf="trends.length">
+            <div
+              class="spy-trend"
+              *ngFor="let t of trends">
+              <div class="spy-trend-head">
+                <span class="spy-trend-label">{{ t.label }}</span>
+                <span class="spy-trend-now">{{ t.latest }}</span>
+                <span
+                  class="spy-trend-change"
+                  [ngClass]="'is-' + (t.verdict || 'plain')">
+                  {{ t.change }}
+                </span>
+              </div>
+              <svg
+                class="spy-plot"
+                [attr.viewBox]="'0 0 ' + trendW + ' ' + trendH"
+                aria-hidden="true">
+                <polyline
+                  *ngFor="let line of t.segments"
+                  [attr.points]="line" />
+                <circle
+                  *ngFor="let dot of t.dots"
+                  [attr.cx]="dot.x"
+                  [attr.cy]="dot.y"
+                  [attr.r]="dot.empty ? 3.2 : 2.6"
+                  [class.empty]="dot.empty"
+                  [class.last]="dot === t.dots[t.dots.length - 1]">
+                  <title>{{ dot.label }} · {{ dot.empty ? "produced nothing" : dot.value }}</title>
+                </circle>
+              </svg>
+              <p class="spy-trend-foot">{{ t.dots.length }} runs, from {{ t.low }} to {{ t.high }}</p>
+            </div>
+          </div>
+
+          <p
+            *ngIf="e.runs.length === 0"
+            class="spy-note">
+            This workflow has never been run, so there is nothing to compare yet.
+          </p>
+
+          <p
+            *ngIf="e.runs.length && knobs.length === 0"
+            class="spy-note">
+            Every run used exactly the same settings. Whatever differs between these runs, it is not something anyone
+            typed into the canvas.
+          </p>
+
+          <!-- One dial at a time: every value it was run at, and what came out. -->
+          <div
+            class="spy-dials"
+            *ngIf="dials.length">
+            <div
+              class="spy-dial"
+              *ngFor="let dial of dials">
+              <div class="spy-dial-head">
+                <b>{{ dial.knob.step }}</b>
+                <span class="spy-muted">{{ knobLabel(dial.knob) }}</span>
+              </div>
+              <ol class="spy-dial-values">
+                <li *ngFor="let value of dial.values">
+                  <span class="spy-dial-value">{{ value.text }}</span>
+                  <span class="spy-bar later">
+                    <span class="spy-dial-track">
+                      <span
+                        class="spy-fill spy-fill-spread"
+                        [style.width.%]="value.bar"></span>
+                      <span
+                        class="spy-fill"
+                        [style.width.%]="value.floor"></span>
+                    </span>
+                    <span class="spy-bar-n"
+                      >{{ value.mixed ? count(value.low) + "–" + count(value.high) : count(value.high) }} out</span
+                    >
+                  </span>
+                  <span class="spy-dial-runs">
+                    <i
+                      *ngFor="let i of range(value.runs - value.empty)"
+                      class="tried"></i>
+                    <i *ngFor="let i of range(value.empty)"></i>
+                    <span class="spy-muted"
+                      >{{ value.runs }} {{ value.runs === 1 ? "run" : "runs" }}<span *ngIf="value.empty"
+                        >, {{ value.empty }} empty</span
+                      ></span
+                    >
+                  </span>
+                </li>
+              </ol>
+              <p class="spy-dial-verdict">{{ dial.verdict }}</p>
+            </div>
+          </div>
+
+          <!-- What was tried, which is a shorter list than what was run. -->
+          <table
+            class="spy-table spy-trials"
+            *ngIf="trials.length">
+            <caption>
+              One row per experiment, oldest first. The columns in between are the only settings that were not the same
+              in every run; everything else was left alone. Running the same settings again is the same experiment, and
+              is counted here rather than repeated.
+            </caption>
+            <thead>
+              <tr>
+                <th
+                  scope="col"
+                  *ngFor="let knob of knobs">
+                  {{ knob.step }}
+                  <span class="spy-id">{{ knobLabel(knob) }}</span>
+                </th>
+                <th scope="col">when it was run</th>
+                <th
+                  scope="col"
+                  class="num">
+                  rows out
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                *ngFor="let trial of trials"
+                [class.spy-empty-trial]="trial.produced === 0">
+                <td *ngFor="let value of trial.values">
+                  <span class="spy-setting-value">{{ value.text }}</span>
+                </td>
+                <td class="spy-muted">{{ trialWhen(trial.runs) }}</td>
+                <td class="num">
+                  <span class="spy-bar later spy-bar-inline">
+                    <span
+                      class="spy-fill"
+                      [style.width.%]="trialBar(trial.produced)"></span>
+                    <span class="spy-bar-n">{{ count(trial.produced) }}</span>
+                  </span>
+                  <span
+                    class="spy-nothing"
+                    *ngIf="trial.produced === 0"
+                    >nothing came out of this one</span
+                  >
+                </td>
+              </tr>
+            </tbody>
+          </table>
+
+          <p
+            class="spy-disclosure"
+            *ngIf="e.runs.length">
+            <button
+              type="button"
+              (click)="showEveryRun = !showEveryRun">
+              {{ showEveryRun ? "Hide the run log" : "Show every run, one by one" }}
+            </button>
+          </p>
+
+          <table
+            class="spy-table spy-trials"
+            *ngIf="e.runs.length && showEveryRun">
+            <caption>
+              Every run, oldest first. A run in grey repeats an earlier experiment exactly. To compare two of them row
+              by row, open "Why did my results change?".
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">run</th>
+                <th scope="col">when</th>
+                <th
+                  scope="col"
+                  *ngFor="let knob of knobs">
+                  {{ knob.step }}
+                  <span class="spy-id">{{ knobLabel(knob) }}</span>
+                </th>
+                <th
+                  scope="col"
+                  class="num">
+                  rows out
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <ng-container *ngFor="let row of experimentRows">
+                <tr
+                  class="spy-move-row"
+                  *ngIf="moveText(row.move)">
+                  <td [attr.colspan]="knobs.length + 3">
+                    <span class="spy-move">changed in between · {{ moveText(row.move) }}</span>
+                  </td>
+                </tr>
+                <tr [class.spy-repeat]="row.repeatOf !== undefined && row.repeatOf !== row.run.eid">
+                  <td>
+                    {{ row.run.name || "unnamed run" }}
+                    <span class="spy-id">{{ row.run.who }}</span>
+                    <span
+                      class="spy-off-tag"
+                      *ngIf="row.run.status !== 'completed'"
+                      >{{ row.run.status }}</span
+                    >
+                  </td>
+                  <td class="spy-muted">{{ when(row.run.started) }}</td>
+                  <td *ngFor="let value of row.values">
+                    <span [class.spy-chip-now]="value.changed">{{ value.text }}</span>
+                  </td>
+                  <td class="num">
+                    <span class="spy-bar later spy-bar-inline">
+                      <span
+                        class="spy-fill"
+                        [style.width.%]="row.bar"></span>
+                      <span class="spy-bar-n">{{ count(row.run.produced) }}</span>
+                    </span>
+                  </td>
+                </tr>
+              </ng-container>
+            </tbody>
+          </table>
+
+          <ng-container *ngTemplateOutlet="askBox"></ng-container>
+        </div>
+      </section>
+
+      <!-- ======================= run comparison ======================= -->
+      <section
+        class="spy-panel"
+        *ngIf="tab === 'autopsy'">
+        <p class="spy-lead">
+          Pick two runs and this will tell you where their results start to disagree, and what you changed in between.
+        </p>
+
+        <p class="spy-disclosure">
+          <button
+            type="button"
+            (click)="showMethod = !showMethod">
+            {{ showMethod ? "Hide how this is worked out" : "How is this worked out?" }}
+          </button>
+        </p>
+        <p
+          *ngIf="showMethod"
+          class="spy-method">
+          The two runs are compared one step at a time, following the flow from the sources onwards. The first step
+          whose output is not identical is where the difference entered; everything after it only carries it along. The
+          settings of both versions are then compared to see what you changed in between.
+        </p>
+
+        <div class="spy-controls spy-controls-compare">
+          <label>
+            <span>The earlier run</span>
+            <select
+              class="spy-select"
+              (change)="eidA = +$any($event.target).value">
+              <option
+                *ngFor="let r of comparable"
+                [value]="r.eid"
+                [selected]="r.eid === eidA">
+                {{ runLabel(r) }}
+              </option>
+            </select>
+          </label>
+          <label>
+            <span>The later run</span>
+            <select
+              class="spy-select"
+              (change)="eidB = +$any($event.target).value">
+              <option
+                *ngFor="let r of comparable"
+                [value]="r.eid"
+                [selected]="r.eid === eidB">
+                {{ runLabel(r) }}
+              </option>
+            </select>
+          </label>
+          <button
+            type="button"
+            class="spy-primary"
+            [disabled]="eidA === undefined || eidB === undefined || eidA === eidB"
+            (click)="compare()">
+            Compare
+          </button>
+        </div>
+
+        <p
+          *ngIf="keepingStep"
+          class="spy-loading">
+          {{ keepingStep }}
+        </p>
+        <p
+          *ngIf="keptError"
+          class="spy-note spy-warn">
+          {{ keptError }}
+        </p>
+        <p
+          *ngIf="kept?.kept && !keeping"
+          class="spy-note">
+          Kept run {{ kept?.eid }}: {{ kept?.steps }} steps, {{ count(kept?.rows ?? 0) }} rows written down. It is the
+          later side of the comparison below.
+        </p>
+
+        <p
+          *ngIf="comparable.length < 2"
+          class="spy-note">
+          This needs two runs whose rows were kept, and this workflow has {{ comparable.length }}. Texera throws a run's
+          results away 30 seconds after you stop working on the workflow, so by the time you want to compare them they
+          are already gone. Press "Run and keep rows" at the top to make one that survives. The runs above it are still
+          on record, with their row counts, under "What has been tried?".
+        </p>
+
+        <p
+          *ngIf="loadingAutopsy"
+          class="spy-loading">
+          Looking for where they disagree…
+        </p>
+
+        <div *ngIf="autopsy as a">
+          <!-- The answer in two columns: what happened on the left, what caused it
+           on the right, so the panel's width carries something. -->
+          <div class="spy-answer">
+            <div class="spy-answer-main">
+              <p
+                class="spy-headline"
+                *ngIf="narration.headline">
+                {{ narration.headline }}
+              </p>
+              <p
+                class="spy-headline-wait"
+                *ngIf="narrationPending && !narration.headline">
+                Reading the two runs…
+              </p>
+
+              <div
+                class="spy-summary"
+                [class.clean]="!a.firstDivergent">
+                <div
+                  class="spy-figures"
+                  *ngIf="figures.length">
+                  <div
+                    class="spy-figure"
+                    *ngFor="let h of figures"
+                    [ngClass]="'spy-figure-' + h.tone">
+                    <span class="spy-figure-value">{{ h.value }}</span>
+                    <span class="spy-figure-label">{{ h.label }}</span>
+                  </div>
+                </div>
+
+                <p>{{ verdict }}</p>
+                <p *ngIf="blame">{{ blame }}</p>
+              </div>
+            </div>
+            <aside class="spy-answer-side">
+              <!-- The edit itself, drawn: what the dial said before, and after. -->
+              <div class="spy-swaps-card">
+                <h4>What you changed in between</h4>
+                <p
+                  *ngIf="a.edits.length === 0"
+                  class="spy-muted">
+                  Nothing on the canvas. If the results still differ, the cause is somewhere else: the incoming data, a
+                  random draw, or the engine itself.
+                </p>
+                <ul class="spy-swaps">
+                  <li
+                    *ngFor="let e of a.edits"
+                    [class.blamed]="e.operatorId === a.firstDivergent">
+                    <span class="spy-swap-where">
+                      <b>{{ opName(e.operatorId) }}</b>
+                      <span class="spy-muted">{{ settingLabel(e) }}</span>
+                    </span>
+                    <span class="spy-swap-pair">
+                      <span class="spy-chip-was">{{ said(e.before) }}</span>
+                      <svg
+                        class="spy-swap-arrow"
+                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                        aria-hidden="true">
+                        <path d="M4 11h11V7.2L20 12l-5 4.8V13H4z" />
+                      </svg>
+                      <span class="spy-chip-now">{{ said(e.after) }}</span>
+                    </span>
+                    <span
+                      class="spy-swap-tag"
+                      *ngIf="e.operatorId === a.firstDivergent"
+                      >this is the one</span
+                    >
+                  </li>
+                </ul>
+              </div>
+            </aside>
+          </div>
+
+          <!-- The data, drawn: two bars per step say it before any number does. -->
+          <div
+            class="spy-flow"
+            *ngIf="pipeline.length">
+            <div class="spy-flow-head">
+              <h4>What it did to your data</h4>
+              <span class="spy-runkeys">
+                <span class="spy-runkey earlier">{{ earlierName }}</span>
+                <span class="spy-runkey later">{{ laterName }}</span>
+              </span>
+            </div>
+            <p class="spy-flow-lead">
+              Each bar is how many rows came out of that step. The data flows downwards, from the sources to the
+              outputs.
+            </p>
+            <ol class="spy-steps">
+              <li
+                *ngFor="let step of pipeline"
+                [ngClass]="'spy-step-' + step.state">
+                <span class="spy-step-no">{{ step.position }}</span>
+                <span class="spy-step-body">
+                  <span class="spy-step-name">{{ step.name }}</span>
+                  <span class="spy-bar earlier">
+                    <span
+                      class="spy-fill"
+                      [style.width.%]="step.barA"></span>
+                    <span class="spy-bar-n">{{ count(step.rowsA) }}</span>
+                  </span>
+                  <span class="spy-bar later">
+                    <span
+                      class="spy-fill"
+                      [style.width.%]="step.barB"></span>
+                    <span class="spy-bar-n">{{ count(step.rowsB) }}</span>
+                  </span>
+                </span>
+                <span class="spy-step-note">
+                  <span
+                    class="spy-starts"
+                    *ngIf="step.state === 'starts'"
+                    >the difference starts here</span
+                  >
+                  <span
+                    class="spy-carried"
+                    *ngIf="step.state === 'carried'"
+                    >carried along from above</span
+                  >
+                  <span
+                    class="spy-carried"
+                    *ngIf="step.state === 'reordered'"
+                    >not a change, only the order</span
+                  >
+                  <span class="spy-step-said">{{ sentenceFor(step.id) || step.note }}</span>
+                  <span
+                    class="spy-step-count"
+                    *ngIf="sentenceFor(step.id)"
+                    >{{ step.note }}</span
+                  >
+                </span>
+              </li>
+            </ol>
+            <p
+              class="spy-takeaway"
+              *ngIf="narration.takeaway">
+              {{ narration.takeaway }}
+            </p>
+            <p class="spy-source">
+              The counts, the step where the difference starts and the edit behind it are worked out from the record.
+              The sentences are written from those facts, and from nothing else.
+            </p>
+          </div>
+
+          <p class="spy-disclosure">
+            <button
+              type="button"
+              (click)="showNumbers = !showNumbers">
+              {{ showNumbers ? "Hide the exact numbers" : "Show the exact numbers, step by step" }}
+            </button>
+          </p>
+
+          <table
+            class="spy-table"
+            *ngIf="showNumbers">
+            <caption>
+              The steps in the order the data flows through them; the counts are what each step produced. A difference
+              of zero next to "differs" means the same number of rows came out, but not the same rows.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">step</th>
+                <th
+                  scope="col"
+                  class="num">
+                  earlier
+                </th>
+                <th
+                  scope="col"
+                  class="num">
+                  later
+                </th>
+                <th
+                  scope="col"
+                  class="num">
+                  difference
+                </th>
+                <th scope="col">verdict</th>
+              </tr>
+            </thead>
+            <tbody>
+              <ng-container *ngFor="let oid of a.order; let i = index">
+                <tr
+                  [ngClass]="{ 'spy-divergent': oid === a.firstDivergent, 'spy-clickable': !!finding(oid)?.diff }"
+                  (click)="toggle(oid)">
+                  <td class="spy-muted">{{ i + 1 }}</td>
+                  <td>
+                    {{ opName(oid) }}
+                    <span class="spy-id">{{ oid }}</span>
+                  </td>
+                  <td class="num">{{ finding(oid)?.diff?.rowsA ?? "—" }}</td>
+                  <td class="num">{{ finding(oid)?.diff?.rowsB ?? "—" }}</td>
+                  <td class="num">{{ delta(oid) }}</td>
+                  <td>
+                    <span
+                      *ngIf="!finding(oid)?.diff"
+                      class="spy-muted"
+                      >identical</span
+                    >
+                    <span *ngIf="finding(oid)?.diff">
+                      <b [class.spy-flag]="oid === a.firstDivergent"
+                        >{{ oid === a.firstDivergent ? "differs · starts here" : "differs" }}</b
+                      >
+                      <span class="spy-muted">{{ isExpanded(oid) ? " · hide rows" : " · show rows" }}</span>
+                    </span>
+                  </td>
+                </tr>
+                <tr
+                  class="spy-detail"
+                  *ngIf="isExpanded(oid) && finding(oid)?.diff as d">
+                  <td colspan="6">
+                    <div class="spy-rows">
+                      <div>
+                        <h5>Only in the earlier run</h5>
+                        <table
+                          class="spy-grid"
+                          *ngIf="d.onlyInA.length">
+                          <thead>
+                            <tr>
+                              <th *ngFor="let col of columns(d.onlyInA)">{{ col }}</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr *ngFor="let row of d.onlyInA">
+                              <td *ngFor="let col of columns(d.onlyInA)">{{ cell(row, col) }}</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <p
+                          *ngIf="d.onlyInA.length === 0"
+                          class="spy-muted">
+                          nothing
+                        </p>
+                      </div>
+                      <div>
+                        <h5>Only in the later run</h5>
+                        <table
+                          class="spy-grid"
+                          *ngIf="d.onlyInB.length">
+                          <thead>
+                            <tr>
+                              <th *ngFor="let col of columns(d.onlyInB)">{{ col }}</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr *ngFor="let row of d.onlyInB">
+                              <td *ngFor="let col of columns(d.onlyInB)">{{ cell(row, col) }}</td>
+                            </tr>
+                          </tbody>
+                        </table>
+                        <p
+                          *ngIf="d.onlyInB.length === 0"
+                          class="spy-muted">
+                          nothing
+                        </p>
+                      </div>
+                    </div>
+                    <p
+                      class="spy-muted"
+                      *ngIf="d.sameSetDifferentOrder">
+                      The same rows came out on both sides, just in a different order. Nothing about the data changed.
+                    </p>
+                    <p
+                      class="spy-muted"
+                      *ngIf="!d.sampleTruncated">
+                      Up to five rows are shown from each side.
+                    </p>
+                    <p
+                      class="spy-warn"
+                      *ngIf="d.sampleTruncated">
+                      The counts above are the real ones, reported by the engine. The rows are not: this step produced
+                      more output than Texera hands back in one go, so it returned only part of it. A row shown on one
+                      side may well exist on the other.
+                    </p>
+                  </td>
+                </tr>
+              </ng-container>
+            </tbody>
+          </table>
+
+          <ng-container *ngTemplateOutlet="askBox"></ng-container>
+        </div>
+      </section>
+
+      <!-- ======================= the report ======================= -->
+      <section
+        class="spy-panel"
+        *ngIf="tab === 'report'">
+        <p class="spy-lead">
+          The whole record written up as a handover document: what this workflow does, how it got here, what has been
+          tried, and what the record cannot tell you. Written once, from the same facts the other tabs draw.
+        </p>
+
+        <div
+          class="spy-report-actions"
+          *ngIf="!report && !reportPending">
+          <button
+            type="button"
+            class="spy-primary"
+            (click)="writeReport()">
+            Write the report
+          </button>
+          <span class="spy-muted">Takes about a minute. Nothing is written until you ask for it.</span>
+        </div>
+
+        <p
+          *ngIf="reportPending"
+          class="spy-loading">
+          Writing the report. It reads every version and every run first, so this takes a minute.
+        </p>
+
+        <p
+          *ngIf="reportFailed && !reportPending"
+          class="spy-note">
+          No report came back. Everything else in this panel is unaffected: it is derived, and does not need a model at
+          all.
+          <button
+            type="button"
+            class="spy-quiet"
+            (click)="writeReport(true)">
+            Try again
+          </button>
+        </p>
+
+        <article
+          class="spy-report"
+          *ngIf="report as r">
+          <h3>{{ r.title }}</h3>
+          <p class="spy-report-summary">{{ r.summary }}</p>
+
+          <!-- Five sections, each folded until it is asked for: a report is a wall
+           of prose otherwise, and nobody reads a wall. -->
+          <section
+            *ngFor="let section of r.sections; let i = index"
+            class="spy-report-section">
+            <button
+              type="button"
+              class="spy-report-toggle"
+              [class.open]="isUnfolded(section.heading) || i === 0"
+              (click)="unfold(section.heading)">
+              <svg
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true">
+                <path d="M9 5l8 7-8 7z" />
+              </svg>
+              {{ section.heading }}
+            </button>
+            <div *ngIf="isUnfolded(section.heading) || i === 0">
+              <p *ngFor="let part of paragraphs(section.body)">{{ part }}</p>
+            </div>
+          </section>
+
+          <div class="spy-report-actions">
+            <button
+              type="button"
+              class="spy-primary"
+              (click)="downloadReport()">
+              Save as a file
+            </button>
+            <button
+              type="button"
+              class="spy-quiet"
+              (click)="copyReport()">
+              {{ copied ? "copied" : "copy it" }}
+            </button>
+            <button
+              type="button"
+              class="spy-quiet"
+              [disabled]="reportPending"
+              (click)="writeReport(true)">
+              write it again
+            </button>
+          </div>
+
+          <p class="spy-source">
+            Every figure in this report was derived from Texera's saved versions and run statistics. {{ r.model }} wrote
+            the prose from those figures and was given nothing else.
+          </p>
+        </article>
+      </section>
+    </div>
+  </div>
+</div>
+
+<ng-template #askBox>
+  <!-- The only part of the panel that talks back, so the only one that carries
+       real colour: a spark and a gradient hairline. -->
+  <section
+    class="spy-ask"
+    [class.thinking]="asking">
+    <div class="spy-ask-head">
+      <svg
+        class="spy-spark"
+        viewBox="0 0 24 24"
+        aria-hidden="true">
+        <defs>
+          <linearGradient
+            id="spySpark"
+            x1="0"
+            y1="0"
+            x2="1"
+            y2="1">
+            <stop
+              offset="0%"
+              stop-color="#0071e3" />
+            <stop
+              offset="48%"
+              stop-color="#6b5cf6" />
+            <stop
+              offset="100%"
+              stop-color="#ff7fae" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M12 1.8c.95 4.85 3 6.9 7.85 7.85C15 10.6 12.95 12.65 12 17.5c-.95-4.85-3-6.9-7.85-7.85C9 8.7 11.05 6.65 12 1.8z"
+          fill="url(#spySpark)" />
+        <path
+          d="M18.6 15.1c.44 2.3 1.4 3.26 3.7 3.7-2.3.44-3.26 1.4-3.7 3.7-.44-2.3-1.4-3.26-3.7-3.7 2.3-.44 3.26-1.4 3.7-3.7z"
+          fill="url(#spySpark)"
+          opacity="0.5" />
+      </svg>
+      <h4>Ask about this</h4>
+    </div>
+
+    <p class="spy-ask-lead">
+      Anything you want to understand about what is on screen. It answers from the record only, and says so when the
+      record does not hold the answer.
+    </p>
+
+    <div
+      class="spy-suggestions"
+      *ngIf="suggestions.length">
+      <button
+        type="button"
+        *ngFor="let s of suggestions"
+        [disabled]="asking"
+        (click)="askAbout(s)">
+        {{ s }}
+      </button>
+    </div>
+
+    <div
+      class="spy-turn"
+      *ngFor="let t of turns">
+      <p class="spy-question">{{ t.question }}</p>
+      <div class="spy-reply">
+        <span
+          class="spy-reply-mark"
+          [class.waiting]="!t.answer && !t.failed"
+          aria-hidden="true"></span>
+        <p
+          class="spy-answer"
+          *ngIf="t.answer">
+          {{ t.answer }}
+        </p>
+        <p
+          class="spy-answer spy-pending"
+          *ngIf="!t.answer && !t.failed">
+          Reading the record…
+        </p>
+        <p
+          class="spy-answer spy-failed"
+          *ngIf="t.failed">
+          No answer came back. The record above is unaffected.
+        </p>
+      </div>
+    </div>
+
+    <div class="spy-askline">
+      <input
+        class="spy-input"
+        type="text"
+        placeholder="Ask your own question"
+        [value]="draft"
+        [disabled]="asking"
+        (input)="draft = $any($event.target).value"
+        (keydown.enter)="askAbout(draft)" />
+      <button
+        type="button"
+        class="spy-ask-go"
+        [disabled]="asking || !draft.trim()"
+        (click)="askAbout(draft)">
+        {{ asking ? "Reading" : "Ask" }}
+      </button>
+    </div>
+  </section>
+</ng-template>

--- a/frontend/src/app/workspace/component/spy/spy.component.scss
+++ b/frontend/src/app/workspace/component/spy/spy.component.scss
@@ -1,0 +1,2952 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// The panel as a window: one white sheet on a pale ground, hairline rules, and
+// a single blue that only ever means "this is the thing you are looking at".
+// Two surfaces and no more. The drawings sit on bare paper because they are the
+// content; only the readings beside them are put on a card.
+
+:host {
+  // ink
+  --spy-text: #1d1d1f;
+  --spy-secondary: #55606c;
+  --spy-muted: #89919c;
+  --spy-faint: #b4bac2;
+
+  // paper
+  --spy-paper: #fff;
+  --spy-ground: #f8fafc;
+  --spy-surface: #f3f6fa;
+  --spy-rule: #ecf0f4;
+  --spy-border: #dee3ea;
+  --spy-grid: #f5f8fb;
+  --spy-ghost: #e8ecf2;
+  --spy-edge: #c7ced7;
+  --spy-chip-bg: #f1f4f9;
+  --spy-carried-bg: #fcfdfe;
+
+  // the one accent
+  --spy-accent: #0071e3;
+  --spy-accent-ink: #0057b3;
+  --spy-accent-hover: #1a84ef;
+  --spy-accent-wash: #edf4ff;
+
+  // the four meanings, kept as quiet as they can be and still be read
+  --spy-added-tint: #edf8f1;
+  --spy-added: #1f8a4c;
+  --spy-edited-tint: #fdf4e7;
+  --spy-edited: #b4740f;
+  --spy-alert-tint: #fdf0ef;
+  --spy-alert: #cf3127;
+  --spy-alert-line: #f6d4d1;
+  --spy-now-line: #cfe9d8;
+  --spy-now-ink: #1f8a4c;
+  --spy-filter-line: #cfe2fb;
+  --spy-filter-bg: #f4f9ff;
+
+  // the two runs held side by side: yesterday in grey, today in blue
+  --spy-run-a: #b3bcc6;
+  --spy-run-b: #0071e3;
+
+  // the ribbon of saves
+  --spy-tape-quiet: #e5eaf0;
+  --spy-tape-added: #8cc9a4;
+  --spy-tape-removed: #e0a49e;
+  --spy-tape-edited: #e6c088;
+  --spy-tape-broken: #f6dedb;
+  --spy-ran: #0b4d8f;
+  --spy-box-line: #cdd5de;
+
+  --spy-sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "Helvetica Neue", Inter, Arial,
+    sans-serif;
+  --spy-mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+
+  // Radius carries rank: the window, then a card, then a node, then a chip.
+  --r-window: 18px;
+  --r-card: 14px;
+  --r-node: 10px;
+  --r-chip: 7px;
+
+  // Barely there on purpose. A card is lifted off the page, not floating over it.
+  --lift: 0 1px 2px rgba(16, 24, 40, 0.05), 0 0 0 0.5px rgba(16, 24, 40, 0.03);
+  --lift-high: 0 10px 28px rgba(16, 24, 40, 0.09), 0 1px 3px rgba(16, 24, 40, 0.05);
+}
+
+@mixin label {
+  font-size: 11.5px;
+  font-weight: 590;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--spy-muted);
+}
+
+:host {
+  display: block;
+  color: var(--spy-text);
+  font-family: var(--spy-sans);
+  font-size: 13.5px;
+  line-height: 1.55;
+  letter-spacing: -0.004em;
+  -webkit-font-smoothing: antialiased;
+  font-variant-numeric: tabular-nums;
+
+  // One spacing scale, so everything lands on the same grid.
+  --gap: 8px;
+}
+
+// ---------- the window ----------
+
+.spy {
+  display: grid;
+  // The rail sets its own width, so folding it is a transition rather than
+  // the whole grid jumping.
+  grid-template-columns: auto minmax(0, 1fr);
+  height: min(78vh, 880px);
+  min-height: 560px;
+  overflow: hidden;
+  border-radius: var(--r-window);
+  background: var(--spy-ground);
+}
+
+.spy-rail {
+  --rail-pad: 14px;
+
+  display: flex;
+  width: 232px;
+  flex-direction: column;
+  padding: 20px var(--rail-pad) 16px;
+  overflow: hidden;
+  border-right: 1px solid var(--spy-rule);
+  background: var(--spy-surface);
+  transition: width 220ms cubic-bezier(0.32, 0.72, 0, 1);
+
+  &.folded {
+    --rail-pad: 10px;
+    width: 60px;
+  }
+}
+
+.spy-mark {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 0 8px 20px 12px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  color: var(--spy-text);
+}
+
+.spy-mark-name {
+  flex: 1;
+}
+
+// The sidebar button, where macOS puts it: top left.
+.spy-fold {
+  display: flex;
+  width: 26px;
+  height: 26px;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-radius: 7px;
+  background: none;
+  color: var(--spy-muted);
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+
+  svg {
+    width: 17px;
+    height: 17px;
+    stroke: currentColor;
+    stroke-width: 1.4;
+    stroke-linecap: round;
+  }
+
+  &:hover {
+    background: rgba(15, 23, 42, 0.06);
+    color: var(--spy-text);
+  }
+}
+
+.spy-rail.folded {
+  .spy-mark {
+    justify-content: center;
+    padding: 0 0 18px;
+  }
+
+  .spy-emblem,
+  .spy-mark-name {
+    display: none;
+  }
+
+  .spy-nav button {
+    justify-content: center;
+    height: 36px;
+    padding: 0;
+  }
+}
+
+// Folded, the group headings do not fit: a hairline stands in for them.
+.spy-nav-split {
+  height: 0;
+  margin: 9px 6px;
+  border: 0;
+  border-top: 1px solid var(--spy-rule);
+
+  &:first-child {
+    display: none;
+  }
+}
+
+.spy-emblem {
+  width: 21px;
+  height: 21px;
+  color: var(--spy-accent);
+}
+
+.spy-nav {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.spy-nav-group {
+  margin: 14px 0 5px;
+  padding: 0 12px;
+  @include label;
+  font-size: 11px;
+
+  &:first-child {
+    margin-top: 0;
+  }
+}
+
+// Where you are, not somewhere to go: a wash of the accent and a short mark on
+// the rail's own edge, so the eye finds it without anything shouting.
+.spy-nav button {
+  position: relative;
+  display: flex;
+  width: 100%;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  white-space: nowrap;
+  border: 0;
+  border-radius: 8px;
+  background: none;
+  font: inherit;
+  font-size: 13.5px;
+  text-align: left;
+  color: var(--spy-secondary);
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    color 160ms ease;
+
+  &:hover:not(.on) {
+    background: rgba(15, 23, 42, 0.05);
+    color: var(--spy-text);
+  }
+
+  &.on {
+    background: var(--spy-accent-wash);
+    font-weight: 590;
+    color: var(--spy-accent-ink);
+  }
+
+  &.on::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: calc(var(--rail-pad) * -1);
+    width: 3px;
+    height: 15px;
+    margin-top: -7.5px;
+    border-radius: 0 2px 2px 0;
+    background: var(--spy-accent);
+  }
+}
+
+.spy-nav-icon {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  stroke: currentColor;
+  stroke-width: 1.35;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.85;
+}
+
+.spy-nav button.on .spy-nav-icon {
+  opacity: 1;
+}
+
+.spy-rail-foot {
+  margin: 20px 0 0;
+  padding: 0 12px;
+  font-size: 11.5px;
+  line-height: 1.5;
+  color: var(--spy-muted);
+}
+
+.spy-main {
+  display: flex;
+  min-width: 0;
+  // Without this the scrolling stage pushes the window taller than the sheet.
+  min-height: 0;
+  flex-direction: column;
+  background: var(--spy-ground);
+}
+
+// ---------- the title bar ----------
+
+.spy-topbar {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+  padding: 13px 62px 13px 26px;
+  border-bottom: 1px solid var(--spy-rule);
+  background: var(--spy-paper);
+}
+
+.spy-topbar-name {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 8ch;
+  align-items: center;
+  gap: 10px;
+
+  h3 {
+    min-width: 0;
+    overflow: hidden;
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.014em;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--spy-text);
+  }
+}
+
+.spy-state {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 9px 2px 7px;
+  border-radius: 999px;
+  background: var(--spy-chip-bg);
+  font-size: 11.5px;
+  font-weight: 560;
+  color: var(--spy-secondary);
+
+  i {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: var(--spy-faint);
+  }
+
+  &.is-good i {
+    background: var(--spy-added);
+  }
+
+  &.is-bad {
+    background: var(--spy-alert-tint);
+    color: var(--spy-alert);
+
+    i {
+      background: var(--spy-alert);
+    }
+  }
+
+  // The only thing on the panel that moves on its own, and only while a run is
+  // actually on: a breathing dot, which is what "still going" looks like.
+  &.is-live {
+    background: var(--spy-accent-wash);
+    color: var(--spy-accent-ink);
+
+    i {
+      background: var(--spy-accent);
+      animation: spy-breathe 1.8s ease-in-out infinite;
+    }
+  }
+}
+
+@keyframes spy-breathe {
+  0%,
+  100% {
+    opacity: 1;
+    box-shadow: 0 0 0 0 rgba(0, 113, 227, 0.35);
+  }
+
+  50% {
+    opacity: 0.55;
+    box-shadow: 0 0 0 4px rgba(0, 113, 227, 0);
+  }
+}
+
+.spy-topbar-meta {
+  display: flex;
+  flex: none;
+  gap: 26px;
+  margin: 0;
+
+  dt {
+    @include label;
+    margin-bottom: 1px;
+    font-size: 10.5px;
+    font-weight: 500;
+  }
+
+  dd {
+    max-width: 18ch;
+    overflow: hidden;
+    margin: 0;
+    font-size: 13px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--spy-text);
+  }
+}
+
+.spy-topbar-actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: 10px;
+}
+
+.spy-version {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 11.5px;
+  color: var(--spy-muted);
+
+  select {
+    height: 28px;
+    max-width: 150px;
+    padding: 0 8px;
+    border: 1px solid var(--spy-border);
+    border-radius: var(--r-chip);
+    background: var(--spy-paper);
+    font: inherit;
+    font-size: 12.5px;
+    color: var(--spy-text);
+    cursor: pointer;
+  }
+}
+
+.spy-run {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  height: 30px;
+  padding: 0 15px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--spy-accent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 550;
+  color: #fff;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+
+  &:hover:not(:disabled) {
+    background: var(--spy-accent-hover);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
+  &:disabled {
+    background: var(--spy-accent);
+    opacity: 0.55;
+    cursor: default;
+  }
+}
+
+.spy-run-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #fff;
+  animation: spy-breathe 1.8s ease-in-out infinite;
+}
+
+// ---------- the stage ----------
+
+.spy-scroll {
+  min-height: 0;
+  flex: 1;
+  overflow-y: auto;
+  padding: 24px 30px 44px;
+  scroll-behavior: smooth;
+}
+
+.spy-title {
+  margin: 0 0 18px;
+  font-size: 25px;
+  font-weight: 620;
+  letter-spacing: -0.022em;
+  color: var(--spy-text);
+}
+
+// The drawing keeps the paper to itself; the reading of it sits alongside on a
+// card, which is what makes one of the two the subject and the other a note.
+.spy-stage-main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.spy-stage {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 22px;
+  align-items: start;
+}
+
+.spy-stage-hint {
+  margin: 0;
+  padding: 22px 18px;
+  border: 1px dashed var(--spy-border);
+  border-radius: var(--r-card);
+  font-size: 12.5px;
+  text-align: center;
+  color: var(--spy-faint);
+}
+
+@media (max-width: 1180px) {
+  .spy-stage {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spy * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+.spy-panel > div > * + * {
+  margin-top: calc(var(--gap) * 3.5);
+}
+
+.spy-muted {
+  color: var(--spy-muted);
+}
+
+.spy-mono {
+  font-family: var(--spy-mono);
+}
+
+.spy-warn {
+  color: var(--spy-alert);
+}
+
+// The error strip: still the only place a whole block turns red.
+.spy-error {
+  margin: 0 0 18px;
+  padding: 10px 14px;
+  border: 1px solid var(--spy-alert-line);
+  border-radius: var(--r-card);
+  background: var(--spy-alert-tint);
+  color: var(--spy-alert);
+}
+
+.spy-loading {
+  padding: 20px 0;
+  color: var(--spy-muted);
+}
+
+// ---------- method note ----------
+
+.spy-method {
+  max-width: 100ch;
+  margin: 0 0 14px;
+  color: var(--spy-secondary);
+
+  b {
+    font-weight: 600;
+    color: var(--spy-text);
+  }
+}
+
+.spy-note {
+  max-width: 92ch;
+  margin: 14px 0 0;
+  color: var(--spy-secondary);
+
+  code {
+    padding: 0 4px;
+    border: 1px solid var(--spy-rule);
+    border-radius: 5px;
+    background: var(--spy-surface);
+    font-family: var(--spy-mono);
+    font-size: 12px;
+    color: var(--spy-secondary);
+  }
+}
+
+// ---------- controls ----------
+
+.spy-controls {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 9px 12px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-surface);
+}
+
+.spy-transport-group {
+  display: flex;
+  gap: 4px;
+}
+
+.spy-transport {
+  width: 30px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid var(--spy-border);
+  border-radius: var(--r-chip);
+  background: var(--spy-paper);
+  color: var(--spy-secondary);
+  cursor: pointer;
+
+  &:hover:not(:disabled) {
+    border-color: var(--spy-accent);
+    color: var(--spy-accent-ink);
+  }
+
+  &:disabled {
+    color: var(--spy-faint);
+    cursor: default;
+  }
+}
+
+.spy-glyph {
+  display: block;
+  width: 10px;
+  height: 10px;
+  margin: 0 auto;
+}
+
+.spy-position {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-family: var(--spy-mono);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+  color: var(--spy-muted);
+}
+
+.spy-vid {
+  font-weight: 600;
+  color: var(--spy-text);
+}
+
+.spy-count {
+  color: var(--spy-secondary);
+}
+
+// ---------- caption ----------
+
+.spy-caption {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  margin: 12px 2px 0;
+
+  b {
+    font-weight: 600;
+  }
+}
+
+// ---------- canvas ----------
+
+.spy-columns {
+  display: flex;
+  gap: 16px;
+  margin-top: 10px;
+}
+
+.spy-canvas {
+  display: flex;
+  flex: 2;
+  flex-direction: column;
+  margin: 0;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: repeating-linear-gradient(0deg, transparent 0 23px, var(--spy-grid) 23px 24px),
+    repeating-linear-gradient(90deg, transparent 0 23px, var(--spy-grid) 23px 24px), var(--spy-paper);
+
+  svg {
+    width: 100%;
+    height: 372px;
+  }
+}
+
+.spy-canvas-head {
+  display: flex;
+  justify-content: space-between;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--spy-rule);
+  background: var(--spy-paper);
+  font-size: 12px;
+  color: var(--spy-secondary);
+}
+
+.spy-canvas figcaption {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 7px 12px;
+  border-top: 1px solid var(--spy-rule);
+  background: var(--spy-paper);
+  @include label;
+}
+
+.spy-key {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  &::before {
+    content: "";
+    width: 11px;
+    height: 11px;
+    border: 1px solid var(--spy-border);
+    border-radius: 5px;
+    background: var(--spy-paper);
+  }
+
+  &.added::before {
+    border-color: var(--spy-added);
+    background: var(--spy-added-tint);
+  }
+
+  &.edited::before {
+    border-color: var(--spy-edited);
+    background: var(--spy-edited-tint);
+  }
+
+  &.ghost::before {
+    border-style: dashed;
+    border-color: var(--spy-faint);
+    background: transparent;
+  }
+}
+
+.spy-edge {
+  stroke: var(--spy-edge);
+  stroke-width: 1;
+}
+
+.spy-ghost {
+  fill: none;
+  stroke: var(--spy-ghost);
+  stroke-width: 1;
+  stroke-dasharray: 3 4;
+}
+
+.spy-node {
+  cursor: pointer;
+}
+
+.spy-box {
+  fill: var(--spy-paper);
+  stroke: var(--spy-border);
+  stroke-width: 1;
+}
+
+.spy-box-added {
+  fill: var(--spy-added-tint);
+  stroke: var(--spy-added);
+}
+
+.spy-box-edited {
+  fill: var(--spy-edited-tint);
+  stroke: var(--spy-edited);
+}
+
+.spy-box-focused {
+  stroke: var(--spy-accent);
+  stroke-width: 2;
+}
+
+.spy-box-name {
+  font-size: 11px;
+  font-weight: 600;
+  fill: var(--spy-text);
+}
+
+.spy-box-id {
+  font-family: var(--spy-mono);
+  font-size: 9px;
+  fill: var(--spy-muted);
+}
+
+// ---------- change log ----------
+
+.spy-log {
+  flex: 1;
+  max-height: 430px;
+  overflow-y: auto;
+  padding: 10px 14px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+
+  h4 {
+    margin: 0 0 8px;
+    @include label;
+    color: var(--spy-secondary);
+  }
+
+  p {
+    margin: 0 0 8px;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  li {
+    padding: 5px 0 5px 11px;
+    border-left: 2px solid var(--spy-rule);
+    line-height: 1.5;
+    color: var(--spy-secondary);
+    word-break: break-word;
+  }
+}
+
+.spy-c-operator_added,
+.spy-c-link_added {
+  border-left-color: var(--spy-added);
+}
+
+.spy-c-operator_deleted,
+.spy-c-link_removed {
+  border-left-color: var(--spy-alert);
+}
+
+.spy-c-property,
+.spy-c-renamed {
+  border-left-color: var(--spy-edited);
+}
+
+.spy-filter {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 5px 9px;
+  border: 1px solid var(--spy-filter-line);
+  border-radius: var(--r-chip);
+  background: var(--spy-filter-bg);
+  font-size: 12px;
+
+  button {
+    margin-left: auto;
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--spy-accent-ink);
+    font-size: 12px;
+    cursor: pointer;
+  }
+}
+
+.spy-runs {
+  margin-top: 14px;
+  padding-top: 10px;
+  border-top: 1px solid var(--spy-rule);
+}
+
+.spy-help {
+  margin: 12px 2px 0;
+  color: var(--spy-muted);
+  font-size: 12px;
+}
+
+// ---------- run comparison ----------
+
+.spy-controls-compare {
+  flex-wrap: wrap;
+  gap: 18px;
+  margin-top: 4px;
+
+  label {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+
+    span {
+      @include label;
+    }
+  }
+}
+
+// A run is named in words, not in code, so the picker is set in words too.
+.spy-select {
+  min-width: 320px;
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid var(--spy-border);
+  border-radius: var(--r-chip);
+  background: var(--spy-paper);
+  font-family: inherit;
+  font-size: 12.5px;
+  color: var(--spy-text);
+  cursor: pointer;
+  transition: border-color 160ms ease;
+
+  &:hover {
+    border-color: var(--spy-edge);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--spy-accent);
+    outline-offset: 1px;
+  }
+}
+
+.spy-primary {
+  align-self: flex-end;
+  height: 30px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 9px;
+  background: var(--spy-accent);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 550;
+  color: #fff;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+
+  &:hover:not(:disabled) {
+    background: var(--spy-accent-hover);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.97);
+  }
+
+  &:disabled {
+    background: var(--spy-chip-bg);
+    color: var(--spy-faint);
+    cursor: default;
+  }
+}
+
+// The button that runs sits one weight below Compare: it is the one that costs
+// time and data, so it should not ask for the finger first. It is not called
+// .spy-quiet because that name already belongs to the panel's text links.
+.spy-second {
+  align-self: flex-end;
+  height: 30px;
+  padding: 0 14px;
+  border: 1px solid var(--spy-border);
+  border-radius: 9px;
+  background: var(--spy-paper);
+  font: inherit;
+  font-size: 13px;
+  color: var(--spy-text);
+  cursor: pointer;
+  transition:
+    border-color 160ms ease,
+    color 160ms ease;
+
+  &:hover:not(:disabled) {
+    border-color: var(--spy-accent);
+    color: var(--spy-accent);
+  }
+
+  &:disabled {
+    color: var(--spy-faint);
+    cursor: default;
+  }
+}
+
+// The verdict is no longer a grey box with a red rule. The sentence above is
+// the headline, the two figures back it up and these lines are the footnote:
+// three different weights in one column, with nothing boxed in.
+.spy-summary {
+  margin: 0;
+
+  p {
+    max-width: 74ch;
+    margin: 0;
+    font-size: 13.5px;
+    color: var(--spy-secondary);
+
+    & + p {
+      margin-top: 2px;
+    }
+  }
+}
+
+.spy-table {
+  width: 100%;
+  margin: 16px 0 20px;
+  border-collapse: collapse;
+  font-size: 12.5px;
+
+  // Table notes belong under the table, as in a paper.
+  caption {
+    padding-top: 8px;
+    caption-side: bottom;
+    max-width: 104ch;
+    text-align: left;
+    color: var(--spy-muted);
+    font-size: 12px;
+  }
+
+  // Only this table's own cells: the samples inside a row are a table too.
+  > thead > tr > th,
+  > tbody > tr > td {
+    padding: 6px 12px;
+    text-align: left;
+    border-bottom: 1px solid var(--spy-rule);
+  }
+
+  > thead > tr > th {
+    border-bottom: 1px solid var(--spy-border);
+    @include label;
+  }
+
+  .num {
+    text-align: right;
+    font-family: var(--spy-mono);
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+.spy-clickable {
+  cursor: pointer;
+
+  &:hover > td {
+    background: var(--spy-surface);
+  }
+}
+
+.spy-divergent > td {
+  background: var(--spy-alert-tint);
+}
+
+.spy-flag {
+  color: var(--spy-alert);
+}
+
+.spy-detail > td {
+  padding-top: 10px;
+  padding-bottom: 12px;
+  background: var(--spy-surface);
+}
+
+.spy-rows {
+  display: flex;
+  gap: 32px;
+
+  > div {
+    flex: 1;
+    min-width: 0;
+  }
+
+  h5 {
+    margin: 0 0 5px;
+    @include label;
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+.spy-sample {
+  overflow: hidden;
+  font-family: var(--spy-mono);
+  font-size: 11.5px;
+  color: var(--spy-secondary);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.spy-was {
+  font-family: var(--spy-mono);
+  color: var(--spy-alert);
+}
+
+.spy-now {
+  font-family: var(--spy-mono);
+  color: var(--spy-added);
+}
+
+// ---------- plain words ----------
+
+.spy-story {
+  max-width: 96ch;
+  margin: 0 0 10px;
+  font-size: 14px;
+  color: var(--spy-text);
+}
+
+// Prose written from the derived facts. A neutral rule, never the red one:
+// the verdict above is worked out, this is only put into words.
+.spy-reading {
+  margin: 12px 0 4px;
+  padding: 2px 0 2px 14px;
+  border-left: 1px solid var(--spy-border);
+
+  h4 {
+    margin: 0 0 6px;
+    @include label;
+  }
+
+  p {
+    max-width: 96ch;
+    margin: 0 0 8px;
+    color: var(--spy-text);
+    line-height: 1.55;
+  }
+
+  .spy-source {
+    margin: 10px 0 0;
+    font-size: 11px;
+    line-height: 1.45;
+    color: var(--spy-muted);
+  }
+}
+
+.spy-reading-wait {
+  margin: 12px 0 4px;
+  padding-left: 15px;
+  @include label;
+}
+
+// The verdict's figures. They come first and large because magnitude reads
+// before explanation; the paragraph below no longer repeats them.
+.spy-figures {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 26px;
+  margin: 0 0 14px;
+}
+
+.spy-figure {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  padding-left: 14px;
+  border-left: 1px solid var(--spy-border);
+
+  &:first-child {
+    padding-left: 0;
+    border-left: 0;
+  }
+}
+
+.spy-figure-value {
+  font-size: 29px;
+  font-weight: 500;
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+  color: var(--spy-text);
+}
+
+.spy-figure-loud .spy-figure-value {
+  color: var(--spy-alert);
+}
+
+.spy-figure-label {
+  max-width: 22ch;
+  font-size: 11.5px;
+  line-height: 1.35;
+  color: var(--spy-muted);
+}
+
+// Questions: the conversational part, set apart from the record by a full
+// rule, so it reads as something else beginning.
+// ---------- the one part that answers back ----------
+
+// The whole panel is flat blue because the whole panel derives what it says.
+// Not this: this one is written by a model, and it is the only thing here with
+// a gradient. That is the point.
+.spy-ask {
+  margin: 34px 0 0;
+  padding: 18px 20px 20px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-paper);
+  box-shadow: var(--lift);
+}
+
+.spy-ask-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 3px;
+
+  h4 {
+    margin: 0;
+    font-size: 15.5px;
+    font-weight: 600;
+    letter-spacing: -0.012em;
+    color: var(--spy-text);
+  }
+}
+
+.spy-spark {
+  width: 18px;
+  height: 18px;
+  flex: none;
+}
+
+// While it reads, the spark pulses. At rest, nothing moves.
+.spy-ask.thinking .spy-spark {
+  animation: spy-twinkle 1.9s ease-in-out infinite;
+}
+
+@keyframes spy-twinkle {
+  0%,
+  100% {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+
+  50% {
+    opacity: 0.68;
+    transform: scale(0.9) rotate(-12deg);
+  }
+}
+
+.spy-ask-lead {
+  max-width: 78ch;
+  margin: 0 0 14px;
+  font-size: 12.5px;
+  color: var(--spy-muted);
+}
+
+.spy-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin: 0 0 16px;
+
+  button {
+    padding: 6px 13px;
+    border: 1px solid var(--spy-border);
+    border-radius: 999px;
+    background: var(--spy-paper);
+    font: inherit;
+    font-size: 12.5px;
+    color: var(--spy-secondary);
+    cursor: pointer;
+    transition:
+      border-color 160ms ease,
+      color 160ms ease,
+      background 160ms ease,
+      transform 160ms ease;
+
+    &:hover:not(:disabled) {
+      border-color: var(--spy-accent);
+      background: var(--spy-accent-wash);
+      color: var(--spy-accent-ink);
+      transform: translateY(-1px);
+    }
+
+    &:disabled {
+      color: var(--spy-faint);
+      cursor: default;
+    }
+  }
+}
+
+.spy-turn {
+  margin: 0 0 16px;
+
+  .spy-question {
+    max-width: 88ch;
+    margin: 0 0 7px;
+    font-weight: 600;
+    color: var(--spy-text);
+  }
+}
+
+// The answer arrives once. Nothing moves after that.
+.spy-reply {
+  display: flex;
+  gap: 10px;
+  animation: spy-rise 280ms cubic-bezier(0.32, 0.72, 0, 1);
+
+  .spy-answer {
+    max-width: 88ch;
+    margin: 0;
+    color: var(--spy-text);
+    line-height: 1.58;
+  }
+
+  .spy-failed {
+    color: var(--spy-muted);
+  }
+}
+
+@keyframes spy-rise {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+}
+
+// A gradient dot instead of the grey rule: it says who is talking.
+.spy-reply-mark {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  margin-top: 7px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #0071e3, #6b5cf6 50%, #ff7fae);
+
+  &.waiting {
+    animation: spy-breathe 1.6s ease-in-out infinite;
+  }
+}
+
+// While it reads, the sentence carries a sweep of light. It is the only way to
+// say "this is not finished yet" without putting another spinner on screen.
+.spy-pending {
+  background: linear-gradient(100deg, var(--spy-muted) 20%, var(--spy-text) 42%, var(--spy-muted) 62%);
+  background-size: 260% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: spy-sweep 1.7s linear infinite;
+}
+
+@keyframes spy-sweep {
+  from {
+    background-position: 130% 0;
+  }
+
+  to {
+    background-position: -30% 0;
+  }
+}
+
+// The field: a gradient hairline, dim at rest and lit while you are talking to
+// it or while it answers.
+.spy-askline {
+  position: relative;
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  padding: 4px 4px 4px 6px;
+  border-radius: 999px;
+  background: var(--spy-paper);
+  transition: box-shadow 220ms ease;
+
+  &::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    padding: 1.3px;
+    border-radius: inherit;
+    background: linear-gradient(100deg, #0071e3, #6b5cf6 32%, #ff7fae 56%, #6b5cf6 78%, #0071e3);
+    background-size: 300% 100%;
+    opacity: 0.42;
+    -webkit-mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+    mask:
+      linear-gradient(#000 0 0) content-box,
+      linear-gradient(#000 0 0);
+    mask-composite: exclude;
+    pointer-events: none;
+    transition: opacity 220ms ease;
+  }
+
+  &:focus-within::before {
+    opacity: 1;
+  }
+
+  &:focus-within {
+    box-shadow: 0 0 0 4px rgba(107, 92, 246, 0.1);
+  }
+
+  .spy-input {
+    min-width: 0;
+    flex: 1;
+    padding: 5px 8px;
+    border: 0;
+    background: none;
+    font: inherit;
+    color: var(--spy-text);
+
+    &:focus {
+      outline: none;
+    }
+
+    &::placeholder {
+      color: var(--spy-faint);
+    }
+  }
+}
+
+// While it reads, the hairline drifts: the only thing here that moves on its own.
+.spy-ask.thinking .spy-askline::before {
+  opacity: 1;
+  animation: spy-drift 2.6s linear infinite;
+}
+
+@keyframes spy-drift {
+  from {
+    background-position: 0 0;
+  }
+
+  to {
+    background-position: 300% 0;
+  }
+}
+
+.spy-ask-go {
+  height: 28px;
+  flex: none;
+  padding: 0 15px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--spy-accent);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 550;
+  color: #fff;
+  cursor: pointer;
+  transition:
+    background 160ms ease,
+    transform 160ms ease;
+
+  &:hover:not(:disabled) {
+    background: var(--spy-accent-hover);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.96);
+  }
+
+  &:disabled {
+    background: var(--spy-chip-bg);
+    color: var(--spy-faint);
+    cursor: default;
+  }
+}
+
+.spy-lead {
+  max-width: 96ch;
+  margin: 0 0 6px;
+  color: var(--spy-text);
+}
+
+.spy-disclosure {
+  margin: 0 0 12px;
+
+  button {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--spy-accent-ink);
+    font-size: 12px;
+    cursor: pointer;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+// A second register for the same fact: the id behind the name.
+.spy-id {
+  margin-left: 6px;
+  font-family: var(--spy-mono);
+  font-size: 11px;
+  color: var(--spy-faint);
+}
+
+.spy-quiet {
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: var(--spy-muted);
+  font-size: 12px;
+  cursor: pointer;
+
+  &:hover {
+    color: var(--spy-accent-ink);
+  }
+}
+
+// Sample rows, shown as the little table they are.
+.spy-grid {
+  border-collapse: collapse;
+  font-size: 11.5px;
+
+  // The outer table styles every descendant cell; these are a table of their
+  // own and read as data, not as headings.
+  th,
+  td {
+    padding: 3px 14px 3px 0;
+    border: 0;
+    text-align: left;
+    white-space: nowrap;
+  }
+
+  th {
+    border-bottom: 1px solid var(--spy-rule);
+    font-weight: 400;
+    font-size: 11px;
+    letter-spacing: normal;
+    text-transform: none;
+    color: var(--spy-muted);
+  }
+
+  td {
+    font-family: var(--spy-mono);
+    color: var(--spy-secondary);
+  }
+}
+
+// ---------- the filmstrip ----------
+// Twenty-nine saves as twenty-nine blocks. The colour says what that save did,
+// so the shape of the work is visible before a single word is read.
+
+.spy-tape {
+  display: flex;
+  flex: 1;
+  gap: 2px;
+  align-items: stretch;
+  height: 30px;
+  padding-top: 7px;
+}
+
+.spy-block {
+  position: relative;
+  flex: 1 1 0;
+  min-width: 5px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: var(--spy-tape-quiet);
+  cursor: pointer;
+
+  &:hover {
+    filter: brightness(0.94);
+  }
+
+  &.added {
+    background: var(--spy-tape-added);
+  }
+
+  &.removed {
+    background: var(--spy-tape-removed);
+  }
+
+  &.edited {
+    background: var(--spy-tape-edited);
+  }
+
+  &.quiet {
+    background: var(--spy-tape-quiet);
+  }
+
+  &.broken {
+    background: repeating-linear-gradient(45deg, var(--spy-tape-removed) 0 3px, var(--spy-tape-broken) 3px 6px);
+  }
+
+  // Where you are: a blue playhead down the ribbon, not a colour change, so
+  // the block underneath keeps saying what kind of save it was.
+  &.here::before {
+    content: "";
+    position: absolute;
+    top: -7px;
+    left: 50%;
+    border: 4px solid transparent;
+    border-top-color: var(--spy-accent);
+    transform: translateX(-50%);
+  }
+
+  &.here::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    width: 2px;
+    margin-left: -1px;
+    border-radius: 1px;
+    background: var(--spy-accent);
+  }
+}
+
+// A run is a fact about a save, so it rides on the block rather than beside it.
+.spy-ran {
+  position: absolute;
+  bottom: 3px;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--spy-ran);
+  transform: translateX(-50%);
+}
+
+.spy-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 16px;
+  margin: 9px 2px 0;
+  font-size: 12px;
+  color: var(--spy-secondary);
+}
+
+.spy-key-word {
+  color: var(--spy-muted);
+}
+
+.spy-swatch {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  &::before {
+    content: "";
+    width: 11px;
+    height: 11px;
+    border-radius: 3px;
+    background: var(--spy-tape-quiet);
+  }
+
+  &.added::before {
+    background: var(--spy-tape-added);
+  }
+
+  &.removed::before {
+    background: var(--spy-tape-removed);
+  }
+
+  &.edited::before {
+    background: var(--spy-tape-edited);
+  }
+
+  &.ran::before {
+    width: 6px;
+    height: 6px;
+    margin: 0 2px;
+    border-radius: 50%;
+    background: var(--spy-ran);
+  }
+}
+
+// ---------- an icon for every edit ----------
+
+.spy-log li {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.spy-chip {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  margin-top: 2px;
+  padding: 2px;
+  border-radius: 50%;
+  background: var(--spy-chip-bg);
+  color: var(--spy-secondary);
+
+  li.added & {
+    background: var(--spy-added-tint);
+    color: var(--spy-added);
+  }
+
+  li.removed & {
+    background: var(--spy-alert-tint);
+    color: var(--spy-alert);
+  }
+
+  li.edited & {
+    background: var(--spy-edited-tint);
+    color: var(--spy-edited);
+  }
+}
+
+.spy-said {
+  min-width: 0;
+}
+
+// ---------- the edit that did it ----------
+// The dial before and the dial after, side by side. This is the whole answer
+// for most comparisons, so it is drawn, not described.
+
+.spy-swaps-card {
+  margin: 24px 0 0;
+
+  h4 {
+    margin: 0 0 10px;
+    @include label;
+    color: var(--spy-muted);
+  }
+}
+
+.spy-swaps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 20px;
+    align-items: center;
+    padding: 14px 16px;
+    border: 1px solid var(--spy-rule);
+    border-radius: 5px;
+
+    & + li {
+      margin-top: 6px;
+    }
+
+    // The only tinted box on screen: it is the answer to the view's own
+    // question, and nothing else should compete with it.
+    &.blamed {
+      border-color: var(--spy-alert-line);
+      background: var(--spy-alert-tint);
+    }
+  }
+}
+
+.spy-swap-where {
+  display: flex;
+  flex-direction: column;
+  min-width: 190px;
+
+  b {
+    font-weight: 600;
+  }
+
+  span {
+    font-size: 12px;
+  }
+}
+
+.spy-swap-pair {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.spy-swap-arrow {
+  width: 15px;
+  height: 15px;
+  color: var(--spy-muted);
+}
+
+.spy-chip-was,
+.spy-chip-now {
+  padding: 4px 12px;
+  border: 1px solid;
+  border-radius: 5px;
+  font-family: var(--spy-mono);
+  font-size: 13.5px;
+}
+
+.spy-chip-was {
+  border-color: var(--spy-border);
+  background: var(--spy-paper);
+  color: var(--spy-secondary);
+}
+
+.spy-chip-now {
+  border-color: var(--spy-filter-line);
+  background: var(--spy-accent-wash);
+  color: var(--spy-accent-ink);
+}
+
+.spy-swap-tag {
+  margin-left: auto;
+  padding: 3px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--spy-alert-line);
+  background: var(--spy-paper);
+  color: var(--spy-alert);
+  font-size: 11.5px;
+  font-weight: 560;
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+// ---------- the data, as volume ----------
+// One row per step, two bars per row. Equal bars mean the two runs agreed;
+// the first row where they stop matching is where the difference was born.
+
+.spy-flow {
+  margin: 28px 0 0;
+}
+
+.spy-flow-head {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: baseline;
+  justify-content: space-between;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--spy-rule);
+
+  h4 {
+    margin: 0;
+    @include label;
+    color: var(--spy-muted);
+  }
+}
+
+.spy-runkeys {
+  display: flex;
+  gap: 14px;
+}
+
+.spy-runkey {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--spy-secondary);
+
+  &::before {
+    content: "";
+    width: 14px;
+    height: 9px;
+    border-radius: 3px;
+  }
+
+  &.earlier::before {
+    background: var(--spy-run-a);
+  }
+
+  &.later::before {
+    background: var(--spy-run-b);
+  }
+}
+
+.spy-flow-lead {
+  max-width: 72ch;
+  margin: 10px 0 6px;
+  font-size: 12px;
+  color: var(--spy-muted);
+}
+
+.spy-steps {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: grid;
+    // Number, the step with its bars, and the sentence always at the same
+    // place: the left edge of the text does not dance from row to row.
+    grid-template-columns: 26px minmax(0, 1fr) minmax(260px, 38%);
+    gap: 18px;
+    align-items: center;
+    padding: 11px 12px 11px 10px;
+    border-left: 2px solid transparent;
+    border-radius: 5px;
+
+    &:hover {
+      background: var(--spy-surface);
+    }
+  }
+
+  li:last-child .spy-step-no::after {
+    display: none;
+  }
+}
+
+.spy-step-no {
+  position: relative;
+  align-self: start;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--spy-border);
+  border-radius: 50%;
+  background: var(--spy-paper);
+  font-family: var(--spy-mono);
+  font-size: 11px;
+  line-height: 20px;
+  text-align: center;
+  color: var(--spy-secondary);
+
+  // The thread that makes a list of rows read as a flow.
+  &::after {
+    content: "";
+    position: absolute;
+    top: 23px;
+    left: 50%;
+    width: 1px;
+    height: 32px;
+    background: var(--spy-rule);
+  }
+}
+
+.spy-step-body {
+  display: block;
+  min-width: 0;
+}
+
+.spy-step-name {
+  display: block;
+  margin-bottom: 7px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.spy-bar {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  max-width: 460px;
+
+  & + .spy-bar {
+    margin-top: 4px;
+  }
+}
+
+.spy-fill {
+  height: 11px;
+  min-width: 2px;
+  border-radius: 3px;
+  background: var(--spy-run-a);
+  transition: width 0.2s ease;
+}
+
+.spy-bar.later .spy-fill {
+  background: var(--spy-run-b);
+}
+
+.spy-bar-n {
+  font-family: var(--spy-mono);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+  color: var(--spy-muted);
+  white-space: nowrap;
+}
+
+.spy-step-note {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--spy-muted);
+}
+
+.spy-starts {
+  @include label;
+  color: var(--spy-alert);
+}
+
+// Said quietly, and four times over: it is the same fact each time, and the
+// row above is where the eye should stay.
+.spy-carried {
+  font-size: 11px;
+  color: var(--spy-faint);
+}
+
+// The step where the two runs part company: the only red in the picture.
+.spy-step-starts {
+  border-left-color: var(--spy-alert);
+  background: var(--spy-alert-tint);
+
+  .spy-step-no {
+    border-color: var(--spy-alert);
+    color: var(--spy-alert);
+  }
+
+  .spy-step-note > span:last-child {
+    color: var(--spy-alert);
+    font-weight: 500;
+  }
+}
+
+.spy-step-carried {
+  background: var(--spy-carried-bg);
+}
+
+// ---------- the band above the film ----------
+// The counts on one side, the shape of the workflow on the other, so the width
+// of the panel carries something instead of sitting empty.
+
+.spy-band {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 24px 40px;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin: 10px 0 14px;
+}
+
+.spy-shape {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  padding: 10px 16px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-surface);
+}
+
+.spy-shape-group {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  align-items: center;
+}
+
+.spy-boxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 3px;
+  max-width: 116px;
+  justify-content: center;
+
+  i {
+    width: 15px;
+    height: 15px;
+    border: 1px solid var(--spy-box-line);
+    border-radius: 5px;
+    background: var(--spy-paper);
+  }
+}
+
+.spy-shape-label {
+  font-size: 11px;
+  color: var(--spy-muted);
+}
+
+.spy-shape-arrow {
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  color: var(--spy-faint);
+}
+
+// ---------- what gets read first ----------
+// The headline, one sentence per step, and the closing line. The counts are
+// still underneath, but nobody has to translate them: that is already done.
+
+// The first thing read, and it shows: more weight than anything on screen but
+// the workflow's name, and a short measure so the sentence lands at a glance.
+.spy-headline {
+  max-width: 56ch;
+  margin: 22px 0 16px;
+  font-size: 21px;
+  font-weight: 400;
+  line-height: 1.38;
+  letter-spacing: -0.01em;
+  color: var(--spy-text);
+}
+
+.spy-headline-wait {
+  margin: 22px 0 16px;
+  font-size: 21px;
+  line-height: 1.38;
+  color: var(--spy-faint);
+}
+
+.spy-step-said {
+  color: var(--spy-text);
+  font-size: 12.5px;
+  line-height: 1.45;
+}
+
+.spy-step-count {
+  color: var(--spy-muted);
+}
+
+.spy-takeaway {
+  max-width: 78ch;
+  margin: 18px 0 0;
+  padding: 14px 16px;
+  border-radius: var(--r-card);
+  background: var(--spy-surface);
+  font-size: 14.5px;
+  line-height: 1.55;
+  color: var(--spy-text);
+}
+
+.spy-flow .spy-source {
+  margin: 10px 0 0;
+  font-size: 11px;
+  line-height: 1.45;
+  color: var(--spy-muted);
+}
+
+// ===================== the walk-through =====================
+// The flow read top to bottom, one step per row: a sentence, what the step is
+// set to do, and how much data came out of it. Everything else folds away.
+
+.spy-walk-head {
+  margin: 22px 0 10px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.spy-walk {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid var(--spy-rule);
+
+  > li {
+    border-bottom: 1px solid var(--spy-rule);
+    padding: 12px 0;
+
+    &.off {
+      opacity: 0.55;
+    }
+  }
+}
+
+// The rail on the left says where a step sits in the flow without a word: the
+// two ends of the pipe are marked, the middle is not.
+.spy-walk-source .spy-step-no {
+  border-color: var(--spy-accent);
+  color: var(--spy-accent-ink);
+}
+
+.spy-walk-output .spy-step-no {
+  background: var(--spy-chip-bg);
+}
+
+.spy-walk-line {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+}
+
+.spy-walk-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.spy-walk-title {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+
+  b {
+    font-weight: 600;
+  }
+
+  .spy-muted {
+    font-size: 12px;
+  }
+}
+
+.spy-walk-said {
+  margin: 3px 0 0;
+  color: var(--spy-secondary);
+}
+
+.spy-off-tag {
+  @include label;
+  color: var(--spy-edited);
+  border: 1px solid var(--spy-edited-tint);
+  background: var(--spy-edited-tint);
+  padding: 0 5px;
+  border-radius: 5px;
+}
+
+.spy-setting-list {
+  list-style: none;
+  margin: 6px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 14px;
+  font-size: 12px;
+
+  > li {
+    display: flex;
+    gap: 6px;
+    align-items: baseline;
+  }
+}
+
+.spy-setting-label {
+  @include label;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.spy-setting-value {
+  font-family: var(--spy-mono);
+  font-size: 11.5px;
+  background: var(--spy-chip-bg);
+  border-radius: 5px;
+  padding: 0 5px;
+}
+
+.spy-setting-big {
+  color: var(--spy-muted);
+  font-style: italic;
+}
+
+.spy-walk-volume {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-end;
+  min-width: 190px;
+
+  .spy-bar {
+    width: 170px;
+    max-width: 170px;
+  }
+}
+
+.spy-walk-rows-label {
+  @include label;
+  font-size: 10px;
+}
+
+.spy-walk-detail {
+  margin: 10px 0 0 36px;
+  padding: 10px 12px;
+  background: var(--spy-surface);
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+
+  h5 {
+    @include label;
+    margin: 0 0 6px;
+  }
+}
+
+.spy-walk-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 26px;
+  margin: 0 0 10px;
+
+  dt {
+    @include label;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 12.5px;
+  }
+}
+
+.spy-caution {
+  border-left: 2px solid var(--spy-edited);
+  background: var(--spy-edited-tint);
+}
+
+// ===================== what people keep changing =====================
+
+.spy-knobs {
+  margin: 0;
+  padding: 15px 18px 14px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-paper);
+  box-shadow: var(--lift);
+
+  h4 {
+    margin: 0 0 4px;
+    font-size: 13px;
+    font-weight: 600;
+  }
+
+  ul {
+    list-style: none;
+    margin: 8px 0 0;
+    padding: 0;
+  }
+
+  li {
+    display: flex;
+    gap: 10px;
+    align-items: baseline;
+    flex-wrap: wrap;
+    padding: 5px 0;
+    border-top: 1px solid var(--spy-rule);
+    font-size: 12.5px;
+  }
+}
+
+// ===================== what has been tried =====================
+
+.spy-trials {
+  th .spy-id {
+    display: block;
+    font-weight: 400;
+  }
+
+  .spy-bar-inline {
+    width: 150px;
+    max-width: 150px;
+    margin-left: auto;
+  }
+}
+
+// A run that repeats an earlier one is not news, and reads quieter for it.
+.spy-repeat td {
+  color: var(--spy-muted);
+}
+
+.spy-repeat-note td {
+  padding-top: 0;
+  border-top: 0;
+  font-size: 11.5px;
+}
+
+.spy-move-row td {
+  border-top: 1px solid var(--spy-rule);
+  padding-top: 8px;
+}
+
+.spy-move {
+  @include label;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--spy-edited);
+}
+
+// ===================== the report =====================
+
+.spy-report {
+  max-width: 760px;
+  margin-top: 6px;
+
+  h3 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 0 0 6px;
+  }
+
+  h4 {
+    font-size: 13px;
+    font-weight: 600;
+    margin: 18px 0 4px;
+  }
+
+  p {
+    margin: 0 0 8px;
+    color: var(--spy-secondary);
+  }
+}
+
+.spy-report-summary {
+  font-size: 14px;
+  color: var(--spy-text) !important;
+  border-left: 2px solid var(--spy-border);
+  padding-left: 12px;
+}
+
+.spy-report-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin: 18px 0 6px;
+}
+
+// The report tab sits apart: it is the one thing here that is written, not read.
+.spy-tab-report {
+  margin-left: auto;
+}
+
+// A setting that holds a whole program, printed only when its step is opened.
+.spy-program {
+  font-family: var(--spy-mono);
+  font-size: 11px;
+  line-height: 1.5;
+  margin: 0 0 10px;
+  padding: 8px 10px;
+  max-height: 220px;
+  overflow: auto;
+  white-space: pre;
+  background: var(--spy-paper);
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  color: var(--spy-secondary);
+}
+
+// The canvas in the walkthrough is the same drawing as in the footage, but it
+// stands alone rather than beside a log, so it gets the full width.
+.spy-canvas-today {
+  margin: 18px 0 0;
+  max-height: 300px;
+
+  svg {
+    max-height: 240px;
+  }
+}
+
+// A run that produced nothing is not a small result: it is a different event,
+// and the table says so rather than leaving a zero to be noticed.
+.spy-empty-trial td {
+  color: var(--spy-muted);
+}
+
+.spy-nothing {
+  @include label;
+  display: block;
+  color: var(--spy-alert);
+  text-align: right;
+}
+
+// ===================== the flow, drawn =====================
+// The whole workflow as one picture: a box per step, a pipe per connection, and
+// every pipe as thick as the rows that run through it. Where the flow narrows
+// is seen before a number is read, which is the entire point of drawing it.
+
+.spy-flowmap {
+  margin: 0;
+  padding: 18px 18px 12px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-paper);
+  box-shadow: var(--lift);
+
+  svg {
+    display: block;
+    width: 100%;
+    max-height: 340px;
+  }
+
+  figcaption {
+    display: flex;
+    gap: 18px;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--spy-rule);
+  }
+}
+
+.spy-pipe {
+  fill: none;
+  stroke: var(--spy-run-b);
+  stroke-opacity: 0.32;
+  stroke-linecap: round;
+}
+
+.spy-pipe-n {
+  font-family: var(--spy-mono);
+  font-size: 10px;
+  fill: var(--spy-muted);
+}
+
+.spy-map-node {
+  cursor: pointer;
+
+  .spy-map-box {
+    fill: var(--spy-paper);
+    stroke: var(--spy-box-line);
+    stroke-width: 1;
+  }
+
+  .spy-map-glyph {
+    fill: var(--spy-muted);
+  }
+
+  .spy-map-name {
+    font-size: 12.5px;
+    font-weight: 600;
+    fill: var(--spy-text);
+  }
+
+  .spy-map-rows {
+    font-family: var(--spy-mono);
+    font-size: 11px;
+    fill: var(--spy-secondary);
+  }
+
+  // What a step swallows, said where it happens rather than in a table.
+  .spy-map-drop {
+    font-family: var(--spy-mono);
+    font-size: 11px;
+    fill: var(--spy-alert);
+  }
+
+  &:hover .spy-map-box {
+    stroke: var(--spy-accent);
+  }
+
+  &.here .spy-map-box {
+    stroke: var(--spy-accent);
+    stroke-width: 2;
+  }
+}
+
+// The two ends of the pipe are the only ones that need a colour of their own.
+.spy-map-source .spy-map-box {
+  stroke: var(--spy-added);
+}
+
+.spy-map-source .spy-map-glyph {
+  fill: var(--spy-added);
+}
+
+.spy-map-output .spy-map-box {
+  stroke: var(--spy-edited);
+}
+
+.spy-map-output .spy-map-glyph {
+  fill: var(--spy-edited);
+}
+
+.spy-map-legend {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  @include label;
+
+  i {
+    display: block;
+    width: 22px;
+    border-radius: 5px;
+    background: var(--spy-run-b);
+    opacity: 0.32;
+  }
+
+  i.thin {
+    height: 2px;
+  }
+
+  i.thick {
+    height: 9px;
+  }
+}
+
+// ===================== the step being looked at =====================
+
+.spy-picked {
+  position: sticky;
+  top: 0;
+  margin: 0;
+  padding: 16px 18px 18px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-paper);
+  box-shadow: var(--lift);
+}
+
+.spy-picked-kicker {
+  margin: 0 0 10px;
+  @include label;
+}
+
+.spy-picked-head {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+
+  h4 {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+  }
+
+  > div:nth-child(2) {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .spy-muted {
+    font-size: 12px;
+  }
+}
+
+.spy-picked-glyph {
+  width: 30px;
+  height: 30px;
+  flex: none;
+  color: var(--spy-secondary);
+}
+
+.spy-picked-walk {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  @include label;
+}
+
+.spy-picked-said {
+  margin: 10px 0 0;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--spy-text);
+}
+
+.spy-picked-volume {
+  margin: 12px 0 0;
+
+  .spy-bar {
+    max-width: 420px;
+  }
+}
+
+.spy-picked-keeps {
+  display: block;
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--spy-muted);
+}
+
+.spy-picked-rows {
+  margin-top: 12px;
+
+  .spy-muted {
+    font-size: 11.5px;
+  }
+}
+
+.spy-picked-foot {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  flex-wrap: wrap;
+  margin: 12px 0 0;
+  font-size: 11.5px;
+  color: var(--spy-muted);
+}
+
+// A dot per change, filled when that value was actually run: the dials of this
+// workflow at a glance, without a column of counts.
+.spy-knob-dots {
+  display: flex;
+  gap: 3px;
+  align-items: center;
+
+  i {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    border: 1px solid var(--spy-border);
+  }
+
+  i.tried {
+    background: var(--spy-accent);
+    border-color: var(--spy-accent);
+  }
+}
+
+.spy-knob-where {
+  border: 0;
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  color: inherit;
+  font: inherit;
+
+  &:hover b {
+    color: var(--spy-accent-ink);
+  }
+}
+
+// ===================== one dial at a time =====================
+// What a setting was tried at, and what came out each time. Two or three bars
+// answer the tab's question before the table underneath is even looked at.
+
+.spy-dials {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin: 16px 0 18px;
+}
+
+.spy-dial {
+  flex: 1 1 320px;
+  min-width: 300px;
+  padding: 12px 14px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-paper);
+}
+
+.spy-dial-head {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+
+  b {
+    font-weight: 600;
+  }
+
+  .spy-muted {
+    font-size: 11.5px;
+  }
+}
+
+.spy-dial-values {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+
+  > li {
+    display: flex;
+    gap: 10px;
+    align-items: center;
+    padding: 4px 0;
+  }
+
+  .spy-bar {
+    flex: 1;
+    max-width: none;
+  }
+}
+
+.spy-dial-value {
+  font-family: var(--spy-mono);
+  font-size: 11.5px;
+  background: var(--spy-chip-bg);
+  border-radius: 5px;
+  padding: 1px 6px;
+  min-width: 62px;
+  text-align: center;
+}
+
+// A tick per run at that value: how much evidence there is, drawn.
+.spy-dial-runs {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+  min-width: 92px;
+
+  i {
+    width: 3px;
+    height: 11px;
+    border-radius: 3px;
+    background: var(--spy-faint);
+  }
+
+  .spy-muted {
+    margin-left: 4px;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+}
+
+.spy-dial-verdict {
+  margin: 8px 0 0;
+  padding-top: 8px;
+  border-top: 1px solid var(--spy-rule);
+  font-size: 12px;
+  color: var(--spy-secondary);
+}
+
+// A value whose runs disagreed is drawn as a spread, not as a single bar: the
+// pale part is how far apart those runs were.
+.spy-dial-track {
+  position: relative;
+  flex: 1;
+  height: 11px;
+
+  .spy-fill {
+    position: absolute;
+    left: 0;
+    top: 0;
+    height: 11px;
+  }
+
+  .spy-fill-spread {
+    opacity: 0.3;
+  }
+}
+
+// The report's sections open one at a time. The first is already open, so the
+// tab never opens on a closed door.
+.spy-report-section {
+  border-top: 1px solid var(--spy-rule);
+  padding: 4px 0 8px;
+}
+
+.spy-report-toggle {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  width: 100%;
+  padding: 8px 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--spy-text);
+  text-align: left;
+
+  svg {
+    width: 14px;
+    height: 14px;
+    flex: none;
+    color: var(--spy-muted);
+    transition: transform 0.15s ease;
+  }
+
+  &.open svg {
+    transform: rotate(90deg);
+  }
+}
+
+// A tick for a run that produced rows, a hollow one for a run that came out
+// empty: how much evidence a value has, and how much of it is worth anything.
+.spy-dial-runs i.tried {
+  background: var(--spy-run-b);
+}
+
+// ---------- how the runs moved ----------
+
+// Thin lines, small dots, and room around them. Two metrics is all the record
+// actually holds: how long a run took, and how many rows came out the end.
+.spy-trends {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.spy-trend {
+  padding: 15px 18px 13px;
+  border: 1px solid var(--spy-rule);
+  border-radius: var(--r-card);
+  background: var(--spy-paper);
+  box-shadow: var(--lift);
+}
+
+.spy-trend-head {
+  display: flex;
+  align-items: baseline;
+  gap: 9px;
+}
+
+.spy-trend-label {
+  flex: 1;
+  @include label;
+  font-size: 12px;
+}
+
+.spy-trend-now {
+  font-size: 19px;
+  font-weight: 500;
+  letter-spacing: -0.018em;
+  color: var(--spy-text);
+}
+
+// Blue when it got quicker, red only when it got slower. More rows is neither,
+// so that one stays grey rather than pretending to be a verdict.
+.spy-trend-change {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--spy-muted);
+
+  &.is-better {
+    color: var(--spy-accent-ink);
+  }
+
+  &.is-worse {
+    color: var(--spy-alert);
+  }
+}
+
+.spy-plot {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 6px 0 2px;
+  overflow: visible;
+
+  polyline {
+    fill: none;
+    stroke: var(--spy-accent);
+    stroke-width: 1.4;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  circle {
+    fill: var(--spy-paper);
+    stroke: var(--spy-accent);
+    stroke-width: 1.4;
+  }
+
+  // The run you are looking at last is the filled one.
+  circle.last {
+    fill: var(--spy-accent);
+  }
+
+  // A run that produced nothing is drawn hollow, on the floor, with the line
+  // broken either side of it: it is a different event, not a small number.
+  circle.empty {
+    fill: var(--spy-paper);
+    stroke: var(--spy-edge);
+    stroke-dasharray: 2 1.6;
+  }
+}
+
+.spy-trend-foot {
+  margin: 0;
+  font-size: 11.5px;
+  color: var(--spy-faint);
+}

--- a/frontend/src/app/workspace/component/spy/spy.component.ts
+++ b/frontend/src/app/workspace/component/spy/spy.component.ts
@@ -1,0 +1,2778 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * The spy button: opens the record Texera keeps of a workflow without showing it.
+ *
+ * Two tabs. THE FOOTAGE replays the canvas one saved version at a time, rebuilt
+ * from the inverse patches in `workflow_version`. THE AUTOPSY compares two runs
+ * operator by operator and names the edit that moved the numbers.
+ *
+ * The data comes from spy/server.py, which reads the database directly. That
+ * server only reads, with one exception: the autopsy tab can ask it to run the
+ * workflow and keep every step's rows, because Texera throws them away.
+ */
+import { HttpClient } from "@angular/common/http";
+import { Component, HostListener, OnDestroy, OnInit, inject } from "@angular/core";
+import { NgClass, NgFor, NgIf, NgTemplateOutlet } from "@angular/common";
+import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
+import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
+import { CustomJSONSchema7 } from "../../types/custom-json-schema.interface";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { map, switchMap, tap } from "rxjs/operators";
+import { Observable, of } from "rxjs";
+import { AuthService } from "../../../common/service/user/auth.service";
+import { ComputingUnitStatusService } from "../../../common/service/computing-unit/computing-unit-status/computing-unit-status.service";
+import { WorkflowPersistService } from "../../../common/service/workflow-persist/workflow-persist.service";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { Workflow } from "../../../common/type/workflow";
+
+export const SPY_API = "http://127.0.0.1:5055/api/spy";
+
+/** The five views. Each one is a question somebody actually asks. */
+export type SpyTab = "brief" | "footage" | "experiments" | "autopsy" | "report";
+
+/** Milliseconds each version is held on screen while the footage plays. */
+const FRAME_MS = 950;
+
+const BOX_WIDTH = 150;
+const BOX_HEIGHT = 46;
+const BOX_MARGIN = 40;
+
+// The walkthrough's own diagram, which is laid out here rather than taken from
+// the canvas: bigger boxes, because each one carries an icon and a count.
+const NODE_WIDTH = 178;
+const NODE_HEIGHT = 66;
+const NODE_GAP_X = 70;
+const NODE_GAP_Y = 26;
+
+// The kinds of step whose job is to let some rows through and not others.
+const DISCARDS = new Set(["filter", "limit"]);
+
+// The autopsy's own boxes: wider and taller, because each one carries two
+// volume bars and the counts behind them.
+
+interface SpyOperator {
+  id: string;
+  type: string;
+  name: string;
+  x: number;
+  y: number;
+  disabled: boolean;
+  /** Display names of its input ports, to tell one input from another. */
+  inputs?: string[];
+}
+
+interface SpyLink {
+  from: string;
+  to: string;
+}
+
+/** One edit the workflow's author made, read back from the saved patch. */
+interface SpyChange {
+  kind: string;
+  text: string;
+  operatorId?: string;
+  operatorType?: string;
+  name?: string;
+  from?: string;
+  to?: string;
+  path?: string;
+  before?: string;
+  after?: string;
+  /** The value itself, when it was small enough to travel, for describing it. */
+  beforeValue?: unknown;
+  afterValue?: unknown;
+  /** Which input of the target operator the link lands on. */
+  port?: string;
+}
+
+/** One question put to the record, and what came back. */
+interface SpyTurn {
+  question: string;
+  answer?: string;
+  failed?: boolean;
+}
+
+/** A change written the way the person who made it would say it. */
+interface Told {
+  lead: string;
+  before?: string;
+  after?: string;
+  join?: string;
+  detail: string;
+}
+
+interface SpyRunStub {
+  eid: number;
+  status: string;
+  started: string;
+}
+
+/** The canvas as it stood right after one saved version. */
+interface SpyFrame {
+  vid: number;
+  time: string;
+  broken: boolean;
+  recoverable: boolean;
+  operators: SpyOperator[];
+  links: SpyLink[];
+  changes: SpyChange[];
+  runs: SpyRunStub[];
+}
+
+interface SpyHistory {
+  wid: number;
+  name: string;
+  description: string;
+  total: number;
+  recovered: number;
+  /** Undo steps Texera saved that had nothing left to undo. */
+  tolerated: number;
+  broken: { vid: number; error: string } | null;
+  reachesOrigin: boolean;
+  frames: SpyFrame[];
+}
+
+interface SpyRun {
+  eid: number;
+  vid: number;
+  status: string;
+  started: string;
+  ended: string;
+  snapshot: boolean;
+  name: string | null;
+  rows: number;
+}
+
+/** What the spy server reports after running the workflow and keeping its rows. */
+interface SpyKept {
+  kept: boolean;
+  eid?: number;
+  name?: string;
+  state?: string;
+  success?: boolean;
+  steps?: number;
+  rows?: number;
+  error?: string;
+}
+
+interface SpyDiff {
+  rowsA: number;
+  rowsB: number;
+  /** How many rows the engine actually handed back for this step. */
+  sampleA?: number;
+  sampleB?: number;
+  /** True when the engine cut the output, so the sample proves nothing absent. */
+  sampleTruncated?: boolean;
+  onlyInA: object[];
+  onlyInB: object[];
+  sameSetDifferentOrder: boolean;
+}
+
+interface SpyFinding {
+  /** Real counts as the engine reported them, present even when the two match. */
+  rowsA: number;
+  rowsB: number;
+  truncated: boolean;
+  operatorId: string;
+  diff: SpyDiff | null;
+}
+
+interface SpyEdit {
+  operatorId: string;
+  path: string;
+  before: unknown;
+  after: unknown;
+}
+
+interface SpyAutopsy {
+  wid: number;
+  name: string;
+  a: { eid: number; vid: number; name: string };
+  b: { eid: number; vid: number; name: string };
+  order: string[];
+  findings: SpyFinding[];
+  firstDivergent: string | null;
+  edits: SpyEdit[];
+}
+
+/** An operator box already placed inside the drawn canvas. */
+interface CanvasBox {
+  op: SpyOperator;
+  x: number;
+  y: number;
+  mark: "added" | "edited" | "untouched";
+  note: string;
+}
+
+interface CanvasArrow {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+/** An operator that is not on the canvas yet, drawn where it will land. */
+interface GhostBox {
+  id: string;
+  x: number;
+  y: number;
+}
+
+/** One block of the filmstrip: a save, coloured by what it did to the canvas. */
+interface TapeBlock {
+  index: number;
+  tone: "added" | "removed" | "edited" | "quiet" | "broken";
+  label: string;
+  ran: boolean;
+}
+
+/** One step of the run comparison, drawn as two bars instead of two numbers. */
+interface PipelineStep {
+  id: string;
+  position: number;
+  name: string;
+  rowsA: number;
+  rowsB: number;
+  barA: number;
+  barB: number;
+  state: "same" | "starts" | "carried" | "reordered";
+  note: string;
+  truncated: boolean;
+}
+
+/** One setting of a step, as the panel is given it: raw, to be worded here. */
+interface BriefSetting {
+  path: string;
+  value?: unknown;
+  /** Set instead of the value when the value is too big to describe. */
+  lines?: number;
+  size?: number;
+}
+
+/** One step of the workflow as it stands today, with what it does and moves. */
+interface BriefStep {
+  id: string;
+  position: number;
+  name: string;
+  type: string;
+  role: "source" | "step" | "output";
+  disabled: boolean;
+  settings: BriefSetting[];
+  fedBy: { id: string; port: string }[];
+  feeds: string[];
+  rowsIn: number | null;
+  rowsOut: number | null;
+  workers: number | null;
+  seconds: number | null;
+  columns: string[];
+  sample: Record<string, unknown>[];
+  edits: number;
+  lastEdited: string | null;
+  addedOn: string | null;
+}
+
+/** A setting people actually turn, either repeatedly or between two runs. */
+interface BriefKnob {
+  stepId: string;
+  step: string;
+  type: string;
+  path: string;
+  times: number;
+  tried: boolean;
+  value?: unknown;
+}
+
+interface SpyBrief {
+  wid: number;
+  name: string;
+  description: string;
+  people: { name: string; access: string; owner: boolean }[];
+  ranBy: string[];
+  shape: { sources: number; middle: number; outputs: number };
+  steps: BriefStep[];
+  knobs: BriefKnob[];
+  sampleFrom: { eid: number; name: string; when: string; current: boolean } | null;
+  record: {
+    saves: number;
+    sessions: number;
+    started: string | null;
+    lastEdited: string | null;
+    runs: number;
+    completed: number;
+    lastRun: string | null;
+    lastRunName: string;
+    unreadable: number;
+    broken: boolean;
+  };
+}
+
+/** The workflow walked through for someone who has never opened it. */
+interface Tour {
+  headline: string;
+  purpose: string;
+  steps: Record<string, string>;
+  watchOut: string;
+  model: string;
+}
+
+/** What one step did in one run, as the engine's own statistics recorded it. */
+interface RunStep {
+  in: number;
+  out: number;
+  workers: number;
+  seconds: number;
+}
+
+/** One run of the workflow, read as an experiment: settings in, rows out. */
+interface ExperimentRun {
+  eid: number;
+  vid: number;
+  name: string;
+  who: string;
+  started: string;
+  ended: string;
+  seconds: number | null;
+  status: string;
+  snapshot: boolean;
+  measured: boolean;
+  steps: Record<string, RunStep>;
+  readIn: number;
+  produced: number;
+  settings: Record<string, unknown>;
+  canvasSteps: number;
+}
+
+/** A setting that was not the same in every run: the dial of an experiment. */
+interface KnobDef {
+  id: string;
+  stepId: string;
+  step: string;
+  type: string;
+  path: string;
+}
+
+/** What changed between one run and the next one after it. */
+interface RunMove {
+  from: number;
+  to: number;
+  edits: { knob: string; step: string; stepId: string; type: string; path: string; before: unknown; after: unknown }[];
+  structure: { kind: string; step: string; stepId: string; before?: string }[];
+  producedBefore: number;
+  producedAfter: number;
+}
+
+interface SpyExperiments {
+  wid: number;
+  name: string;
+  knobs: KnobDef[];
+  runs: ExperimentRun[];
+  moves: RunMove[];
+}
+
+interface SpyReport {
+  title: string;
+  summary: string;
+  sections: { heading: string; body: string }[];
+  markdown: string;
+  model: string;
+  written: boolean;
+}
+
+/** One step drawn as a box in the flow diagram, with its own volume. */
+/** One run's place on a metric line: a dot, and what it says when hovered. */
+interface TrendDot {
+  x: number;
+  y: number;
+  eid: number;
+  label: string;
+  value: string;
+  /** A run that produced nothing is a different event, not a low point. */
+  empty: boolean;
+}
+
+/** One metric read across every run that measured it. */
+interface Trend {
+  key: string;
+  label: string;
+  /** The line is cut wherever a run produced nothing, so it never lies. */
+  segments: string[];
+  dots: TrendDot[];
+  high: string;
+  low: string;
+  latest: string;
+  change: string;
+  /** Only latency is judged. More rows is not better or worse, it is different. */
+  verdict: "" | "better" | "worse" | "same";
+}
+
+interface FlowNode {
+  step: BriefStep;
+  x: number;
+  y: number;
+  kind: string;
+  glyph: string;
+  rows: number | null;
+  /** How many rows this step swallows, when it swallows a noticeable share. */
+  drop: number;
+}
+
+/** One pipe between two boxes, as thick as the data that runs through it. */
+interface FlowPipe {
+  path: string;
+  width: number;
+  rows: number;
+  midX: number;
+  midY: number;
+}
+
+/** One row of the experiments table, already worked out for the template. */
+interface ExperimentRow {
+  run: ExperimentRun;
+  values: { knob: KnobDef; text: string; changed: boolean }[];
+  bar: number;
+  move?: RunMove;
+  repeatOf?: number;
+}
+
+@UntilDestroy()
+@Component({
+  selector: "texera-spy",
+  templateUrl: "spy.component.html",
+  styleUrls: ["spy.component.scss"],
+  imports: [NgIf, NgFor, NgClass, NgTemplateOutlet],
+})
+export class SpyComponent implements OnInit, OnDestroy {
+  private readonly http = inject(HttpClient);
+  private readonly metadata = inject(OperatorMetadataService);
+  private readonly computingUnits = inject(ComputingUnitStatusService);
+  private readonly workflowPersist = inject(WorkflowPersistService);
+  private readonly workflowAction = inject(WorkflowActionService);
+  private readonly modalData = inject<{ wid: number }>(NZ_MODAL_DATA, { optional: true });
+
+  public wid = 0;
+  public error = "";
+  /**
+   * The tabs are the questions they answer. The first one is where someone who
+   * has never opened this workflow lands, so it is the one that opens first.
+   */
+  public tab: SpyTab = "brief";
+
+  // ----- the workflow as it stands today -----
+  public brief?: SpyBrief;
+  public loadingBrief = true;
+  public tour: Tour = { headline: "", purpose: "", steps: {}, watchOut: "", model: "" };
+  public tourPending = false;
+  /** The step whose detail is open in the walkthrough. */
+  public opened: string | null = null;
+
+  // ----- what has been tried -----
+  public experiments?: SpyExperiments;
+  public loadingExperiments = false;
+  // ----- the report -----
+  public report?: SpyReport;
+  public reportPending = false;
+  public reportFailed = false;
+  public copied = false;
+
+  // ----- the footage -----
+  public history?: SpyHistory;
+  public loadingHistory = true;
+  public index = 0;
+  public playing = false;
+  private clock?: ReturnType<typeof setInterval>;
+
+  /** Fixed camera: the frame is computed once over every version at once. */
+  public viewBox = "0 0 800 400";
+  public boxes: CanvasBox[] = [];
+  public arrows: CanvasArrow[] = [];
+  public ghosts: GhostBox[] = [];
+  /** When set, the activity log only shows what touched this operator. */
+  public focused: string | null = null;
+  /** Whether saves that changed nothing visible are listed too. */
+  public showEverySave = false;
+  /** Whether the note on how the rebuild works is unfolded. */
+  public showMethod = false;
+
+  /** The exact counts, kept behind a disclosure: the bars say it first. */
+  public showNumbers = false;
+
+  // ----- the autopsy -----
+  public runs: SpyRun[] = [];
+  public comparable: SpyRun[] = [];
+  public eidA?: number;
+  public eidB?: number;
+  public autopsy?: SpyAutopsy;
+  public loadingAutopsy = false;
+
+  // ----- running a workflow and keeping its rows -----
+  /** Whether a run asked for from this panel is still on. */
+  public keeping = false;
+  /** What that run is doing right now, for the line under the button. */
+  public keepingStep = "";
+  public keptError?: string;
+  public kept?: SpyKept;
+  public expanded = new Set<string>();
+
+  public readonly boxWidth = BOX_WIDTH;
+  public readonly boxHeight = BOX_HEIGHT;
+
+  ngOnInit(): void {
+    this.wid = this.modalData?.wid ?? 0;
+    if (!this.wid) {
+      this.error = "this workflow has not been saved yet, so there is nothing on record to open.";
+      this.loadingHistory = false;
+      return;
+    }
+    this.http
+      .get<SpyHistory>(`${SPY_API}/history?wid=${this.wid}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: h => {
+          this.history = h;
+          this.loadingHistory = false;
+          this.frameCamera();
+          this.goTo(this.frames.length - 1);
+          this.readOut("footage", `wid=${this.wid}`);
+        },
+        error: (e: unknown) => {
+          this.loadingHistory = false;
+          this.error = this.explain(e);
+        },
+      });
+    this.http
+      .get<SpyBrief>(`${SPY_API}/brief?wid=${this.wid}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: b => {
+          this.brief = b;
+          this.loadingBrief = false;
+          this.layOut();
+          this.walkThrough();
+        },
+        error: (e: unknown) => {
+          this.loadingBrief = false;
+          this.error = this.explain(e);
+        },
+      });
+    this.loadRuns()
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => this.pickLastTwo(),
+        error: (e: unknown) => {
+          this.error = this.explain(e);
+        },
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.stop();
+  }
+
+  private explain(e: unknown): string {
+    const failure = e as { status?: number; error?: { error?: string } };
+    if (failure?.status === 0) {
+      return "the spy server is not answering. Start it with: /home/bruno/texera/start-spy.sh";
+    }
+    return failure?.error?.error ?? "the request to the spy server failed.";
+  }
+
+  // ---------- keyboard ----------
+
+  @HostListener("document:keydown", ["$event"])
+  public onKey(event: KeyboardEvent): void {
+    if (this.tab !== "footage" || !this.history) {
+      return;
+    }
+    const target = event.target as HTMLElement | null;
+    // The scrubber already moves itself with the arrows; stepping twice skips.
+    if (target && (target.tagName === "INPUT" || target.tagName === "SELECT")) {
+      return;
+    }
+    switch (event.key) {
+      case "ArrowLeft":
+        this.previous();
+        break;
+      case "ArrowRight":
+        this.next();
+        break;
+      case "Home":
+        this.stop();
+        this.goTo(0);
+        break;
+      case "End":
+        this.stop();
+        this.goTo(this.last);
+        break;
+      case " ":
+        this.play();
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+  }
+
+  // ---------- the footage ----------
+
+  /**
+   * Saves that changed nothing visible are noise for anyone who is not reading
+   * the database, so they are left out unless asked for.
+   */
+  public get frames(): SpyFrame[] {
+    const all = this.history?.frames ?? [];
+    if (this.showEverySave) {
+      return all;
+    }
+    return all.filter(
+      (f, i) => i === 0 || i === all.length - 1 || f.changes.length > 0 || f.runs.length > 0 || !f.recoverable
+    );
+  }
+
+  public get hiddenCount(): number {
+    return (this.history?.frames.length ?? 0) - this.frames.length;
+  }
+
+  public get frame(): SpyFrame | undefined {
+    return this.frames[this.index];
+  }
+
+  public get last(): number {
+    return Math.max(0, this.frames.length - 1);
+  }
+
+  /** Keeps the same version on screen when saves are hidden or shown again. */
+  public toggleEverySave(): void {
+    const vid = this.frame?.vid;
+    this.showEverySave = !this.showEverySave;
+    const frames = this.frames;
+    const found = frames.findIndex(f => f.vid === vid);
+    this.goTo(found >= 0 ? found : frames.length - 1);
+  }
+
+  /** The changes to list: all of them, or only those touching the focus. */
+  public get log(): SpyChange[] {
+    const changes = this.frame?.changes ?? [];
+    if (!this.focused) {
+      return changes;
+    }
+    const id = this.focused;
+    return changes.filter(c => c.operatorId === id || c.text.includes(id));
+  }
+
+  /** The log already written out, so the template does not compose sentences. */
+  public get toldLog(): { change: SpyChange; told: Told }[] {
+    return this.fold(this.log);
+  }
+
+  /**
+   * One save often holds several patches that were a single gesture: dropping
+   * an operator into the middle of a connection is a cut and two joins. Read
+   * back one by one they hide what happened, so they are told as one sentence.
+   */
+  private fold(changes: SpyChange[]): { change: SpyChange; told: Told }[] {
+    const added = changes.filter(c => c.kind === "link_added");
+    const spent = new Set<SpyChange>();
+    // The sentence is filed under the member that comes first, so it lands
+    // where the reader expects it and the rest of the group drops out.
+    const grouped = new Map<SpyChange, Told>();
+
+    const file = (members: SpyChange[], lead: string) => {
+      members.forEach(member => spent.add(member));
+      const first = changes.find(c => members.includes(c))!;
+      grouped.set(first, { lead, detail: members.map(m => m.text).join(" · ") });
+    };
+
+    for (const change of changes) {
+      // Cut A into C, then A into B and B into C: something was put in between.
+      if (change.kind === "link_removed" && !spent.has(change)) {
+        const intoMiddle = added.find(l => l.from === change.from && !spent.has(l));
+        const outOfMiddle =
+          intoMiddle && added.find(l => l.from === intoMiddle.to && l.to === change.to && !spent.has(l));
+        if (intoMiddle && outOfMiddle) {
+          file(
+            [change, intoMiddle, outOfMiddle],
+            `You put ${this.nameOf(intoMiddle.to)} between ${this.nameOf(change.from)} and ${this.inputOf(
+              change.to,
+              outOfMiddle.port
+            )}.`
+          );
+        }
+      }
+    }
+
+    for (const change of changes) {
+      // An operator added and wired up in the same save.
+      if (change.kind !== "operator_added" || spent.has(change) || !change.operatorId) {
+        continue;
+      }
+      const id = change.operatorId;
+      const feeding = added.find(l => l.to === id && !spent.has(l));
+      const feeds = added.find(l => l.from === id && !spent.has(l));
+      if (!feeding && !feeds) {
+        continue;
+      }
+      const opening = this.tell(change).lead.replace(/\.$/, "");
+      let wiring: string;
+      if (feeding && feeds) {
+        wiring = `, between ${this.nameOf(feeding.from)} and ${this.inputOf(feeds.to, feeds.port)}`;
+      } else if (feeding) {
+        wiring = ` and fed ${this.nameOf(feeding.from)} into it`;
+      } else {
+        wiring = ` and sent it into ${this.inputOf(feeds!.to, feeds!.port)}`;
+      }
+      file(
+        [change, feeding, feeds].filter((c): c is SpyChange => !!c),
+        `${opening}${wiring}.`
+      );
+    }
+
+    const out: { change: SpyChange; told: Told }[] = [];
+    for (const change of changes) {
+      const told = grouped.get(change);
+      if (told) {
+        out.push({ change, told });
+      } else if (!spent.has(change)) {
+        out.push({ change, told: this.tell(change) });
+      }
+    }
+    return out;
+  }
+
+  /** One line saying what this version did, for someone not reading the log. */
+  public get headline(): string {
+    const f = this.frame;
+    if (!f) {
+      return "";
+    }
+    if (!f.recoverable) {
+      return "Version could not be rebuilt";
+    }
+    if (f.changes.length === 0) {
+      return this.index === 0 ? "Empty canvas" : "No change on the canvas";
+    }
+    const counted = new Map<string, number>();
+    for (const c of f.changes) {
+      counted.set(c.kind, (counted.get(c.kind) ?? 0) + 1);
+    }
+    const phrases: string[] = [];
+    const say = (kind: string, singular: string, plural: string) => {
+      const n = counted.get(kind);
+      if (n) {
+        phrases.push(`${n} ${n === 1 ? singular : plural}`);
+      }
+    };
+    say("operator_added", "operator added", "operators added");
+    say("operator_deleted", "operator deleted", "operators deleted");
+    say("link_added", "link added", "links added");
+    say("link_removed", "link removed", "links removed");
+    say("property", "setting changed", "settings changed");
+    say("renamed", "operator renamed", "operators renamed");
+    say("disabled", "operator toggled", "operators toggled");
+    say("moved", "operator moved", "operators moved");
+    const text = phrases.join(", ");
+    return text.charAt(0).toUpperCase() + text.slice(1);
+  }
+
+  /** How long the author waited before saving this version. */
+  public get sincePrevious(): string {
+    const frames = this.frames;
+    if (!frames.length || this.index === 0) {
+      return "the very beginning";
+    }
+    const before = Date.parse(frames[this.index - 1].time.replace(" ", "T"));
+    const now = Date.parse(frames[this.index].time.replace(" ", "T"));
+    if (isNaN(before) || isNaN(now)) {
+      return "";
+    }
+    return this.spell(Math.max(0, Math.round((now - before) / 1000))) + " later";
+  }
+
+  /** Fixed camera so the graph does not jump around as versions advance. */
+  private frameCamera(): void {
+    const ops = (this.history?.frames ?? []).flatMap(f => f.operators);
+    if (ops.length === 0) {
+      return;
+    }
+    const minX = Math.min(...ops.map(o => o.x));
+    const minY = Math.min(...ops.map(o => o.y));
+    const maxX = Math.max(...ops.map(o => o.x));
+    const maxY = Math.max(...ops.map(o => o.y));
+    const width = maxX - minX + BOX_WIDTH + 2 * BOX_MARGIN;
+    const height = maxY - minY + BOX_HEIGHT + 2 * BOX_MARGIN;
+    this.viewBox = `${minX - BOX_MARGIN} ${minY - BOX_MARGIN} ${width} ${height}`;
+  }
+
+  private draw(): void {
+    const f = this.frame;
+    if (!f) {
+      this.boxes = [];
+      this.arrows = [];
+      this.ghosts = [];
+      return;
+    }
+    const added = new Set(f.changes.filter(c => c.kind === "operator_added").map(c => c.operatorId));
+    const notes = new Map<string, string[]>();
+    for (const c of f.changes) {
+      if (!c.operatorId || c.kind === "operator_deleted") {
+        continue;
+      }
+      const list = notes.get(c.operatorId) ?? [];
+      list.push(c.text);
+      notes.set(c.operatorId, list);
+    }
+    this.boxes = f.operators.map(o => {
+      const touched = notes.get(o.id) ?? [];
+      return {
+        op: o,
+        x: o.x,
+        y: o.y,
+        mark: added.has(o.id) ? "added" : touched.length ? "edited" : "untouched",
+        note: [`${o.id} · ${o.type}`, ...touched].join("\n"),
+      };
+    });
+    const placed = new Map(this.boxes.map(b => [b.op.id, b]));
+    this.arrows = [];
+    for (const link of f.links) {
+      const from = placed.get(link.from);
+      const to = placed.get(link.to);
+      if (from && to) {
+        this.arrows.push({
+          x1: from.x + BOX_WIDTH,
+          y1: from.y + BOX_HEIGHT / 2,
+          x2: to.x,
+          y2: to.y + BOX_HEIGHT / 2,
+        });
+      }
+    }
+    if (this.focused && !placed.has(this.focused)) {
+      this.focused = null;
+    }
+    // Everything the workflow will end up with but does not have yet, drawn as
+    // an outline. Otherwise the early frames are a nearly empty screen and the
+    // fixed camera looks like a bug.
+    const final = this.frames[this.last]?.operators ?? [];
+    this.ghosts = final.filter(o => !placed.has(o.id)).map(o => ({ id: o.id, x: o.x, y: o.y }));
+  }
+
+  public goTo(i: number): void {
+    this.index = Math.max(0, Math.min(this.last, i));
+    this.draw();
+  }
+
+  public previous(): void {
+    this.stop();
+    this.goTo(this.index - 1);
+  }
+
+  public next(): void {
+    this.stop();
+    this.goTo(this.index + 1);
+  }
+
+  public onScrub(value: string | number): void {
+    this.stop();
+    this.goTo(typeof value === "number" ? value : parseInt(value, 10));
+  }
+
+  public play(): void {
+    if (this.playing) {
+      this.stop();
+      return;
+    }
+    if (this.index >= this.last) {
+      this.goTo(0);
+    }
+    this.playing = true;
+    this.clock = setInterval(() => {
+      if (this.index >= this.last) {
+        this.stop();
+        return;
+      }
+      this.goTo(this.index + 1);
+    }, FRAME_MS);
+  }
+
+  public stop(): void {
+    this.playing = false;
+    if (this.clock) {
+      clearInterval(this.clock);
+      this.clock = undefined;
+    }
+  }
+
+  public focus(id: string): void {
+    this.focused = this.focused === id ? null : id;
+  }
+
+  /** Rewinds to the first version where this operator was touched. */
+  public rewindTo(id: string): void {
+    const frames = this.frames;
+    const found = frames.findIndex(f => f.changes.some(c => c.operatorId === id));
+    if (found >= 0) {
+      this.stop();
+      this.goTo(found);
+    }
+  }
+
+  // ---------- the autopsy ----------
+
+  /**
+   * The written-out reading of the record. The panel never waits for it: the
+   * derived text stands on its own and this arrives underneath when it can.
+   * Facts are worked out here; the model only puts them into words.
+   */
+  /**
+   * What the model writes about the comparison: a headline, one sentence per
+   * step and a closing line. The rules still decide which step is to blame and
+   * how many rows moved; this only puts that into words, so that nobody has to
+   * translate a row count into what it means for their data.
+   */
+  public narration: { headline: string; steps: Record<string, string>; takeaway: string } = {
+    headline: "",
+    steps: {},
+    takeaway: "",
+  };
+  public narrationPending = false;
+
+  public reading: { footage?: string; autopsy?: string } = {};
+  public readingPending = { footage: false, autopsy: false };
+
+  /** Pide la lectura de la comparacion: titular, una frase por paso y final. */
+  private narrate(): void {
+    this.narration = { headline: "", steps: {}, takeaway: "" };
+    this.narrationPending = true;
+    this.http
+      .get<{ headline: string; steps: Record<string, string>; takeaway: string }>(
+        `${SPY_API}/narrate?wid=${this.wid}&a=${this.eidA}&b=${this.eidB}`
+      )
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: r => {
+          this.narration = { headline: r.headline ?? "", steps: r.steps ?? {}, takeaway: r.takeaway ?? "" };
+          this.narrationPending = false;
+        },
+        // With no key or no server there are no sentences, and the panel keeps
+        // what it worked out on its own: the counts and the step to blame.
+        error: () => (this.narrationPending = false),
+      });
+  }
+
+  /** La frase escrita para un paso, si llego. */
+  public sentenceFor(id: string): string {
+    return this.narration.steps[id] ?? "";
+  }
+
+  private readOut(which: "footage" | "autopsy", query: string): void {
+    if (this.reading[which] || this.readingPending[which]) {
+      return;
+    }
+    this.readingPending[which] = true;
+    this.http
+      .get<{ text: string }>(`${SPY_API}/explain?${query}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: r => {
+          this.reading[which] = (r.text ?? "").trim() || undefined;
+          this.readingPending[which] = false;
+        },
+        // Silence is the right failure here: no key, no server, no paragraph.
+        error: () => (this.readingPending[which] = false),
+      });
+  }
+
+  // ---------- asking it things ----------
+
+  /** What has been asked and answered, kept per tab so they do not mix. */
+  public chat: Record<string, SpyTurn[]> = { brief: [], footage: [], experiments: [], autopsy: [] };
+  public draft = "";
+  public asking = false;
+
+  /** Which set of facts a question is answered from, per tab. */
+  private get asked(): string {
+    return this.tab === "report" ? "brief" : this.tab;
+  }
+
+  public get turns(): SpyTurn[] {
+    return this.chat[this.asked] ?? [];
+  }
+
+  /** Openers, for the person who does not know what can be asked. */
+  public get suggestions(): string[] {
+    const asked = new Set(this.turns.map(t => t.question));
+    if (this.tab === "brief") {
+      const output = this.steps.filter(x => x.role === "output")[0];
+      return [
+        "What does this workflow actually answer?",
+        output ? `Where do the rows in ${output.name} come from?` : "Which step decides how many rows come out?",
+        "Which settings here are the ones worth changing?",
+        "Is there anything in this workflow that does nothing?",
+      ].filter(q => !asked.has(q));
+    }
+    if (this.tab === "experiments") {
+      const knob = this.knobs[0];
+      return [
+        knob ? `What did changing ${knob.step} do to the results?` : "What has actually been varied between runs?",
+        "Which of these runs are the same experiment repeated?",
+        "Has anything been tried that made no difference at all?",
+        "What has never been tried here?",
+      ].filter(q => !asked.has(q));
+    }
+    if (this.tab === "autopsy") {
+      const a = this.autopsy;
+      if (!a) {
+        return [];
+      }
+      const step = a.firstDivergent ? this.opName(a.firstDivergent) : "the first step that differs";
+      return [
+        `What kind of rows did ${step} stop letting through?`,
+        "Which of the two runs should I trust for my question?",
+        "Do the row counts add up from one step to the next?",
+        "What else changed besides the edit you found?",
+      ].filter(q => !asked.has(q));
+    }
+    return [
+      "What was this workflow built to answer?",
+      "Where did I change my mind while building it?",
+      "Is there anything here that does nothing?",
+      "What was the last real change, ignoring the automatic saves?",
+    ].filter(q => !asked.has(q));
+  }
+
+  public askAbout(question: string): void {
+    const text = (question ?? "").trim();
+    if (!text || this.asking) {
+      return;
+    }
+    const turn: SpyTurn = { question: text };
+    const where = this.asked;
+    this.chat[where] = this.chat[where] ?? [];
+    this.chat[where].push(turn);
+    this.draft = "";
+    this.asking = true;
+    const body: Record<string, unknown> = {
+      wid: this.wid,
+      question: text,
+      // The facts a question is answered from are the ones on screen: the
+      // walkthrough, the experiments table, the comparison or the history.
+      mode: where === "footage" ? "history" : where,
+      previous: this.chat[where].filter(t => t.answer).map(t => ({ question: t.question, answer: t.answer })),
+    };
+    if (where === "autopsy" && this.autopsy) {
+      body["a"] = this.autopsy.a.eid;
+      body["b"] = this.autopsy.b.eid;
+    }
+    this.http
+      .post<{ text: string }>(`${SPY_API}/ask`, body)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: r => {
+          turn.answer = (r.text ?? "").trim() || "No answer came back.";
+          this.asking = false;
+        },
+        error: () => {
+          turn.failed = true;
+          this.asking = false;
+        },
+      });
+  }
+
+  /** The reading of one paragraph at a time, so it lays out as prose. */
+  public paragraphs(text: string | undefined): string[] {
+    return (text ?? "").split(/\n\s*\n/).filter(p => p.trim().length > 0);
+  }
+
+  /**
+   * Fills the list of runs. Only the ones whose rows were kept can be compared,
+   * so those are the ones the two pickers offer.
+   */
+  private loadRuns(): Observable<SpyRun[]> {
+    return this.http.get<{ runs: SpyRun[] }>(`${SPY_API}/executions?wid=${this.wid}`).pipe(
+      map(r => r.runs),
+      tap(runs => {
+        this.runs = runs;
+        this.comparable = runs.filter(run => run.snapshot);
+      })
+    );
+  }
+
+  /** The two runs the panel opens with: the last two, which is what people ask about. */
+  private pickLastTwo(): void {
+    if (this.comparable.length >= 2) {
+      this.eidA = this.comparable[this.comparable.length - 2].eid;
+      this.eidB = this.comparable[this.comparable.length - 1].eid;
+    }
+  }
+
+  /**
+   * Runs the workflow and keeps every step's rows, so this run can be compared.
+   *
+   * Texera throws a run's results away 30 seconds after the workflow goes
+   * quiet, which is why the list of comparable runs is shorter than the list of
+   * runs. The engine's synchronous route hands the rows back in its own reply,
+   * so they are written down on the way past. Nothing here disables or delays
+   * that cleanup.
+   *
+   * The workflow is saved first on purpose. A run is recorded against whichever
+   * version was current when it started, so running with unsaved edits would
+   * have the autopsy blame an edit that never ran.
+   */
+  public runAndKeep(): void {
+    if (this.keeping) {
+      return;
+    }
+    const cuid = this.computingUnits.getSelectedComputingUnitValue()?.computingUnit.cuid;
+    if (cuid === undefined) {
+      this.keptError = "choose a computing unit first. This run goes to the same engine as the Run button.";
+      return;
+    }
+    const token = AuthService.getAccessToken();
+    if (!token) {
+      this.keptError = "your session has no token, so the run cannot be asked for on your behalf.";
+      return;
+    }
+    this.keeping = true;
+    this.keptError = undefined;
+    this.kept = undefined;
+    this.keepingStep = "Saving the workflow, so the run is recorded against what you have on screen…";
+    this.workflowPersist
+      .persistWorkflow(this.workflowAction.getWorkflow())
+      .pipe(
+        tap((saved: Workflow) => this.workflowAction.setWorkflowMetadata(saved)),
+        switchMap(() => {
+          this.keepingStep = "Running every step and keeping its rows. A full run takes as long as it takes…";
+          return this.http.post<SpyKept>(`${SPY_API}/run`, {
+            wid: this.wid,
+            cuid,
+            token,
+            name: "kept from the spy panel",
+          });
+        }),
+        switchMap(kept => {
+          this.kept = kept;
+          if (!kept.kept) {
+            return of([] as SpyRun[]);
+          }
+          this.keepingStep = "Adding it to the list…";
+          return this.loadRuns();
+        }),
+        untilDestroyed(this)
+      )
+      .subscribe({
+        next: () => {
+          this.keeping = false;
+          this.keepingStep = "";
+          const eid = this.kept?.eid;
+          if (!this.kept?.kept || eid === undefined) {
+            this.keptError = this.kept?.error ?? "the run did not finish, so nothing was kept.";
+            return;
+          }
+          // The new run becomes the later side of the comparison, and the one
+          // kept before it the earlier side. That is the comparison someone who
+          // just pressed this button wants to see.
+          const spot = this.comparable.findIndex(r => r.eid === eid);
+          this.eidB = eid;
+          if (spot > 0) {
+            this.eidA = this.comparable[spot - 1].eid;
+            this.compare();
+          }
+        },
+        error: (e: unknown) => {
+          this.keeping = false;
+          this.keepingStep = "";
+          this.keptError = this.explain(e);
+        },
+      });
+  }
+
+  public compare(): void {
+    if (this.eidA === undefined || this.eidB === undefined) {
+      return;
+    }
+    this.loadingAutopsy = true;
+    this.autopsy = undefined;
+    this.expanded.clear();
+    this.http
+      .get<SpyAutopsy>(`${SPY_API}/autopsy?wid=${this.wid}&a=${this.eidA}&b=${this.eidB}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: r => {
+          this.autopsy = r;
+          this.loadingAutopsy = false;
+          if (r.firstDivergent) {
+            this.expanded.add(r.firstDivergent);
+          }
+          this.narrate();
+        },
+        error: (e: unknown) => {
+          this.loadingAutopsy = false;
+          this.error = this.explain(e);
+        },
+      });
+  }
+
+  public finding(id: string): SpyFinding | undefined {
+    return this.autopsy?.findings.find(f => f.operatorId === id);
+  }
+
+  public isExpanded(id: string): boolean {
+    return this.expanded.has(id);
+  }
+
+  public toggle(id: string): void {
+    if (!this.finding(id)?.diff) {
+      return;
+    }
+    if (this.expanded.has(id)) {
+      this.expanded.delete(id);
+    } else {
+      this.expanded.add(id);
+    }
+  }
+
+  /** How many operators came out clean, for the summary line. */
+  public get cleanCount(): number {
+    return (this.autopsy?.findings ?? []).filter(f => !f.diff).length;
+  }
+
+  /** The finding in plain words, so nobody has to read the table to get it. */
+  /**
+   * The two numbers worth reading before anything else. What was changed is a
+   * card of its own below, drawn rather than counted, so this stops saying it.
+   */
+  public get figures(): { value: string; label: string; tone: string }[] {
+    const a = this.autopsy;
+    if (!a?.firstDivergent) {
+      return [];
+    }
+    const out: { value: string; label: string; tone: string }[] = [];
+
+    const diff = this.finding(a.firstDivergent)?.diff;
+    const delta = diff ? diff.rowsB - diff.rowsA : 0;
+    out.push(
+      delta === 0
+        ? { value: "same", label: "row count, but different rows", tone: "flat" }
+        : {
+            value: this.count(Math.abs(delta)),
+            label: delta < 0 ? "rows stopped coming through" : "rows arrived that did not before",
+            tone: "loud",
+          }
+    );
+
+    // A step that returns the same rows in a different order does not count as
+    // different: the order comes from how work was split between workers, not
+    // from the edit.
+    const affected = a.findings.filter(f => f.diff && !f.diff.sameSetDifferentOrder).length;
+    out.push({ value: `${affected} of ${a.findings.length}`, label: "steps left different", tone: "flat" });
+
+    return out;
+  }
+
+  // ---------- the comparison, drawn ----------
+
+  /**
+   * The two runs as a picture: one row per step, a bar each for how many rows
+   * came out of it, and a mark on the first step whose bars stop matching.
+   * Reading it needs no numbers at all, which is the point.
+   */
+  public get pipeline(): PipelineStep[] {
+    const a = this.autopsy;
+    if (!a) {
+      return [];
+    }
+    const top = Math.max(1, ...a.findings.flatMap(f => [f.rowsA ?? 0, f.rowsB ?? 0]));
+    // A straight share of the largest step, so the narrowing of the pipe is the
+    // real one. A floor keeps the last steps, which end in a handful of rows,
+    // from disappearing altogether; their counts are printed beside them.
+    const bar = (n: number) => (n <= 0 ? 0 : Math.max(1.2, (n / top) * 100));
+    const firstAt = a.firstDivergent ? a.order.indexOf(a.firstDivergent) : -1;
+    return a.order.map((oid, i) => {
+      const found = this.finding(oid);
+      const rowsA = found?.rowsA ?? 0;
+      const rowsB = found?.rowsB ?? 0;
+      const state: PipelineStep["state"] = !found?.diff
+        ? "same"
+        : i === firstAt
+          ? "starts"
+          : found.diff.sameSetDifferentOrder
+            ? "reordered"
+            : "carried";
+      return {
+        id: oid,
+        position: i + 1,
+        name: this.opName(oid),
+        rowsA,
+        rowsB,
+        barA: bar(rowsA),
+        barB: bar(rowsB),
+        state,
+        note: this.stepNote(state, rowsA, rowsB, found?.diff?.sameSetDifferentOrder ?? false),
+        truncated: !!found?.truncated,
+      };
+    });
+  }
+
+  /** What one step's pair of bars says, in the words you would say out loud. */
+  private stepNote(state: PipelineStep["state"], rowsA: number, rowsB: number, sameSet: boolean): string {
+    if (state === "same") {
+      return "same rows both times";
+    }
+    if (state === "reordered") {
+      return "same rows, in a different order";
+    }
+    const moved = rowsB - rowsA;
+    if (moved === 0) {
+      return sameSet ? "same rows, different order" : "same amount, different rows";
+    }
+    return moved < 0 ? `${this.count(-moved)} fewer rows` : `${this.count(moved)} more rows`;
+  }
+
+  /** The name of each run, for the legend over the bars. */
+  public get earlierName(): string {
+    const a = this.autopsy;
+    return a ? a.a.name || `run ${a.a.eid}` : "";
+  }
+
+  public get laterName(): string {
+    const a = this.autopsy;
+    return a ? a.b.name || `run ${a.b.eid}` : "";
+  }
+
+  // ---------- the edits, drawn ----------
+
+  /** The filmstrip: every save as a block, coloured by what it did. */
+  public get tape(): TapeBlock[] {
+    return this.frames.map((f, i) => {
+      const kinds = new Set(f.changes.map(c => c.kind));
+      const tone: TapeBlock["tone"] = !f.recoverable
+        ? "broken"
+        : kinds.has("operator_deleted") || kinds.has("link_removed")
+          ? "removed"
+          : kinds.has("operator_added") || kinds.has("link_added")
+            ? "added"
+            : f.changes.length
+              ? "edited"
+              : "quiet";
+      return { index: i, tone, ran: f.runs.length > 0, label: `${this.when(f.time)} · ${this.summaryOf(f)}` };
+    });
+  }
+
+  /** One line about a save, for the tooltip of its block on the filmstrip. */
+  private summaryOf(f: SpyFrame): string {
+    if (!f.recoverable) {
+      return "this moment can no longer be read back";
+    }
+    if (f.changes.length === 0) {
+      return "nothing changed";
+    }
+    const first = this.tell(f.changes[0]).lead.trim();
+    const rest = f.changes.length - 1;
+    return rest > 0 ? `${first} (+${rest} more)` : first;
+  }
+
+  /** A small drawing for each kind of edit, so the list reads without reading. */
+  public glyphOf(kind: string): string {
+    switch (kind) {
+      case "operator_added":
+        return "M11 5h2v6h6v2h-6v6h-2v-6H5v-2h6z";
+      case "operator_deleted":
+        return "M5 11h14v2H5z";
+      case "link_added":
+        return "M4 11h11V7.2L20 12l-5 4.8V13H4z";
+      case "link_removed":
+        return "M6.4 5 19 17.6 17.6 19 5 6.4zM17.6 5 19 6.4 6.4 19 5 17.6z";
+      case "renamed":
+        return "M12.4 3H5a2 2 0 0 0-2 2v7.4c0 .6.2 1.1.6 1.5l7.5 7.5a2 2 0 0 0 2.8 0l7.4-7.4a2 2 0 0 0 0-2.8L13.9 3.6a2 2 0 0 0-1.5-.6zM7.5 9.5a2 2 0 1 1 0-4 2 2 0 0 1 0 4z";
+      case "property":
+        return "M3 17.2V21h3.8L17.9 9.9l-3.8-3.8zM20.7 7.1a1 1 0 0 0 0-1.4l-2.4-2.4a1 1 0 0 0-1.4 0l-1.8 1.8 3.8 3.8z";
+      default:
+        return "M12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8z";
+    }
+  }
+
+  /** Which of the four colours an edit belongs to. */
+  public toneOf(kind: string): string {
+    if (kind === "operator_added" || kind === "link_added") {
+      return "added";
+    }
+    if (kind === "operator_deleted" || kind === "link_removed") {
+      return "removed";
+    }
+    if (kind === "property" || kind === "renamed") {
+      return "edited";
+    }
+    return "quiet";
+  }
+
+  public get verdict(): string {
+    const a = this.autopsy;
+    if (!a) {
+      return "";
+    }
+    if (!a.firstDivergent) {
+      return "Both runs produced identical output at every operator, so nothing that changed between the two versions moved the data.";
+    }
+    const downstream = a.order.length - a.order.indexOf(a.firstDivergent) - 1;
+    const inherited = downstream > 0 ? ", and every step after it carries that along" : "";
+    return `It starts at ${this.opName(a.firstDivergent)}${inherited}.`;
+  }
+
+  /** The second half of the verdict: what was edited in between. */
+  public get blame(): string {
+    const a = this.autopsy;
+    if (!a || !a.firstDivergent) {
+      return "";
+    }
+    const first = this.when(this.timeOfVersion(a.a.vid));
+    const second = this.when(this.timeOfVersion(a.b.vid));
+    // When both runs come from the same minute, naming the time twice is noise.
+    const opening = first === second ? "In between" : `Between ${first} and ${second}`;
+    if (a.edits.length === 0) {
+      return `${opening} you changed nothing on the canvas, so the cause is somewhere else: the incoming data, a random draw, or the engine itself.`;
+    }
+    const mine = a.edits.filter(e => e.operatorId === a.firstDivergent);
+    if (a.edits.length === 1 && mine.length === 1) {
+      return `${opening}, that step was the only thing you touched.`;
+    }
+    return `${opening} you made ${a.edits.length} changes, ${mine.length} of them on ${this.opName(a.firstDivergent)}.`;
+  }
+
+  /** Signed row difference for the table, or an em dash when both are absent. */
+  public delta(id: string): string {
+    const diff = this.finding(id)?.diff;
+    if (!diff) {
+      return "—";
+    }
+    const d = diff.rowsB - diff.rowsA;
+    if (d === 0) {
+      return "0";
+    }
+    return `${d > 0 ? "+" : "\u2212"}${this.count(Math.abs(d))}`;
+  }
+
+  // ---------- saying it in plain words ----------
+
+  /** A duration in words: nobody reads "+540 s". */
+  private spell(seconds: number): string {
+    const unit = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;
+    if (seconds < 60) {
+      return unit(seconds, "second");
+    }
+    if (seconds < 3600) {
+      return unit(Math.round(seconds / 60), "minute");
+    }
+    if (seconds < 86400) {
+      return unit(Math.round(seconds / 3600), "hour");
+    }
+    return unit(Math.round(seconds / 86400), "day");
+  }
+
+  /** A timestamp the way you would say it out loud. */
+  public when(value: string): string {
+    const at = new Date(value.replace(" ", "T"));
+    if (isNaN(at.getTime())) {
+      return value;
+    }
+    const clock = at.toTimeString().slice(0, 5);
+    const midnight = (d: Date) => new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+    const days = Math.round((midnight(new Date()) - midnight(at)) / 86400000);
+    if (days === 0) {
+      return `today at ${clock}`;
+    }
+    if (days === 1) {
+      return `yesterday at ${clock}`;
+    }
+    if (days < 7) {
+      return `${at.toLocaleDateString("en-US", { weekday: "long" })} at ${clock}`;
+    }
+    return `${at.toLocaleDateString("en-US", { day: "numeric", month: "long" })} at ${clock}`;
+  }
+
+  /** The whole record in one or two sentences, before any detail. */
+  public get story(): string {
+    const frames = this.history?.frames ?? [];
+    if (frames.length === 0) {
+      return "";
+    }
+    const parsed = frames.map(f => Date.parse(f.time.replace(" ", "T"))).filter(t => !isNaN(t));
+    let sessions = parsed.length ? 1 : 0;
+    for (let i = 1; i < parsed.length; i++) {
+      // Half an hour of silence reads as having come back to it later.
+      if (parsed[i] - parsed[i - 1] > 30 * 60 * 1000) {
+        sessions++;
+      }
+    }
+    const started = this.when(frames[0].time);
+    const touched = this.when(frames[frames.length - 1].time);
+    const sitting = sessions === 1 ? "in one sitting" : `over ${sessions} separate sessions`;
+    const runs = this.runs.length;
+    const ran =
+      runs === 0 ? "It has never been run." : runs === 1 ? "It has been run once." : `It has been run ${runs} times.`;
+    return `You started this workflow ${started} and last changed it ${touched}, ${sitting}. ${ran}`;
+  }
+
+  /**
+   * What the workflow is, in the only terms the record can vouch for: where
+   * data comes in, how many steps it goes through, where it ends up. Drawn
+   * rather than said, because three groups of boxes need no reading.
+   */
+  public get shapeCounts(): { sources: number; middle: number; outputs: number } | null {
+    const last = this.history?.frames.filter(f => f.recoverable).pop();
+    const operators = last?.operators ?? [];
+    if (operators.length === 0) {
+      return null;
+    }
+    const fed = new Set((last?.links ?? []).map(l => l.to));
+    const feeding = new Set((last?.links ?? []).map(l => l.from));
+    const sources = operators.filter(o => !fed.has(o.id)).length;
+    const outputs = operators.filter(o => !feeding.has(o.id)).length;
+    return { sources, middle: operators.length - sources - outputs, outputs };
+  }
+
+  /** Counting to n, for drawing n little boxes in a template. */
+  public range(n: number): number[] {
+    return Array.from({ length: Math.max(0, n) }, (_, i) => i);
+  }
+
+  /** The record in three numbers, read before the sentence underneath. */
+  public get recordFigures(): { value: string; label: string; tone: string }[] {
+    const h = this.history;
+    if (!h) {
+      return [];
+    }
+    const last = h.frames.filter(f => f.recoverable).pop();
+    const out = [
+      { value: this.count(h.total), label: "times you saved this workflow", tone: "flat" },
+      { value: this.count(last?.operators.length ?? 0), label: "steps on the canvas now", tone: "flat" },
+      {
+        value: this.count(this.runs.length),
+        label: this.runs.length === 1 ? "run on record" : "runs on record",
+        tone: "flat",
+      },
+    ];
+    if (h.broken) {
+      out.push({
+        value: this.count(h.total - h.recovered),
+        label: "versions Texera can no longer rebuild",
+        tone: "loud",
+      });
+    }
+    return out;
+  }
+
+  /** The name shown on the canvas for an operator, at this point in time. */
+  public nameOf(id: string | undefined, frame = this.frame): string {
+    if (!id) {
+      return "an operator";
+    }
+    const operator = frame?.operators.find(o => o.id === id);
+    if (!operator) {
+      return id;
+    }
+    // Two operators can carry the same name until they are renamed; the id is
+    // the only thing that tells them apart.
+    const twins = frame?.operators.filter(o => o.name === operator.name).length ?? 1;
+    return twins > 1 ? `${operator.name} (${operator.id})` : operator.name;
+  }
+
+  /**
+   * Where a link lands. An operator with two inputs, like a join, is two
+   * different places on the canvas, so the input gets named.
+   */
+  private inputOf(id: string | undefined, port: string | undefined): string {
+    const name = this.nameOf(id);
+    if (!id || !port) {
+      return name;
+    }
+    const inputs = this.frame?.operators.find(o => o.id === id)?.inputs ?? [];
+    if (inputs.length < 2) {
+      return name;
+    }
+    const index = Number(port.replace(/\D/g, ""));
+    if (isNaN(index) || index < 0 || index >= inputs.length) {
+      return name;
+    }
+    // Most ports have no display name of their own; then it is just the order.
+    return inputs[index] ? `the ${inputs[index]} input of ${name}` : `the ${this.ordinal(index + 1)} input of ${name}`;
+  }
+
+  /** Small ordinals in words, because "the 2nd input" reads like a form. */
+  private ordinal(position: number): string {
+    return ["first", "second", "third", "fourth", "fifth"][position - 1] ?? `${position}th`;
+  }
+
+  /** The name Texera puts in the operator palette, e.g. "Hash Join". */
+  private friendlyType(operatorType: string | undefined): string {
+    if (!operatorType) {
+      return "an operator";
+    }
+    try {
+      return this.metadata.getOperatorSchema(operatorType).additionalMetadata.userFriendlyName || operatorType;
+    } catch {
+      return operatorType;
+    }
+  }
+
+  /** camelCase field names, when the schema has no title of its own. */
+  private humanize(segment: string): string {
+    const spaced = segment.replace(/([a-z0-9])([A-Z])/g, "$1 $2").replace(/[_-]+/g, " ");
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+  }
+
+  /**
+   * Turns a JSON pointer into the labels the person actually saw in the
+   * operator's form, by walking the same schema the form is built from.
+   */
+  private labelFor(operatorType: string | undefined, path: string | undefined): string {
+    if (!path) {
+      return "a setting";
+    }
+    let node: CustomJSONSchema7 | undefined;
+    let root: CustomJSONSchema7 | undefined;
+    if (operatorType) {
+      try {
+        root = this.metadata.getOperatorSchema(operatorType).jsonSchema as CustomJSONSchema7;
+        node = root;
+      } catch {
+        node = undefined;
+      }
+    }
+    const deref = (schema: unknown): CustomJSONSchema7 | undefined => {
+      const s = schema as CustomJSONSchema7 & { $ref?: string };
+      if (!s) {
+        return undefined;
+      }
+      if (s.$ref && root) {
+        const key = s.$ref.replace("#/definitions/", "");
+        return (root as { definitions?: Record<string, CustomJSONSchema7> }).definitions?.[key];
+      }
+      return s;
+    };
+
+    const parts: string[] = [];
+    for (const segment of path.split("/").filter(Boolean)) {
+      if (/^\d+$/.test(segment)) {
+        // An index belongs to the list above it: "Predicates" + 0 reads as
+        // "Predicate 1", which is what the form shows.
+        const list = parts.pop() ?? "item";
+        parts.push(`${list.replace(/s$/, "")} ${Number(segment) + 1}`);
+        node = deref((node as { items?: unknown })?.items);
+        continue;
+      }
+      const property = (node as { properties?: Record<string, CustomJSONSchema7> })?.properties?.[segment];
+      parts.push(property?.title ?? this.humanize(segment));
+      node = deref(property);
+    }
+    if (parts.length === 0) {
+      return "a setting";
+    }
+    const leaf = parts[parts.length - 1];
+    const rest = parts.slice(0, -1);
+    return rest.length ? `${leaf} of ${rest.join(", ")}` : leaf;
+  }
+
+  /**
+   * A setting's value said the way its own form says it: a filter row reads
+   * "amount > 100", not the JSON the patch happens to store.
+   */
+  private describe(value: unknown): string {
+    if (value === null || value === undefined) {
+      return "nothing";
+    }
+    if (value === "") {
+      return "empty";
+    }
+    if (Array.isArray(value)) {
+      return value.length === 0 ? "nothing" : value.map(entry => this.describeEntry(entry)).join("; ");
+    }
+    if (typeof value === "object") {
+      return this.describeEntry(value);
+    }
+    return String(value);
+  }
+
+  /** One row of a setting that holds a list, e.g. one filter condition. */
+  private describeEntry(value: unknown): string {
+    if (value === null || value === undefined) {
+      return "nothing";
+    }
+    if (typeof value !== "object") {
+      return String(value);
+    }
+    const row = value as Record<string, unknown>;
+    const has = (...keys: string[]) => keys.every(key => row[key] !== undefined && row[key] !== "");
+
+    // A filter condition, as the operator's own row reads: amount > 100.
+    if (has("attribute", "condition")) {
+      return `${row["attribute"]} ${row["condition"]} ${row["value"] ?? ""}`.trim();
+    }
+    // An aggregation, named after the column it produces.
+    if (has("aggFunction", "attribute")) {
+      const named = row["result attribute"] ?? row["resultAttribute"];
+      return `${row["aggFunction"]} of ${row["attribute"]}${named ? `, as ${named}` : ""}`;
+    }
+    // A sort key, said as a direction rather than as DESC.
+    if (has("attribute", "sortPreference")) {
+      const descending = String(row["sortPreference"]).toUpperCase().startsWith("DESC");
+      return `${row["attribute"]}, ${descending ? "highest first" : "lowest first"}`;
+    }
+    // Anything else: its own fields, labelled the way the form labels them.
+    const parts = Object.entries(row)
+      .filter(([, field]) => field !== "" && field !== null && field !== undefined)
+      .map(([key, field]) => `${this.humanize(key).toLowerCase()} ${this.clip(field, 40)}`);
+    return parts.length ? parts.join(", ") : "nothing";
+  }
+
+  /** A setting's value for the screen: described first, then cut to size. */
+  public said(value: unknown, max = 60): string {
+    return this.clip(this.describe(value), max);
+  }
+
+  /** Neither value is visible anywhere, so the save changed nothing on screen. */
+  private invisible(text: string): boolean {
+    return text === "nothing" || text === "empty";
+  }
+
+  /** A raw value as a reader would expect to see it. */
+  private readable(value: string | undefined): string {
+    if (value === undefined || value === "null") {
+      return "nothing";
+    }
+    if (value === '""' || value === "") {
+      return "empty";
+    }
+    return value;
+  }
+
+  /** One saved change, written the way the person who made it would say it. */
+  public tell(change: SpyChange): Told {
+    const raw = change.text;
+    switch (change.kind) {
+      case "operator_added":
+        return {
+          lead: `You added ${this.friendlyType(change.operatorType)}${
+            change.name && change.name !== change.operatorType ? `, called "${change.name}"` : ""
+          }.`,
+          detail: raw,
+        };
+      case "operator_deleted":
+        return {
+          lead: `You deleted ${this.friendlyType(change.operatorType)}${
+            change.name && change.name !== change.operatorType ? `, called "${change.name}"` : ""
+          }.`,
+          detail: raw,
+        };
+      case "link_added":
+        return {
+          lead: `You connected ${this.nameOf(change.from)} into ${this.inputOf(change.to, change.port)}.`,
+          detail: raw,
+        };
+      case "link_removed":
+        return {
+          lead: `You disconnected ${this.nameOf(change.from)} from ${this.inputOf(change.to, change.port)}.`,
+          detail: raw,
+        };
+      case "renamed":
+        return {
+          lead: "You renamed",
+          before: this.readable(change.before),
+          join: "to",
+          after: this.readable(change.after),
+          detail: raw,
+        };
+      case "property": {
+        const where = this.nameOf(change.operatorId);
+        const setting = this.labelFor(change.operatorType, change.path);
+        // The value itself when it came through, the clipped text otherwise.
+        const was = "beforeValue" in change ? this.describe(change.beforeValue) : this.readable(change.before);
+        const now = "afterValue" in change ? this.describe(change.afterValue) : this.readable(change.after);
+        if (this.invisible(was) && this.invisible(now)) {
+          // Empty rewritten as absent, or the other way round. Texera saved it,
+          // but nobody would see a difference on the canvas.
+          return { lead: `In ${where}, ${setting} was written again, with nothing to show either way.`, detail: raw };
+        }
+        if (this.invisible(was)) {
+          return { lead: `In ${where}, you set ${setting} to`, after: now, detail: raw };
+        }
+        if (this.invisible(now)) {
+          return { lead: `In ${where}, you cleared ${setting}, which was`, before: was, detail: raw };
+        }
+        return { lead: `In ${where}, ${setting} went from`, before: was, join: "to", after: now, detail: raw };
+      }
+      case "moved":
+        return { lead: `You moved ${this.nameOf(change.operatorId)} on the canvas.`, detail: raw };
+      default:
+        return { lead: raw.charAt(0).toUpperCase() + raw.slice(1) + ".", detail: raw };
+    }
+  }
+
+  /** The label a setting has in the operator's own form. */
+  public settingLabel(edit: SpyEdit): string {
+    return this.labelFor(this.typeOf(edit.operatorId), edit.path);
+  }
+
+  /** When the readable part of the record stops, for the warning sentence. */
+  public get brokenTime(): string {
+    const vid = this.history?.broken?.vid;
+    return vid === undefined ? "" : this.timeOfVersion(vid);
+  }
+
+  /** When a given version was saved, for sentences that talk about time. */
+  private timeOfVersion(vid: number): string {
+    return this.history?.frames.find(f => f.vid === vid)?.time ?? "";
+  }
+
+  /** The operator type behind an id, needed to read its form labels. */
+  private typeOf(id: string): string | undefined {
+    const frames = this.history?.frames ?? [];
+    for (let i = frames.length - 1; i >= 0; i--) {
+      const found = frames[i].operators.find(o => o.id === id);
+      if (found) {
+        return found.type;
+      }
+    }
+    return undefined;
+  }
+
+  /** The canvas name of an operator as it stood in the run being compared. */
+  public opName(id: string): string {
+    const vid = this.autopsy?.b.vid;
+    const frames = this.history?.frames ?? [];
+    const frame = frames.find(f => f.vid === vid) ?? frames[frames.length - 1];
+    return frame?.operators.find(o => o.id === id)?.name ?? id;
+  }
+
+  /** Column headers for a sample of rows, in the order the engine returned. */
+  public columns(rows: object[]): string[] {
+    const seen: string[] = [];
+    for (const row of rows) {
+      for (const key of Object.keys(row ?? {})) {
+        if (!seen.includes(key)) {
+          seen.push(key);
+        }
+      }
+    }
+    return seen;
+  }
+
+  public cell(row: object, key: string): string {
+    const value = (row as Record<string, unknown>)[key];
+    if (value === null || value === undefined) {
+      return "";
+    }
+    return typeof value === "object" ? JSON.stringify(value) : String(value);
+  }
+
+  // ---------- the walk-through: how this thing works ----------
+
+  /**
+   * The tour is one call to the model, asked for as soon as the facts are in.
+   * It is a sentence per step and nothing else: what each step does is derived
+   * from its settings, and the sentence only says it in words a newcomer reads.
+   */
+  private walkThrough(): void {
+    this.tourPending = true;
+    this.http
+      .get<Tour>(`${SPY_API}/tour?wid=${this.wid}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: t => {
+          this.tour = { ...t, steps: t.steps ?? {} };
+          this.tourPending = false;
+        },
+        // No key, no server, no sentences. The walkthrough stands without them.
+        error: () => (this.tourPending = false),
+      });
+  }
+
+  /** Moving to a tab that costs a fetch only pays for it when it is opened. */
+  public show(tab: SpyTab): void {
+    this.tab = tab;
+    this.stop();
+    if (tab === "experiments" && !this.experiments && !this.loadingExperiments) {
+      this.loadExperiments();
+    }
+  }
+
+  public get steps(): BriefStep[] {
+    return this.brief?.steps ?? [];
+  }
+
+  // The flow drawn as what it is: pipes carrying rows. The thickness of a pipe
+  // is how much data runs through it, so where the flow narrows is seen before
+  // a single number is read. Texera's own canvas positions are not used: they
+  // are wherever somebody dropped the boxes, and a diagram has to be laid out.
+  public flowNodes: FlowNode[] = [];
+  public flowPipes: FlowPipe[] = [];
+  public flowViewBox = "0 0 900 320";
+  public readonly nodeWidth = NODE_WIDTH;
+  public readonly nodeHeight = NODE_HEIGHT;
+
+  /** The step being looked at. The flow is walked one step at a time. */
+  public picked: string | null = null;
+
+  private layOut(): void {
+    const steps = this.steps;
+    if (steps.length === 0) {
+      this.flowNodes = [];
+      this.flowPipes = [];
+      return;
+    }
+    // A step sits one column to the right of the furthest step feeding it, so
+    // the data always flows left to right however the canvas was arranged.
+    const column = new Map<string, number>();
+    for (const step of steps) {
+      const feeders = step.fedBy.map(f => column.get(f.id) ?? 0);
+      column.set(step.id, feeders.length ? Math.max(...feeders) + 1 : 0);
+    }
+    const columns = new Map<number, BriefStep[]>();
+    for (const step of steps) {
+      const at = column.get(step.id) ?? 0;
+      columns.set(at, [...(columns.get(at) ?? []), step]);
+    }
+    const tallest = Math.max(...[...columns.values()].map(list => list.length));
+    const top = Math.max(1, ...steps.map(step => step.rowsOut ?? 0));
+
+    this.flowNodes = [];
+    for (const [at, list] of columns) {
+      const offset = ((tallest - list.length) * (NODE_HEIGHT + NODE_GAP_Y)) / 2;
+      list.forEach((step, i) => {
+        const kind = this.kindOf(step);
+        const rowsIn = step.rowsIn ?? 0;
+        const rowsOut = step.rowsOut ?? 0;
+        this.flowNodes.push({
+          step,
+          x: at * (NODE_WIDTH + NODE_GAP_X),
+          y: offset + i * (NODE_HEIGHT + NODE_GAP_Y),
+          kind,
+          glyph: this.glyphForKind(kind),
+          rows: step.rowsOut,
+          // Only where throwing rows away is the whole job. An aggregate turns
+          // 668 rows into 3 groups and nothing was dropped, so marking that in
+          // red would be a lie told in colour.
+          drop: DISCARDS.has(kind) && rowsIn > 0 && rowsOut < rowsIn * 0.9 ? rowsIn - rowsOut : 0,
+        });
+      });
+    }
+
+    const placed = new Map(this.flowNodes.map(node => [node.step.id, node]));
+    this.flowPipes = [];
+    for (const step of steps) {
+      for (const feeder of step.fedBy) {
+        const from = placed.get(feeder.id);
+        const to = placed.get(step.id);
+        if (!from || !to) {
+          continue;
+        }
+        const x1 = from.x + NODE_WIDTH;
+        const y1 = from.y + NODE_HEIGHT / 2;
+        const x2 = to.x;
+        const y2 = to.y + NODE_HEIGHT / 2;
+        const bend = Math.max(24, (x2 - x1) / 2);
+        const rows = from.step.rowsOut ?? 0;
+        this.flowPipes.push({
+          path: `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`,
+          // Square root, not a straight share: a pipe ten times thicker than
+          // another is unreadable, and the eye reads area anyway.
+          width: rows <= 0 ? 1.5 : 1.5 + 13 * Math.sqrt(rows / top),
+          rows,
+          midX: (x1 + x2) / 2,
+          midY: (y1 + y2) / 2 - 7,
+        });
+      }
+    }
+    const width = (Math.max(...columns.keys()) + 1) * (NODE_WIDTH + NODE_GAP_X) - NODE_GAP_X;
+    const height = tallest * (NODE_HEIGHT + NODE_GAP_Y) - NODE_GAP_Y;
+    this.flowViewBox = `-10 -14 ${width + 20} ${height + 28}`;
+    if (!this.picked || !placed.has(this.picked)) {
+      this.picked = steps[0].id;
+    }
+  }
+
+  /**
+   * What a step is, as a picture rather than a class name. Texera has 166
+   * operator types and a newcomer knows none of them, but everyone knows a
+   * funnel keeps some things and drops others.
+   */
+  private kindOf(step: BriefStep): string {
+    const type = (step.type || "").toLowerCase();
+    if (step.role === "source" || type.includes("source") || type.includes("scan")) {
+      return "source";
+    }
+    if (type.includes("filter")) {
+      return "filter";
+    }
+    if (type.includes("join")) {
+      return "join";
+    }
+    if (type.includes("aggregate") || type.includes("count") || type.includes("sum")) {
+      return "aggregate";
+    }
+    if (type.includes("sort")) {
+      return "sort";
+    }
+    if (type.includes("limit")) {
+      return "limit";
+    }
+    if (type.includes("projection") || type.includes("select")) {
+      return "projection";
+    }
+    if (type.includes("udf") || type.includes("python") || type.includes("java")) {
+      return "code";
+    }
+    return step.role === "output" ? "output" : "step";
+  }
+
+  public glyphForKind(kind: string): string {
+    switch (kind) {
+      case "source":
+        return "M12 4c4 0 7 1 7 2.2S16 8.4 12 8.4 5 7.4 5 6.2 8 4 12 4zM5 9.2c1.5.9 4.2 1.4 7 1.4s5.5-.5 7-1.4v3.4c0 1.2-3 2.2-7 2.2s-7-1-7-2.2zm0 6.6c1.5.9 4.2 1.4 7 1.4s5.5-.5 7-1.4v2c0 1.2-3 2.2-7 2.2s-7-1-7-2.2z";
+      case "filter":
+        return "M3.5 5h17l-6.8 8v6.2l-3.4 1.8V13z";
+      case "join":
+        return "M3 5.6h4.6l3.6 5.2h9.6v2.4h-9.6l-3.6 5.2H3v-2.4h3.4l3-4L6.4 8H3z";
+      case "aggregate":
+        return "M4 19h3.4v-7H4zm6.3 0h3.4V5h-3.4zM16.6 19H20v-4.4h-3.4z";
+      case "sort":
+        return "M7 3.6l3.4 4.4H8.2v12H5.8V8H3.6zM17 20.4 13.6 16h2.2V4h2.4v12h2.2z";
+      case "limit":
+        return "M4 5.6h16V8H4zm0 5.2h11v2.4H4zm0 5.2h6v2.4H4z";
+      case "projection":
+        return "M4 5h4.4v14H4zm6.8 0h4.4v14h-4.4zm6.8 0H20v14h-2.4z";
+      case "code":
+        return "M9.4 16.6 4.8 12l4.6-4.6L8 6l-6 6 6 6zm5.2 0 4.6-4.6-4.6-4.6L16 6l6 6-6 6z";
+      case "output":
+        return "M5 19.6h14V22H5zM12 2v11.2l3.8-3.8 1.7 1.7-6.5 6.5-6.5-6.5 1.7-1.7L10 13.2V2z";
+      default:
+        return "M5 6h14v12H5z";
+    }
+  }
+
+  /** The same reading of a step's kind, for the template. */
+  public kindOfStep(step: BriefStep): string {
+    return this.kindOf(step);
+  }
+
+  /** Whether a step has an input worth drawing: a source does not. */
+  public hasInput(step: BriefStep): boolean {
+    return step.role !== "source" && !!step.rowsIn;
+  }
+
+  /** The two bars of one step, drawn against the busiest step in the flow. */
+  public inBar(step: BriefStep): number {
+    return this.share(step.rowsIn ?? 0);
+  }
+
+  public outBar(step: BriefStep): number {
+    return this.share(step.rowsOut ?? 0);
+  }
+
+  private share(rows: number): number {
+    const top = Math.max(1, ...this.steps.flatMap(step => [step.rowsIn ?? 0, step.rowsOut ?? 0]));
+    return rows <= 0 ? 0 : Math.max(1.2, (rows / top) * 100);
+  }
+
+  public pickStep(id: string): void {
+    this.picked = id;
+    this.opened = null;
+  }
+
+  public get pickedStep(): BriefStep | undefined {
+    return this.steps.find(step => step.id === this.picked);
+  }
+
+  public get pickedAt(): number {
+    return this.steps.findIndex(step => step.id === this.picked);
+  }
+
+  /** Walking the flow one step at a time, which is how it is meant to be read. */
+  public stepAlong(by: number): void {
+    const at = this.pickedAt;
+    const next = this.steps[Math.max(0, Math.min(this.steps.length - 1, at + by))];
+    if (next) {
+      this.pickStep(next.id);
+    }
+  }
+
+  /**
+   * How much of what reached a step came out of it again, for the one line
+   * that says what a filter or a join actually did to the data.
+   */
+  public keepsOf(step: BriefStep | undefined): string {
+    if (!step || !step.rowsIn || step.rowsOut === null || step.rowsOut === undefined) {
+      return "";
+    }
+    if (step.rowsOut === step.rowsIn) {
+      return "every row that reached it came out again";
+    }
+    if (step.rowsOut < step.rowsIn) {
+      const share = Math.round((step.rowsOut / step.rowsIn) * 100);
+      return `${this.count(step.rowsIn - step.rowsOut)} of the ${this.count(step.rowsIn)} rows that reached it stopped here, leaving ${share} in every 100`;
+    }
+    return `it gave back more rows than it was given: ${this.count(step.rowsOut)} out of ${this.count(step.rowsIn)} in`;
+  }
+
+  /** Prose is folded by default: the drawing answers first, words come second. */
+  public unfolded = new Set<string>();
+
+  public unfold(key: string): void {
+    if (this.unfolded.has(key)) {
+      this.unfolded.delete(key);
+    } else {
+      this.unfolded.add(key);
+    }
+  }
+
+  public isUnfolded(key: string): boolean {
+    return this.unfolded.has(key);
+  }
+
+  /** The sentence written for one step, if one came back. */
+  public stepTold(id: string): string {
+    return this.tour.steps[id] ?? "";
+  }
+
+  public openStep(id: string): void {
+    this.opened = this.opened === id ? null : id;
+  }
+
+  /**
+   * What a step is set to do, in the words of its own form. A setting that
+   * holds a whole program is not a phrase and never reads as one, so it is
+   * counted in lines here and printed in full only when the step is opened.
+   */
+  public settingsOf(step: BriefStep): { label: string; text: string; big: boolean; raw?: string }[] {
+    return step.settings.map(setting => {
+      const label = this.labelFor(step.type, setting.path);
+      if (!("value" in setting)) {
+        return { label, text: this.lineCount(setting.lines ?? 0), big: true };
+      }
+      const written = this.describe(setting.value);
+      const program = typeof setting.value === "string" && (written.includes("⏎") || written.length > 90);
+      if (program) {
+        const raw = setting.value as string;
+        return { label, text: this.lineCount(raw.split("\n").length), big: true, raw };
+      }
+      return { label, text: written, big: false };
+    });
+  }
+
+  private lineCount(lines: number): string {
+    return `${this.count(lines)} ${lines === 1 ? "line" : "lines"} of it`;
+  }
+
+  /** The settings of a step that are worth printing in full when it is opened. */
+  public programsOf(step: BriefStep): { label: string; raw: string }[] {
+    return this.settingsOf(step)
+      .filter((setting): setting is { label: string; text: string; big: boolean; raw: string } => !!setting.raw)
+      .map(setting => ({ label: setting.label, raw: setting.raw }));
+  }
+
+  /** Where a step sits in the flow, said rather than coloured. */
+  public roleWord(step: BriefStep): string {
+    if (step.role === "source") {
+      return "reads data in";
+    }
+    return step.role === "output" ? "ends the flow" : "passes data on";
+  }
+
+  /** How wide to draw the volume of a step, against the widest step there is. */
+  public rowsBar(step: BriefStep): number {
+    const top = Math.max(1, ...this.steps.map(x => x.rowsOut ?? 0));
+    const rows = step.rowsOut ?? 0;
+    return rows <= 0 ? 0 : Math.max(1.2, (rows / top) * 100);
+  }
+
+  /** The names of the steps feeding this one, for the line under its title. */
+  public feedersOf(step: BriefStep): string {
+    const names = step.fedBy.map(f => this.briefName(f.id));
+    if (names.length === 0) {
+      return "";
+    }
+    return `fed by ${names.join(" and ")}`;
+  }
+
+  public briefName(id: string): string {
+    return this.steps.find(x => x.id === id)?.name ?? id;
+  }
+
+  /** The label a knob carries in its own form, e.g. "Value of Predicate 1". */
+  public knobLabel(knob: BriefKnob | KnobDef): string {
+    return this.labelFor(knob.type, knob.path);
+  }
+
+  public knobValue(knob: BriefKnob): string {
+    return "value" in knob ? this.said(knob.value, 40) : "";
+  }
+
+  /** Who can open this workflow, in one line. */
+  public get whoLine(): string {
+    const people = this.brief?.people ?? [];
+    if (people.length === 0) {
+      return "";
+    }
+    const owner = people.find(p => p.owner);
+    const others = people.filter(p => !p.owner).map(p => p.name);
+    const rest = others.length
+      ? `, shared with ${others.length === 1 ? others[0] : `${others.length} other people`}`
+      : ", not shared with anyone";
+    return `${owner ? `${owner.name} owns it` : "Nobody owns it"}${rest}.`;
+  }
+
+  /** The one line that says how alive this workflow is. */
+  public get pulseLine(): string {
+    const record = this.brief?.record;
+    if (!record) {
+      return "";
+    }
+    const built = record.started ? `Started ${this.when(record.started)}` : "";
+    const last = record.lastEdited ? `, last changed ${this.when(record.lastEdited)}` : "";
+    const ran = record.runs === 0 ? ". Never run." : `. Run ${this.count(record.runs)} times`;
+    const lastRun = record.lastRun ? `, the last one ${this.when(record.lastRun)}.` : ".";
+    return `${built}${last}${ran}${lastRun}`;
+  }
+
+  /** The three numbers of the walkthrough, read before any sentence. */
+  public get briefFigures(): { value: string; label: string; tone: string }[] {
+    const b = this.brief;
+    if (!b) {
+      return [];
+    }
+    const measured = b.steps.filter(x => x.rowsOut !== null && x.rowsOut !== undefined);
+    const read = b.steps.filter(x => x.role === "source").reduce((n, x) => n + (x.rowsOut ?? 0), 0);
+    const out = b.steps.filter(x => x.role === "output").reduce((n, x) => n + (x.rowsOut ?? 0), 0);
+    const figures = [
+      { value: this.count(b.steps.length), label: "steps in the flow", tone: "flat" },
+      {
+        value: this.count(b.record.runs),
+        label: b.record.runs === 1 ? "run on record" : "runs on record",
+        tone: "flat",
+      },
+    ];
+    if (measured.length) {
+      figures.unshift({ value: `${this.count(read)} → ${this.count(out)}`, label: "rows in, rows out", tone: "flat" });
+    }
+    return figures;
+  }
+
+  /** True while there is nothing at all to show in the walkthrough. */
+  public get briefEmpty(): boolean {
+    return !this.loadingBrief && this.steps.length === 0;
+  }
+
+  // ---------- what has been tried ----------
+
+  private loadExperiments(): void {
+    this.loadingExperiments = true;
+    this.http
+      .get<SpyExperiments>(`${SPY_API}/experiments?wid=${this.wid}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: e => {
+          this.experiments = e;
+          this.loadingExperiments = false;
+          this.trends = this.linesOverRuns();
+        },
+        error: (err: unknown) => {
+          this.loadingExperiments = false;
+          this.error = this.explain(err);
+        },
+      });
+  }
+
+  /**
+   * Every run as a row: what the dials were set to, and what came out. Two runs
+   * with the same dials and the same output are the same experiment run twice,
+   * and saying so is half of what a newcomer needs from this table.
+   */
+  public get experimentRows(): ExperimentRow[] {
+    const e = this.experiments;
+    if (!e) {
+      return [];
+    }
+    const top = Math.max(1, ...e.runs.map(r => r.produced));
+    const seen = new Map<string, number>();
+    return e.runs.map((run, i) => {
+      const before = e.runs[i - 1];
+      const values = e.knobs.map(knob => ({
+        knob,
+        text: knob.id in run.settings ? this.said(run.settings[knob.id], 40) : "—",
+        changed:
+          !!before &&
+          JSON.stringify(before.settings[knob.id] ?? null) !== JSON.stringify(run.settings[knob.id] ?? null),
+      }));
+      // The fingerprint of an experiment is its dials plus what came out of it.
+      const print = JSON.stringify([values.map(v => v.text), run.produced]);
+      const first = seen.get(print);
+      if (first === undefined) {
+        seen.set(print, run.eid);
+      }
+      return {
+        run,
+        values,
+        bar: run.produced <= 0 ? 0 : Math.max(1.2, (run.produced / top) * 100),
+        move: e.moves.find(m => m.to === run.eid),
+        repeatOf: first,
+      };
+    });
+  }
+
+  /** How many of the runs were genuinely different experiments. */
+  public get distinctRuns(): number {
+    return this.trials.length;
+  }
+
+  /**
+   * The experiments themselves, which is not the same list as the runs: the
+   * same settings run five times is one experiment, and saying so is most of
+   * what someone wants from this table. Runs that produced a different result
+   * from the same settings are kept apart, because that is worth seeing.
+   */
+  public get trials(): { values: { knob: KnobDef; text: string }[]; runs: ExperimentRun[]; produced: number }[] {
+    const out: { key: string; values: { knob: KnobDef; text: string }[]; runs: ExperimentRun[]; produced: number }[] =
+      [];
+    for (const row of this.experimentRows) {
+      const values = row.values.map(v => ({ knob: v.knob, text: v.text }));
+      const key = JSON.stringify([values.map(v => v.text), row.run.produced]);
+      const found = out.find(t => t.key === key);
+      if (found) {
+        found.runs.push(row.run);
+      } else {
+        out.push({ key, values, runs: [row.run], produced: row.run.produced });
+      }
+    }
+    return out.map(({ values, runs, produced }) => ({ values, runs, produced }));
+  }
+
+  /**
+   * One dial at a time: every value it was ever run at, and what came out.
+   * This is the question behind the whole tab, and it is a picture of two or
+   * three bars rather than a table anyone has to read across.
+   */
+  public get dials(): {
+    knob: KnobDef;
+    values: {
+      text: string;
+      runs: number;
+      empty: number;
+      low: number;
+      high: number;
+      bar: number;
+      floor: number;
+      mixed: boolean;
+    }[];
+    verdict: string;
+  }[] {
+    const rows = this.experimentRows;
+    if (rows.length === 0) {
+      return [];
+    }
+    const top = Math.max(1, ...rows.map(r => r.run.produced));
+    return this.knobs.map(knob => {
+      const byValue = new Map<string, number[]>();
+      for (const row of rows) {
+        const value = row.values.find(v => v.knob.id === knob.id)?.text ?? "—";
+        byValue.set(value, [...(byValue.get(value) ?? []), row.run.produced]);
+      }
+      const values = [...byValue.entries()].map(([text, all]) => {
+        // A run that produced nothing says nothing about the dial: it says the
+        // run failed. Counted and named, but kept out of the bars.
+        const produced = all.filter(rows => rows > 0);
+        const empty = all.length - produced.length;
+        const low = produced.length ? Math.min(...produced) : 0;
+        const high = produced.length ? Math.max(...produced) : 0;
+        const bar = (n: number) => (n <= 0 ? 0 : Math.max(1.2, (n / top) * 100));
+        return {
+          text,
+          runs: all.length,
+          empty,
+          low,
+          high,
+          bar: bar(high),
+          // The solid part is what every run at this value produced at least;
+          // the pale part is how far apart those runs were.
+          floor: bar(low),
+          // The same value coming out differently means something else moved
+          // in those runs, and the bar alone would be telling half a story.
+          mixed: low !== high,
+        };
+      });
+      const results = new Set(values.map(v => `${v.low}-${v.high}`));
+      const verdict = values.some(v => v.mixed)
+        ? "runs at the same value came out differently, so something else was moving too"
+        : values.length < 2
+          ? "only ever run at one value"
+          : results.size === 1
+            ? "the same number of rows came out whichever value was used"
+            : "how many rows came out depended on this";
+      return { knob, values, verdict };
+    });
+  }
+
+  /** Whether the whole run log is unfolded under the experiments. */
+  public showEveryRun = false;
+
+  /** One trial's bar, against the biggest result any trial produced. */
+  public trialBar(produced: number): number {
+    const top = Math.max(1, ...this.trials.map(t => t.produced));
+    return produced <= 0 ? 0 : Math.max(1.2, (produced / top) * 100);
+  }
+
+  /** When a trial was run, said once however many times it was repeated. */
+  public trialWhen(runs: ExperimentRun[]): string {
+    if (runs.length === 1) {
+      return this.when(runs[0].started);
+    }
+    return `${runs.length} times, last ${this.when(runs[runs.length - 1].started)}`;
+  }
+
+  public get knobs(): KnobDef[] {
+    return this.experiments?.knobs ?? [];
+  }
+
+  /** What changed between one run and the one before it, said in one line. */
+  public moveText(move: RunMove | undefined): string {
+    if (!move) {
+      return "";
+    }
+    const said = move.edits.map(e => `${e.step}: ${this.said(e.before, 24)} → ${this.said(e.after, 24)}`);
+    for (const change of move.structure) {
+      if (change.kind === "added") {
+        said.push(`${change.step} added`);
+      } else if (change.kind === "removed") {
+        said.push(`${change.step} removed`);
+      } else if (change.kind === "renamed") {
+        said.push(`${change.before || "a step"} renamed to ${change.step}`);
+      } else {
+        said.push(`${change.step} switched ${change.kind === "disabled" ? "off" : "on"}`);
+      }
+    }
+    return said.join(" · ");
+  }
+
+  // ---------- the report ----------
+
+  /**
+   * The one thing here that is written rather than derived, and the one thing
+   * that costs real money, so it is never asked for on its own: somebody has to
+   * press the button. Everything in it comes from the same derived facts the
+   * other tabs draw; the model only writes them up as a handover document.
+   */
+  public writeReport(refresh = false): void {
+    if (this.reportPending) {
+      return;
+    }
+    this.reportPending = true;
+    this.reportFailed = false;
+    this.http
+      .get<SpyReport>(`${SPY_API}/report?wid=${this.wid}${refresh ? "&refresh=1" : ""}`)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: r => {
+          this.report = r;
+          this.reportPending = false;
+          this.reportFailed = !r.written;
+        },
+        error: () => {
+          this.reportPending = false;
+          this.reportFailed = true;
+        },
+      });
+  }
+
+  public copyReport(): void {
+    const text = this.report?.markdown;
+    if (!text) {
+      return;
+    }
+    navigator.clipboard?.writeText(text).then(
+      () => {
+        this.copied = true;
+        setTimeout(() => (this.copied = false), 2000);
+      },
+      () => (this.copied = false)
+    );
+  }
+
+  /** The report as a file, for whoever wants it outside this panel. */
+  public downloadReport(): void {
+    const text = this.report?.markdown;
+    if (!text) {
+      return;
+    }
+    const blob = new Blob([text], { type: "text/markdown;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `workflow-${this.wid}-report.md`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  // ---------- shared ----------
+
+  /** For the signed row difference drawn inside a step. */
+  public abs(n: number): number {
+    return Math.abs(n);
+  }
+
+  /** Thousands separators, for counts shown inside a sentence. */
+  public count(n: number): string {
+    return n.toLocaleString("en-US");
+  }
+
+  /** Properties can carry a whole program; the screen gets a slice. */
+  public clip(value: unknown, max = 120): string {
+    // An empty string would print as nothing and the change would look
+    // half-written, so it is shown quoted.
+    if (value === "") {
+      return '""';
+    }
+    const raw = typeof value === "string" ? value : JSON.stringify(value);
+    const flat = (raw ?? "").replace(/\n/g, " ⏎ ");
+    return flat.length <= max ? flat : flat.slice(0, max) + "…";
+  }
+
+  public runLabel(run: SpyRun): string {
+    return `${run.name ?? "unnamed run"} · ${this.when(run.started)} · ${this.count(run.rows)} rows`;
+  }
+
+  public stamp(value: string): string {
+    return value ? value.substring(0, 19) : "";
+  }
+
+  public timeOnly(value: string): string {
+    return value ? value.substring(11, 19) : "";
+  }
+
+  // ---------- the window's own furniture ----------
+
+  /**
+   * The sidebar. Every destination on it is a view that exists: there are no
+   * placeholders here, so nothing in the rail leads to an empty room.
+   */
+  public readonly rail: { group: string; items: { id: SpyTab; label: string; icon: string[] }[] }[] = [
+    {
+      group: "Observe",
+      items: [
+        // Three boxes chained: the flow as the first view draws it.
+        {
+          id: "brief",
+          label: "Workflow",
+          icon: ["M2.5 7.5h4v5h-4zM13.5 4h4v5h-4zM13.5 11h4v5h-4z", "M6.5 10h3.5V6.5h3.5M10 10v3.5h3.5"],
+        },
+        // A timeline with its marks.
+        { id: "footage", label: "Timeline", icon: ["M2.5 10h15", "M5.5 7v6M10 6v8M14.5 7.5v5"] },
+      ],
+    },
+    {
+      group: "Compare",
+      items: [
+        // A line that rises and falls: how the runs came out, one after another.
+        { id: "experiments", label: "Runs", icon: ["M2.5 13.5l4-5 3.5 3 3-5.5 4.5 3"] },
+        // Bars of different lengths, which is exactly what the comparison draws.
+        { id: "autopsy", label: "Results", icon: ["M3 5.5h10M3 10h6M3 14.5h13"] },
+      ],
+    },
+    {
+      // A written page.
+      group: "Explain",
+      items: [{ id: "report", label: "Report", icon: ["M4.5 2.5h8l3.5 3.5v11h-11.5z", "M7 9h6M7 12.5h4"] }],
+    },
+  ];
+
+  /**
+   * Whether the rail is open. Folded it keeps only the icons, so the drawings
+   * get the width back without anybody losing their way around.
+   */
+  public railOpen = true;
+
+  public toggleRail(): void {
+    this.railOpen = !this.railOpen;
+  }
+
+  /**
+   * The question each view answers. The rail carries a short noun so it stays
+   * quiet; the question itself is the page's title, which is where it reads.
+   */
+  public readonly titles: Record<SpyTab, string> = {
+    brief: "How does this work?",
+    footage: "What did I change?",
+    experiments: "What has been tried?",
+    autopsy: "Why did my results change?",
+    report: "Report",
+  };
+
+  /** The most recent run, which is what the title bar reports on. */
+  public get lastRun(): SpyRun | undefined {
+    return this.runs.length ? this.runs[this.runs.length - 1] : undefined;
+  }
+
+  /** One word for where the workflow stands, taken from its last run. */
+  public get state(): string {
+    if (this.keeping) {
+      return "Running";
+    }
+    const run = this.lastRun;
+    if (!run) {
+      return "Never run";
+    }
+    return run.status.charAt(0).toUpperCase() + run.status.slice(1);
+  }
+
+  /** Which of the four meanings that state carries. */
+  public get stateKind(): string {
+    if (this.keeping) {
+      return "live";
+    }
+    const status = this.lastRun?.status ?? "";
+    if (status === "running" || status === "paused") {
+      return "live";
+    }
+    if (status === "failed" || status === "killed") {
+      return "bad";
+    }
+    if (status === "completed") {
+      return "good";
+    }
+    return "idle";
+  }
+
+  /** How long the last run took, wall clock, from the record. */
+  public get lastRunTook(): string {
+    const run = this.lastRun;
+    if (!run?.started || !run?.ended) {
+      return "—";
+    }
+    const from = new Date(run.started.replace(" ", "T")).getTime();
+    const to = new Date(run.ended.replace(" ", "T")).getTime();
+    if (isNaN(from) || isNaN(to) || to < from) {
+      return "—";
+    }
+    return this.lasted((to - from) / 1000);
+  }
+
+  /** A duration in the shortest form that is still exact enough to trust. */
+  public lasted(seconds: number): string {
+    if (seconds < 10) {
+      return `${seconds.toFixed(1)}s`;
+    }
+    if (seconds < 60) {
+      return `${Math.round(seconds)}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}m ${Math.round(seconds - minutes * 60)}s`;
+  }
+
+  // ---------- how the runs moved, run after run ----------
+
+  public readonly trendW = 292;
+  public readonly trendH = 68;
+
+  /** Worked out once, when the runs arrive: a getter here would redraw forever. */
+  public trends: Trend[] = [];
+
+  private linesOverRuns(): Trend[] {
+    const out: Trend[] = [];
+    const time = this.trendOf("seconds", "Time to run");
+    const rows = this.trendOf("produced", "Rows produced");
+    if (time) {
+      out.push(time);
+    }
+    if (rows) {
+      out.push(rows);
+    }
+    return out;
+  }
+
+  /**
+   * One metric across every run that measured it. Two rules keep this honest:
+   * a run that produced nothing breaks the line instead of dipping it, and
+   * only time gets called better or worse, because more rows is neither.
+   */
+  private trendOf(metric: "seconds" | "produced", label: string): Trend | null {
+    const seen = (this.experiments?.runs ?? []).filter(run =>
+      metric === "seconds" ? run.seconds != null && run.seconds > 0 : run.measured
+    );
+    if (seen.length < 2) {
+      return null;
+    }
+    const valueOf = (run: ExperimentRun) => (metric === "seconds" ? run.seconds ?? 0 : run.produced);
+    const values = seen.map(valueOf);
+    const top = Math.max(...values);
+    const floor = Math.min(...values);
+    const span = top - floor;
+    const pad = 11;
+    const width = this.trendW - pad * 2;
+    const height = this.trendH - pad * 2;
+    const stepX = seen.length > 1 ? width / (seen.length - 1) : 0;
+
+    const dots: TrendDot[] = seen.map((run, i) => {
+      const value = valueOf(run);
+      const empty = metric === "produced" && run.produced === 0;
+      // With every run the same, a line at the floor would read as the worst
+      // possible result. Flat means flat, so it sits in the middle.
+      const lift = span === 0 ? 0.5 : (value - floor) / span;
+      return {
+        x: Math.round((pad + i * stepX) * 10) / 10,
+        y: empty ? this.trendH - pad : Math.round((pad + height - lift * height) * 10) / 10,
+        eid: run.eid,
+        label: run.name || `run ${run.eid}`,
+        value: metric === "seconds" ? this.lasted(value) : this.count(value),
+        empty,
+      };
+    });
+
+    const segments: string[] = [];
+    let stretch: TrendDot[] = [];
+    for (const dot of dots) {
+      if (dot.empty) {
+        if (stretch.length > 1) {
+          segments.push(stretch.map(d => `${d.x},${d.y}`).join(" "));
+        }
+        stretch = [];
+      } else {
+        stretch.push(dot);
+      }
+    }
+    if (stretch.length > 1) {
+      segments.push(stretch.map(d => `${d.x},${d.y}`).join(" "));
+    }
+
+    const last = values[values.length - 1];
+    const before = values[values.length - 2];
+    const moved = last - before;
+    const written = (n: number) =>
+      metric === "seconds"
+        ? `${n > 0 ? "+" : "−"}${this.lasted(Math.abs(n))}`
+        : `${n > 0 ? "+" : "−"}${this.count(Math.abs(n))}`;
+    return {
+      key: metric,
+      label,
+      segments,
+      dots,
+      high: metric === "seconds" ? this.lasted(top) : this.count(top),
+      low: metric === "seconds" ? this.lasted(floor) : this.count(floor),
+      latest: metric === "seconds" ? this.lasted(last) : this.count(last),
+      change: moved === 0 ? "no change" : written(moved),
+      verdict: metric !== "seconds" ? "" : moved === 0 ? "same" : moved < 0 ? "better" : "worse",
+    };
+  }
+}

--- a/spy-service/README.md
+++ b/spy-service/README.md
@@ -1,0 +1,91 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+# spy-service
+
+Serves the workflow panel in the GUI with what Texera already records about a
+workflow and does not show: every save, and every run.
+
+Nothing here is new data. `workflow_version` keeps one inverse JSON patch per
+save, and the runtime statistics of every run stay in Iceberg long after the
+results themselves are dropped. This service reads both and answers questions
+about them.
+
+## What each module does
+
+| Module | What it does |
+| --- | --- |
+| `core.py` | Rebuilds a workflow's whole history from the inverse patches in `workflow_version`. Tolerates a patch that removes what is already gone, and reports where that happened. |
+| `autopsy.py` | Compares two runs operator by operator in topological order and names the edit behind the first difference. |
+| `brief.py` | Today's workflow step by step, and every run read as an experiment. |
+| `stats.py` | Reads the Iceberg runtime statistics of a run: rows in and out of each step, workers, time. Needs `pyarrow`. |
+| `server.py` | The HTTP boundary. Everything it returns is in English, keys and text alike. |
+
+## Running it
+
+```bash
+python3 spy-service/server.py
+```
+
+It listens on `127.0.0.1:5055` and reads the database directly, so it holds no
+Texera session or token of its own. The one route that writes, `POST
+/api/spy/run`, carries the token of the user who has Texera open, so whoever
+cannot run a workflow themselves cannot run it from here either.
+
+`stats.py` needs `pyarrow`; without it the panel still works and simply shows no
+per-step row counts for older runs.
+
+## Configuration
+
+Every setting is an environment variable with the development bundle's default,
+so a standard checkout needs none of them.
+
+| Variable | Default | What it is |
+| --- | --- | --- |
+| `SPY_PORT` | `5055` | Port to listen on. |
+| `SPY_PG_HOST` / `SPY_PG_PORT` | `127.0.0.1` / `5432` | Where PostgreSQL is. |
+| `SPY_PG_USER` / `SPY_PG_PASSWORD` | `texera` / empty | Credentials to read with. |
+| `SPY_PG_DATABASE` / `SPY_PG_SCHEMA` | `texera_db` | Database and schema. |
+| `SPY_ICEBERG_CATALOG` | `texera_iceberg_catalog` | Catalog holding the runtime statistics. |
+| `SPY_TEXERA_ROOT` | this checkout | Root the catalog's relative paths resolve against. |
+| `SPY_SNAPSHOTS` | `spy-service/snapshots` | Where rows kept from a run are written. See the note below. |
+| `SPY_LITELLM` | `http://127.0.0.1:4000/v1/chat/completions` | LiteLLM endpoint for the written explanations. |
+| `SPY_LITELLM_ENV` | unset | File to read `LITELLM_MASTER_KEY` from, when it is not in the environment. |
+| `SPY_MODEL` / `SPY_NARRATOR_MODEL` | `claude-haiku-4.5` | Models that write the prose. |
+
+Without a model the panel loses only its sentences: every count, every state and
+the edit to blame are derived by the rules and shown either way.
+
+## Open question: where a kept run should live
+
+A run whose rows the user wants to compare is written here as one JSON file per
+run under `SPY_SNAPSHOTS`. That is the weakest part of this service and is meant
+to change before this is anything but a draft.
+
+The rows do not need copying at all. When a run finishes they are already in an
+Iceberg table; the reason they cannot be compared later is that
+`WorkflowService.clearExecutionResources` drops them once the workflow has been
+idle for `executionStateCleanUpInSecs`, thirty seconds by default. Keeping a run
+for comparison is therefore not a write but a flag: mark the execution as
+retained, and let the cleanup skip it the way it already skips per-user
+warehouses through `WarehouseReadGuard.skipWhileDisabled`.
+
+That would drop this directory entirely, keep the workflow's own access control
+in force, and stop the service needing a disk of its own. It also needs a
+retention policy, since nothing would otherwise ever free the space.

--- a/spy-service/autopsy.py
+++ b/spy-service/autopsy.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Autopsia: en que operador empiezan a diferir dos ejecuciones, y que edicion lo causo.
+
+Compares the snapshots of two runs operator by operator, in topological order,
+and names the first one whose output changes. It then crosses the workflow
+versions each run came from to show the edit responsible.
+"""
+import json, os, sys
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import core
+
+# Where the rows kept from a run are written. Texera throws its own away
+# thirty seconds after you stop working on the workflow.
+SNAPS = os.environ.get("SPY_SNAPSHOTS", os.path.join(os.path.dirname(os.path.abspath(__file__)), "snapshots"))
+
+
+def load(wid, eid):
+    p = "%s/wid_%d_eid_%d.json" % (SNAPS, wid, eid)
+    if not os.path.exists(p):
+        raise SystemExit("no hay instantanea de eid %d" % eid)
+    return json.load(open(p))
+
+
+def topo(canvas):
+    """Operators in topological order, following the canvas links."""
+    ops = [o["operatorID"] for o in canvas.get("operators", [])]
+    edges = {}
+    indeg = {o: 0 for o in ops}
+    for l in canvas.get("links", []):
+        a, b = l["source"]["operatorID"], l["target"]["operatorID"]
+        edges.setdefault(a, []).append(b)
+        if b in indeg:
+            indeg[b] += 1
+    queue = [o for o in ops if indeg[o] == 0]
+    out = []
+    while queue:
+        n = queue.pop(0)
+        out.append(n)
+        for m in edges.get(n, []):
+            indeg[m] -= 1
+            if indeg[m] == 0:
+                queue.append(m)
+    for o in ops:                       # ciclos o islas, al final
+        if o not in out:
+            out.append(o)
+    return out
+
+
+def rows_of(snap, oid):
+    v = (snap.get("operators") or {}).get(oid) or {}
+    rows = v.get("result") or []
+    return [{k: x[k] for k in x if k != "__row_index__"} for x in rows]
+
+
+def count_of(snap, oid):
+    """How many rows the operator really produced, and whether the sample is cut.
+
+    The engine does not return every row: there is a hard cap of 100,000
+    characters per operator (MAX_OPERATOR_RESULT_CHARS in SyncExecutionResource)
+    and past it the head and the tail are kept. But it declares the real total in
+    outputTuples and, in newer snapshots, in totalRowCount. Counting the rows of
+    the sample gives a false number; the engine is the one to believe.
+    """
+    v = (snap.get("operators") or {}).get(oid) or {}
+    shown = len(v.get("result") or [])
+    total = v.get("totalRowCount")
+    if total is None:
+        total = v.get("outputTuples")
+    if total is None:
+        total = shown
+    cut = bool(v.get("truncated")) or shown < total
+    return int(total), shown, cut
+
+
+def compare_rows(a, b, total_a=None, total_b=None, cut=False):
+    """Resumen de la diferencia entre dos salidas.
+
+    The counts are the ones the engine declares; the rows are only a sample.
+    If either side comes back cut, rows that appear on one side and not the
+    other may be an artefact of the cut, and are marked inconclusive.
+    """
+    ka = [json.dumps(r, sort_keys=True, ensure_ascii=False) for r in a]
+    kb = [json.dumps(r, sort_keys=True, ensure_ascii=False) for r in b]
+    total_a = len(a) if total_a is None else total_a
+    total_b = len(b) if total_b is None else total_b
+    if ka == kb and total_a == total_b:
+        return None
+    sa, sb = set(ka), set(kb)
+    return {
+        "filas_a": total_a, "filas_b": total_b,
+        "muestra_a": len(a), "muestra_b": len(b), "muestra_cortada": cut,
+        "solo_en_a": [json.loads(x) for x in list(sa - sb)[:8]],
+        "solo_en_b": [json.loads(x) for x in list(sb - sa)[:8]],
+        "mismo_conjunto_distinto_orden": sa == sb and total_a == total_b,
+    }
+
+
+def operator_props(canvas):
+    return {o["operatorID"]: o.get("operatorProperties", {})
+            for o in canvas.get("operators", [])}
+
+
+def prop_diff(pa, pb, path=""):
+    """Diferencias entre dos arboles de propiedades, como lista de rutas."""
+    out = []
+    if type(pa) is not type(pb):
+        return [(path, pa, pb)]
+    if isinstance(pa, dict):
+        for k in sorted(set(pa) | set(pb)):
+            out += prop_diff(pa.get(k), pb.get(k), "%s/%s" % (path, k))
+    elif isinstance(pa, list):
+        if len(pa) != len(pb):
+            return [(path, pa, pb)]
+        for i, (x, y) in enumerate(zip(pa, pb)):
+            out += prop_diff(x, y, "%s/%d" % (path, i))
+    elif pa != pb:
+        out.append((path, pa, pb))
+    return out
+
+
+def autopsy(wid, eid_a, eid_b):
+    sa, sb = load(wid, eid_a), load(wid, eid_b)
+    execs = {e["eid"]: e for e in core.executions(wid)}
+    vid_a, vid_b = execs[eid_a]["vid"], execs[eid_b]["vid"]
+
+    wf, hist, origin, broken = core.history(wid)
+    states = {h["vid"]: h["state"] for h in hist}
+    canvas_a, canvas_b = states.get(vid_a), states.get(vid_b)
+    canvas = canvas_b or canvas_a or wf["content"]
+
+    order = topo(canvas)
+    findings = []
+    # Two candidates to blame. A step that returns exactly the same rows in a
+    # different order has not changed the data: the engine splits the work
+    # entre varios trabajadores y el orden de salida baila entre ejecuciones,
+    # so naming it would hide the real edit further down. A reordering is only
+    # accused when there is no difference in content anywhere in the flow;
+    # then it really is all that happened.
+    first_content = None
+    first_any = None
+    for oid in order:
+        ta, _, cut_a = count_of(sa, oid)
+        tb, _, cut_b = count_of(sb, oid)
+        d = compare_rows(rows_of(sa, oid), rows_of(sb, oid), ta, tb, cut_a or cut_b)
+        # The counts live outside the diff because the panel draws them even
+        # when both sides agree: an identical step still has volume.
+        findings.append({"operatorID": oid, "diff": d,
+                         "filas_a": ta, "filas_b": tb, "cortada": cut_a or cut_b})
+        if d:
+            if first_any is None:
+                first_any = oid
+            if first_content is None and not d["mismo_conjunto_distinto_orden"]:
+                first_content = oid
+    first = first_content or first_any
+
+    # the edit to blame: properties that changed between the two versions
+    culprit = []
+    if canvas_a and canvas_b:
+        pa, pb = operator_props(canvas_a), operator_props(canvas_b)
+        for oid in order:
+            for path, va, vb in prop_diff(pa.get(oid, {}), pb.get(oid, {})):
+                culprit.append({"operatorID": oid, "path": path, "antes": va, "despues": vb})
+
+    return {"wid": wid, "name": wf["name"],
+            "a": {"eid": eid_a, "vid": vid_a, "name": sa.get("name")},
+            "b": {"eid": eid_b, "vid": vid_b, "name": sb.get("name")},
+            "orden": order, "hallazgos": findings,
+            # The later version's whole canvas travels along because the panel
+            # has to say what each step does, not only how many rows it emits.
+            "lienzo": canvas,
+            "primer_divergente": first, "ediciones": culprit}
+
+
+if __name__ == "__main__":
+    wid, ea, eb = int(sys.argv[1]), int(sys.argv[2]), int(sys.argv[3])
+    r = autopsy(wid, ea, eb)
+    print("flujo %d: %s" % (r["wid"], r["name"]))
+    print("A = eid %d (version %d, %s)" % (r["a"]["eid"], r["a"]["vid"], r["a"]["name"]))
+    print("B = eid %d (version %d, %s)" % (r["b"]["eid"], r["b"]["vid"], r["b"]["name"]))
+    print("\norden topologico: %s" % " -> ".join(r["orden"]))
+    print("\npor operador:")
+    for h in r["hallazgos"]:
+        if not h["diff"]:
+            print("  %-5s identico" % h["operatorID"])
+        else:
+            d = h["diff"]
+            marca = "  <-- PRIMERO QUE DIVERGE" if h["operatorID"] == r["primer_divergente"] else ""
+            print("  %-5s DIFIERE  filas %d vs %d%s" % (
+                h["operatorID"], d["filas_a"], d["filas_b"], marca))
+            for r_ in d["solo_en_a"][:2]:
+                print("        solo en A:", json.dumps(r_, ensure_ascii=False)[:90])
+            for r_ in d["solo_en_b"][:2]:
+                print("        solo en B:", json.dumps(r_, ensure_ascii=False)[:90])
+    print("\nediciones entre las dos versiones:")
+    if not r["ediciones"]:
+        print("  none in the operators' properties")
+    for e in r["ediciones"]:
+        print("  %-5s %s : %s -> %s" % (e["operatorID"], e["path"],
+                                        json.dumps(e["antes"], ensure_ascii=False),
+                                        json.dumps(e["despues"], ensure_ascii=False)))

--- a/spy-service/brief.py
+++ b/spy-service/brief.py
@@ -1,0 +1,502 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Lo que hace falta para entender un flujo que uno no ha construido.
+
+The panel started out answering "what did I change" and "why did my results
+change", which are the questions of someone who already knows the workflow.
+Whoever has just joined has two others: "how does this work" and "what has been
+tried". This
+modulo deriva ambas del mismo registro.
+
+Dos salidas:
+
+  orientation(wid)  the workflow as it stands today, step by step in the order
+                    the data flows, with what each one does, how many rows it
+                    moves, who has touched it and which settings are the ones
+                    cambia de verdad.
+  experiments(wid)  every run as a table of experiments: which dial was set to
+                    what in each one, and what came out the other end.
+
+The keys travel in English because this goes out over HTTP as it is.
+"""
+import json
+import os
+
+import autopsy
+import core
+import stats
+
+# Above this, describing a value costs more than it gives: they are
+# programas, consultas o tablas pegadas.
+DESCRIBABLE = 600
+
+# The panel does want them whole, because a user function's code is precisely
+# the only thing that step does. It shows them folded, not on one line.
+SHOWABLE = 4000
+
+# Settings that say nothing about what a step does: form scaffolding or
+# del reparto de trabajo.
+# `envName` belongs here because nobody writes it: opening a user function's
+# property panel leaves it empty and the next save removes it, so it shows up as
+# the most edited setting in the workflow without being one.
+SILENT_SETTINGS = {"dummyPropertyList", "defaultEnv", "workers", "columns",
+                   "limit_dummy", "attributeType", "envName"}
+
+# Half an hour of silence between two saves reads as having come back later.
+SESSION_GAP = 30 * 60
+
+
+def shape(value, key):
+    """A property's raw value, when it is small enough to describe."""
+    try:
+        if len(json.dumps(value, ensure_ascii=False)) <= DESCRIBABLE:
+            return {key: value}
+    except (TypeError, ValueError):
+        pass
+    return {}
+
+
+def settings_of(operator):
+    """An operator's settings worth showing, uncut.
+
+    They travel raw on purpose: the panel words them with the same JSON schema
+    that draws the form, so it says "amount > 100" instead of dumping JSON.
+    """
+    out = []
+    for key, value in (operator.get("operatorProperties") or {}).items():
+        if key in SILENT_SETTINGS or value in ("", None, [], {}):
+            continue
+        text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False)
+        entry = {"path": "/" + key, "lines": text.count("\n") + 1, "size": len(text)}
+        if len(text) <= SHOWABLE:
+            entry["value"] = value
+        out.append(entry)
+    return out
+
+
+def leaves(value, prefix=""):
+    """The leaves of a property tree, as {path: value}.
+
+    A dial is a leaf: a filter's threshold, the column something groups by. A
+    whole subtree is not, because changing it changes several at once.
+    """
+    out = {}
+    if isinstance(value, dict):
+        for key, sub in value.items():
+            if key in SILENT_SETTINGS:
+                continue
+            out.update(leaves(sub, "%s/%s" % (prefix, key)))
+    elif isinstance(value, list):
+        for i, sub in enumerate(value):
+            out.update(leaves(sub, "%s/%d" % (prefix, i)))
+    else:
+        out[prefix] = value
+    return out
+
+
+def noisy(path):
+    """Paths that are not a setting anyone ever decided to touch."""
+    return any(part in SILENT_SETTINGS for part in path.split("/") if part)
+
+
+def props_of(state):
+    """The leaves of every operator on a canvas: {oid: {path: value}}."""
+    return {o["operatorID"]: leaves(o.get("operatorProperties") or {})
+            for o in (state or {}).get("operators", [])}
+
+
+# ---------- the workflow as it stands today ----------
+
+def latest(hist):
+    """The last rebuildable state, which is today's canvas."""
+    for h in reversed(hist):
+        if h["state"] is not None:
+            return h
+    return None
+
+
+def wiring(state):
+    """Who feeds whom, with the target port when there is more than one."""
+    fed_by = {}
+    feeds = {}
+    for link in (state or {}).get("links", []):
+        a = link["source"]["operatorID"]
+        b = link["target"]["operatorID"]
+        fed_by.setdefault(b, []).append({"id": a, "port": link["target"].get("portID", "")})
+        feeds.setdefault(a, []).append(b)
+    return fed_by, feeds
+
+
+def activity(hist):
+    """How many times each operator was touched, and when it last was.
+
+    This is not the narrated log of the timeline: here it is only counted, so
+    that one step can be called untouched for months and another daily.
+    """
+    touched = {}
+    previous = None
+    for h in hist:
+        state = h["state"]
+        if state is None:
+            continue
+        if previous is not None:
+            was = {o["operatorID"]: o for o in previous.get("operators", [])}
+            now = {o["operatorID"]: o for o in state.get("operators", [])}
+            for oid in now:
+                entry = touched.setdefault(oid, {"count": 0, "last": None, "born": h["time"],
+                                                 "settings": {}})
+                if oid not in was:
+                    entry["born"] = h["time"]
+                    entry["count"] += 1
+                    entry["last"] = h["time"]
+                    continue
+                changed = False
+                for path, before, after in autopsy.prop_diff(
+                        was[oid].get("operatorProperties", {}),
+                        now[oid].get("operatorProperties", {})):
+                    entry["settings"][path] = entry["settings"].get(path, 0) + 1
+                    changed = True
+                if was[oid].get("customDisplayName") != now[oid].get("customDisplayName"):
+                    changed = True
+                if bool(was[oid].get("isDisabled")) != bool(now[oid].get("isDisabled")):
+                    changed = True
+                if changed:
+                    entry["count"] += 1
+                    entry["last"] = h["time"]
+        previous = state
+    return touched
+
+
+def snapshot_of(wid, eid):
+    path = "%s/wid_%d_eid_%d.json" % (autopsy.SNAPS, wid, eid)
+    if not os.path.exists(path):
+        return None
+    try:
+        return json.load(open(path))
+    except Exception:
+        return None
+
+
+def sample_of(snapshot, oid, rows=3):
+    """The first rows a step emitted, with its columns, if they were kept."""
+    entry = ((snapshot or {}).get("operators") or {}).get(oid) or {}
+    result = entry.get("result") or []
+    clean = [{k: v for k, v in row.items() if k != "__row_index__"} for row in result[:rows]]
+    columns = []
+    for row in clean:
+        for key in row:
+            if key not in columns:
+                columns.append(key)
+    return columns, clean
+
+
+def sessions_of(times):
+    """How many sittings this was built in, counting the long silences."""
+    stamps = []
+    for value in times:
+        try:
+            from datetime import datetime
+            stamps.append(datetime.fromisoformat(value))
+        except (ValueError, TypeError):
+            continue
+    if not stamps:
+        return 0
+    count = 1
+    for before, after in zip(stamps, stamps[1:]):
+        if (after - before).total_seconds() > SESSION_GAP:
+            count += 1
+    return count
+
+
+def orientation(wid):
+    """The workflow explained to whoever did not build it, sources to outputs."""
+    wf, hist, _origin, broken = core.history(wid)
+    runs = core.executions(wid)
+    frame = latest(hist)
+    state = (frame or {}).get("state") or wf["content"]
+    states_by_vid = {h["vid"]: h["state"] for h in hist}
+    order = autopsy.topo(state)
+    fed_by, feeds = wiring(state)
+    touched = activity(hist)
+
+    # The figures of the last attempt that completed: it is what someone
+    # recien llegado vera si le da al play hoy.
+    dirs = stats.table_dirs(wid)
+    last_run = None
+    volumes = {}
+    for run in reversed(runs):
+        found = stats.totals(wid, run["eid"], dirs.get(run["eid"]))
+        if found:
+            last_run, volumes = run, found
+            break
+
+    # The sample rows come from the most recent snapshot there is; it need not
+    # be the one of the last run, because Texera drops results after thirty
+    # seconds and this service only keeps its own.
+    snapshot = None
+    sampled = None
+    for run in reversed(runs):
+        snapshot = snapshot_of(wid, run["eid"])
+        if snapshot:
+            sampled = run
+            break
+
+    steps = []
+    for position, oid in enumerate(order, start=1):
+        operator = next((o for o in state.get("operators", []) if o["operatorID"] == oid), {})
+        columns, sample = sample_of(snapshot, oid)
+        seen = touched.get(oid) or {}
+        volume = volumes.get(oid) or {}
+        steps.append({
+            "id": oid,
+            "position": position,
+            "name": operator.get("customDisplayName") or operator.get("operatorType", oid),
+            "type": operator.get("operatorType", ""),
+            "role": ("source" if not fed_by.get(oid) else
+                     "output" if not feeds.get(oid) else "step"),
+            "disabled": bool(operator.get("isDisabled")),
+            "settings": settings_of(operator),
+            "fedBy": fed_by.get(oid, []),
+            "feeds": feeds.get(oid, []),
+            "rowsIn": volume.get("in"),
+            "rowsOut": volume.get("out"),
+            "workers": volume.get("workers"),
+            "seconds": volume.get("seconds"),
+            "columns": columns,
+            "sample": sample,
+            "edits": seen.get("count", 0),
+            "lastEdited": seen.get("last"),
+            "addedOn": seen.get("born"),
+        })
+
+    # The dials: the settings somebody changed more than once. They are the map
+    # of what gets touched in this workflow and what was left alone.
+    knobs = []
+    names = {s["id"]: s["name"] for s in steps}
+    types = {s["id"]: s["type"] for s in steps}
+    now = props_of(state)
+    # A setting that differs between two runs is a dial even if it was touched
+    # only once: it is the variable of an experiment somebody ran.
+    tried = set()
+    seen_values = {}
+    for vid in dict.fromkeys(r["vid"] for r in runs):
+        ran = states_by_vid.get(vid)
+        if not ran:
+            continue
+        for oid, tree in props_of(ran).items():
+            for path, value in tree.items():
+                key = (oid, path)
+                seen_values.setdefault(key, set()).add(
+                    json.dumps(value, ensure_ascii=False, sort_keys=True)[:DESCRIBABLE])
+    for key, values in seen_values.items():
+        if len(values) > 1:
+            tried.add(key)
+    for oid, seen in touched.items():
+        if oid not in names:
+            continue
+        for path, times in (seen.get("settings") or {}).items():
+            if noisy(path):
+                continue
+            if times < 2 and (oid, path) not in tried:
+                continue
+            entry = {"stepId": oid, "step": names[oid], "type": types[oid],
+                     "path": path, "times": times,
+                     "tried": (oid, path) in tried}
+            entry.update(shape(now.get(oid, {}).get(path), "value"))
+            knobs.append(entry)
+    # First what somebody really tried in a run, then what was edited most.
+    knobs.sort(key=lambda k: (not k["tried"], -k["times"]))
+
+    times = [h["time"] for h in hist]
+    completed = [r for r in runs if r["status"] == 3]
+    return {
+        "wid": wid,
+        "name": wf["name"],
+        "description": wf["description"],
+        "people": [{"name": p["name"], "access": p["privilege"], "owner": p["owner"]}
+                   for p in core.people(wid)],
+        "ranBy": sorted({r["who"] for r in runs if r["who"]}),
+        "shape": {
+            "sources": sum(1 for s in steps if s["role"] == "source"),
+            "middle": sum(1 for s in steps if s["role"] == "step"),
+            "outputs": sum(1 for s in steps if s["role"] == "output"),
+        },
+        "steps": steps,
+        "knobs": knobs[:8],
+        # Which attempt the sample rows come from. Worth saying: it may not be
+        # the last one, and its settings may not be today's.
+        "sampleFrom": ({"eid": sampled["eid"], "name": sampled["name"] or "",
+                        "when": sampled["start"],
+                        "current": sampled["vid"] == (frame or {}).get("vid")}
+                       if sampled else None),
+        "record": {
+            "saves": len(hist),
+            "sessions": sessions_of(times),
+            "started": times[0] if times else None,
+            "lastEdited": times[-1] if times else None,
+            "runs": len(runs),
+            "completed": len(completed),
+            "lastRun": last_run["start"] if last_run else None,
+            "lastRunName": (last_run.get("name") or "") if last_run else "",
+            "unreadable": (len(hist) - sum(1 for h in hist if h["state"] is not None)),
+            "broken": bool(broken),
+        },
+    }
+
+
+# ---------- what has been tried already ----------
+
+STATUS = {0: "ready", 1: "running", 2: "paused", 3: "completed",
+          4: "failed", 5: "killed"}
+
+
+def seconds_between(start, end):
+    try:
+        from datetime import datetime
+        return round((datetime.fromisoformat(end) - datetime.fromisoformat(start)).total_seconds(), 1)
+    except (ValueError, TypeError):
+        return None
+
+
+def experiments(wid):
+    """Every run as what it is: an attempt with one dial set differently.
+
+    What makes an old run comparable is not its results, which Texera drops
+    after thirty seconds, but its statistics, which it keeps. That is where the
+    rows of each step of each attempt come from.
+    """
+    wf, hist, _origin, _broken = core.history(wid)
+    runs = core.executions(wid)
+    states = {h["vid"]: h["state"] for h in hist}
+    dirs = stats.table_dirs(wid)
+
+    # Only the versions somebody ran from: comparing the settings of every
+    # version would mix in edits nobody ever tried.
+    ran_versions = [vid for vid in dict.fromkeys(r["vid"] for r in runs) if states.get(vid)]
+    props = {vid: props_of(states[vid]) for vid in ran_versions}
+
+    # A dial is a leaf whose value is not the same across every version that
+    # was run. That is exactly the variable of an experiment.
+    knobs = []
+    everywhere = {}
+    for vid in ran_versions:
+        for oid, tree in props[vid].items():
+            for path, value in tree.items():
+                everywhere.setdefault((oid, path), {})[vid] = value
+    last_state = states.get(ran_versions[-1]) if ran_versions else None
+    names = {o["operatorID"]: (o.get("customDisplayName") or o.get("operatorType", ""))
+             for o in (last_state or {}).get("operators", [])}
+    types = {o["operatorID"]: o.get("operatorType", "")
+             for o in (last_state or {}).get("operators", [])}
+    for (oid, path), by_version in everywhere.items():
+        values = [json.dumps(v, ensure_ascii=False, sort_keys=True) for v in by_version.values()]
+        if len(set(values)) < 2:
+            continue
+        # A huge value is not a dial anyone reads off a table.
+        if max(len(v) for v in values) > DESCRIBABLE:
+            continue
+        knobs.append({"id": "%s%s" % (oid, path), "stepId": oid,
+                      "step": names.get(oid, oid), "type": types.get(oid, ""),
+                      "path": path})
+    knobs.sort(key=lambda k: (k["step"], k["path"]))
+
+    out = []
+    for run in runs:
+        state = states.get(run["vid"])
+        totals = stats.totals(wid, run["eid"], dirs.get(run["eid"]))
+        _fed_by, feeds = wiring(state)
+        sinks = [o["operatorID"] for o in (state or {}).get("operators", [])
+                 if not feeds.get(o["operatorID"])]
+        sources = [o["operatorID"] for o in (state or {}).get("operators", [])
+                   if not _fed_by.get(o["operatorID"])]
+        tree = props.get(run["vid"]) or props_of(state)
+        settings = {}
+        for knob in knobs:
+            value = tree.get(knob["stepId"], {}).get(knob["path"])
+            settings.update(shape(value, knob["id"]))
+        out.append({
+            "eid": run["eid"],
+            "vid": run["vid"],
+            "name": run["name"] or "",
+            "who": run["who"] or "",
+            "started": run["start"],
+            "ended": run["end"],
+            "seconds": seconds_between(run["start"], run["end"]),
+            "status": STATUS.get(run["status"], str(run["status"])),
+            "snapshot": snapshot_of(wid, run["eid"]) is not None,
+            "measured": bool(totals),
+            "steps": {oid: {"in": v["in"], "out": v["out"], "workers": v["workers"],
+                            "seconds": v["seconds"]}
+                      for oid, v in totals.items()},
+            "readIn": sum((totals.get(oid) or {}).get("out", 0) for oid in sources),
+            "produced": sum((totals.get(oid) or {}).get("out", 0) for oid in sinks),
+            "settings": settings,
+            "canvasSteps": len((state or {}).get("operators", [])),
+        })
+
+    # What changed from one attempt to the next, so the table reads as a
+    # sequence and not as a loose list.
+    moves = []
+    for before, after in zip(out, out[1:]):
+        if before["vid"] == after["vid"]:
+            continue
+        edits = []
+        for knob in knobs:
+            was = before["settings"].get(knob["id"])
+            now = after["settings"].get(knob["id"])
+            if json.dumps(was, sort_keys=True) != json.dumps(now, sort_keys=True):
+                edits.append({"knob": knob["id"], "step": knob["step"], "stepId": knob["stepId"],
+                              "type": knob["type"], "path": knob["path"],
+                              "before": was, "after": now})
+        # Entre dos intentos puede no haberse tocado ninguna perilla y aun asi
+        # have changed the workflow: a new step, a deleted one, a rename.
+        was = {o["operatorID"]: o for o in (states.get(before["vid"]) or {}).get("operators", [])}
+        now = {o["operatorID"]: o for o in (states.get(after["vid"]) or {}).get("operators", [])}
+        structure = []
+        for oid in now:
+            if oid not in was:
+                structure.append({"kind": "added", "stepId": oid,
+                                  "step": now[oid].get("customDisplayName") or now[oid].get("operatorType", oid)})
+        for oid in was:
+            if oid not in now:
+                structure.append({"kind": "removed", "stepId": oid,
+                                  "step": was[oid].get("customDisplayName") or was[oid].get("operatorType", oid)})
+        for oid in set(was) & set(now):
+            if was[oid].get("customDisplayName") != now[oid].get("customDisplayName"):
+                structure.append({"kind": "renamed", "stepId": oid,
+                                  "step": now[oid].get("customDisplayName") or oid,
+                                  "before": was[oid].get("customDisplayName") or ""})
+            if bool(was[oid].get("isDisabled")) != bool(now[oid].get("isDisabled")):
+                structure.append({"kind": "disabled" if now[oid].get("isDisabled") else "enabled",
+                                  "stepId": oid,
+                                  "step": now[oid].get("customDisplayName") or oid})
+        moves.append({"from": before["eid"], "to": after["eid"], "edits": edits,
+                      "structure": structure,
+                      "producedBefore": before["produced"], "producedAfter": after["produced"]})
+
+    return {"wid": wid, "name": wf["name"], "knobs": knobs, "runs": out, "moves": moves}
+
+
+if __name__ == "__main__":
+    import sys
+    what = sys.argv[1]
+    wid = int(sys.argv[2])
+    print(json.dumps(orientation(wid) if what == "brief" else experiments(wid),
+                     indent=1, ensure_ascii=False, default=str))

--- a/spy-service/core.py
+++ b/spy-service/core.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Nucleo del boton espia: reconstruye el historial completo de un flujo.
+
+Texera stores one *inverse* JSON patch per version in workflow_version:
+applying the patch of version N to the current content gives the state before
+it. Walking the patches from newest to oldest recovers every state the canvas
+ever passed through.
+"""
+import json, os, subprocess, copy
+
+# Every connection detail comes from the environment, with the defaults of the
+# development bundle, so that nothing about one machine is written into the code.
+HOST = os.environ.get("SPY_PG_HOST", "127.0.0.1")
+PORT = os.environ.get("SPY_PG_PORT", "5432")
+USER = os.environ.get("SPY_PG_USER", "texera")
+PASSWORD = os.environ.get("SPY_PG_PASSWORD", "")
+DATABASE = os.environ.get("SPY_PG_DATABASE", "texera_db")
+SCHEMA = os.environ.get("SPY_PG_SCHEMA", "texera_db")
+
+DB = ["psql", "-h", HOST, "-p", PORT, "-U", USER, "-d", DATABASE, "-tAc"]
+ENV = {"PGPASSWORD": PASSWORD, "PATH": os.environ.get("PATH", "/usr/bin:/bin")}
+
+
+def qraw(sql):
+    out = subprocess.run(DB + [sql], capture_output=True, text=True, env=ENV, check=True)
+    return out.stdout
+
+
+def q(sql):
+    return [l for l in qraw(sql).split("\n") if l != ""]
+
+
+# ---------- JSON Patch (RFC 6902), only as much as Texera emits ----------
+
+def _tokens(path):
+    if path == "":
+        return []
+    return [t.replace("~1", "/").replace("~0", "~") for t in path.lstrip("/").split("/")]
+
+
+def _resolve(doc, tokens):
+    """Devuelve (contenedor, clave) del ultimo token."""
+    cur = doc
+    for t in tokens[:-1]:
+        cur = cur[int(t)] if isinstance(cur, list) else cur[t]
+    last = tokens[-1]
+    if isinstance(cur, list) and last != "-":
+        last = int(last)
+    return cur, last
+
+
+def apply_patch(doc, patch, tolerated=None):
+    """Applies one inverse patch to the canvas.
+
+    Texera guarda a veces la misma operacion repetida en versiones seguidas
+    ("remove envName" on three consecutive saves). The first one applies and
+    the rest cannot find the key, so the chain breaks and everything before it
+    becomes unrecoverable. Removing what is already gone leaves exactly the
+    document the patch describes, so it is tolerated here and counted in
+    `tolerated`: the rebuilt state is still the one the patch asks for, and
+    whoever opens the panel is told the record came that way.
+    """
+    doc = copy.deepcopy(doc)
+    for op in patch:
+        o, path = op["op"], op["path"]
+        tokens = _tokens(path)
+        if not tokens:                      # la raiz entera
+            if o in ("replace", "add"):
+                doc = copy.deepcopy(op["value"])
+                continue
+            if o == "remove":
+                return {}
+            raise ValueError("op %s en la raiz" % o)
+        if o in ("add", "replace"):
+            cont, key = _resolve(doc, tokens)
+            if isinstance(cont, list):
+                if o == "add":
+                    cont.insert(len(cont) if key == "-" else key, copy.deepcopy(op["value"]))
+                else:
+                    cont[key] = copy.deepcopy(op["value"])
+            else:
+                cont[key] = copy.deepcopy(op["value"])
+        elif o == "remove":
+            cont, key = _resolve(doc, tokens)
+            try:
+                del cont[key]
+            except (KeyError, IndexError):
+                if tolerated is None:
+                    raise
+                tolerated.append(path)
+        elif o in ("move", "copy"):
+            src = _tokens(op["from"])
+            sc, sk = _resolve(doc, src)
+            val = copy.deepcopy(sc[sk])
+            if o == "move":
+                del sc[sk]
+            cont, key = _resolve(doc, tokens)
+            if isinstance(cont, list):
+                cont.insert(len(cont) if key == "-" else key, val)
+            else:
+                cont[key] = val
+        elif o == "test":
+            pass
+        else:
+            raise ValueError("op desconocida: %s" % o)
+    return doc
+
+
+# ---------- historial ----------
+
+def qjson(sql):
+    """Runs a query and returns the result as JSON, without splitting text."""
+    raw = qraw("select coalesce(json_agg(t), '[]'::json)::text from (%s) t" % sql)
+    return json.loads(raw)
+
+
+def workflow(wid):
+    rows = qjson("select name, coalesce(description,'') as description, content "
+                 "from texera_db.workflow where wid=%d" % wid)
+    if not rows:
+        raise SystemExit("no workflow with id %d" % wid)
+    r = rows[0]
+    return {"wid": wid, "name": r["name"], "description": r["description"],
+            "content": json.loads(r["content"])}
+
+
+def versions(wid):
+    """Versions from oldest to newest: [{vid, time, patch}]."""
+    rows = qjson("select vid, creation_time::text as time, content "
+                 "from texera_db.workflow_version where wid=%d order by vid" % wid)
+    return [{"vid": r["vid"], "time": r["time"], "patch": json.loads(r["content"])}
+            for r in rows]
+
+
+def history(wid):
+    """Canvas states from oldest to newest.
+
+    Each entry: {vid, time, state, broken}. The state of version N is the
+    canvas as it stood *after* that edit. `broken` marks the version whose
+    patch could not be applied: from there backwards, the history Texera keeps
+    is inconsistent and cannot be rebuilt. The
+    versiones anteriores a ese punto quedan con state=None.
+
+    Equivalent to Texera's own applier (WorkflowVersionResource.applyPatch),
+    contrastado version por version; ver verify.py.
+    """
+    wf = workflow(wid)
+    vs = versions(wid)
+    state = wf["content"]
+    states = [None] * len(vs)
+    broken_at = None
+    # Per version, the operations that found nothing to remove.
+    forgiven = {}
+    for i in range(len(vs) - 1, -1, -1):
+        states[i] = state
+        if state is None:
+            continue
+        eased = []
+        try:
+            state = apply_patch(state, vs[i]["patch"], eased)
+        except Exception as e:
+            broken_at = {"vid": vs[i]["vid"], "error": "%s: %s" % (type(e).__name__, e)}
+            state = None
+        forgiven[vs[i]["vid"]] = eased
+    origin = state
+    out = []
+    for v, s in zip(vs, states):
+        out.append({"vid": v["vid"], "time": v["time"], "state": s,
+                    "broken": bool(broken_at and v["vid"] == broken_at["vid"]),
+                    "tolerated": forgiven.get(v["vid"], [])})
+    return wf, out, origin, broken_at
+
+
+def people(wid):
+    """Who owns the workflow and who else has access, with their level."""
+    return qjson("select u.name, u.email, a.privilege, "
+                 "(o.uid is not null) as owner "
+                 "from texera_db.workflow_user_access a "
+                 "join texera_db.\"user\" u on u.uid=a.uid "
+                 "left join texera_db.workflow_of_user o on o.uid=a.uid and o.wid=a.wid "
+                 "where a.wid=%d order by owner desc, u.name" % wid)
+
+
+def executions(wid):
+    return qjson("select e.eid, e.vid, e.status, e.starting_time::text as start, "
+                 "e.last_update_time::text as \"end\", e.runtime_stats_uri as stats_uri, "
+                 "coalesce(e.runtime_stats_size,0) as stats_size, e.uid, "
+                 "coalesce(e.name,'') as name, coalesce(u.name,'') as who "
+                 "from texera_db.workflow_executions e "
+                 "join texera_db.workflow_version v on v.vid=e.vid "
+                 "left join texera_db.\"user\" u on u.uid=e.uid "
+                 "where v.wid=%d order by e.eid" % wid)
+
+
+if __name__ == "__main__":
+    import sys
+    wid = int(sys.argv[1])
+    wf, hist, origin, broken = history(wid)
+    usable = [h for h in hist if h["state"] is not None]
+    print("flujo %d: %s" % (wid, wf["name"]))
+    print("versiones: %d   reconstruidas: %d" % (len(hist), len(usable)))
+    print("ultimo estado == contenido actual -> %s"
+          % ("OK" if hist[-1]["state"] == wf["content"] else "FALLA"))
+    if broken:
+        print("CADENA ROTA en vid %s (%s)" % (broken["vid"], broken["error"]))
+        print("  the %d versions before it cannot be rebuilt"
+              % (len(hist) - len(usable)))
+    else:
+        print("cadena completa -> %s" % ("OK, llega al vacio" if origin in ({}, None) else "raro: %s" % json.dumps(origin)[:80]))
+    for h in hist:
+        st = h["state"]
+        if st is None:
+            print("  vid %-4d %s  (irrecuperable)" % (h["vid"], h["time"][:19]))
+        else:
+            print("  vid %-4d %s  operadores=%d links=%d%s" % (
+                h["vid"], h["time"][:19], len(st.get("operators", [])),
+                len(st.get("links", [])), "   <-- cadena rota aqui" if h["broken"] else ""))

--- a/spy-service/server.py
+++ b/spy-service/server.py
@@ -1,0 +1,1088 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Servidor del boton espia: sirve a la interfaz de Texera lo que el producto
+guarda en silencio sobre un flujo.
+
+Routes. Every one of them reads, except the last, which runs:
+
+  GET /api/spy/brief?wid=N          today's workflow, step by step, for a newcomer
+  GET /api/spy/tour?wid=N           the same, told: one sentence per step
+  GET /api/spy/history?wid=N        the timeline: one frame per version
+  GET /api/spy/executions?wid=N     the workflow's runs, with or without a snapshot
+  GET /api/spy/experiments?wid=N    every run as a table of experiments
+  GET /api/spy/narrate?wid=N&a=&b=  the comparison, told: one sentence per step
+  GET /api/spy/autopsy?wid=N&a=&b=  the comparison: where and why two runs diverge
+  GET /api/spy/report?wid=N         the whole handover document, written in one go
+  POST /api/spy/ask                 a question about what the open view is showing
+  POST /api/spy/run                 runs the workflow and keeps the rows for comparison
+
+It leans on core.py (rebuilding the history), autopsy.py (comparing results),
+brief.py (today's workflow and its experiments) and stats.py (the statistics
+Texera does keep for every run). It reads the database directly, so it needs no
+Texera session or token of its own.
+
+This file is the boundary with the interface: everything that goes out over
+HTTP is in English, keys and text alike.
+"""
+import json
+import os
+import sys
+import traceback
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse, parse_qs
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import brief
+import core
+import autopsy
+import run_workflow
+
+PORT = int(os.environ.get("SPY_PORT", "5055"))
+
+# Status codes exactly as Utils.maptoStatusCode writes them into the table.
+STATUS = {0: "ready", 1: "running", 2: "paused", 3: "completed",
+          4: "failed", 5: "killed"}
+
+# An operator's properties can carry a whole program inside.
+# For the timeline a fragment is enough.
+CLIP = 160
+
+
+def clip(v):
+    # An empty string would print as nothing and the change would look
+    # half-written, so it is shown quoted.
+    if v == "":
+        return '""'
+    s = v if isinstance(v, str) else json.dumps(v, ensure_ascii=False)
+    s = s.replace("\n", "⏎ ")
+    return s if len(s) <= CLIP else s[:CLIP] + "…"
+
+
+# Which values are small enough to describe and which settings are form
+# scaffolding: brief.py decides, since it is the one that reads the whole canvas
+# for the orientation view.
+DESCRIBABLE = brief.DESCRIBABLE
+SILENT_SETTINGS = brief.SILENT_SETTINGS
+
+# What the interface writes by itself, not a person. It is a shorter list than
+# SILENT_SETTINGS on purpose: there it is decided what does not deserve
+# describing, and here what does not deserve accusing. A user function's declared
+# columns, for instance, are not described because they are long, but changing
+# them does move the data, and the comparison has to be able to name them.
+MACHINE_WRITTEN = {"envName", "dummyPropertyList", "limit_dummy", "defaultEnv"}
+
+
+def machine_written(path):
+    """Whether a property path is one the interface writes on its own."""
+    return any(part in MACHINE_WRITTEN for part in path.split("/") if part)
+shape = brief.shape
+
+
+# ---------- la pelicula ----------
+
+def canvas(state):
+    """Just enough to draw the graph: operators with their position, and links."""
+    pos = state.get("operatorPositions", {}) or {}
+    operators = []
+    for o in state.get("operators", []):
+        oid = o["operatorID"]
+        p = pos.get(oid) or {}
+        operators.append({
+            "id": oid,
+            "type": o.get("operatorType", ""),
+            "name": o.get("customDisplayName") or o.get("operatorType", ""),
+            "x": p.get("x", 0),
+            "y": p.get("y", 0),
+            "disabled": bool(o.get("isDisabled")),
+            # The names of the inputs, so a link can be said to arrive at one
+            # of them when the operator has more than one.
+            "inputs": [p.get("displayName") or "" for p in o.get("inputPorts", [])],
+        })
+    links = [{"from": l["source"]["operatorID"], "to": l["target"]["operatorID"]}
+             for l in state.get("links", [])]
+    return {"operators": operators, "links": links}
+
+
+def changes(before, after):
+    """What the user did between two consecutive states of the canvas."""
+    if before is None or after is None:
+        return []
+    out = []
+    was = {o["operatorID"]: o for o in before.get("operators", [])}
+    now = {o["operatorID"]: o for o in after.get("operators", [])}
+
+    # Every change carries the raw data as well as the text: the interface uses
+    # it to write the sentence with the names the user sees on screen.
+    for oid in sorted(now):
+        if oid not in was:
+            out.append({"kind": "operator_added", "operatorId": oid,
+                        "operatorType": now[oid].get("operatorType", ""),
+                        "name": now[oid].get("customDisplayName") or "",
+                        "text": "added %s (%s)" % (oid, now[oid].get("operatorType", ""))})
+    for oid in sorted(was):
+        if oid not in now:
+            out.append({"kind": "operator_deleted", "operatorId": oid,
+                        "operatorType": was[oid].get("operatorType", ""),
+                        "name": was[oid].get("customDisplayName") or "",
+                        "text": "deleted %s (%s)" % (oid, was[oid].get("operatorType", ""))})
+
+    def ends(l):
+        # The target port tells apart a join's two inputs, which on the canvas
+        # are different things even though the operator is the same.
+        return (l["source"]["operatorID"], l["target"]["operatorID"],
+                l["target"].get("portID", ""))
+
+    old_links = {ends(l) for l in before.get("links", [])}
+    new_links = {ends(l) for l in after.get("links", [])}
+    for a, b, port in sorted(new_links - old_links):
+        out.append({"kind": "link_added", "from": a, "to": b, "port": port,
+                    "text": "connected %s → %s" % (a, b)})
+    for a, b, port in sorted(old_links - new_links):
+        out.append({"kind": "link_removed", "from": a, "to": b, "port": port,
+                    "text": "disconnected %s → %s" % (a, b)})
+
+    for oid in sorted(set(was) & set(now)):
+        pa = was[oid].get("operatorProperties", {})
+        pb = now[oid].get("operatorProperties", {})
+        for path, va, vb in autopsy.prop_diff(pa, pb):
+            change = {"kind": "property", "operatorId": oid, "path": path,
+                      "operatorType": now[oid].get("operatorType", ""),
+                      "before": clip(va), "after": clip(vb),
+                      "text": "%s%s: %s → %s" % (oid, path, clip(va), clip(vb))}
+            # The clipped text is fine to read but not to describe: the
+            # interface needs the value as it is to say "sum of amount" instead
+            # of dumping the JSON. It only travels when small, because a
+            # propiedad puede traer un programa entero dentro.
+            change.update(shape(va, "beforeValue"))
+            change.update(shape(vb, "afterValue"))
+            out.append(change)
+
+        na, nb = was[oid].get("customDisplayName"), now[oid].get("customDisplayName")
+        if na != nb:
+            out.append({"kind": "renamed", "operatorId": oid,
+                        "before": na, "after": nb,
+                        "text": "renamed %s: %s → %s" % (oid, na, nb)})
+
+        if bool(was[oid].get("isDisabled")) != bool(now[oid].get("isDisabled")):
+            verb = "disabled" if now[oid].get("isDisabled") else "re-enabled"
+            out.append({"kind": "disabled", "operatorId": oid,
+                        "text": "%s %s" % (verb, oid)})
+
+    pa = before.get("operatorPositions", {}) or {}
+    pb = after.get("operatorPositions", {}) or {}
+    for oid in sorted(set(pa) & set(pb)):
+        if pa[oid] != pb[oid]:
+            out.append({"kind": "moved", "operatorId": oid,
+                        "text": "moved %s on the canvas" % oid})
+    return out
+
+
+def history(wid):
+    wf, hist, origin, broken = core.history(wid)
+
+    runs_by_version = {}
+    for e in core.executions(wid):
+        runs_by_version.setdefault(e["vid"], []).append(
+            {"eid": e["eid"], "status": STATUS.get(e["status"], str(e["status"])),
+             "started": e["start"]})
+
+    frames = []
+    previous = None
+    for h in hist:
+        st = h["state"]
+        frame = {"vid": h["vid"], "time": h["time"], "broken": h["broken"],
+                 "recoverable": st is not None,
+                 # Texera asked to remove something that was already gone. The
+                 # state is still the one its own patch describes, but say so.
+                 "tolerated": len(h.get("tolerated") or []),
+                 "runs": runs_by_version.get(h["vid"], [])}
+        if st is not None:
+            frame.update(canvas(st))
+            frame["changes"] = changes(previous, st)
+        else:
+            frame.update({"operators": [], "links": [], "changes": []})
+        frames.append(frame)
+        previous = st
+
+    return {
+        "wid": wid,
+        "name": wf["name"],
+        "description": wf["description"],
+        "total": len(frames),
+        "recovered": sum(1 for f in frames if f["recoverable"]),
+        "tolerated": sum(f["tolerated"] for f in frames),
+        "broken": ({"vid": broken["vid"], "error": broken["error"]} if broken else None),
+        # With the chain broken the rebuilder runs out of state, and that None
+        # does not mean having reached the empty canvas at the start.
+        "reachesOrigin": broken is None and origin in ({}, None),
+        "frames": frames,
+    }
+
+
+# ---------- la autopsia ----------
+
+def executions(wid):
+    runs = []
+    for e in core.executions(wid):
+        path = "%s/wid_%d_eid_%d.json" % (autopsy.SNAPS, wid, e["eid"])
+        snapshot = os.path.exists(path)
+        name = None
+        rows = 0
+        if snapshot:
+            try:
+                s = json.load(open(path))
+                name = s.get("name")
+                rows = sum(len(v.get("result") or [])
+                           for v in (s.get("operators") or {}).values())
+            except Exception:
+                snapshot = False
+        runs.append({"eid": e["eid"], "vid": e["vid"],
+                     "status": STATUS.get(e["status"], str(e["status"])),
+                     "started": e["start"], "ended": e["end"],
+                     "snapshot": snapshot, "name": name, "rows": rows})
+    return {"wid": wid, "runs": runs}
+
+
+def autopsy_report(wid, eid_a, eid_b):
+    """Puts the report autopsy.py returns into the shape the interface reads."""
+    r = autopsy.autopsy(wid, eid_a, eid_b)
+    findings = []
+    for h in r["hallazgos"]:
+        d = h["diff"]
+        findings.append({
+            "operatorId": h["operatorID"],
+            "rowsA": h["filas_a"], "rowsB": h["filas_b"], "truncated": h["cortada"],
+            "diff": None if d is None else {
+                "rowsA": d["filas_a"], "rowsB": d["filas_b"],
+                "onlyInA": d["solo_en_a"], "onlyInB": d["solo_en_b"],
+                "sameSetDifferentOrder": d["mismo_conjunto_distinto_orden"],
+                # The engine cuts the output at 100,000 characters per operator
+                # and keeps head and tail. When that happens the counts are still
+                # good, but the sample rows do not prove absence.
+                "sampleA": d["muestra_a"], "sampleB": d["muestra_b"],
+                "sampleTruncated": d["muestra_cortada"],
+            },
+        })
+    # What each step does, not only how many rows it emits: the small properties
+    # of the later version, so the panel can say "amount > 400" or
+    # "sum of amount, as total" en vez de dejar la caja muda. Las grandes
+    # (a UDF's code, a pasted query) are left out on purpose.
+    props = autopsy.operator_props(r.get("lienzo") or {})
+    names = {o["operatorID"]: (o.get("customDisplayName") or o.get("operatorType", ""))
+             for o in (r.get("lienzo") or {}).get("operators", [])}
+    types = {o["operatorID"]: o.get("operatorType", "")
+             for o in (r.get("lienzo") or {}).get("operators", [])}
+    steps = []
+    for oid in r["orden"]:
+        settings = []
+        for key, value in (props.get(oid) or {}).items():
+            if key in SILENT_SETTINGS or value in ("", None, [], {}):
+                continue
+            described = shape(value, "value")
+            if described:
+                settings.append({"path": "/" + key, "value": described["value"]})
+        steps.append({"operatorId": oid, "name": names.get(oid, oid),
+                      "type": types.get(oid, ""), "settings": settings})
+
+    return {
+        "wid": r["wid"],
+        "name": r["name"],
+        "steps": steps,
+        "a": {"eid": r["a"]["eid"], "vid": r["a"]["vid"], "name": r["a"]["name"]},
+        "b": {"eid": r["b"]["eid"], "vid": r["b"]["vid"], "name": r["b"]["name"]},
+        "order": r["orden"],
+        "findings": findings,
+        "firstDivergent": r["primer_divergente"],
+        # `envName` shows up because opening a user function's property panel
+        # writes it empty, and the next save removes it. Announcing that as the
+        # edit between two runs would accuse a gesture nobody made, so it drops
+        # out along with the rest of the form's scaffolding.
+        "edits": [{"operatorId": e["operatorID"], "path": e["path"],
+                   "before": e["antes"], "after": e["despues"]}
+                  for e in r["ediciones"] if not machine_written(e["path"])],
+    }
+
+
+# ---------- la voz ----------
+#
+# A model writes, it never decides. It is handed the facts core.py and
+# autopsy.py already derived and puts them into prose; which operator diverges
+# and which edit caused it are worked out here, not asked. With no key, or on a
+# timeout, or on a failure, the panel keeps its own text and nobody notices.
+
+LITELLM = os.environ.get("SPY_LITELLM", "http://127.0.0.1:4000/v1/chat/completions")
+MODEL = os.environ.get("SPY_MODEL", "claude-haiku-4.5")
+# The step-by-step narration is what a person reads first, so it goes through
+# the fast model: five seconds, and the panel never waits on it. With
+# claude-sonnet-5 the same request spends all 4000 output tokens and LiteLLM
+# returns empty content, so changing the model means raising the budget.
+NARRATOR = os.environ.get("SPY_NARRATOR_MODEL", "claude-haiku-4.5")
+NARRATION_BUDGET = int(os.environ.get("SPY_NARRATION_BUDGET", "6000"))
+ENV_FILE = os.environ.get("SPY_LITELLM_ENV", "")
+TIMEOUT = int(os.environ.get("SPY_LLM_TIMEOUT", "40"))
+NARRATION_TIMEOUT = int(os.environ.get("SPY_NARRATION_TIMEOUT", "120"))
+
+# Reopening the panel should not cost money all over again.
+_said = {}
+
+
+def master_key():
+    key = os.environ.get("LITELLM_MASTER_KEY")
+    if key:
+        return key
+    try:
+        for line in open(ENV_FILE):
+            if line.startswith("LITELLM_MASTER_KEY="):
+                return line.split("=", 1)[1].strip()
+    except OSError:
+        pass
+    return ""
+
+
+def ask(system, user, model=None, timeout=None, budget=None):
+    """One call, one answer. No tools and no conversation."""
+    return converse(system, [{"role": "user", "content": user}], model, timeout, budget)
+
+
+def converse(system, messages, model=None, timeout=None, budget=None):
+    """The same, but carrying the previous turns when questions are being asked."""
+    body = json.dumps({
+        "model": model or MODEL,
+        # Wide on purpose: the model reasons before writing and with a small
+        # budget it spends the lot thinking, returning half a sentence.
+        "max_tokens": budget or 4000,
+        "messages": [{"role": "system", "content": system}] + messages,
+    }).encode()
+    req = urllib.request.Request(LITELLM, data=body, headers={
+        "Content-Type": "application/json",
+        "Authorization": "Bearer %s" % master_key(),
+    })
+    with urllib.request.urlopen(req, timeout=timeout or TIMEOUT) as r:
+        answer = json.load(r)
+    return (answer["choices"][0]["message"]["content"] or "").strip()
+
+
+VOICE = """You write for someone who runs data workflows in Texera and does not program.
+
+You are given facts that were derived from the workflow's own saved record. Your job \
+is to put those facts into plain prose, and to draw out what they mean for the person's \
+data. You are not the one who works out what changed or what caused what: that is \
+already done and handed to you.
+
+Rules you do not break:
+- Use only the facts given. Never invent an operator, a number, a column or a version.
+- Never assert a cause the facts do not state. If something is unexplained, say so.
+- Never add a unit, a currency or a label the data does not carry. An amount of 377 \
+is "377", not "377 dollars". Copy a threshold exactly: above 400 is not 400 or more.
+- Use the canvas names, never the short internal ids. If a fact gives you an id \
+such as "flt", find its canvas name and use that instead.
+- No preamble, no headings, no bullet lists, no markdown. Plain sentences.
+- Short words. Say "rows", not "records". Say "dropped", not "excluded"."""
+
+
+def names_at(wid, vid=None):
+    """The canvas names, which are the only ones a person recognises."""
+    record = history(wid)
+    frames = [f for f in record["frames"] if f["recoverable"]]
+    frame = next((f for f in frames if f["vid"] == vid), None) or (frames[-1] if frames else None)
+    return {o["id"]: o["name"] for o in (frame or {}).get("operators", [])}
+
+
+def named(value, names):
+    """Sustituye identificadores por nombres en claves, listas y cadenas sueltas."""
+    if isinstance(value, dict):
+        return {names.get(k, k): named(v, names) for k, v in value.items()}
+    if isinstance(value, list):
+        return [named(v, names) for v in value]
+    if isinstance(value, str):
+        return names.get(value, value)
+    return value
+
+
+def facts_autopsy(wid, eid_a, eid_b):
+    report = autopsy_report(wid, eid_a, eid_b)
+    first = report["firstDivergent"]
+    rows = {f["operatorId"]: f["diff"] for f in report["findings"] if f["diff"]}
+    names = names_at(wid, report["b"]["vid"])
+    return {
+        "workflow": report["name"],
+        "the two runs": {"earlier": report["a"], "later": report["b"]},
+        "order the data flows": named(report["order"], names),
+        "where they first disagree": named(first, names),
+        "row counts and sample rows per step": named(rows, names),
+        "how to read those rows": "rowsA and rowsB are the true counts, as the engine reported "
+                                  "them. onlyInA and onlyInB are drawn from a sample: when "
+                                  "sampleTruncated is true the engine returned only part of that "
+                                  "step's output, so a row listed on one side may still exist on "
+                                  "the other. Never say a row is missing from a truncated step, "
+                                  "and never say counts fail to add up because a sample is short.",
+        "what was edited in between": [
+            {"step": names.get(e["operatorId"], e["operatorId"]), "setting": e["path"],
+             "before": e["before"], "after": e["after"]}
+            for e in report["edits"]
+        ],
+    }
+
+
+def explain_autopsy(wid, eid_a, eid_b):
+    facts = facts_autopsy(wid, eid_a, eid_b)
+    task = """Here are the facts about two runs of the same workflow.
+
+Write two short paragraphs.
+
+First: what the edit actually did to the data. Not that the numbers changed, but what \
+kind of rows stopped coming through and what that does to every step after it. Use the \
+sample rows to say what was lost in concrete terms.
+
+Second: what each version is good for. Neither is simply better: say what the earlier \
+run answers well, what the later one answers well, and which question each one suits. \
+If the facts do not support a trade-off, say plainly that the change only narrows the \
+data and leaves the rest alone.
+
+FACTS:
+""" + json.dumps(facts, ensure_ascii=False, indent=1)
+    return ask(VOICE, task)
+
+
+def facts_history(wid):
+    record = history(wid)
+    steps = [{"version": f["vid"], "when": f["time"],
+              "changes": [c["text"] for c in f["changes"]]}
+             for f in record["frames"] if f["changes"]]
+    return {"workflow": record["name"], "versions": record["total"],
+             "unreadable from": record["broken"],
+             # The vid is a global counter on the table, shared by every
+             # workflow. Without this note the model reads the gaps as lost
+             # saves, which is exactly what they are not.
+             "note on version numbers": "Version numbers come from a counter shared by every "
+                                        "workflow in Texera, so gaps between them are normal and "
+                                        "mean nothing. Never say saves are missing because of a gap.",
+             "what each step is called on the canvas today": names_at(wid),
+             "the edits in order": steps}
+
+
+def explain_history(wid):
+    facts = facts_history(wid)
+    task = """Here is the full edit history of one workflow, oldest first.
+
+Write one short paragraph telling the story of how it was built: what the person set out \
+to do, where they changed their mind, and what the workflow ended up doing. Name the \
+turning points, not every save. If part of the record is unreadable, say so at the end.
+
+FACTS:
+""" + json.dumps(facts, ensure_ascii=False, indent=1)
+    return ask(VOICE, task)
+
+
+ASKED = """You are answering a question about the record above.
+
+Answer in two or three sentences. No preamble, no headings, no lists.
+
+Your first sentence is your answer. Everything after it supports that sentence and \
+never walks it back. If you find yourself about to write "however", the first sentence \
+was wrong: fix it instead.
+
+If the facts do not settle the question, say so in the first sentence and then say \
+what would settle it. Never guess a cause, a number or a column. If the question is \
+about something the record simply does not hold, such as money, people or why someone \
+made a decision, say that the record does not say."""
+
+
+# A sane cap: the box is for questions, not for pasting documents.
+MAX_QUESTION = 500
+
+
+def answer(wid, question, eid_a=None, eid_b=None, previous=None, mode=None):
+    question = (question or "").strip()[:MAX_QUESTION]
+    if not question:
+        raise ValueError("empty question")
+    # Each view asks about what it has in front of it: the comparison of two
+    # runs, today's workflow, the table of experiments, or the history.
+    if mode == "brief":
+        facts = facts_brief(wid)
+    elif mode == "experiments":
+        facts = facts_experiments(wid)
+    elif eid_a and eid_b:
+        facts = facts_autopsy(wid, eid_a, eid_b)
+    else:
+        facts = facts_history(wid)
+    messages = [{"role": "user", "content": "FACTS:\n" + json.dumps(facts, ensure_ascii=False, indent=1)},
+                {"role": "assistant", "content": "Understood. Ask me about this record."}]
+    for turn in (previous or [])[-3:]:
+        if turn.get("question") and turn.get("answer"):
+            messages.append({"role": "user", "content": turn["question"][:MAX_QUESTION]})
+            messages.append({"role": "assistant", "content": turn["answer"]})
+    messages.append({"role": "user", "content": question})
+    return {"wid": wid, "model": MODEL, "text": converse(VOICE + "\n\n" + ASKED, messages)}
+
+
+# ---------- what happened, step by step ----------
+# The difference between showing figures and explaining: the rules say where the
+# divergence starts and how many rows moved, but leave the person to translate
+# that into their own problem. Here the model writes that translation, one
+# sentence per step, over the same derived facts. It decides nothing: the step to
+# blame, the counts and the edits were all settled before it was asked.
+
+NARRATION = """Here are the facts about two runs of the same workflow, and what each \
+step of it does.
+
+Reply with JSON and nothing else, in this shape:
+
+{"headline": "...", "steps": {"<step name>": "...", ...}, "takeaway": "..."}
+
+headline: one sentence a person reads first, saying what changed about their results \
+and why. Name the step that caused it and what it now does differently.
+
+steps: one short sentence for EVERY step listed in "order the data flows", using the \
+canvas name as the key. Say what that step does to the data and what is different \
+between the two runs at that point, in the terms of the data itself: which rows, which \
+values, which groups. For a step whose output is identical, say what it does and that \
+it is untouched. For a step that returns the same rows in a different order, say that \
+nothing about the data changed there. Never write a bare number without saying what it \
+counts.
+
+takeaway: one sentence saying which run answers which question, or, if the change only \
+narrows or regroups the data, say that plainly.
+
+A step's name is a label the person typed and it can be out of date: what the step \
+actually does is in its settings and in the list of edits, never in its name. If a name \
+no longer matches what the step does, say so in that step's sentence. Never say one step \
+was replaced by another: every step in the list exists in both runs.
+
+Every sentence must be readable by someone who does not know what a join or an \
+aggregation is. No jargon, no markdown, no quotes around names.
+
+Keep every sentence under 35 words. Never copy the facts back: write about them.
+
+FACTS:
+"""
+
+
+def fence_free(text):
+    """The model sometimes returns the JSON inside a code fence."""
+    t = (text or "").strip()
+    if t.startswith("```"):
+        t = t.split("\n", 1)[-1]
+        t = t.rsplit("```", 1)[0]
+    return t.strip()
+
+
+def narration_facts(wid, eid_a, eid_b):
+    """One card per step, in the order the data flows.
+
+    facts_autopsy is enough to write a paragraph, but it leaves out the counts
+    of the steps that agree, and telling the story step by step then forces the
+    model to invent the figures it is missing. Here every step carries its own:
+    what it does, how many rows it emitted in each run, and how the comparison
+    came out.
+    """
+    report = autopsy_report(wid, eid_a, eid_b)
+    names = names_at(wid, report["b"]["vid"])
+    found = {f["operatorId"]: f for f in report["findings"]}
+    settings = {st["operatorId"]: {x["path"].lstrip("/"): x["value"] for x in st["settings"]}
+                for st in report["steps"]}
+    first = report["firstDivergent"]
+
+    steps = []
+    for position, oid in enumerate(report["order"], start=1):
+        f = found.get(oid) or {}
+        d = f.get("diff")
+        if not d:
+            verdict = "identical in both runs"
+        elif d.get("sameSetDifferentOrder"):
+            verdict = "same rows, only in a different order, which is not a change in the data"
+        elif oid == first:
+            verdict = "the first step whose data is genuinely different: the difference is born here"
+        else:
+            verdict = "different, but only because it is fed by a step that changed earlier"
+        entry = {
+            "position in the flow": position,
+            "step": names.get(oid, oid),
+            "what it is set to do": settings.get(oid) or "nothing worth reporting",
+            "rows out in the earlier run": f.get("rowsA"),
+            "rows out in the later run": f.get("rowsB"),
+            "verdict": verdict,
+        }
+        if d and not d.get("sameSetDifferentOrder"):
+            entry["rows only in the earlier run"] = d.get("onlyInA")
+            entry["rows only in the later run"] = d.get("onlyInB")
+            if d.get("sampleTruncated"):
+                entry["warning"] = ("the engine returned only part of this step's output, so these "
+                                    "sample rows do not prove a row is absent from the other run")
+        steps.append(entry)
+
+    return {
+        "workflow": report["name"],
+        "the two runs": {"earlier": report["a"], "later": report["b"]},
+        "what was edited in between": [
+            {"step": names.get(e["operatorId"], e["operatorId"]), "setting": e["path"],
+             "before": e["before"], "after": e["after"]}
+            for e in report["edits"]
+        ],
+        "how to read this": ("The steps are listed in the order the data flows through them. A step "
+                             "only ever sees what the steps before it produced, so a step cannot "
+                             "reduce or change rows it never received. The row counts are the true "
+                             "ones reported by the engine."),
+        "the steps": steps,
+    }
+
+
+def narrate_autopsy(wid, eid_a, eid_b):
+    report = autopsy_report(wid, eid_a, eid_b)
+    names = names_at(wid, report["b"]["vid"])
+    facts = narration_facts(wid, eid_a, eid_b)
+    raw = ask(VOICE, NARRATION + json.dumps(facts, ensure_ascii=False, indent=1),
+              NARRATOR, NARRATION_TIMEOUT, NARRATION_BUDGET)
+    try:
+        told = json.loads(fence_free(raw))
+    except (ValueError, TypeError):
+        return {"headline": "", "steps": {}, "takeaway": "", "model": NARRATOR}
+    # The sentences come back keyed by canvas name; the panel looks them up by
+    # identifier, so they are translated back here.
+    back = {v: k for k, v in names.items()}
+    steps = {back.get(k, k): v for k, v in (told.get("steps") or {}).items()
+             if isinstance(v, str)}
+    return {"headline": str(told.get("headline") or ""),
+            "steps": steps,
+            "takeaway": str(told.get("takeaway") or ""),
+            "model": NARRATOR}
+
+
+_told = {}
+
+
+def narrate(wid, eid_a, eid_b):
+    key = (wid, eid_a, eid_b)
+    if key not in _told:
+        _told[key] = narrate_autopsy(wid, eid_a, eid_b)
+    return dict(_told[key], wid=wid)
+
+
+def explain(wid, eid_a=None, eid_b=None):
+    key = (wid, eid_a, eid_b)
+    if key not in _said:
+        text = explain_autopsy(wid, eid_a, eid_b) if eid_a and eid_b else explain_history(wid)
+        _said[key] = text
+    return {"wid": wid, "model": MODEL, "text": _said[key]}
+
+
+# ---------- el flujo explicado a quien acaba de llegar ----------
+#
+# The two original views answer the questions of someone who already knows the
+# workflow. Whoever joins needs something else first: what this does, step by
+# step, and what has been tried. brief.py derives the facts; here they are put
+# into words under the same rule as always, the model writes and does not decide.
+
+def told_setting(setting):
+    """A setting as the model gets it: whole when short, measured when not."""
+    value = setting.get("value")
+    text = value if isinstance(value, str) else json.dumps(value, ensure_ascii=False, default=str)
+    if value is None or len(text) > DESCRIBABLE:
+        return "%d lines of it, too long to show here" % setting.get("lines", 0)
+    return value
+
+
+def compact_steps(orientation):
+    """The steps as the model gets them: canvas names, no identifiers."""
+    steps = []
+    for step in orientation["steps"]:
+        entry = {
+            "position in the flow": step["position"],
+            "step": step["name"],
+            "kind of step": step["type"],
+            # The model does not need a user function's whole program, and
+            # paying for it on every step adds up: its size is enough.
+            "what it is set to do": {s["path"].lstrip("/"): told_setting(s)
+                                     for s in step["settings"]} or "nothing worth reporting",
+            "where its data comes from": [orientation_name(orientation, f["id"]) for f in step["fedBy"]] or "it reads data itself, nothing feeds it",
+            "where its data goes": [orientation_name(orientation, f) for f in step["feeds"]] or "nothing: this is where the flow ends",
+            "rows it last produced": step["rowsOut"],
+            "columns it produces": step["columns"] or "not recorded",
+            "times it has been edited": step["edits"],
+        }
+        if step["sample"]:
+            entry["a few of its rows"] = step["sample"]
+            entry["where those rows came from"] = (
+                "the run named %s, which %s the settings the workflow has today"
+                % ((orientation.get("sampleFrom") or {}).get("name") or "unnamed",
+                   "used" if (orientation.get("sampleFrom") or {}).get("current") else "did NOT use"))
+        if step["disabled"]:
+            entry["switched off"] = True
+        steps.append(entry)
+    return steps
+
+
+def orientation_name(orientation, oid):
+    for step in orientation["steps"]:
+        if step["id"] == oid:
+            return step["name"]
+    return oid
+
+
+def facts_brief(wid):
+    o = brief.orientation(wid)
+    return {
+        "workflow": o["name"],
+        "its description, written by whoever built it": o["description"] or "none",
+        "who can open it": [p["name"] + (" (owner)" if p["owner"] else "") for p in o["people"]],
+        "who has run it": o["ranBy"],
+        "its shape": o["shape"],
+        "the record": o["record"],
+        "settings that have been changed more than once": [
+            {"step": k["step"], "setting": k["path"], "changed": k["times"], "value now": k.get("value")}
+            for k in o["knobs"]],
+        "the steps, in the order the data flows": compact_steps(o),
+        "how to read this": ("Row counts come from the engine's own statistics for the last run that "
+                             "was measured. A step with no rows recorded simply was not measured, "
+                             "which is not the same as producing nothing."),
+    }
+
+
+TOUR = """Here are the facts about a workflow. Someone has just joined the team and has \
+never seen it. They are about to open it and they do not know what it does.
+
+Reply with JSON and nothing else, in this shape:
+
+{"headline": "...", "purpose": "...", "steps": {"<step name>": "...", ...}, "watchOut": "..."}
+
+headline: one sentence saying what question this workflow answers, in the terms of \
+whoever needs the answer, not in the terms of the software.
+
+purpose: two or three sentences on what goes in, what comes out, and what happens in \
+between. Say what the data is about, judging only by its columns and the rows you were \
+given. Never name a unit, a currency or a meaning the data does not carry.
+
+steps: one sentence for EVERY step listed, using the step name as the key. Say what that \
+step does to the data in the terms of the data itself: which rows it keeps, what it \
+groups, what it adds. Read its settings, never its name: a name is a label someone typed \
+and it can be out of date. If a step's name no longer matches what it does, say so.
+
+watchOut: one or two sentences on what a newcomer should be careful with here, drawn \
+only from the facts: a setting that keeps being changed, a step that is switched off, a \
+step that produces nothing, part of the record that cannot be read. If there is nothing \
+to warn about, say what is worth knowing instead.
+
+Keep every sentence under 35 words. No jargon, no markdown, no bullet lists.
+
+FACTS:
+"""
+
+
+_toured = {}
+
+
+def tour(wid):
+    """The guided tour: what the workflow does, step by step, for a newcomer."""
+    if wid in _toured:
+        return dict(_toured[wid], wid=wid)
+    o = brief.orientation(wid)
+    facts = facts_brief(wid)
+    told = {"headline": "", "purpose": "", "steps": {}, "watchOut": "", "model": NARRATOR}
+    try:
+        raw = ask(VOICE, TOUR + json.dumps(facts, ensure_ascii=False, indent=1),
+                  NARRATOR, NARRATION_TIMEOUT, NARRATION_BUDGET)
+        parsed = json.loads(fence_free(raw))
+    except (ValueError, TypeError, OSError):
+        parsed = None
+    if parsed:
+        back = {step["name"]: step["id"] for step in o["steps"]}
+        told = {
+            "headline": str(parsed.get("headline") or ""),
+            "purpose": str(parsed.get("purpose") or ""),
+            "steps": {back.get(k, k): v for k, v in (parsed.get("steps") or {}).items()
+                      if isinstance(v, str)},
+            "watchOut": str(parsed.get("watchOut") or ""),
+            "model": NARRATOR,
+        }
+        _toured[wid] = told
+    return dict(told, wid=wid)
+
+
+def facts_experiments(wid):
+    e = brief.experiments(wid)
+    labels = {k["id"]: "%s, %s" % (k["step"], k["path"].lstrip("/")) for k in e["knobs"]}
+    runs = []
+    for run in e["runs"]:
+        runs.append({
+            "run": run["name"] or "unnamed",
+            "number": run["eid"],
+            "when": run["started"],
+            "who ran it": run["who"],
+            "how it ended": run["status"],
+            "seconds it took": run["seconds"],
+            "settings that differ between runs": {labels.get(k, k): v for k, v in run["settings"].items()}
+                                                  or "none: every run used the same settings",
+            "rows read in": run["readIn"],
+            "rows it ended up producing": run["produced"],
+            "rows out of each step": {k: v["out"] for k, v in run["steps"].items()},
+        })
+    return {
+        "workflow": e["name"],
+        "the settings that were tried at different values": [labels[k["id"]] for k in e["knobs"]]
+                                                             or "none",
+        "the runs, oldest first": runs,
+        "what changed between one run and the next": [
+            {"from run": m["from"], "to run": m["to"],
+             "settings changed": [{"setting": labels.get(x["knob"], x["knob"]),
+                                   "before": x["before"], "after": x["after"]} for x in m["edits"]],
+             "steps added or removed": m["structure"],
+             "rows produced before": m["producedBefore"],
+             "rows produced after": m["producedAfter"]}
+            for m in e["moves"]],
+        "how to read this": ("The row counts come from the engine's own statistics, which Texera keeps "
+                             "for every run, unlike the results themselves. Two runs with the same "
+                             "settings and the same counts are the same experiment run twice."),
+    }
+
+
+# ---------- el informe ----------
+#
+# A report is not a longer paragraph: it is what somebody sends their team when
+# they want another person to understand the workflow without opening it. It is
+# asked for by hand, never on its own, because it costs money; and it is written
+# with the good model, because it is the only thing here anyone reads off-screen.
+
+REPORTER = os.environ.get("SPY_REPORT_MODEL", "claude-sonnet-5")
+REPORT_BUDGET = int(os.environ.get("SPY_REPORT_BUDGET", "10000"))
+REPORT_TIMEOUT = int(os.environ.get("SPY_REPORT_TIMEOUT", "180"))
+
+REPORT = """Here is everything Texera has recorded about one workflow: how it is built \
+today, how it was built over time, and every run of it with the settings each run used.
+
+Write the report someone would hand to a colleague who has to take this workflow over.
+
+Reply with JSON and nothing else, in this shape:
+
+{"title": "...", "summary": "...", "sections": [{"heading": "...", "body": "..."}, ...]}
+
+title: a short name for the report, naming the workflow.
+
+summary: three or four sentences. What the workflow answers, what it reads, what it \
+produces, and the one thing the next person most needs to know.
+
+sections: write exactly these five, in this order, with these headings:
+  "What it does" - the flow from its sources to its outputs, in the order the data \
+moves. Say what each part contributes. Do not list every step mechanically: group them \
+the way a person would explain it out loud.
+  "How it was built" - the story the edit history tells: what was there first, what was \
+changed later, where whoever built it changed their mind. Name the turning points only.
+  "What has been tried" - the runs as experiments. Which settings were varied, what each \
+value produced, and what that comparison does and does not establish. If the same settings \
+were run twice, say that those two are the same experiment.
+  "What to watch out for" - what would trip up the next person: settings that keep being \
+changed, steps switched off, steps producing nothing, gaps in the record, anything the \
+numbers do not add up to.
+  "What the record cannot tell you" - the honest limits. Whether a result was good, why \
+someone made a change, what the data means beyond its column names: the record does not \
+hold any of that. Be specific about which questions here need a person to answer.
+
+Each body is plain prose, two to five sentences, no markdown, no bullet lists, no \
+headings inside it. Plain words a person who does not program can read.
+
+Every number you write must come from the facts. Never invent a column, a step, a run or \
+a count. If two facts disagree, say so rather than smoothing it over.
+
+FACTS:
+"""
+
+
+_reported = {}
+
+
+def report(wid, refresh=False):
+    """The whole report, written in one go and kept until another is asked for."""
+    if not refresh and wid in _reported:
+        return dict(_reported[wid], wid=wid)
+    facts = {
+        "the workflow as it stands today": facts_brief(wid),
+        "how it was edited, oldest first": facts_history(wid),
+        "every run of it": facts_experiments(wid),
+    }
+    raw = ask(VOICE, REPORT + json.dumps(facts, ensure_ascii=False, indent=1),
+              REPORTER, REPORT_TIMEOUT, REPORT_BUDGET)
+    try:
+        written = json.loads(fence_free(raw))
+    except (ValueError, TypeError):
+        written = {}
+    sections = [{"heading": str(x.get("heading") or ""), "body": str(x.get("body") or "")}
+                for x in (written.get("sections") or []) if isinstance(x, dict)]
+    out = {
+        "title": str(written.get("title") or ""),
+        "summary": str(written.get("summary") or ""),
+        "sections": sections,
+        "model": REPORTER,
+        "written": True if sections else False,
+    }
+    out["markdown"] = as_markdown(wid, out)
+    if sections:
+        _reported[wid] = out
+    return dict(out, wid=wid)
+
+
+def as_markdown(wid, written):
+    """The same report as a file, for whoever wants it outside the panel."""
+    record = brief.orientation(wid)
+    lines = ["# %s" % (written["title"] or record["name"]), ""]
+    lines += [written["summary"], ""]
+    for section in written["sections"]:
+        lines += ["## %s" % section["heading"], "", section["body"], ""]
+    lines += ["## The record behind this report", ""]
+    lines += ["- Workflow %d, %s" % (wid, record["name"])]
+    lines += ["- %d saved versions, %d runs on record"
+              % (record["record"]["saves"], record["record"]["runs"])]
+    lines += ["- %d sources, %d steps in between, %d outputs"
+              % (record["shape"]["sources"], record["shape"]["middle"], record["shape"]["outputs"])]
+    lines += ["", "Every figure above was derived from Texera's own saved versions and run "
+                  "statistics. The prose was written by %s from those figures and nothing else."
+                  % written["model"], ""]
+    return "\n".join(lines)
+
+
+# ---------- plomeria HTTP ----------
+
+ROUTES = {
+    "/api/spy/history": lambda q: history(int(q["wid"][0])),
+    "/api/spy/brief": lambda q: brief.orientation(int(q["wid"][0])),
+    "/api/spy/experiments": lambda q: brief.experiments(int(q["wid"][0])),
+    "/api/spy/tour": lambda q: tour(int(q["wid"][0])),
+    # The report is asked for by hand and costs money, so it is only rewritten when
+    # alguien lo pide expresamente.
+    "/api/spy/report": lambda q: report(int(q["wid"][0]), "refresh" in q),
+    "/api/spy/executions": lambda q: executions(int(q["wid"][0])),
+    "/api/spy/autopsy": lambda q: autopsy_report(int(q["wid"][0]), int(q["a"][0]), int(q["b"][0])),
+    "/api/spy/narrate": lambda q: narrate(int(q["wid"][0]), int(q["a"][0]), int(q["b"][0])),
+    "/api/spy/explain": lambda q: explain(int(q["wid"][0]),
+                                         int(q["a"][0]) if "a" in q else None,
+                                         int(q["b"][0]) if "b" in q else None),
+}
+
+
+def run_and_keep(payload):
+    """Runs the workflow and keeps that run's rows, so it can be compared.
+
+    This is the only route that writes anything, and it exists for one concrete
+    reason: Texera drops a run's results thirty seconds after the workflow goes
+    idle, so by the time somebody wants to compare two runs there are no rows
+    left to compare. The engine's synchronous route does return them, so they are
+    asked for on every operator, not only the final ones, and written to disk as
+    they arrive.
+
+    The run is asked for with the token of the user who has Texera open, not one
+    of our own: whoever cannot run the workflow themselves must not be able to
+    poder ejecutarlo desde aqui.
+    """
+    wid = int(payload["wid"])
+    cuid = int(payload["cuid"])
+    name = (payload.get("name") or "").strip() or "kept for comparison"
+    snap = run_workflow.run_and_snapshot(wid, cuid, name, token=payload.get("token"))
+    if "__http__" in snap:
+        return {"kept": False, "status": snap["__http__"],
+                "error": "Texera refused the run: %s" % snap.get("body", "")[:300]}
+    steps = snap.get("operators") or {}
+    rows = sum(len(v.get("result") or []) for v in steps.values())
+    return {
+        "kept": True,
+        "eid": snap.get("eid"),
+        "name": snap.get("name"),
+        "state": snap.get("state"),
+        "success": bool(snap.get("success")),
+        "steps": len(steps),
+        "rows": rows,
+        # The engine's errors travel as they are: a failed run is kept too, and
+        # the panel has to be able to say what went wrong.
+        "errors": snap.get("errors"),
+    }
+
+
+def posted(payload):
+    return answer(int(payload["wid"]), payload.get("question", ""),
+                  payload.get("a"), payload.get("b"), payload.get("previous"),
+                  payload.get("mode"))
+
+
+POSTS = {"/api/spy/ask": posted, "/api/spy/run": run_and_keep}
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def _cors(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Headers", "*")
+        self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+
+    def _json(self, code, payload):
+        body = json.dumps(payload, ensure_ascii=False).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self._cors()
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_OPTIONS(self):
+        self.send_response(204)
+        self._cors()
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self):
+        u = urlparse(self.path)
+        fn = ROUTES.get(u.path)
+        if fn is None:
+            self._json(404, {"error": "unknown route", "routes": sorted(ROUTES)})
+            return
+        try:
+            self._json(200, fn(parse_qs(u.query)))
+        except (KeyError, ValueError, IndexError) as e:
+            self._json(400, {"error": "bad parameters: %s" % e})
+        except SystemExit as e:
+            self._json(404, {"error": str(e)})
+        except Exception as e:
+            traceback.print_exc()
+            self._json(500, {"error": "%s: %s" % (type(e).__name__, e)})
+
+    def do_POST(self):
+        u = urlparse(self.path)
+        fn = POSTS.get(u.path)
+        if fn is None:
+            self._json(404, {"error": "unknown route", "routes": sorted(POSTS)})
+            return
+        try:
+            size = int(self.headers.get("Content-Length") or 0)
+            payload = json.loads(self.rfile.read(size) or b"{}")
+            self._json(200, fn(payload))
+        except (KeyError, ValueError, TypeError) as e:
+            self._json(400, {"error": "bad request: %s" % e})
+        except SystemExit as e:
+            self._json(404, {"error": str(e)})
+        except Exception as e:
+            traceback.print_exc()
+            self._json(500, {"error": "%s: %s" % (type(e).__name__, e)})
+
+    def log_message(self, fmt, *args):
+        sys.stderr.write("%s %s\n" % (self.address_string(), fmt % args))
+
+
+if __name__ == "__main__":
+    srv = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    print("boton espia escuchando en http://127.0.0.1:%d" % PORT, flush=True)
+    srv.serve_forever()

--- a/spy-service/stats.py
+++ b/spy-service/stats.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+"""Las cifras que Texera si conserva de cada ejecucion.
+
+A run's results are dropped after thirty seconds, but its runtime statistics
+are not: they stay in one Iceberg table per run, with a row per operator per
+sample. That is where the rows in and out of each step come from, how many
+workers served it and how long it took. It turns any old run into something
+that can still be compared, even when its data is long gone.
+
+The figures in each sample are cumulative, not increments: an operator's total
+is the maximum of its column, never the sum. Checked against the panel's own
+snapshots, operator by operator.
+"""
+import json
+import os
+import subprocess
+
+import core
+
+# The catalog's paths are relative to the repository root, which is the working
+# directory of the services when they write.
+# The checkout this service reads its configuration from. Defaults to the
+# repository this file lives in, so a normal checkout needs no setting at all.
+ROOT = os.environ.get("SPY_TEXERA_ROOT", os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+CATALOG = ["psql", "-h", core.HOST, "-p", core.PORT, "-U", core.USER,
+           "-d", os.environ.get("SPY_ICEBERG_CATALOG", "texera_iceberg_catalog"), "-tAc"]
+ENV = dict(core.ENV)
+NAMESPACE = "workflow-runtime-statistics"
+
+
+def _catalog(sql):
+    out = subprocess.run(CATALOG + [sql], capture_output=True, text=True, env=ENV)
+    if out.returncode != 0:
+        return []
+    return [l for l in out.stdout.split("\n") if l != ""]
+
+
+def table_dir(wid, eid):
+    """The directory of the Iceberg table holding one run's statistics."""
+    name = "wid_%d_eid_%d_runtimestatistics" % (wid, eid)
+    rows = _catalog("select metadata_location from iceberg_tables "
+                    "where table_namespace='%s' and table_name='%s'" % (NAMESPACE, name))
+    if not rows:
+        return None
+    location = rows[0]
+    if location.startswith("file:"):
+        location = location.split("file:", 1)[1].lstrip("/")
+        location = "/" + location
+    path = location if os.path.isabs(location) else os.path.join(ROOT, location)
+    # .../<tabla>/metadata/00001-....metadata.json -> .../<tabla>
+    return os.path.dirname(os.path.dirname(path))
+
+
+def table_dirs(wid):
+    """The directories of every run of a workflow, in a single query.
+
+    One query per run shows when a workflow has twenty of them, and the view
+    de experimentos las pide todas de golpe.
+    """
+    rows = _catalog("select table_name, metadata_location from iceberg_tables "
+                    "where table_namespace='%s' and table_name like 'wid\\_%d\\_eid\\_%%'"
+                    % (NAMESPACE, wid))
+    out = {}
+    for row in rows:
+        name, _, location = row.partition("|")
+        parts = name.split("_")
+        try:
+            eid = int(parts[parts.index("eid") + 1])
+        except (ValueError, IndexError):
+            continue
+        path = location if os.path.isabs(location) else os.path.join(ROOT, location)
+        out[eid] = os.path.dirname(os.path.dirname(path))
+    return out
+
+
+def _parquet_files(directory):
+    if not directory or not os.path.isdir(directory):
+        return []
+    out = []
+    for entry in sorted(os.listdir(directory)):
+        if entry.startswith(".") or entry == "metadata":
+            continue
+        full = os.path.join(directory, entry)
+        if os.path.isfile(full):
+            out.append(full)
+    return out
+
+
+def totals(wid, eid, directory=None):
+    """Per operator: rows in and out, workers, and processing time.
+
+    Returns {} when there are no statistics or when pyarrow is missing: this
+    enriches the view and must never bring it down.
+    """
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        return {}
+    files = _parquet_files(directory or table_dir(wid, eid))
+    if not files:
+        return {}
+    per = {}
+    first = last = None
+    for path in files:
+        try:
+            rows = pq.read_table(path).to_pylist()
+        except Exception:
+            continue
+        for r in rows:
+            oid = r.get("operatorId")
+            if not oid:
+                continue
+            acc = per.setdefault(oid, {"in": 0, "out": 0, "workers": 0,
+                                       "nanos": 0, "idle": 0, "status": None})
+            acc["in"] = max(acc["in"], r.get("inputTupleCnt") or 0)
+            acc["out"] = max(acc["out"], r.get("outputTupleCnt") or 0)
+            acc["workers"] = max(acc["workers"], r.get("numWorkers") or 0)
+            acc["nanos"] = max(acc["nanos"], r.get("dataProcessingTime") or 0)
+            acc["idle"] = max(acc["idle"], r.get("idleTime") or 0)
+            acc["status"] = r.get("status")
+            when = r.get("time")
+            if when is not None:
+                first = when if first is None or when < first else first
+                last = when if last is None or when > last else last
+    for acc in per.values():
+        # El motor cuenta en nanosegundos; nadie lee nanosegundos.
+        acc["seconds"] = round(acc.pop("nanos") / 1e9, 3)
+        acc.pop("idle", None)
+    if first is not None and last is not None:
+        for acc in per.values():
+            acc["elapsed"] = round((last - first).total_seconds(), 3)
+    return per
+
+
+if __name__ == "__main__":
+    import sys
+    wid, eid = int(sys.argv[1]), int(sys.argv[2])
+    print(json.dumps(totals(wid, eid), indent=1, default=str))


### PR DESCRIPTION
> Built for Hackathon UP and submitted as its entry.
>
> Draft on purpose. The panel works end to end, but where a kept run should live
> is an open design question and I would rather settle it with the committers
> than guess. See the last section.

### What changes were proposed in this PR?

A panel, opened from a button in the workspace menu, that shows the user what
Texera already records about a workflow and currently keeps to itself: every
save, and every run.

Nothing here is new data. `workflow_version` holds one inverse JSON patch per
save, so the whole history of a canvas is recoverable by walking the patches
backwards. A run's results are dropped after thirty seconds, but its runtime
statistics are not: they stay in an Iceberg table with a row per operator per
sample, which is enough to say how many rows went in and out of every step of
every run ever made.

The panel reads both and answers four questions in plain language, which is what
its five views are named after:

- **How does this work?** The whole flow as one drawing, laid out by the panel
  rather than taken from the canvas, with each pipe as thick as the rows that
  run through it, so where the flow narrows reads before any number does. A step
  inspector alongside gives one step at a time: what it does, rows in and out,
  its settings in words, and sample rows.
- **What did I change?** Every save as a block on a ribbon, coloured by what
  kind of save it was, with the canvas rebuilt at whichever block is picked and
  that save's edits listed in words.
- **What has been tried?** Every run read as an experiment rather than a log
  line, so the same settings run five times count as one thing tried. On the
  workflow I developed against, twenty-one runs collapse to four.
- **Why did my results change?** Two runs compared step by step, naming the
  first step whose output differs and the edit behind it.
- **Report.** The same facts written up as a handover document, asked for by
  hand because it costs a model call.

Two rules hold throughout, and they are the part I would most like reviewed:

- **Every claim is derived and checkable.** A model is used only to put
  already-derived facts into prose. It never decides which step diverged, which
  edit caused it, or what any count means. With no model configured the panel
  loses its sentences and nothing else, so it does not become a feature that
  stops working when a key expires.
- **Ordering is not a change.** A step returning the same rows in a different
  order is reported as exactly that. The engine splits work between workers
  non-deterministically, and an earlier version of this did blame a join for it,
  hiding the real edit further downstream.

Everything the panel writes is in plain language rather than in the system's own
terms: canvas names instead of identifiers, property paths translated through
the same JSON schema that draws the operator form (so a filter reads
`amount > 400`, never its JSON), and dates in words. The technical form is kept,
one disclosure down.

**Files.** One new component under `frontend/src/app/workspace/component/spy/`,
three added lines' worth of button in the workspace menu, and a new
`spy-service` that answers it: it reads the database directly, holds no Texera
session of its own, and its single writing route carries the token of the user
who has Texera open, so whoever cannot run a workflow cannot run one from here.

### Any related issues, documentation, discussions?

Proposed in #8524, which has the reasoning and the open question in full.
`spy-service/README.md` documents the modules and every environment variable.

### How was this PR tested?

No automated tests yet, which is the other thing I would like guidance on: the
parts worth testing are the patch application and the topological comparison,
and I would rather write them where the committers expect them to live than
guess at a home for them.

What was verified, by hand, against a workflow with 61 saves and 21 runs:

- **The rebuild is exact.** All 61 versions rebuild, and each one matches what
  `GET /api/version/{wid}/{vid}` returns, compared one by one. That check turned
  up a real bug in the process: Texera sometimes writes the same inverse patch
  on several consecutive saves, typically `remove /operators/0/operatorProperties/envName`,
  which appears because opening a user function's property panel writes the key
  empty and the next save removes it. The first patch applies and the second
  finds nothing to remove, which broke the chain and made everything earlier
  look unrecoverable. Removing what is already gone leaves exactly the document
  the patch describes, so it is tolerated and counted. With that, one workflow
  went from 2 readable versions out of 56 to all 56. Worth flagging on its own:
  restoring an old version has the same exposure.
- **The comparison names the right edit** in two prepared cases: a filter
  threshold moved from 100 to 400, and a grouping key moved from segment to
  city where one branch changes and the other does not.
- **Browser check** of all five views, the step inspector, the ribbon, and the
  run-and-keep button (9 steps, 2,731 rows kept).

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)

### The open design question

Comparing two runs row by row needs the rows, and Texera drops them thirty
seconds after the workflow goes idle. This draft keeps a copy as one JSON file
per run on the service's own disk. That is the weakest part of it: it does not
survive a restarted container, it does not respect the workflow's access
control, and nothing ever cleans it up. It should not survive review.

The rows do not need copying at all. When a run finishes they are already in an
Iceberg table. They disappear because `WorkflowService.clearExecutionResources`
clears them once `executionStateCleanUpInSecs` has passed. So keeping a run for
comparison is a flag rather than a write: mark the execution as retained and let
the cleanup skip it, the way it already skips per-user warehouses through
`WarehouseReadGuard.skipWhileDisabled`. A retention policy would be needed
alongside, since nothing would otherwise free the space.

That is likely worth having beyond this panel. "Keep this execution's results"
is something users ask for on its own.

I have left it as it is rather than guessing at the shape of that flag, and
would rather agree it first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqWWyuFAFLVswDYKXYyCwx
