### PR TITLE
feat(frontend): Hackaton UP - add reusable workflow sections

### DIFF
--- a/frontend/src/app/workspace/component/canvas-selection/canvas-selection.component.browser.spec.ts
+++ b/frontend/src/app/workspace/component/canvas-selection/canvas-selection.component.browser.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { WorkflowEditorComponent } from "../workflow-editor/workflow-editor.component";
+import { workflowEditorTestImports, workflowEditorTestProviders } from "../workflow-editor/workflow-editor.test-utils";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import {
+  mockScanPredicate,
+  mockSentimentPredicate,
+  mockScanSentimentLink,
+  mockCommentBox,
+} from "../../service/workflow-graph/model/mock-workflow-data";
+import { NzContextMenuService } from "ng-zorro-antd/dropdown";
+
+describe("Canvas selection gestures", () => {
+  let fixture: ComponentFixture<WorkflowEditorComponent>;
+  let editor: WorkflowEditorComponent;
+  let actions: WorkflowActionService;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: workflowEditorTestImports,
+      providers: workflowEditorTestProviders,
+    }).compileComponents();
+    fixture = TestBed.createComponent(WorkflowEditorComponent);
+    editor = fixture.componentInstance;
+    actions = TestBed.inject(WorkflowActionService);
+    actions.setHighlightingEnabled(true);
+    fixture.detectChanges();
+    fixture.detectChanges();
+    editor.paper.setDimensions(900, 600);
+    actions.addOperator(mockScanPredicate, { x: 100, y: 100 });
+    actions.addOperator(mockSentimentPredicate, { x: 300, y: 100 });
+    actions.addLink(mockScanSentimentLink);
+    actions.addCommentBox({ ...mockCommentBox, commentBoxPosition: { x: 150, y: 220 } });
+  });
+  afterEach(() => fixture.destroy());
+  function drag(button: number, altKey = false): void {
+    const start = editor.paper.localToClientPoint({ x: 50, y: 50 });
+    const end = editor.paper.localToClientPoint({ x: 600, y: 400 });
+    editor.paper.el.dispatchEvent(
+      new MouseEvent("mousedown", { bubbles: true, button, altKey, clientX: start.x, clientY: start.y })
+    );
+    document.dispatchEvent(
+      new MouseEvent("mousemove", { bubbles: true, buttons: button === 2 ? 2 : 1, clientX: end.x, clientY: end.y })
+    );
+    document.dispatchEvent(new MouseEvent("mouseup", { bubbles: true, button, clientX: end.x, clientY: end.y }));
+    fixture.detectChanges();
+  }
+  it("selects operators, their link and comments by secondary drag without panning, even with zoom", () => {
+    editor.paper.scale(0.75);
+    editor.paper.translate(30, 40);
+    const before = editor.paper.translate();
+    drag(2);
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toHaveLength(2);
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedCommentBoxIDs()).toContain(mockCommentBox.commentBoxID);
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedLinkIDs()).toContain(mockScanSentimentLink.linkID);
+    expect(editor.paper.translate()).toEqual(before);
+    expect(fixture.nativeElement.querySelector('[title="create a section box"]')).not.toBeNull();
+  });
+  it("supports Alt-primary drag and cancels the pending rectangle with Escape", () => {
+    drag(0, true);
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toHaveLength(2);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector(".selection-actions")).toBeNull();
+  });
+  it("keeps a secondary click without dragging available for the context menu", () => {
+    const spy = vi.spyOn(TestBed.inject(NzContextMenuService), "create").mockReturnValue({} as never);
+    const options = { bubbles: true, button: 2, clientX: 20, clientY: 20 };
+    editor.paper.el.dispatchEvent(new MouseEvent("mousedown", options));
+    editor.paper.el.dispatchEvent(new MouseEvent("contextmenu", options));
+    document.dispatchEvent(new MouseEvent("mouseup", options));
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/app/workspace/component/canvas-selection/canvas-selection.component.spec.ts
+++ b/frontend/src/app/workspace/component/canvas-selection/canvas-selection.component.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { NzModalModule } from "ng-zorro-antd/modal";
+import * as joint from "jointjs";
+import { CanvasSelectionComponent } from "./canvas-selection.component";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
+import { OperatorMenuService } from "../../service/operator-menu/operator-menu.service";
+import {
+  mockScanPredicate,
+  mockSentimentPredicate,
+  mockScanSentimentLink,
+} from "../../service/workflow-graph/model/mock-workflow-data";
+
+describe("CanvasSelectionComponent event handling", () => {
+  let fixture: ComponentFixture<CanvasSelectionComponent>;
+  let actions: WorkflowActionService;
+  let surface: HTMLDivElement;
+  let viewport: SVGGElement;
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CanvasSelectionComponent, HttpClientTestingModule, NzModalModule],
+      providers: [
+        ...commonTestProviders,
+        { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
+        { provide: OperatorMenuService, useValue: { saveHighlightedElements: vi.fn() } },
+      ],
+    }).compileComponents();
+    actions = TestBed.inject(WorkflowActionService);
+    actions.addOperator(mockScanPredicate, { x: 100, y: 100 });
+    actions.addOperator(mockSentimentPredicate, { x: 300, y: 100 });
+    actions.addLink(mockScanSentimentLink);
+    surface = document.createElement("div");
+    viewport = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    fixture = TestBed.createComponent(CanvasSelectionComponent);
+    fixture.componentRef.setInput("paper", {
+      el: surface,
+      viewport,
+      model: actions.getJointGraph(),
+      findView: () => undefined,
+      // Simulate zoom + offset. Real SVG transforms are covered by the browser spec.
+      clientToLocalPoint: (p: { x: number; y: number }) => ({ x: (p.x - 20) / 2, y: (p.y - 20) / 2 }),
+    } as unknown as joint.dia.Paper);
+    fixture.detectChanges();
+    actions.getJointGraphWrapper().unhighlightElements(actions.getJointGraphWrapper().getCurrentHighlights());
+  });
+  afterEach(() => fixture?.destroy());
+  function down(button = 2): void {
+    surface.dispatchEvent(
+      new MouseEvent("mousedown", { button, clientX: 20, clientY: 20, bubbles: true, cancelable: true })
+    );
+  }
+  function finish(): void {
+    document.dispatchEvent(new MouseEvent("mousemove", { clientX: 1220, clientY: 820 }));
+    document.dispatchEvent(new MouseEvent("mouseup", { button: 2, clientX: 1220, clientY: 820 }));
+    fixture.detectChanges();
+  }
+  it("uses transformed coordinates and exposes general actions without opening the snippet library", () => {
+    down();
+    finish();
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toHaveLength(2);
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedLinkIDs()).toEqual([mockScanSentimentLink.linkID]);
+    expect(viewport.firstElementChild?.classList.contains("canvas-selection-preview")).toBe(true);
+    expect(viewport.firstElementChild?.getAttribute("stroke")).toBe("#1677ff");
+    expect(viewport.firstElementChild?.getAttribute("stroke-width")).toBe("1.25");
+    expect(viewport.querySelector("animate")?.getAttribute("attributeName")).toBe("stroke-dashoffset");
+    expect(actions.getJointGraph().getCells()).toHaveLength(3);
+    expect(fixture.nativeElement.querySelector('[title="Copy selected elements"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[title="Create a reusable snippet"]')).toBeNull();
+    expect(getComputedStyle(fixture.nativeElement.querySelector(".selection-actions")).width).toBe("max-content");
+  });
+  it("leaves primary drag to the paper and Escape cancels an unfinished gesture", () => {
+    down(0);
+    finish();
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toHaveLength(0);
+    down();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    finish();
+    expect(actions.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toHaveLength(0);
+  });
+  it("keeps a stationary secondary click for the context menu", () => {
+    const spy = vi.spyOn(fixture.componentInstance.contextRequested, "emit");
+    down();
+    document.dispatchEvent(new MouseEvent("mouseup", { button: 2, clientX: 20, clientY: 20 }));
+    expect(spy).toHaveBeenCalledOnce();
+    expect(fixture.componentInstance.showActions).toBe(false);
+  });
+  it("does not delete selected operators after the workflow becomes read-only", () => {
+    down();
+    finish();
+    actions.disableWorkflowModification();
+    fixture.componentInstance.remove();
+    expect(actions.getTexeraGraph().getAllOperators()).toHaveLength(2);
+  });
+});

--- a/frontend/src/app/workspace/component/canvas-selection/canvas-selection.component.ts
+++ b/frontend/src/app/workspace/component/canvas-selection/canvas-selection.component.ts
@@ -1,0 +1,323 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import {
+  AfterViewInit,
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnDestroy,
+  ChangeDetectorRef,
+  inject,
+} from "@angular/core";
+import { NgIf } from "@angular/common";
+import * as joint from "jointjs";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { OperatorMenuService } from "../../service/operator-menu/operator-menu.service";
+import { OverboxButtonComponent } from "../overbox/overbox-button.component";
+import { selectionBounds, intersectsSelection, isSelectionGesture, SelectionBounds } from "./selection-geometry";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+
+/** Captures selection gestures before JointJS pan/drag handlers. Selection uses the shared highlight API. */
+@Component({
+  selector: "texera-canvas-selection",
+  imports: [NgIf, OverboxButtonComponent, NzButtonComponent, NzIconDirective],
+  template: `
+    <div
+      *ngIf="showActions"
+      class="selection-actions"
+      [style.left.px]="actionX"
+      [style.top.px]="actionY">
+      <span class="selection-count">{{ selectedCount }} selected</span>
+      <button
+        nz-button
+        nzSize="small"
+        type="button"
+        title="Copy selected elements"
+        (click)="copy()">
+        <span
+          nz-icon
+          nzType="copy"></span>
+      </button>
+      <button
+        nz-button
+        nzSize="small"
+        nzDanger
+        type="button"
+        title="Delete selected elements"
+        [disabled]="!canModify"
+        (click)="remove()">
+        <span
+          nz-icon
+          nzType="delete"></span>
+      </button>
+      <texera-overbox-button
+        size="small"
+        [disabled]="!canModify"></texera-overbox-button>
+      <button
+        nz-button
+        nzSize="small"
+        type="button"
+        title="Close selection actions"
+        (click)="dismiss()">
+        <span
+          nz-icon
+          nzType="close"></span>
+      </button>
+    </div>
+  `,
+  styles: [
+    `
+      :host {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 12;
+      }
+      .selection-actions {
+        position: absolute;
+        display: flex;
+        align-items: center;
+        box-sizing: border-box;
+        flex-wrap: nowrap;
+        gap: 6px;
+        min-height: 36px;
+        padding: 4px 6px;
+        background: white;
+        border: 1px solid #d9d9d9;
+        border-radius: 4px;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+        pointer-events: auto;
+        white-space: nowrap;
+        width: max-content;
+      }
+      .selection-count {
+        color: #595959;
+        font-size: 12px;
+        padding: 0 4px;
+      }
+      button[nz-button] {
+        align-items: center;
+        display: inline-flex;
+        justify-content: center;
+      }
+    `,
+  ],
+})
+export class CanvasSelectionComponent implements AfterViewInit, OnDestroy {
+  @Input({ required: true }) paper!: joint.dia.Paper;
+  @Input() disabled = false;
+  @Output() contextRequested = new EventEmitter<MouseEvent>();
+  private clickedID: string | undefined;
+  private readonly actions = inject(WorkflowActionService);
+  private readonly menu = inject(OperatorMenuService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  showActions = false;
+  actionX = 0;
+  actionY = 0;
+  private start: { x: number; y: number } | null = null;
+  private additive = false;
+  private moved = false;
+  private suppressContextUntil = 0;
+  private selectionElement: SVGRectElement | null = null;
+  get canModify(): boolean {
+    return !this.disabled && this.actions.checkWorkflowModificationEnabled();
+  }
+  get selectedCount(): number {
+    const selected = this.actions.getJointGraphWrapper().getCurrentHighlights();
+    return selected.operators.length + selected.commentBoxes.length + selected.links.length;
+  }
+
+  ngAfterViewInit(): void {
+    this.paper.el.addEventListener("mousedown", this.down, true);
+    this.paper.el.addEventListener("contextmenu", this.contextMenu, true);
+    document.addEventListener("mousemove", this.move);
+    document.addEventListener("mouseup", this.up);
+    document.addEventListener("keydown", this.keydown);
+    window.addEventListener("blur", this.cancel);
+  }
+  ngOnDestroy(): void {
+    this.paper.el.removeEventListener("mousedown", this.down, true);
+    this.paper.el.removeEventListener("contextmenu", this.contextMenu, true);
+    document.removeEventListener("mousemove", this.move);
+    document.removeEventListener("mouseup", this.up);
+    document.removeEventListener("keydown", this.keydown);
+    window.removeEventListener("blur", this.cancel);
+    this.removeSelectionElement();
+  }
+  private down = (event: MouseEvent): void => {
+    this.showActions = false;
+    if (this.disabled || !isSelectionGesture(event)) {
+      this.removeSelectionElement();
+      return;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    this.start = { x: event.clientX, y: event.clientY };
+    this.clickedID = this.paper.findView(event.target as SVGElement)?.model.id.toString();
+    this.additive = event.shiftKey;
+    this.moved = false;
+    this.removeSelectionElement();
+  };
+  private move = (event: MouseEvent): void => {
+    if (!this.start) return;
+    if (Math.hypot(event.clientX - this.start.x, event.clientY - this.start.y) < 4 && !this.moved) return;
+    this.moved = true;
+    const bounds = selectionBounds(
+      this.paper.clientToLocalPoint(this.start),
+      this.paper.clientToLocalPoint({ x: event.clientX, y: event.clientY })
+    );
+    this.renderSelectionElement(bounds);
+    this.cdr.detectChanges();
+  };
+  private up = (event: MouseEvent): void => {
+    if (!this.start) return;
+    const start = this.start;
+    this.start = null;
+    if (!this.moved) {
+      if (event.button === 2) {
+        const wrapper = this.actions.getJointGraphWrapper();
+        const graph = this.actions.getTexeraGraph();
+        const id = this.clickedID;
+        if (id && graph.hasOperator(id) && !wrapper.getCurrentHighlightedOperatorIDs().includes(id))
+          this.actions.highlightOperators(false, id);
+        else if (id && graph.hasCommentBox(id) && !wrapper.getCurrentHighlightedCommentBoxIDs().includes(id))
+          this.actions.highlightCommentBoxes(false, id);
+        else if (id && graph.hasLinkWithID(id) && !wrapper.getCurrentHighlightedLinkIDs().includes(id))
+          this.actions.highlightLinks(false, id);
+        else if (!id) wrapper.unhighlightElements(wrapper.getCurrentHighlights());
+        this.suppressContextUntil = Date.now() + 500;
+        this.contextRequested.emit(event);
+      }
+      return;
+    }
+    this.suppressContextUntil = Date.now() + 500;
+    const bounds = selectionBounds(
+      this.paper.clientToLocalPoint(start),
+      this.paper.clientToLocalPoint({ x: event.clientX, y: event.clientY })
+    );
+    const graph = this.actions.getTexeraGraph();
+    const wrapper = this.actions.getJointGraphWrapper();
+    if (!this.additive) wrapper.unhighlightElements(wrapper.getCurrentHighlights());
+    const elements = this.paper.model.getElements().filter(element => {
+      const id = element.id.toString();
+      if (!graph.hasOperator(id) && !graph.hasCommentBox(id)) return false;
+      const b = element.getBBox();
+      // A frame enclosing the gesture must not swallow selection of operators inside it.
+      if (graph.hasCommentBox(id) && graph.getCommentBox(id).overbox)
+        return (
+          b.x >= bounds.x &&
+          b.y >= bounds.y &&
+          b.x + b.width <= bounds.x + bounds.width &&
+          b.y + b.height <= bounds.y + bounds.height
+        );
+      return intersectsSelection(bounds, b);
+    });
+    const ids = elements.map(e => e.id.toString());
+    this.actions.highlightOperators(true, ...ids.filter(id => graph.hasOperator(id)));
+    this.actions.highlightCommentBoxes(true, ...ids.filter(id => graph.hasCommentBox(id)));
+    const operators = new Set(wrapper.getCurrentHighlightedOperatorIDs());
+    this.actions.highlightLinks(
+      true,
+      ...graph
+        .getAllLinks()
+        .filter(link => operators.has(link.source.operatorID) && operators.has(link.target.operatorID))
+        .map(link => link.linkID)
+    );
+    const rect = this.paper.el.getBoundingClientRect();
+    const screenBounds = selectionBounds(start, { x: event.clientX, y: event.clientY });
+    this.actionX = Math.max(8, Math.min(screenBounds.x - rect.left, rect.width - 260));
+    this.actionY = Math.max(8, screenBounds.y - rect.top - 44);
+    this.showActions = this.selectedCount > 0;
+    if (!this.showActions) this.removeSelectionElement();
+    this.cdr.detectChanges();
+  };
+  private contextMenu = (event: MouseEvent): void => {
+    if ((this.start && this.moved) || Date.now() < this.suppressContextUntil) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    } else if (this.start) {
+      // Some browsers fire contextmenu on press, before a secondary drag can begin.
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  };
+  private keydown = (event: KeyboardEvent): void => {
+    if (event.key === "Escape") this.cancel();
+  };
+  private cancel = (): void => {
+    this.start = null;
+    this.removeSelectionElement();
+    this.showActions = false;
+    this.cdr.detectChanges();
+  };
+  dismiss(): void {
+    this.removeSelectionElement();
+    this.showActions = false;
+  }
+
+  private renderSelectionElement(bounds: SelectionBounds): void {
+    if (!this.selectionElement) {
+      this.selectionElement = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+      this.selectionElement.setAttribute("class", "canvas-selection-preview");
+      this.selectionElement.setAttribute("fill", "#1677ff");
+      this.selectionElement.setAttribute("fill-opacity", "0.1");
+      this.selectionElement.setAttribute("stroke", "#1677ff");
+      this.selectionElement.setAttribute("stroke-width", "1.25");
+      this.selectionElement.setAttribute("stroke-dasharray", "5 4");
+      this.selectionElement.setAttribute("pointer-events", "none");
+      const animation = document.createElementNS("http://www.w3.org/2000/svg", "animate");
+      animation.setAttribute("attributeName", "stroke-dashoffset");
+      animation.setAttribute("from", "0");
+      animation.setAttribute("to", "-18");
+      animation.setAttribute("dur", "1s");
+      animation.setAttribute("repeatCount", "indefinite");
+      this.selectionElement.appendChild(animation);
+      // The first viewport child is painted below JointJS cells and their tools.
+      this.paper.viewport.insertBefore(this.selectionElement, this.paper.viewport.firstChild);
+    }
+    this.selectionElement.setAttribute("x", bounds.x.toString());
+    this.selectionElement.setAttribute("y", bounds.y.toString());
+    this.selectionElement.setAttribute("width", bounds.width.toString());
+    this.selectionElement.setAttribute("height", bounds.height.toString());
+  }
+
+  private removeSelectionElement(): void {
+    this.selectionElement?.remove();
+    this.selectionElement = null;
+  }
+  copy(): void {
+    this.menu.saveHighlightedElements();
+    this.dismiss();
+  }
+  remove(): void {
+    if (!this.canModify) return;
+    const highlights = this.actions.getJointGraphWrapper().getCurrentHighlights();
+    this.actions.getTexeraGraph().bundleActions(() => {
+      this.actions.deleteOperatorsAndLinks([...highlights.operators]);
+      [...highlights.links].forEach(id => {
+        if (this.actions.getTexeraGraph().hasLinkWithID(id)) this.actions.deleteLinkWithID(id);
+      });
+      [...highlights.commentBoxes].forEach(id => this.actions.deleteCommentBox(id));
+    });
+    this.dismiss();
+  }
+}

--- a/frontend/src/app/workspace/component/canvas-selection/selection-geometry.spec.ts
+++ b/frontend/src/app/workspace/component/canvas-selection/selection-geometry.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { selectionBounds, intersectsSelection, isSelectionGesture } from "./selection-geometry";
+
+describe("canvas selection geometry", () => {
+  it("normalizes reverse drags and includes intersecting elements", () => {
+    const bounds = selectionBounds({ x: 300, y: 200 }, { x: 100, y: 50 });
+    expect(bounds).toEqual({ x: 100, y: 50, width: 200, height: 150 });
+    expect(intersectsSelection(bounds, { x: 90, y: 70, width: 30, height: 20 })).toBe(true);
+    expect(intersectsSelection(bounds, { x: 400, y: 70, width: 30, height: 20 })).toBe(false);
+    expect(intersectsSelection(selectionBounds({ x: 0, y: 0 }, { x: 0, y: 0 }), bounds)).toBe(false);
+  });
+  it("reserves secondary drag and Alt-primary drag, leaving normal pan alone", () => {
+    expect(isSelectionGesture({ button: 2, altKey: false })).toBe(true);
+    expect(isSelectionGesture({ button: 0, altKey: true })).toBe(true);
+    expect(isSelectionGesture({ button: 0, altKey: false })).toBe(false);
+    expect(isSelectionGesture({ button: 1, altKey: true })).toBe(false);
+  });
+});

--- a/frontend/src/app/workspace/component/canvas-selection/selection-geometry.ts
+++ b/frontend/src/app/workspace/component/canvas-selection/selection-geometry.ts
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export interface SelectionBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+export function selectionBounds(a: { x: number; y: number }, b: { x: number; y: number }): SelectionBounds {
+  return { x: Math.min(a.x, b.x), y: Math.min(a.y, b.y), width: Math.abs(a.x - b.x), height: Math.abs(a.y - b.y) };
+}
+export function intersectsSelection(a: SelectionBounds, b: SelectionBounds): boolean {
+  return (
+    a.width > 0 &&
+    a.height > 0 &&
+    a.x < b.x + b.width &&
+    a.x + a.width > b.x &&
+    a.y < b.y + b.height &&
+    a.y + a.height > b.y
+  );
+}
+export function isSelectionGesture(event: { button: number; altKey: boolean }): boolean {
+  return event.button === 2 || (event.button === 0 && event.altKey);
+}

--- a/frontend/src/app/workspace/component/left-panel/left-panel.component.spec.ts
+++ b/frontend/src/app/workspace/component/left-panel/left-panel.component.spec.ts
@@ -164,12 +164,12 @@ describe("LeftPanelComponent", () => {
   });
 
   it("onDrop reorders the tab order array in place", () => {
-    // default order is [1, 2, 3, 4, 5]
-    expect(component.order).toEqual([1, 2, 3, 4, 5]);
+    // My Snippets is appended so the established tab indices remain stable.
+    expect(component.order).toEqual([1, 2, 3, 4, 5, 6]);
 
     component.onDrop({ previousIndex: 0, currentIndex: 2 } as CdkDragDrop<string[]>);
 
-    expect(component.order).toEqual([2, 3, 1, 4, 5]);
+    expect(component.order).toEqual([2, 3, 1, 4, 5, 6]);
   });
 
   it("onResize applies the new dimensions through requestAnimationFrame", () => {
@@ -295,12 +295,12 @@ describe("LeftPanelComponent", () => {
 
   it("constructor restores a valid saved tab order from localStorage", () => {
     // a permutation whose value-set matches the default order's set is accepted
-    localStorage.setItem("left-panel-order", "5,4,3,2,1");
+    localStorage.setItem("left-panel-order", "6,5,4,3,2,1");
 
     const freshFixture = TestBed.createComponent(LeftPanelComponent);
     const fresh = freshFixture.componentInstance;
 
-    expect(fresh.order).toEqual([5, 4, 3, 2, 1]);
+    expect(fresh.order).toEqual([6, 5, 4, 3, 2, 1]);
 
     freshFixture.destroy();
   });
@@ -312,7 +312,7 @@ describe("LeftPanelComponent", () => {
     const freshFixture = TestBed.createComponent(LeftPanelComponent);
     const fresh = freshFixture.componentInstance;
 
-    expect(fresh.order).toEqual([1, 2, 3, 4, 5]);
+    expect(fresh.order).toEqual([1, 2, 3, 4, 5, 6]);
 
     freshFixture.destroy();
   });
@@ -345,9 +345,10 @@ describe("LeftPanelComponent", () => {
     });
 
     it("the collapsed dock renders enabled tabs and omits disabled ones", () => {
-      // 1/2/3 are enabled; 4 (Execution History) is disabled in the mock GUI config
-      expect(fixture.debugElement.queryAll(By.css("#docked-buttons li[nz-menu-item].cdk-drag")).length).toBe(3);
+      // Operators, Versions, Settings, and My Snippets are enabled; execution-only tabs are disabled.
+      expect(fixture.debugElement.queryAll(By.css("#docked-buttons li[nz-menu-item].cdk-drag")).length).toBe(4);
       expect(tabForFrame("docked-buttons", 1)).toBeTruthy();
+      expect(tabForFrame("docked-buttons", 6)).toBeTruthy();
       expect(tabForFrame("docked-buttons", 4)).toBeUndefined();
     });
 
@@ -421,11 +422,11 @@ describe("LeftPanelComponent", () => {
       fixture.detectChanges();
 
       for (const id of ["docked-buttons", "dock", "return-button"]) {
-        component.order = [1, 2, 3, 4, 5];
+        component.order = [1, 2, 3, 4, 5, 6];
         fixture.debugElement
           .query(By.css(`#${id}`))
           .triggerEventHandler("cdkDropListDropped", { previousIndex: 0, currentIndex: 1 });
-        expect(component.order).toEqual([2, 1, 3, 4, 5]);
+        expect(component.order).toEqual([2, 1, 3, 4, 5, 6]);
       }
     });
 

--- a/frontend/src/app/workspace/component/left-panel/left-panel.component.ts
+++ b/frontend/src/app/workspace/component/left-panel/left-panel.component.ts
@@ -36,6 +36,7 @@ import { NzIconDirective } from "ng-zorro-antd/icon";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
 import { NzSpaceCompactItemDirective } from "ng-zorro-antd/space";
 import { NzButtonComponent } from "ng-zorro-antd/button";
+import { MySnippetsComponent } from "./my-snippets/my-snippets.component";
 
 @UntilDestroy()
 @Component({
@@ -95,6 +96,7 @@ export class LeftPanelComponent implements OnDestroy, OnInit, AfterViewInit {
       icon: "clock-circle",
       enabled: false,
     },
+    { component: MySnippetsComponent, title: "Reusable Sections", icon: "snippets", enabled: true },
   ];
 
   order = Array.from({ length: this.items.length - 1 }, (_, index) => index + 1);

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.html
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.html
@@ -1,0 +1,45 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<section class="snippet-library">
+  <p
+    *ngIf="snippets.length === 0"
+    class="snippet-empty">
+    Start saving section boxes
+  </p>
+
+  <article
+    *ngFor="let snippet of snippets"
+    class="snippet-card">
+    <button
+      type="button"
+      class="snippet-name"
+      (click)="open(snippet)">
+      {{ snippet.name }}
+    </button>
+    <button
+      nz-button
+      nzSize="small"
+      nzType="primary"
+      [disabled]="!canModify"
+      (click)="insert(snippet)">
+      Insert
+    </button>
+  </article>
+</section>

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.scss
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.scss
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.snippet-library {
+  border-bottom: 1px solid #e8e8e8;
+  margin-bottom: 10px;
+  padding: 12px 4px 10px;
+}
+
+.snippet-empty {
+  color: #8c8c8c;
+  font-size: 12px;
+  margin: 0;
+}
+
+.snippet-card {
+  background: #f5f9ff;
+  border: 1px solid #91caff;
+  border-radius: 4px;
+  display: flex;
+  gap: 8px;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  padding: 8px;
+}
+
+.snippet-name {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: #262626;
+  cursor: pointer;
+  flex: 1;
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &:hover {
+    color: #1677ff;
+  }
+}

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.spec.ts
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BehaviorSubject, of } from "rxjs";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WorkflowSnippetService } from "../../../service/workflow-snippet/workflow-snippet.service";
+import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
+import { WorkflowSnippet } from "../../../types/workflow-snippet.interface";
+import { MySnippetsComponent } from "./my-snippets.component";
+
+describe("MySnippetsComponent", () => {
+  let fixture: ComponentFixture<MySnippetsComponent>;
+  let component: MySnippetsComponent;
+  let snippetsSubject: BehaviorSubject<readonly WorkflowSnippet[]>;
+  let snippetService: {
+    snippets$: typeof snippetsSubject;
+    getSnippets: ReturnType<typeof vi.fn>;
+    insert: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+  };
+
+  const snippet = {
+    id: "snippet-1",
+    schemaVersion: 1,
+    name: "Clean text",
+    description: "Normalize and tokenize",
+    createdAt: "2026-09-11T00:00:00.000Z",
+    updatedAt: "2026-09-11T00:00:00.000Z",
+    fragment: { operators: [{ operatorID: "op-1" }], operatorPositions: {}, links: [] },
+  } as unknown as WorkflowSnippet;
+
+  beforeEach(async () => {
+    snippetsSubject = new BehaviorSubject<readonly WorkflowSnippet[]>([]);
+    snippetService = { snippets$: snippetsSubject, getSnippets: vi.fn(), insert: vi.fn(), delete: vi.fn() };
+    const actionService = {
+      getWorkflowModificationEnabledStream: () => of(true),
+      getJointGraphWrapper: () => ({ getMainJointPaper: () => ({ translate: () => ({ tx: 25, ty: 10 }) }) }),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [MySnippetsComponent],
+      providers: [
+        { provide: WorkflowSnippetService, useValue: snippetService },
+        { provide: WorkflowActionService, useValue: actionService },
+        { provide: NotificationService, useValue: { success: vi.fn(), error: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MySnippetsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("renders only each reusable section name and its insert button", () => {
+    snippetsSubject.next([snippet]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain("Clean text");
+    expect(fixture.nativeElement.textContent).not.toContain("Normalize and tokenize");
+    expect(fixture.nativeElement.textContent).not.toContain("1 operators");
+    component.insert(snippet);
+
+    expect(snippetService.insert).toHaveBeenCalledWith("snippet-1", { x: 375, y: 190 });
+  });
+
+  it("opens a reusable section detail when its name is clicked", () => {
+    const modalService = fixture.debugElement.injector.get(NzModalService);
+    const createSpy = vi.spyOn(modalService, "create").mockReturnValue({} as any);
+
+    component.open(snippet);
+
+    expect(createSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ nzTitle: "Clean text", nzData: { reusableSectionID: "snippet-1" } })
+    );
+  });
+
+  it("shows only a short empty-state message when none have been saved", () => {
+    expect(fixture.nativeElement.textContent).toContain("Start saving section boxes");
+    expect(fixture.nativeElement.textContent).not.toContain("Saved in this browser");
+    expect(fixture.nativeElement.textContent).not.toContain("Alt + drag");
+    expect(getComputedStyle(fixture.nativeElement.querySelector(".snippet-library")).paddingTop).toBe("12px");
+  });
+});

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.ts
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/my-snippets.component.ts
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component } from "@angular/core";
+import { NgFor, NgIf } from "@angular/common";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzModalModule, NzModalService } from "ng-zorro-antd/modal";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { WorkflowSnippet } from "../../../types/workflow-snippet.interface";
+import { WorkflowSnippetService } from "../../../service/workflow-snippet/workflow-snippet.service";
+import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
+import { ReusableSectionInsertionService } from "../../../service/workflow-snippet/reusable-section-insertion.service";
+import { ReusableSectionDetailComponent } from "./reusable-section-detail.component";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-my-snippets",
+  templateUrl: "./my-snippets.component.html",
+  styleUrls: ["./my-snippets.component.scss"],
+  imports: [NgFor, NgIf, NzButtonComponent, NzModalModule],
+})
+export class MySnippetsComponent {
+  public snippets: readonly WorkflowSnippet[] = [];
+  public canModify = true;
+
+  constructor(
+    private readonly snippetService: WorkflowSnippetService,
+    private readonly workflowActionService: WorkflowActionService,
+    private readonly insertion: ReusableSectionInsertionService,
+    private readonly modalService: NzModalService
+  ) {
+    this.snippetService.snippets$.pipe(untilDestroyed(this)).subscribe(snippets => (this.snippets = snippets));
+    this.workflowActionService
+      .getWorkflowModificationEnabledStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(canModify => (this.canModify = canModify));
+  }
+
+  public insert(snippet: WorkflowSnippet): void {
+    this.insertion.insert(snippet);
+  }
+
+  public open(snippet: WorkflowSnippet): void {
+    this.modalService.create({
+      nzTitle: snippet.name,
+      nzContent: ReusableSectionDetailComponent,
+      nzData: { reusableSectionID: snippet.id },
+      nzFooter: null,
+    });
+  }
+}

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.html
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.html
@@ -1,0 +1,78 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<section class="reusable-section-detail">
+  <div>
+    <span class="field-label">Description</span>
+    <p>{{ section.description || "No description" }}</p>
+  </div>
+  <div>
+    <span class="field-label">Preview</span>
+    <div
+      class="preview-frame"
+      [style.border-color]="section.fragment.sectionBox?.color">
+      <svg
+        class="reusable-section-preview"
+        [attr.viewBox]="viewBox"
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        [attr.aria-label]="'Preview of ' + section.name">
+        <line
+          *ngFor="let link of links"
+          [attr.x1]="link.x1"
+          [attr.y1]="link.y1"
+          [attr.x2]="link.x2"
+          [attr.y2]="link.y2"
+          class="preview-link"></line>
+        <g
+          *ngFor="let node of nodes"
+          [attr.transform]="'translate(' + node.x + ' ' + node.y + ')'">
+          <rect
+            width="100"
+            height="42"
+            rx="5"
+            class="preview-node"></rect>
+          <text
+            x="50"
+            y="25"
+            text-anchor="middle"
+            class="preview-label">
+            {{ node.label }}
+          </text>
+        </g>
+      </svg>
+    </div>
+  </div>
+  <div class="detail-actions">
+    <button
+      nz-button
+      nzDanger
+      type="button"
+      (click)="delete()">
+      Delete
+    </button>
+    <button
+      nz-button
+      nzType="primary"
+      type="button"
+      (click)="insert()">
+      Insert into workflow
+    </button>
+  </div>
+</section>

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.scss
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.scss
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.reusable-section-detail {
+  display: grid;
+  gap: 18px;
+}
+
+.field-label {
+  color: #8c8c8c;
+  display: block;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.preview-frame {
+  background: #fafafa;
+  border: 2px solid;
+  border-radius: 6px;
+  height: 220px;
+  overflow: hidden;
+  padding: 12px;
+}
+
+.reusable-section-preview {
+  height: 100%;
+  width: 100%;
+}
+
+.preview-link {
+  stroke: #8c8c8c;
+  stroke-width: 2;
+}
+
+.preview-node {
+  fill: #fff;
+  stroke: #595959;
+  stroke-width: 1.5;
+}
+
+.preview-label {
+  fill: #262626;
+  font-size: 10px;
+  pointer-events: none;
+}
+
+.detail-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.spec.ts
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
+import { WorkflowSnippetService } from "../../../service/workflow-snippet/workflow-snippet.service";
+import { WorkflowSnippet } from "../../../types/workflow-snippet.interface";
+import { ReusableSectionDetailComponent } from "./reusable-section-detail.component";
+
+describe("ReusableSectionDetailComponent", () => {
+  let fixture: ComponentFixture<ReusableSectionDetailComponent>;
+  const section = {
+    id: "section-1",
+    name: "Clean text",
+    description: "Normalize input text",
+    fragment: {
+      operators: [
+        { operatorID: "op-1", operatorType: "PythonUDF" },
+        { operatorID: "op-2", operatorType: "Filter" },
+        { operatorID: "op-3", operatorType: "Projection" },
+        { operatorID: "op-4", operatorType: "Sort" },
+      ],
+      operatorPositions: {
+        "op-1": { x: 40, y: 50 },
+        "op-2": { x: 160, y: 50 },
+        "op-3": { x: 520, y: 50 },
+        "op-4": { x: 520, y: 50 },
+      },
+      links: [
+        { linkID: "link-1", source: { operatorID: "op-1" }, target: { operatorID: "op-2" } },
+        { linkID: "link-2", source: { operatorID: "op-2" }, target: { operatorID: "op-3" } },
+        { linkID: "link-3", source: { operatorID: "op-3" }, target: { operatorID: "op-4" } },
+      ],
+      sectionBox: { name: "Clean text", color: "#1677ff", width: 700, height: 180 },
+    },
+  } as unknown as WorkflowSnippet;
+  const service = { getSnippets: vi.fn(() => [section]), insert: vi.fn(), delete: vi.fn() };
+  const modalRef = { close: vi.fn() };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await TestBed.configureTestingModule({
+      imports: [ReusableSectionDetailComponent],
+      providers: [
+        { provide: NZ_MODAL_DATA, useValue: { reusableSectionID: "section-1" } },
+        { provide: NzModalRef, useValue: modalRef },
+        { provide: WorkflowSnippetService, useValue: service },
+        {
+          provide: WorkflowActionService,
+          useValue: { getJointGraphWrapper: () => ({ getMainJointPaper: () => undefined }) },
+        },
+        { provide: NotificationService, useValue: { success: vi.fn(), error: vi.fn() } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(ReusableSectionDetailComponent);
+    fixture.detectChanges();
+  });
+
+  it("shows only the requested details and a graph preview", () => {
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.textContent).toContain("Normalize input text");
+    expect(Array.from(element.querySelectorAll(".field-label")).map(label => label.textContent?.trim())).toEqual([
+      "Description",
+      "Preview",
+    ]);
+    expect(element.querySelector("svg.reusable-section-preview")).not.toBeNull();
+    expect(element.textContent).toContain("Insert into workflow");
+    expect(element.textContent).toContain("Delete");
+  });
+
+  it("compacts distant operators so preview connections stay short", () => {
+    expect(fixture.componentInstance.links).toHaveLength(3);
+    expect(fixture.componentInstance.links.every(link => Math.abs(link.x2 - link.x1) < 250)).toBe(true);
+  });
+
+  it("keeps compacted operators from overlapping", () => {
+    const nodes = fixture.componentInstance.nodes;
+    nodes.forEach((node, index) => {
+      nodes.slice(index + 1).forEach(other => {
+        const separatedHorizontally = node.x + 100 <= other.x || other.x + 100 <= node.x;
+        const separatedVertically = node.y + 42 <= other.y || other.y + 42 <= node.y;
+        expect(separatedHorizontally || separatedVertically).toBe(true);
+      });
+    });
+  });
+
+  it("fits the view box around every laid-out operator", () => {
+    const [x, y, width, height] = fixture.componentInstance.viewBox.split(" ").map(Number);
+    fixture.componentInstance.nodes.forEach(node => {
+      expect(node.x).toBeGreaterThan(x);
+      expect(node.y).toBeGreaterThan(y);
+      expect(node.x + 100).toBeLessThan(x + width);
+      expect(node.y + 42).toBeLessThan(y + height);
+    });
+  });
+
+  it("inserts the section and closes only after insertion succeeds", () => {
+    fixture.componentInstance.insert();
+    expect(service.insert).toHaveBeenCalledWith("section-1", { x: 400, y: 200 });
+    expect(modalRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps the preview open and reports an insertion failure", () => {
+    service.insert.mockImplementationOnce(() => {
+      throw new Error("Workflow is read-only.");
+    });
+    fixture.componentInstance.insert();
+    expect(modalRef.close).not.toHaveBeenCalled();
+    expect(TestBed.inject(NotificationService).error).toHaveBeenCalledWith("Workflow is read-only.");
+  });
+
+  it("deletes the library definition and closes", () => {
+    fixture.componentInstance.delete();
+    expect(service.delete).toHaveBeenCalledWith("section-1");
+    expect(modalRef.close).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.ts
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.ts
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject } from "@angular/core";
+import { NgFor } from "@angular/common";
+import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { ReusableSectionInsertionService } from "../../../service/workflow-snippet/reusable-section-insertion.service";
+import { WorkflowSnippetService } from "../../../service/workflow-snippet/workflow-snippet.service";
+import { WorkflowSnippet } from "../../../types/workflow-snippet.interface";
+
+import { buildSectionPreview, PreviewNode, PreviewLink } from "./reusable-section-preview";
+
+@Component({
+  selector: "texera-reusable-section-detail",
+  imports: [NgFor, NzButtonComponent],
+  templateUrl: "./reusable-section-detail.component.html",
+  styleUrls: ["./reusable-section-detail.component.scss"],
+})
+export class ReusableSectionDetailComponent {
+  private readonly data = inject(NZ_MODAL_DATA) as { reusableSectionID: string };
+  private readonly service = inject(WorkflowSnippetService);
+  private readonly insertion = inject(ReusableSectionInsertionService);
+  private readonly modal = inject(NzModalRef);
+
+  readonly section: WorkflowSnippet;
+  readonly nodes: readonly PreviewNode[];
+  readonly links: readonly PreviewLink[];
+  readonly viewBox: string;
+
+  constructor() {
+    const section = this.service.getSnippets().find(item => item.id === this.data.reusableSectionID);
+    if (!section) throw new Error("The selected reusable section no longer exists.");
+    this.section = section;
+    const preview = buildSectionPreview(section.fragment);
+    this.nodes = preview.nodes;
+    this.links = preview.links;
+    this.viewBox = preview.viewBox;
+  }
+
+  insert(): void {
+    if (this.insertion.insert(this.section)) this.modal.close(true);
+  }
+
+  delete(): void {
+    this.service.delete(this.section.id);
+    this.modal.close(true);
+  }
+}

--- a/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-preview.ts
+++ b/frontend/src/app/workspace/component/left-panel/my-snippets/reusable-section-preview.ts
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { WorkflowFragment } from "../../../types/workflow-fragment.interface";
+
+export interface PreviewNode {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+}
+
+export interface PreviewLink {
+  id: string;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+}
+
+const NODE_WIDTH = 100;
+const NODE_HEIGHT = 42;
+const NODE_GAP = 12;
+const VIEWBOX_PADDING = 24;
+const POSITION_SCALE = 0.5;
+const MAX_POSITION_SCALE = 1;
+
+/** Pure thumbnail layout; never mutates saved workflow positions. */
+export function buildSectionPreview(fragment: WorkflowFragment): {
+  nodes: PreviewNode[];
+  links: PreviewLink[];
+  viewBox: string;
+} {
+  const rawNodes = fragment.operators.map(operator => {
+    const position = fragment.operatorPositions[operator.operatorID];
+    return {
+      id: operator.operatorID,
+      label: operator.operatorType.split(".").pop() ?? operator.operatorType,
+      x: position.x,
+      y: position.y,
+    };
+  });
+  const nodes = compactNodes(rawNodes);
+  const viewBox = getContentViewBox(nodes);
+  const nodeByID = new Map(nodes.map(node => [node.id, node]));
+  const links = fragment.links.flatMap(link => {
+    const source = nodeByID.get(link.source.operatorID);
+    const target = nodeByID.get(link.target.operatorID);
+    if (!source || !target) return [];
+    return [
+      {
+        id: link.linkID,
+        x1: source.x + NODE_WIDTH,
+        y1: source.y + NODE_HEIGHT / 2,
+        x2: target.x,
+        y2: target.y + NODE_HEIGHT / 2,
+      },
+    ];
+  });
+  return { nodes, links, viewBox };
+}
+function compactNodes(nodes: readonly PreviewNode[]): PreviewNode[] {
+  let minimumScale = POSITION_SCALE;
+  for (let index = 0; index < nodes.length; index++) {
+    const node = nodes[index];
+    for (let otherIndex = index + 1; otherIndex < nodes.length; otherIndex++) {
+      const other = nodes[otherIndex];
+      const horizontalScale =
+        node.x === other.x ? Number.POSITIVE_INFINITY : (NODE_WIDTH + NODE_GAP) / Math.abs(node.x - other.x);
+      const verticalScale =
+        node.y === other.y ? Number.POSITIVE_INFINITY : (NODE_HEIGHT + NODE_GAP) / Math.abs(node.y - other.y);
+      const requiredScale = Math.min(horizontalScale, verticalScale);
+      if (Number.isFinite(requiredScale)) minimumScale = Math.max(minimumScale, requiredScale);
+    }
+  }
+
+  const positionScale = Math.min(minimumScale, MAX_POSITION_SCALE);
+  const compacted = nodes.map(node => ({
+    ...node,
+    x: node.x * positionScale,
+    y: node.y * positionScale,
+  }));
+
+  // Source layouts can contain overlapping operators. Uniform scaling cannot
+  // resolve those, so move each remaining collision past an earlier node.
+  compacted.forEach((node, index) => {
+    const earlierNodes = compacted.slice(0, index);
+    for (let pass = 0; pass <= earlierNodes.length; pass++) {
+      const other = earlierNodes.find(candidate => {
+        const overlapX = NODE_WIDTH + NODE_GAP - Math.abs(node.x - candidate.x);
+        const overlapY = NODE_HEIGHT + NODE_GAP - Math.abs(node.y - candidate.y);
+        return overlapX > 0 && overlapY > 0;
+      });
+      if (!other) break;
+      const overlapX = NODE_WIDTH + NODE_GAP - Math.abs(node.x - other.x);
+      const overlapY = NODE_HEIGHT + NODE_GAP - Math.abs(node.y - other.y);
+      if (overlapX <= overlapY) {
+        node.x = other.x + NODE_WIDTH + NODE_GAP;
+      } else {
+        node.y = other.y + NODE_HEIGHT + NODE_GAP;
+      }
+    }
+  });
+  return compacted;
+}
+
+function getContentViewBox(nodes: readonly PreviewNode[]): string {
+  const minX = Math.min(...nodes.map(node => node.x));
+  const minY = Math.min(...nodes.map(node => node.y));
+  const maxX = Math.max(...nodes.map(node => node.x + NODE_WIDTH));
+  const maxY = Math.max(...nodes.map(node => node.y + NODE_HEIGHT));
+  const padding = VIEWBOX_PADDING;
+  return `${minX - padding} ${minY - padding} ${maxX - minX + padding * 2} ${maxY - minY + padding * 2}`;
+}

--- a/frontend/src/app/workspace/component/menu/menu.component.html
+++ b/frontend/src/app/workspace/component/menu/menu.component.html
@@ -271,6 +271,7 @@
               nz-icon
               nzType="partition"></i>
           </button>
+          <texera-overbox-button [disabled]="!isWorkflowModifiable"></texera-overbox-button>
           <button
             (click)="onClickAddCommentBox()"
             [disabled]="!isWorkflowModifiable"

--- a/frontend/src/app/workspace/component/menu/menu.component.ts
+++ b/frontend/src/app/workspace/component/menu/menu.component.ts
@@ -70,6 +70,7 @@ import { NzPopoverDirective } from "ng-zorro-antd/popover";
 import { NzSwitchComponent } from "ng-zorro-antd/switch";
 import { NzBadgeComponent } from "ng-zorro-antd/badge";
 import { NzTooltipDirective } from "ng-zorro-antd/tooltip";
+import { OverboxButtonComponent } from "../overbox/overbox-button.component";
 import { JupyterPanelService } from "../../service/jupyter-panel/jupyter-panel.service";
 
 /**
@@ -93,6 +94,7 @@ import { JupyterPanelService } from "../../service/jupyter-panel/jupyter-panel.s
   templateUrl: "menu.component.html",
   styleUrls: ["menu.component.scss"],
   imports: [
+    OverboxButtonComponent,
     NgIf,
     NzSpaceCompactItemDirective,
     NzButtonComponent,

--- a/frontend/src/app/workspace/component/overbox/overbox-button.component.ts
+++ b/frontend/src/app/workspace/component/overbox/overbox-button.component.ts
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, Input, inject } from "@angular/core";
+import { NzButtonComponent, NzButtonSize } from "ng-zorro-antd/button";
+import { NzIconDirective } from "ng-zorro-antd/icon";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { OverboxDialogComponent } from "./overbox-dialog.component";
+
+@Component({
+  selector: "texera-overbox-button",
+  imports: [NzButtonComponent, NzIconDirective],
+  template: `<button
+    nz-button
+    [nzSize]="size"
+    [disabled]="disabled"
+    (click)="create()"
+    title="create a section box">
+    <span
+      nz-icon
+      nzType="border"></span>
+  </button>`,
+  styles: [
+    `
+      :host {
+        display: inline-flex;
+      }
+      button {
+        align-items: center;
+        display: inline-flex;
+        justify-content: center;
+        padding: 0;
+        width: 32px;
+      }
+    `,
+  ],
+})
+export class OverboxButtonComponent {
+  @Input() disabled = false;
+  @Input() size: NzButtonSize = "default";
+  private readonly actions = inject(WorkflowActionService);
+  private readonly modal = inject(NzModalService);
+  create(): void {
+    if (this.disabled || !this.actions.checkWorkflowModificationEnabled()) return;
+    this.modal.create({
+      nzTitle: "Create section box",
+      nzContent: OverboxDialogComponent,
+      nzData: { operatorIDs: [...this.actions.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()] },
+      nzFooter: null,
+    });
+  }
+}

--- a/frontend/src/app/workspace/component/overbox/overbox-dialog.component.html
+++ b/frontend/src/app/workspace/component/overbox/overbox-dialog.component.html
@@ -1,0 +1,89 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<form
+  nz-form
+  nzLayout="vertical"
+  (ngSubmit)="save()">
+  <p class="description">Use a labeled section to explain and organize part of the workflow for collaborators.</p>
+
+  <nz-form-item>
+    <nz-form-label
+      nzFor="overbox-name"
+      nzRequired
+      >Section name</nz-form-label
+    >
+    <nz-form-control>
+      <input
+        nz-input
+        id="overbox-name"
+        name="overbox-name"
+        [(ngModel)]="name"
+        maxlength="100"
+        autocomplete="off" />
+      <span class="character-count">{{ name.length }}/100</span>
+    </nz-form-control>
+  </nz-form-item>
+
+  <nz-form-item>
+    <nz-form-label nzFor="overbox-color">Color</nz-form-label>
+    <nz-form-control>
+      <div class="color-row">
+        <button
+          *ngFor="let option of colors"
+          type="button"
+          class="color-swatch"
+          [class.selected]="color === option"
+          [style.background]="option"
+          [attr.aria-label]="'Choose color ' + option"
+          (click)="color = option"></button>
+      </div>
+    </nz-form-control>
+  </nz-form-item>
+
+  <p
+    *ngIf="error"
+    class="error"
+    role="alert">
+    {{ error }}
+  </p>
+
+  <div class="dialog-actions">
+    <button
+      nz-button
+      type="button"
+      [disabled]="!name.trim()"
+      (click)="saveAsReusable()">
+      Save as reusable section
+    </button>
+    <button
+      nz-button
+      type="button"
+      (click)="modal.close()">
+      Cancel
+    </button>
+    <button
+      nz-button
+      nzType="primary"
+      type="submit"
+      [disabled]="!name.trim()">
+      Save section
+    </button>
+  </div>
+</form>

--- a/frontend/src/app/workspace/component/overbox/overbox-dialog.component.scss
+++ b/frontend/src/app/workspace/component/overbox/overbox-dialog.component.scss
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.description {
+  color: rgba(0, 0, 0, 0.45);
+  margin: 0 0 16px;
+}
+
+.character-count {
+  color: rgba(0, 0, 0, 0.45);
+  display: block;
+  font-size: 12px;
+  margin-top: 4px;
+  text-align: right;
+}
+
+.color-row {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.color-swatch {
+  border: 2px solid transparent;
+  border-radius: 50%;
+  cursor: pointer;
+  height: 28px;
+  padding: 0;
+  width: 28px;
+}
+
+.color-swatch:hover,
+.color-swatch.selected {
+  border-color: rgba(0, 0, 0, 0.65);
+  box-shadow: 0 0 0 2px #fff inset;
+}
+
+.error {
+  color: #cf1322;
+}
+
+.dialog-actions {
+  border-top: 1px solid #f0f0f0;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 20px;
+  padding-top: 16px;
+}

--- a/frontend/src/app/workspace/component/overbox/overbox-dialog.component.spec.ts
+++ b/frontend/src/app/workspace/component/overbox/overbox-dialog.component.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
+import { OverboxService } from "../../service/overbox/overbox.service";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { OverboxDialogComponent } from "./overbox-dialog.component";
+import { NzModalService } from "ng-zorro-antd/modal";
+
+describe("OverboxDialogComponent", () => {
+  let fixture: ComponentFixture<OverboxDialogComponent>;
+  const modalData: { id?: string } = {};
+  const modalService = { create: vi.fn() };
+
+  beforeEach(async () => {
+    delete modalData.id;
+    vi.clearAllMocks();
+    await TestBed.configureTestingModule({
+      imports: [OverboxDialogComponent, HttpClientTestingModule],
+      providers: [
+        ...commonTestProviders,
+        { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
+        { provide: NZ_MODAL_DATA, useValue: modalData },
+        { provide: NzModalRef, useValue: { close: vi.fn() } },
+        { provide: NzModalService, useValue: modalService },
+        { provide: OverboxService, useValue: { create: vi.fn(), update: vi.fn() } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(OverboxDialogComponent);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => fixture?.destroy());
+
+  it("offers the original fixed palette including yellow without a custom color input", () => {
+    const element = fixture.nativeElement as HTMLElement;
+    expect(element.querySelector('input[type="color"]')).toBeNull();
+    expect(element.querySelectorAll(".color-swatch")).toHaveLength(8);
+    const yellow = element.querySelector('[aria-label="Choose color #fadb14"]') as HTMLButtonElement;
+    yellow.click();
+    fixture.detectChanges();
+    expect(fixture.componentInstance.color).toBe("#fadb14");
+    expect(element.textContent).toContain("Save section");
+  });
+
+  it("keeps saving disabled until a section name is provided", () => {
+    const nameInput = fixture.nativeElement.querySelector("#overbox-name") as HTMLInputElement;
+    expect(nameInput.placeholder).toBe("");
+    expect(fixture.nativeElement.textContent).not.toContain("After saving");
+    const save = fixture.nativeElement.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(save.disabled).toBe(true);
+    fixture.componentInstance.name = "Preparation";
+    fixture.detectChanges();
+    expect(save.disabled).toBe(false);
+  });
+
+  it("offers saving an existing section box as a reusable section", () => {
+    const actions = TestBed.inject(WorkflowActionService);
+    actions.addCommentBox({
+      commentBoxID: "commentBox-existing",
+      comments: [],
+      commentBoxPosition: { x: 20, y: 20 },
+      overbox: { name: "Preparation", color: "#1677ff", width: 300, height: 180 },
+    });
+    modalData.id = "commentBox-existing";
+    fixture.destroy();
+    fixture = TestBed.createComponent(OverboxDialogComponent);
+    fixture.detectChanges();
+    const reusableButton = Array.from<HTMLButtonElement>(fixture.nativeElement.querySelectorAll("button")).find(
+      button => button.textContent.includes("Save as reusable section")
+    )!;
+    reusableButton.click();
+
+    expect(modalService.create).toHaveBeenCalledWith(expect.objectContaining({ nzTitle: "Preparation" }));
+  });
+});

--- a/frontend/src/app/workspace/component/overbox/overbox-dialog.component.ts
+++ b/frontend/src/app/workspace/component/overbox/overbox-dialog.component.ts
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject } from "@angular/core";
+import { NgFor, NgIf } from "@angular/common";
+import { FormsModule } from "@angular/forms";
+import { NZ_MODAL_DATA, NzModalRef, NzModalService } from "ng-zorro-antd/modal";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzInputDirective } from "ng-zorro-antd/input";
+import { NzFormControlComponent, NzFormDirective, NzFormItemComponent, NzFormLabelComponent } from "ng-zorro-antd/form";
+import { OverboxService } from "../../service/overbox/overbox.service";
+import { normalizeOverboxColor, OVERBOX_COLORS } from "../../service/overbox/overbox-colors";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { CreateSnippetModalComponent } from "../workflow-editor/create-snippet-modal/create-snippet-modal.component";
+
+@Component({
+  selector: "texera-overbox-dialog",
+  imports: [
+    FormsModule,
+    NgFor,
+    NgIf,
+    NzButtonComponent,
+    NzInputDirective,
+    NzFormControlComponent,
+    NzFormDirective,
+    NzFormItemComponent,
+    NzFormLabelComponent,
+  ],
+  templateUrl: "overbox-dialog.component.html",
+  styleUrls: ["overbox-dialog.component.scss"],
+})
+export class OverboxDialogComponent {
+  readonly data = inject(NZ_MODAL_DATA) as { id?: string; operatorIDs?: readonly string[] };
+  readonly modal = inject(NzModalRef);
+  private readonly service = inject(OverboxService);
+  private readonly actions = inject(WorkflowActionService);
+  private readonly modalService = inject(NzModalService);
+  name = "";
+  color = "#1677ff";
+  error = "";
+  readonly colors = OVERBOX_COLORS;
+  constructor() {
+    const frame = this.data.id ? this.actions.getTexeraGraph().getCommentBox(this.data.id).overbox : undefined;
+    if (frame) {
+      this.name = frame.name;
+      this.color = normalizeOverboxColor(frame.color);
+    }
+  }
+  save(): void {
+    try {
+      this.persistSection();
+      this.modal.close(true);
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : "Unable to save section.";
+    }
+  }
+
+  private persistSection(): string {
+    if (this.data.id) {
+      this.service.update(this.data.id, this.name, this.color);
+      return this.data.id;
+    }
+    return this.service.create(this.name, this.color, this.data.operatorIDs ?? []);
+  }
+
+  saveAsReusable(): void {
+    try {
+      const sectionBoxID = this.persistSection();
+      const name = this.name.trim();
+      this.modal.close(true);
+      this.modalService.create({
+        nzTitle: name,
+        nzContent: CreateSnippetModalComponent,
+        nzData: { sectionBoxID, name },
+        nzFooter: null,
+      });
+    } catch (error) {
+      this.error = error instanceof Error ? error.message : "Unable to save section.";
+    }
+  }
+}

--- a/frontend/src/app/workspace/component/overbox/overbox-interaction.component.spec.ts
+++ b/frontend/src/app/workspace/component/overbox/overbox-interaction.component.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import * as joint from "jointjs";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
+import { OverboxService } from "../../service/overbox/overbox.service";
+import { mockScanPredicate } from "../../service/workflow-graph/model/mock-workflow-data";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { OverboxInteractionComponent } from "./overbox-interaction.component";
+
+describe("OverboxInteractionComponent", () => {
+  let fixture: ComponentFixture<OverboxInteractionComponent>;
+  let actions: WorkflowActionService;
+  let overboxes: OverboxService;
+  let paper: joint.dia.Paper;
+  let surface: HTMLDivElement;
+  let overboxID: string;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OverboxInteractionComponent, HttpClientTestingModule],
+      providers: [...commonTestProviders, { provide: OperatorMetadataService, useClass: StubOperatorMetadataService }],
+    }).compileComponents();
+    actions = TestBed.inject(WorkflowActionService);
+    overboxes = TestBed.inject(OverboxService);
+    surface = document.createElement("div");
+    document.body.appendChild(surface);
+    paper = actions.getJointGraphWrapper().attachMainJointPaper({ el: surface, width: 800, height: 600 });
+    vi.spyOn(paper, "clientToLocalPoint").mockImplementation(point => point as joint.g.Point);
+    actions.addOperator(mockScanPredicate, { x: 100, y: 100 });
+    overboxID = overboxes.create("Input", "#6f8fb7", [mockScanPredicate.operatorID]);
+    fixture = TestBed.createComponent(OverboxInteractionComponent);
+    fixture.componentRef.setInput("paper", paper);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture?.destroy();
+    paper?.remove();
+    surface?.remove();
+  });
+
+  it("shows only the resize tool when a section is clicked", () => {
+    const sectionView = paper.findViewByModel(overboxID);
+    paper.trigger("element:pointerdown", sectionView);
+    expect(sectionView.hasTools("overbox-tools")).toBe(true);
+    const tools = (sectionView as any)._toolsView.tools as joint.dia.ToolView[];
+    expect(tools).toHaveLength(1);
+    expect(tools[0]).toBeInstanceOf(joint.elementTools.Control);
+  });
+
+  it("keeps the title centered above the section and disables tools in read-only mode", () => {
+    const section = actions.getJointGraph().getCell(overboxID) as joint.dia.Element;
+    const sectionView = paper.findViewByModel(overboxID);
+    expect(section.attr("label/refX")).toBeUndefined();
+    expect(section.attr("label/refY")).toBeUndefined();
+    expect(section.attr("label/x")).toBe(section.size().width / 2);
+    expect(section.attr("label/y")).toBe(-10);
+    expect(section.attr("label/textAnchor")).toBe("middle");
+
+    fixture.componentRef.setInput("disabled", true);
+    fixture.detectChanges();
+    sectionView.removeTools();
+    paper.trigger("element:pointerdown", sectionView);
+    expect(sectionView.hasTools("overbox-tools")).toBe(false);
+  });
+});

--- a/frontend/src/app/workspace/component/overbox/overbox-interaction.component.ts
+++ b/frontend/src/app/workspace/component/overbox/overbox-interaction.component.ts
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { AfterViewInit, Component, Input, OnDestroy, inject } from "@angular/core";
+import * as joint from "jointjs";
+import { createOverboxResizeTool } from "../../service/overbox/overbox-resize-tool";
+import { OverboxService } from "../../service/overbox/overbox.service";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+
+/** Owns section-only pointer behavior so the generic workflow editor remains unaware of its geometry. */
+@Component({ selector: "texera-overbox-interaction", template: "" })
+export class OverboxInteractionComponent implements AfterViewInit, OnDestroy {
+  @Input({ required: true }) paper!: joint.dia.Paper;
+  @Input() disabled = false;
+  private readonly actions = inject(WorkflowActionService);
+  private readonly overboxes = inject(OverboxService);
+
+  ngAfterViewInit(): void {
+    this.paper.on("element:pointerdown", this.elementPointerDown);
+    this.paper.on("blank:pointerdown", this.blankPointerDown);
+  }
+
+  ngOnDestroy(): void {
+    this.paper.off("element:pointerdown", this.elementPointerDown);
+    this.paper.off("blank:pointerdown", this.blankPointerDown);
+  }
+
+  private elementPointerDown = (view: joint.dia.ElementView): void => {
+    const id = view.model.id.toString();
+    if (!this.disabled && this.isOverbox(id)) this.showTools(view, id);
+  };
+
+  private blankPointerDown = (): void => this.removeTools();
+
+  private showTools(view: joint.dia.ElementView, id: string): void {
+    this.removeTools();
+    view.addTools(
+      new joint.dia.ToolsView({
+        name: "overbox-tools",
+        tools: [
+          createOverboxResizeTool((width, height) => {
+            if (this.canModify()) this.overboxes.resize(id, width, height);
+          }),
+        ],
+      })
+    );
+  }
+
+  private isOverbox(id: string): boolean {
+    const graph = this.actions.getTexeraGraph();
+    return graph.hasCommentBox(id) && graph.getCommentBox(id).overbox !== undefined;
+  }
+
+  private canModify(): boolean {
+    return !this.disabled && this.actions.checkWorkflowModificationEnabled();
+  }
+
+  private removeTools(): void {
+    const graph = this.actions.getTexeraGraph();
+    graph
+      .getAllCommentBoxes()
+      .filter(box => box.overbox)
+      .forEach(box => this.paper.findViewByModel(box.commentBoxID)?.removeTools());
+  }
+}

--- a/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.html
+++ b/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.html
@@ -1,0 +1,43 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
+<div class="snippet-form">
+  <label for="snippet-description">Description</label>
+  <textarea
+    id="snippet-description"
+    nz-input
+    nzAutosize
+    maxlength="240"
+    placeholder="What does this reusable section do?"
+    [(ngModel)]="description"></textarea>
+
+  <div class="snippet-actions">
+    <button
+      nz-button
+      (click)="cancel()">
+      Cancel
+    </button>
+    <button
+      nz-button
+      nzType="primary"
+      (click)="save()">
+      Save section
+    </button>
+  </div>
+</div>

--- a/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.scss
+++ b/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.scss
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+.snippet-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.snippet-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}

--- a/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.spec.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WorkflowSnippetService } from "../../../service/workflow-snippet/workflow-snippet.service";
+import { CreateSnippetModalComponent } from "./create-snippet-modal.component";
+
+describe("CreateSnippetModalComponent", () => {
+  let fixture: ComponentFixture<CreateSnippetModalComponent>;
+  let component: CreateSnippetModalComponent;
+  const modalRef = { close: vi.fn() };
+  const snippetService = { createFromSectionBox: vi.fn() };
+  const notificationService = { success: vi.fn(), error: vi.fn() };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    await TestBed.configureTestingModule({
+      imports: [CreateSnippetModalComponent],
+      providers: [
+        { provide: NZ_MODAL_DATA, useValue: { sectionBoxID: "commentBox-section", name: "Clean text" } },
+        { provide: NzModalRef, useValue: modalRef },
+        { provide: WorkflowSnippetService, useValue: snippetService },
+        { provide: NotificationService, useValue: notificationService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CreateSnippetModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it("creates a reusable section from the section box and closes", () => {
+    expect(fixture.nativeElement.textContent).not.toContain("Name");
+    expect(fixture.nativeElement.textContent).toContain("Description");
+    component.description = "Reusable cleaning";
+    component.save();
+
+    expect(snippetService.createFromSectionBox).toHaveBeenCalledWith("commentBox-section", "Reusable cleaning");
+    expect(notificationService.success).toHaveBeenCalledWith('Reusable section box "Clean text" saved.');
+    expect(modalRef.close).toHaveBeenCalledWith(true);
+  });
+
+  it("stays open and reports a storage error", () => {
+    snippetService.createFromSectionBox.mockImplementationOnce(() => {
+      throw new Error("Storage is full.");
+    });
+
+    component.save();
+
+    expect(notificationService.error).toHaveBeenCalledWith("Storage is full.");
+    expect(modalRef.close).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.ts
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, inject } from "@angular/core";
+import { FormsModule } from "@angular/forms";
+import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
+import { NzButtonComponent } from "ng-zorro-antd/button";
+import { NzInputDirective, NzAutosizeDirective } from "ng-zorro-antd/input";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WorkflowSnippetService } from "../../../service/workflow-snippet/workflow-snippet.service";
+
+export interface CreateSnippetModalData {
+  sectionBoxID: string;
+  name: string;
+}
+
+@Component({
+  selector: "texera-create-snippet-modal",
+  templateUrl: "./create-snippet-modal.component.html",
+  styleUrls: ["./create-snippet-modal.component.scss"],
+  imports: [FormsModule, NzButtonComponent, NzInputDirective, NzAutosizeDirective],
+})
+export class CreateSnippetModalComponent {
+  public description = "";
+  public readonly data: CreateSnippetModalData = inject(NZ_MODAL_DATA);
+
+  constructor(
+    private readonly modalRef: NzModalRef,
+    private readonly snippetService: WorkflowSnippetService,
+    private readonly notificationService: NotificationService
+  ) {}
+
+  public save(): void {
+    try {
+      this.snippetService.createFromSectionBox(this.data.sectionBoxID, this.description);
+      this.notificationService.success(`Reusable section box "${this.data.name}" saved.`);
+      this.modalRef.close(true);
+    } catch (error) {
+      this.notificationService.error(error instanceof Error ? error.message : "Unable to save the reusable section.");
+    }
+  }
+
+  public cancel(): void {
+    this.modalRef.close(false);
+  }
+}

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.html
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.html
@@ -21,6 +21,15 @@
   <div
     id="workflow-editor"
     (contextmenu)="nzContextMenu.create($event, menu)"></div>
+  <texera-canvas-selection
+    *ngIf="paper"
+    [paper]="paper"
+    [disabled]="structureLocked"
+    (contextRequested)="nzContextMenu.create($event, menu)"></texera-canvas-selection>
+  <texera-overbox-interaction
+    *ngIf="paper"
+    [paper]="paper"
+    [disabled]="structureLocked"></texera-overbox-interaction>
   <texera-heatmap-legend></texera-heatmap-legend>
   <div
     class="heatmap-tooltip"

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -1208,6 +1208,32 @@ describe("WorkflowEditorComponent", () => {
         document.dispatchEvent(new MouseEvent("mouseup"));
       });
 
+      it("preserves a multi-selection when dragging one of its selected operators", () => {
+        const wrapper = workflowActionService.getJointGraphWrapper();
+        workflowActionService.addOperatorsAndLinks(
+          [
+            { op: mockScanPredicate, pos: { x: 100, y: 100 } },
+            { op: mockResultPredicate, pos: { x: 300, y: 100 } },
+          ],
+          []
+        );
+        workflowActionService.highlightElements(true, mockScanPredicate.operatorID, mockResultPredicate.operatorID);
+        const scanView = component.paper.findViewByModel(mockScanPredicate.operatorID);
+        const resultBefore = wrapper.getElementPosition(mockResultPredicate.operatorID);
+
+        (component.paper as any).trigger("cell:pointerdown", scanView, { shiftKey: false });
+        wrapper.setElementPosition(mockScanPredicate.operatorID, 40, 25);
+
+        expect(wrapper.getCurrentHighlightedOperatorIDs()).toEqual([
+          mockScanPredicate.operatorID,
+          mockResultPredicate.operatorID,
+        ]);
+        expect(wrapper.getElementPosition(mockResultPredicate.operatorID)).toEqual({
+          x: resultBefore.x + 40,
+          y: resultBefore.y + 25,
+        });
+      });
+
       it("opens the comment box modal on a comment box double-click", () => {
         const nzModalService = TestBed.inject(NzModalService);
         const createSpy = vi.spyOn(nzModalService, "create").mockReturnValue({ afterClose: of(undefined) } as any);

--- a/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/frontend/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -56,6 +56,9 @@ import { ContextMenuComponent } from "./context-menu/context-menu/context-menu.c
 import { NgIf } from "@angular/common";
 import { AgentInteractionComponent } from "../agent/agent-interaction/agent-interaction.component";
 import { HeatmapLegendComponent } from "../heatmap-legend/heatmap-legend.component";
+import { CanvasSelectionComponent } from "../canvas-selection/canvas-selection.component";
+import { OverboxDialogComponent } from "../overbox/overbox-dialog.component";
+import { OverboxInteractionComponent } from "../overbox/overbox-interaction.component";
 import { JupyterPanelService } from "../../service/jupyter-panel/jupyter-panel.service";
 
 // jointjs interactive options for enabling and disabling interactivity
@@ -104,6 +107,8 @@ export const MAIN_CANVAS = {
     NgIf,
     AgentInteractionComponent,
     HeatmapLegendComponent,
+    CanvasSelectionComponent,
+    OverboxInteractionComponent,
   ],
 })
 export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy {
@@ -946,8 +951,12 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
             .map(link => link.linkID);
           this.workflowActionService.highlightLinks(<boolean>event[1].shiftKey, ...linksToBeHighlighted);
         } else {
-          // else only highlight a single operator or group
-          if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
+          const selectedElementIDs = [...highlightedOperatorIDs, ...highlightedCommentBoxIDs];
+          // Keep an existing multi-selection intact when a selected element starts a drag.
+          // Clicking an unselected element still replaces the selection as before.
+          if (selectedElementIDs.length > 1 && selectedElementIDs.includes(elementID)) {
+            this.wrapper.setMultiSelectMode(true);
+          } else if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
             this.workflowActionService.highlightOperators(<boolean>event[1].shiftKey, elementID);
           } else if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.wrapper.highlightCommentBoxes(elementID);
@@ -1041,6 +1050,16 @@ export class WorkflowEditorComponent implements OnInit, AfterViewInit, OnDestroy
 
   private openCommentBox(commentBoxID: string): void {
     const commentBox = this.workflowActionService.getTexeraGraph().getSharedCommentBoxType(commentBoxID);
+    if (commentBox.has("overbox")) {
+      if (this.interactive)
+        this.nzModalService.create({
+          nzTitle: "Edit section box",
+          nzContent: OverboxDialogComponent,
+          nzData: { id: commentBoxID },
+          nzFooter: null,
+        });
+      return;
+    }
     const modalRef: NzModalRef = this.nzModalService.create({
       // modal title
       nzTitle: "Comments",

--- a/frontend/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/frontend/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -18,6 +18,7 @@
  */
 
 import { Injectable } from "@angular/core";
+import { renderOverbox } from "../overbox/overbox-renderer";
 import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
 import { OperatorSchema } from "../../types/operator-schema.interface";
 import { CommentBox, OperatorLink, OperatorPredicate, Point } from "../../types/workflow-common.interface";
@@ -580,6 +581,14 @@ export class JointUIService {
   }
 
   public getCommentElement(commentBox: CommentBox): joint.dia.Element {
+    if (commentBox.overbox) {
+      const frame = new joint.shapes.standard.Rectangle({
+        id: commentBox.commentBoxID,
+        position: commentBox.commentBoxPosition,
+      });
+      renderOverbox(frame, commentBox);
+      return frame;
+    }
     const basic = new joint.shapes.standard.Rectangle();
     if (commentBox.commentBoxPosition) basic.position(commentBox.commentBoxPosition.x, commentBox.commentBoxPosition.y);
     else basic.position(0, 0);

--- a/frontend/src/app/workspace/service/operator-menu/operator-menu.service.ts
+++ b/frontend/src/app/workspace/service/operator-menu/operator-menu.service.ts
@@ -373,6 +373,7 @@ export class OperatorMenuService {
           positions.push(newCommentBoxPosition);
           const newCommentBoxID = this.workflowUtilService.getCommentBoxRandomUUID();
           const newCommentBox: CommentBox = {
+            ...commentBoxCopy,
             commentBoxID: newCommentBoxID,
             comments: commentBoxCopy.comments,
             commentBoxPosition: newCommentBoxPosition,

--- a/frontend/src/app/workspace/service/overbox/overbox-colors.spec.ts
+++ b/frontend/src/app/workspace/service/overbox/overbox-colors.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { normalizeOverboxColor, OVERBOX_COLORS } from "./overbox-colors";
+
+describe("overbox colors", () => {
+  it("restores muted saved colors and retains the fixed original palette", () => {
+    expect(normalizeOverboxColor("#6f8fb7")).toBe("#1677ff");
+    expect(normalizeOverboxColor("#AD9B55")).toBe("#fadb14");
+    expect(OVERBOX_COLORS).toContain("#fadb14");
+  });
+});

--- a/frontend/src/app/workspace/service/overbox/overbox-colors.ts
+++ b/frontend/src/app/workspace/service/overbox/overbox-colors.ts
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export const OVERBOX_COLORS = [
+  "#1677ff",
+  "#722ed1",
+  "#13a8a8",
+  "#52c41a",
+  "#fa8c16",
+  "#eb2f96",
+  "#f5222d",
+  "#fadb14",
+] as const;
+
+const REPLACED_MUTED_COLORS = new Map<string, string>([
+  ["#6f8fb7", "#1677ff"],
+  ["#8877a5", "#722ed1"],
+  ["#6d9995", "#13a8a8"],
+  ["#7e9b77", "#52c41a"],
+  ["#b18d69", "#fa8c16"],
+  ["#a87c91", "#eb2f96"],
+  ["#aa7474", "#f5222d"],
+  ["#ad9b55", "#fadb14"],
+]);
+
+/** Keeps sections saved during the short-lived muted palette visually compatible. */
+export function normalizeOverboxColor(color: string): string {
+  const normalized = color.toLowerCase();
+  return REPLACED_MUTED_COLORS.get(normalized) ?? (/^#[0-9a-f]{6}$/i.test(color) ? color : OVERBOX_COLORS[0]);
+}

--- a/frontend/src/app/workspace/service/overbox/overbox-renderer.ts
+++ b/frontend/src/app/workspace/service/overbox/overbox-renderer.ts
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as joint from "jointjs";
+import { CommentBox } from "../../types/workflow-common.interface";
+import { MIN_OVERBOX_HEIGHT, MIN_OVERBOX_WIDTH } from "./overbox-resize-tool";
+import { normalizeOverboxColor } from "./overbox-colors";
+
+function positionTitle(element: joint.dia.Element, width: number): void {
+  element.removeAttr("label/refX");
+  element.removeAttr("label/refY");
+  element.attr({
+    label: {
+      x: width / 2,
+      y: -10,
+      textAnchor: "middle",
+      textVerticalAnchor: "bottom",
+    },
+  });
+}
+
+/** Uses the existing annotation model, so frames share persistence, undo and collaboration. */
+export function renderOverbox(element: joint.dia.Element, box: CommentBox): void {
+  const frame = box.overbox;
+  if (!frame) return;
+  const color = normalizeOverboxColor(frame.color);
+  const width = Number.isFinite(frame.width) ? Math.max(MIN_OVERBOX_WIDTH, frame.width) : 400;
+  const height = Number.isFinite(frame.height) ? Math.max(MIN_OVERBOX_HEIGHT, frame.height) : 240;
+  element.resize(width, height);
+  element.set("z", -1);
+  element.attr({
+    body: {
+      class: "body",
+      fill: color,
+      fillOpacity: 0.12,
+      stroke: color,
+      strokeOpacity: 1,
+      strokeWidth: 3,
+      rx: 8,
+      ry: 8,
+      pointerEvents: "stroke",
+    },
+    label: {
+      class: "label overbox-title",
+      text: frame.name,
+      fill: color,
+      fillOpacity: 1,
+      fontSize: 16,
+      fontWeight: 600,
+      pointerEvents: "visiblePainted",
+    },
+  });
+  positionTitle(element, width);
+}

--- a/frontend/src/app/workspace/service/overbox/overbox-resize-tool.ts
+++ b/frontend/src/app/workspace/service/overbox/overbox-resize-tool.ts
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as joint from "jointjs";
+
+export const MIN_OVERBOX_WIDTH = 120;
+export const MIN_OVERBOX_HEIGHT = 80;
+
+/** A JointJS tool that previews resizing locally and persists only the final dimensions. */
+export function createOverboxResizeTool(onResizeEnd: (width: number, height: number) => void): joint.dia.ToolView {
+  return new (class extends joint.elementTools.Control {
+    private finalSize: { width: number; height: number } | undefined;
+
+    protected override getPosition(view: joint.dia.ElementView): joint.dia.Point {
+      const size = view.model.size();
+      return { x: size.width, y: size.height };
+    }
+
+    protected override setPosition(view: joint.dia.ElementView, coordinates: joint.g.Point): void {
+      this.finalSize = {
+        width: Math.max(MIN_OVERBOX_WIDTH, Math.round(coordinates.x)),
+        height: Math.max(MIN_OVERBOX_HEIGHT, Math.round(coordinates.y)),
+      };
+      view.model.resize(this.finalSize.width, this.finalSize.height);
+    }
+
+    protected override onPointerUp(event: joint.dia.Event): void {
+      super.onPointerUp(event);
+      if (this.finalSize) onResizeEnd(this.finalSize.width, this.finalSize.height);
+      this.finalSize = undefined;
+    }
+  })({
+    selector: "body",
+    handleAttributes: {
+      r: 7,
+      fill: "#ffffff",
+      stroke: "#1677ff",
+      strokeWidth: 2,
+      cursor: "nwse-resize",
+    },
+  });
+}

--- a/frontend/src/app/workspace/service/overbox/overbox.service.spec.ts
+++ b/frontend/src/app/workspace/service/overbox/overbox.service.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import * as joint from "jointjs";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { OverboxService } from "./overbox.service";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-metadata.service";
+import { mockScanPredicate, mockPoint } from "../workflow-graph/model/mock-workflow-data";
+
+describe("OverboxService", () => {
+  beforeEach(() =>
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [...commonTestProviders, { provide: OperatorMetadataService, useClass: StubOperatorMetadataService }],
+    })
+  );
+  it("stores named colored frames in workflow annotations and supports editing", () => {
+    const actions = TestBed.inject(WorkflowActionService);
+    const service = TestBed.inject(OverboxService);
+    actions.addOperator(mockScanPredicate, mockPoint);
+    const id = service.create("Limpieza ñ", "#1677ff", [mockScanPredicate.operatorID]);
+    const box = actions.getTexeraGraph().getCommentBox(id);
+    expect(box.overbox?.name).toBe("Limpieza ñ");
+    expect(box.overbox?.width).toBeGreaterThan(0);
+    expect(actions.getJointGraph().getCell(id).get("z")).toBe(-1);
+    service.update(id, "Transform", "#ff0000");
+    expect(actions.getTexeraGraph().getCommentBox(id).overbox?.color).toBe("#ff0000");
+    expect(actions.getJointGraph().getCell(id).attr("label/text")).toBe("Transform");
+    service.resize(id, 640.4, 360.6);
+    expect(actions.getTexeraGraph().getCommentBox(id).overbox).toEqual({
+      name: "Transform",
+      color: "#ff0000",
+      width: 640,
+      height: 361,
+    });
+    expect((actions.getJointGraph().getCell(id) as joint.dia.Element).size()).toEqual({ width: 640, height: 361 });
+    actions.highlightCommentBoxes(false, id);
+    actions
+      .getJointGraphWrapper()
+      .setElementPosition(id, 510 - box.commentBoxPosition.x, 320 - box.commentBoxPosition.y);
+    const saved = JSON.parse(JSON.stringify(actions.getWorkflowContent())).commentBoxes[0];
+    expect(saved.commentBoxPosition).toEqual({ x: 510, y: 320 });
+    actions.deleteCommentBox(id);
+    actions.addCommentBox(saved);
+    expect(actions.getJointGraph().getCell(id).attr("label/text")).toBe("Transform");
+    expect(actions.getTexeraGraph().getCommentBox(id).overbox).toEqual(saved.overbox);
+  });
+
+  it("rejects blank names, invalid colors and nonmodifiable workflows", () => {
+    const service = TestBed.inject(OverboxService);
+    expect(() => service.create(" ", "#1677ff", [])).toThrow();
+    expect(() => service.create("Name", "invalid", [])).toThrow();
+    expect(() => service.resize("missing", Number.NaN, 100)).toThrow("Section dimensions must be finite.");
+    const actions = TestBed.inject(WorkflowActionService);
+    actions.disableWorkflowModification();
+    expect(() => service.create("Name", "#1677ff", [])).toThrow("Workflow is read-only.");
+  });
+});

--- a/frontend/src/app/workspace/service/overbox/overbox.service.ts
+++ b/frontend/src/app/workspace/service/overbox/overbox.service.ts
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { YType } from "../../types/shared-editing.interface";
+import { CommentBox } from "../../types/workflow-common.interface";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { WorkflowUtilService } from "../workflow-graph/util/workflow-util.service";
+import { MIN_OVERBOX_HEIGHT, MIN_OVERBOX_WIDTH } from "./overbox-resize-tool";
+
+@Injectable({ providedIn: "root" })
+export class OverboxService {
+  constructor(
+    private actions: WorkflowActionService,
+    private util: WorkflowUtilService
+  ) {}
+  private validate(name: string, color: string): void {
+    if (!this.actions.checkWorkflowModificationEnabled()) throw new Error("Workflow is read-only.");
+    if (!name.trim() || name.trim().length > 100) throw new Error("Use a name between 1 and 100 characters.");
+    if (!/^#[0-9a-f]{6}$/i.test(color)) throw new Error("Choose a valid color.");
+  }
+
+  private getStyle(id: string): YType<NonNullable<CommentBox["overbox"]>> {
+    const graph = this.actions.getTexeraGraph();
+    if (!graph.getCommentBox(id).overbox) throw new Error("Section no longer exists.");
+    return graph.getSharedCommentBoxType(id).get("overbox") as unknown as YType<NonNullable<CommentBox["overbox"]>>;
+  }
+  public create(name: string, color: string, operatorIDs: readonly string[]): string {
+    this.validate(name, color);
+    const bounds = operatorIDs.map(id => {
+      this.actions.getTexeraGraph().assertOperatorExists(id);
+      return this.actions.getJointGraph().getCell(id).getBBox();
+    });
+    const paper = this.actions.getJointGraphWrapper().getMainJointPaper();
+    const origin = paper
+      ? paper.clientToLocalPoint({
+          x: paper.el.getBoundingClientRect().left + 350,
+          y: paper.el.getBoundingClientRect().top + 150,
+        })
+      : { x: 350, y: 150 };
+    const x = bounds.length ? Math.min(...bounds.map(b => b.x)) - 24 : origin.x;
+    const y = bounds.length ? Math.min(...bounds.map(b => b.y)) - 32 : origin.y;
+    const width = bounds.length ? Math.max(...bounds.map(b => b.x + b.width)) - x + 24 : 400;
+    const height = bounds.length ? Math.max(...bounds.map(b => b.y + b.height)) - y + 24 : 240;
+    const commentBoxID = this.util.getCommentBoxRandomUUID();
+    this.actions.addCommentBox({
+      commentBoxID,
+      comments: [],
+      commentBoxPosition: { x, y },
+      overbox: { name: name.trim(), color, width, height },
+    });
+    return commentBoxID;
+  }
+  public update(id: string, name: string, color: string): void {
+    this.validate(name, color);
+    const graph = this.actions.getTexeraGraph();
+    graph.bundleActions(() => {
+      const style = this.getStyle(id);
+      const title = style.get("name");
+      title.delete(0, title.length);
+      title.insert(0, name.trim());
+      const border = style.get("color");
+      border.delete(0, border.length);
+      border.insert(0, color);
+    });
+  }
+
+  public resize(id: string, width: number, height: number): void {
+    if (!this.actions.checkWorkflowModificationEnabled()) throw new Error("Workflow is read-only.");
+    if (!Number.isFinite(width) || !Number.isFinite(height)) throw new Error("Section dimensions must be finite.");
+    const graph = this.actions.getTexeraGraph();
+    const style = this.getStyle(id);
+    graph.bundleActions(() => {
+      style.set("width", Math.max(MIN_OVERBOX_WIDTH, Math.round(width)));
+      style.set("height", Math.max(MIN_OVERBOX_HEIGHT, Math.round(height)));
+    });
+  }
+}

--- a/frontend/src/app/workspace/service/workflow-fragment/workflow-fragment.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-fragment/workflow-fragment.service.spec.ts
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import {
+  mockPoint,
+  mockResultPredicate,
+  mockScanPredicate,
+  mockScanSentimentLink,
+  mockSentimentPredicate,
+  mockSentimentResultLink,
+} from "../workflow-graph/model/mock-workflow-data";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { WorkflowFragmentService } from "./workflow-fragment.service";
+import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-metadata.service";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+
+describe("WorkflowFragmentService", () => {
+  let service: WorkflowFragmentService;
+  let workflowActionService: WorkflowActionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: OperatorMetadataService, useClass: StubOperatorMetadataService }, ...commonTestProviders],
+    });
+    service = TestBed.inject(WorkflowFragmentService);
+    workflowActionService = TestBed.inject(WorkflowActionService);
+
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+    workflowActionService.addOperator(mockSentimentPredicate, { x: 200, y: 100 });
+    workflowActionService.addOperator(mockResultPredicate, { x: 400, y: 100 });
+    workflowActionService.addLink(mockScanSentimentLink);
+    workflowActionService.addLink(mockSentimentResultLink);
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-capture",
+      comments: [],
+      commentBoxPosition: { x: 100, y: 100 },
+      overbox: { name: "Capture", color: "#1677ff", width: 275, height: 180 },
+    });
+  });
+
+  it("rejects a missing section box", () => {
+    expect(() => service.captureSectionBox("missing")).toThrowError("Choose a section box to save.");
+  });
+
+  it("captures only links whose two operators are selected", () => {
+    const fragment = service.captureSectionBox("commentBox-capture");
+
+    expect(fragment.operators.map(operator => operator.operatorID)).toEqual([
+      mockScanPredicate.operatorID,
+      mockSentimentPredicate.operatorID,
+    ]);
+    expect(fragment.links).toEqual([mockScanSentimentLink]);
+    expect(fragment.operatorPositions[mockScanPredicate.operatorID]).toEqual({ x: 0, y: 0 });
+    expect(fragment.operatorPositions[mockSentimentPredicate.operatorID]).toEqual({ x: 100, y: 0 });
+  });
+
+  it("captures only operators geometrically contained by a section box", () => {
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-section",
+      comments: [],
+      commentBoxPosition: { x: 75, y: 70 },
+      overbox: { name: "Text cleaning", color: "#1677ff", width: 300, height: 180 },
+    });
+
+    const fragment = service.captureSectionBox("commentBox-section");
+
+    expect(fragment.operators.map(operator => operator.operatorID)).toEqual([
+      mockScanPredicate.operatorID,
+      mockSentimentPredicate.operatorID,
+    ]);
+    expect(fragment.links).toEqual([mockScanSentimentLink]);
+    expect(fragment.operatorPositions[mockScanPredicate.operatorID]).toEqual({ x: 25, y: 30 });
+    expect(fragment.sectionBox).toEqual({
+      name: "Text cleaning",
+      color: "#1677ff",
+      width: 300,
+      height: 180,
+    });
+  });
+
+  it("rejects an empty section box instead of saving an unusable definition", () => {
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-empty-section",
+      comments: [],
+      commentBoxPosition: { x: 800, y: 700 },
+      overbox: { name: "Empty", color: "#1677ff", width: 300, height: 180 },
+    });
+
+    expect(() => service.captureSectionBox("commentBox-empty-section")).toThrowError(
+      "The section box does not contain any operators."
+    );
+  });
+
+  it("deep-copies operator properties, including UDF code", () => {
+    const udf = {
+      ...mockSentimentPredicate,
+      operatorID: "SentimentAnalysis-udf-code-test",
+      operatorProperties: { code: "yield tuple_", nested: { value: 1 } },
+    };
+    workflowActionService.addOperator(udf, { x: 600, y: 100 });
+
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-udf",
+      comments: [],
+      commentBoxPosition: { x: 600, y: 100 },
+      overbox: { name: "Code", color: "#1677ff", width: 300, height: 180 },
+    });
+    const fragment = service.captureSectionBox("commentBox-udf");
+    (udf.operatorProperties.nested as { value: number }).value = 2;
+
+    expect(fragment.operators[0].operatorProperties["code"]).toBe("yield tuple_");
+    expect(fragment.operators[0].operatorProperties["nested"]).toEqual({ value: 1 });
+  });
+
+  it("inserts independent operators and remaps their internal links", () => {
+    const fragment = service.captureSectionBox("commentBox-capture");
+    const inserted = service.insert(fragment, { x: 800, y: 300 });
+
+    expect(inserted.operatorIDs).toHaveLength(2);
+    expect(inserted.operatorIDs).not.toContain(mockScanPredicate.operatorID);
+    expect(inserted.linkIDs).toHaveLength(1);
+
+    const insertedLink = workflowActionService.getTexeraGraph().getLinkWithID(inserted.linkIDs[0]);
+    expect(inserted.operatorIDs).toContain(insertedLink.source.operatorID);
+    expect(inserted.operatorIDs).toContain(insertedLink.target.operatorID);
+    expect(insertedLink.source.operatorID).not.toBe(mockScanSentimentLink.source.operatorID);
+  });
+
+  it("inserts an independent section box with the captured graph", () => {
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-section",
+      comments: [],
+      commentBoxPosition: { x: 75, y: 70 },
+      overbox: { name: "Text cleaning", color: "#1677ff", width: 300, height: 180 },
+    });
+    const fragment = service.captureSectionBox("commentBox-section");
+
+    const inserted = service.insert(fragment, { x: 700, y: 400 });
+
+    expect(inserted.sectionBoxID).toBeDefined();
+    const sectionBox = workflowActionService.getTexeraGraph().getCommentBox(inserted.sectionBoxID!);
+    expect(sectionBox.commentBoxPosition).toEqual({ x: 700, y: 400 });
+    expect(sectionBox.overbox).toEqual(fragment.sectionBox);
+    expect(workflowActionService.getJointGraphWrapper().getElementPosition(inserted.operatorIDs[0])).toEqual({
+      x: 725,
+      y: 430,
+    });
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toEqual(
+      inserted.operatorIDs
+    );
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedLinkIDs()).toEqual(inserted.linkIDs);
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedCommentBoxIDs()).toEqual([
+      inserted.sectionBoxID,
+    ]);
+  });
+});

--- a/frontend/src/app/workspace/service/workflow-fragment/workflow-fragment.service.ts
+++ b/frontend/src/app/workspace/service/workflow-fragment/workflow-fragment.service.ts
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { CommentBox, OperatorLink, OperatorPredicate, Point } from "../../types/workflow-common.interface";
+import { InsertedWorkflowFragment, WorkflowFragment } from "../../types/workflow-fragment.interface";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { WorkflowUtilService } from "../workflow-graph/util/workflow-util.service";
+
+@Injectable({ providedIn: "root" })
+export class WorkflowFragmentService {
+  constructor(
+    private workflowActionService: WorkflowActionService,
+    private workflowUtilService: WorkflowUtilService
+  ) {}
+
+  public captureSectionBox(sectionBoxID: string): WorkflowFragment {
+    const graph = this.workflowActionService.getTexeraGraph();
+    if (!graph.hasCommentBox(sectionBoxID) || !graph.getCommentBox(sectionBoxID).overbox) {
+      throw new Error("Choose a section box to save.");
+    }
+    const sectionBox = graph.getCommentBox(sectionBoxID);
+    const bounds = this.workflowActionService.getJointGraph().getCell(sectionBoxID).getBBox();
+    const operatorIDs = graph
+      .getAllOperators()
+      .filter(operator => {
+        const operatorBounds = this.workflowActionService.getJointGraph().getCell(operator.operatorID).getBBox();
+        return (
+          operatorBounds.x >= bounds.x &&
+          operatorBounds.y >= bounds.y &&
+          operatorBounds.x + operatorBounds.width <= bounds.x + bounds.width &&
+          operatorBounds.y + operatorBounds.height <= bounds.y + bounds.height
+        );
+      })
+      .map(operator => operator.operatorID);
+    if (operatorIDs.length === 0) {
+      throw new Error("The section box does not contain any operators.");
+    }
+    return {
+      ...this.captureAtOrigin(operatorIDs, { x: bounds.x, y: bounds.y }),
+      sectionBox: this.clone(sectionBox.overbox!),
+    };
+  }
+
+  private captureAtOrigin(operatorIDs: readonly string[], origin: Point): WorkflowFragment {
+    const graph = this.workflowActionService.getTexeraGraph();
+    const selectedIDs = new Set(operatorIDs);
+    const operators = operatorIDs.map(operatorID => this.clone(graph.getOperator(operatorID)));
+    const operatorPositions: Record<string, Point> = {};
+
+    operatorIDs.forEach(operatorID => {
+      const position = this.workflowActionService.getJointGraphWrapper().getElementPosition(operatorID);
+      operatorPositions[operatorID] = { x: position.x - origin.x, y: position.y - origin.y };
+    });
+
+    const links = graph
+      .getAllLinks()
+      .filter(link => selectedIDs.has(link.source.operatorID) && selectedIDs.has(link.target.operatorID))
+      .map(link => this.clone(link));
+
+    return { operators, operatorPositions, links };
+  }
+
+  public insert(fragment: WorkflowFragment, anchor: Point): InsertedWorkflowFragment {
+    this.validate(fragment);
+    const operatorIDMap = new Map<string, string>();
+    const operatorsAndPositions = fragment.operators.map(operator => {
+      const operatorID = `${operator.operatorType}-${this.workflowUtilService.getOperatorRandomUUID()}`;
+      operatorIDMap.set(operator.operatorID, operatorID);
+      const relativePosition = fragment.operatorPositions[operator.operatorID];
+      const copiedOperator: OperatorPredicate = { ...this.clone(operator), operatorID };
+      return {
+        op: copiedOperator,
+        pos: { x: anchor.x + relativePosition.x, y: anchor.y + relativePosition.y },
+      };
+    });
+
+    const links: OperatorLink[] = fragment.links.map(link => ({
+      ...this.clone(link),
+      linkID: this.workflowUtilService.getLinkRandomUUID(),
+      source: { ...link.source, operatorID: operatorIDMap.get(link.source.operatorID)! },
+      target: { ...link.target, operatorID: operatorIDMap.get(link.target.operatorID)! },
+    }));
+
+    let sectionBox: CommentBox | undefined;
+    if (fragment.sectionBox) {
+      sectionBox = {
+        commentBoxID: this.workflowUtilService.getCommentBoxRandomUUID(),
+        comments: [],
+        commentBoxPosition: { ...anchor },
+        overbox: this.clone(fragment.sectionBox),
+      };
+    }
+    this.workflowActionService.addOperatorsAndLinks(
+      operatorsAndPositions,
+      links,
+      sectionBox ? [sectionBox] : undefined
+    );
+    const inserted = {
+      operatorIDs: operatorsAndPositions.map(item => item.op.operatorID),
+      linkIDs: links.map(link => link.linkID),
+      sectionBoxID: sectionBox?.commentBoxID,
+    };
+    this.workflowActionService.highlightElements(
+      true,
+      ...inserted.operatorIDs,
+      ...inserted.linkIDs,
+      ...(inserted.sectionBoxID ? [inserted.sectionBoxID] : [])
+    );
+    return inserted;
+  }
+
+  private validate(fragment: WorkflowFragment): void {
+    if (!fragment || !Array.isArray(fragment.operators) || fragment.operators.length === 0) {
+      throw new Error("The reusable section does not contain any operators.");
+    }
+    if (!fragment.operatorPositions || !Array.isArray(fragment.links)) {
+      throw new Error("The reusable section is malformed.");
+    }
+
+    const operatorIDs = new Set(fragment.operators.map(operator => operator.operatorID));
+    if (operatorIDs.size !== fragment.operators.length) {
+      throw new Error("The reusable section contains duplicate operator IDs.");
+    }
+    fragment.operators.forEach(operator => {
+      if (!fragment.operatorPositions[operator.operatorID]) {
+        throw new Error(`The reusable section is missing the position of ${operator.operatorID}.`);
+      }
+    });
+    fragment.links.forEach(link => {
+      if (!operatorIDs.has(link.source.operatorID) || !operatorIDs.has(link.target.operatorID)) {
+        throw new Error("The reusable section contains a dangling link.");
+      }
+    });
+    if (
+      fragment.sectionBox &&
+      (!fragment.sectionBox.name.trim() ||
+        !Number.isFinite(fragment.sectionBox.width) ||
+        fragment.sectionBox.width <= 0 ||
+        !Number.isFinite(fragment.sectionBox.height) ||
+        fragment.sectionBox.height <= 0 ||
+        !/^#[0-9a-f]{6}$/i.test(fragment.sectionBox.color))
+    ) {
+      throw new Error("The reusable section contains an invalid section box.");
+    }
+  }
+
+  private clone<T>(value: T): T {
+    return JSON.parse(JSON.stringify(value)) as T;
+  }
+}

--- a/frontend/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
@@ -18,6 +18,7 @@
  */
 
 import { WorkflowGraph } from "./workflow-graph";
+import { renderOverbox } from "../../overbox/overbox-renderer";
 import { JointGraphWrapper } from "./joint-graph-wrapper";
 import * as Y from "yjs";
 import {
@@ -475,6 +476,10 @@ export class SharedModelChangeHandler {
       events.forEach(event => {
         if (event.target !== this.texeraGraph.sharedModel.commentBoxMap) {
           const commentBox: CommentBox = this.texeraGraph.getCommentBox(event.path[0] as string);
+          if (commentBox.overbox) {
+            const element = this.jointGraph.getCell(commentBox.commentBoxID);
+            if (element?.isElement()) renderOverbox(element as joint.dia.Element, commentBox);
+          }
           if (event.path.length === 2 && event.path[event.path.length - 1] === "comments") {
             const addedComments = Array.from(event.changes.added.values());
             const deletedComments = Array.from(event.changes.deleted.values());

--- a/frontend/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/frontend/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -798,7 +798,15 @@ export class WorkflowActionService {
     const operators = texeraGraph.getAllOperators();
     const links = texeraGraph.getAllLinks();
     const operatorPositions: { [key: string]: Point } = {};
-    const commentBoxes = texeraGraph.getAllCommentBoxes();
+    const commentBoxes = texeraGraph.getAllCommentBoxes().map(box =>
+      box.overbox
+        ? {
+            ...box,
+            commentBoxPosition:
+              this.texeraGraph.sharedModel.elementPositionMap.get(box.commentBoxID) ?? box.commentBoxPosition,
+          }
+        : box
+    );
     const settings = this.workflowSettings;
 
     texeraGraph

--- a/frontend/src/app/workspace/service/workflow-snippet/reusable-section-insertion.service.ts
+++ b/frontend/src/app/workspace/service/workflow-snippet/reusable-section-insertion.service.ts
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { NotificationService } from "../../../common/service/notification/notification.service";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { WorkflowSnippet } from "../../types/workflow-snippet.interface";
+import { WorkflowSnippetService } from "./workflow-snippet.service";
+
+/** Shared UI insertion action for both the library and its preview dialog. */
+@Injectable({ providedIn: "root" })
+export class ReusableSectionInsertionService {
+  constructor(
+    private readonly actions: WorkflowActionService,
+    private readonly snippets: WorkflowSnippetService,
+    private readonly notifications: NotificationService
+  ) {}
+
+  insert(section: WorkflowSnippet): boolean {
+    try {
+      const translation = this.actions.getJointGraphWrapper().getMainJointPaper()?.translate();
+      this.snippets.insert(section.id, { x: 400 - (translation?.tx ?? 0), y: 200 - (translation?.ty ?? 0) });
+      this.notifications.success(`Reusable section box "${section.name}" inserted as an independent copy.`);
+      return true;
+    } catch (error) {
+      this.notifications.error(error instanceof Error ? error.message : "Unable to insert the reusable section.");
+      return false;
+    }
+  }
+}

--- a/frontend/src/app/workspace/service/workflow-snippet/workflow-snippet.service.spec.ts
+++ b/frontend/src/app/workspace/service/workflow-snippet/workflow-snippet.service.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { TestBed } from "@angular/core/testing";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { mockPoint, mockScanPredicate } from "../workflow-graph/model/mock-workflow-data";
+import { commonTestProviders } from "../../../common/testing/test-utils";
+import { WorkflowSnippetService } from "./workflow-snippet.service";
+import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-metadata.service";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { WorkflowFragmentService } from "../workflow-fragment/workflow-fragment.service";
+
+describe("WorkflowSnippetService", () => {
+  let service: WorkflowSnippetService;
+  let workflowActionService: WorkflowActionService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [{ provide: OperatorMetadataService, useClass: StubOperatorMetadataService }, ...commonTestProviders],
+    });
+    service = TestBed.inject(WorkflowSnippetService);
+    workflowActionService = TestBed.inject(WorkflowActionService);
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  const addSectionBox = () =>
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-reusable",
+      comments: [],
+      commentBoxPosition: { x: mockPoint.x - 30, y: mockPoint.y - 30 },
+      overbox: { name: "Input block", color: "#1677ff", width: 300, height: 180 },
+    });
+
+  it("creates and persists a reusable section from a section box", () => {
+    addSectionBox();
+    const snippet = service.createFromSectionBox("commentBox-reusable", "Reusable input");
+
+    expect(snippet.name).toBe("Input block");
+    expect(service.getSnippets()).toEqual([snippet]);
+    expect(localStorage.getItem(WorkflowSnippetService.STORAGE_KEY)).toContain("Input block");
+    expect(snippet.fragment.sectionBox?.name).toBe(snippet.name);
+  });
+
+  it("trims the description and rejects a regular comment box", () => {
+    workflowActionService.addCommentBox({
+      commentBoxID: "commentBox-regular",
+      comments: [],
+      commentBoxPosition: { x: 0, y: 0 },
+    });
+    expect(() => service.createFromSectionBox("commentBox-regular", "")).toThrowError("Choose a section box to save.");
+    addSectionBox();
+    const snippet = service.createFromSectionBox("commentBox-reusable", "  Reusable input  ");
+    expect(snippet.description).toBe("Reusable input");
+  });
+
+  it("ignores malformed stored data without preventing startup", () => {
+    localStorage.setItem(WorkflowSnippetService.STORAGE_KEY, "not-json");
+
+    const freshService = new WorkflowSnippetService(TestBed.inject(WorkflowFragmentService));
+
+    expect(freshService.getSnippets()).toEqual([]);
+  });
+
+  it("ignores legacy snippets that do not contain a section box", () => {
+    localStorage.setItem(
+      WorkflowSnippetService.STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "legacy",
+          schemaVersion: 1,
+          name: "Old snippet",
+          description: "",
+          fragment: { operators: [mockScanPredicate], operatorPositions: {}, links: [] },
+        },
+      ])
+    );
+
+    const freshService = new WorkflowSnippetService(TestBed.inject(WorkflowFragmentService));
+
+    expect(freshService.getSnippets()).toEqual([]);
+  });
+
+  it("deletes the saved definition without touching inserted operators", () => {
+    addSectionBox();
+    const snippet = service.createFromSectionBox("commentBox-reusable", "");
+    const inserted = service.insert(snippet.id, { x: 500, y: 300 });
+
+    service.delete(snippet.id);
+
+    expect(service.getSnippets()).toEqual([]);
+    expect(workflowActionService.getTexeraGraph().hasOperator(inserted.operatorIDs[0])).toBe(true);
+    expect(workflowActionService.getTexeraGraph().hasCommentBox(inserted.sectionBoxID!)).toBe(true);
+  });
+});

--- a/frontend/src/app/workspace/service/workflow-snippet/workflow-snippet.service.ts
+++ b/frontend/src/app/workspace/service/workflow-snippet/workflow-snippet.service.ts
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Injectable } from "@angular/core";
+import { BehaviorSubject, Observable } from "rxjs";
+import { v4 as uuid } from "uuid";
+import { Point } from "../../types/workflow-common.interface";
+import { WORKFLOW_SNIPPET_SCHEMA_VERSION, WorkflowSnippet } from "../../types/workflow-snippet.interface";
+import { InsertedWorkflowFragment } from "../../types/workflow-fragment.interface";
+import { WorkflowFragmentService } from "../workflow-fragment/workflow-fragment.service";
+
+@Injectable({ providedIn: "root" })
+export class WorkflowSnippetService {
+  public static readonly STORAGE_KEY = "texera.reusable-sections.v1";
+
+  private readonly snippetsSubject: BehaviorSubject<readonly WorkflowSnippet[]>;
+  public readonly snippets$: Observable<readonly WorkflowSnippet[]>;
+
+  constructor(private readonly fragmentService: WorkflowFragmentService) {
+    this.snippetsSubject = new BehaviorSubject<readonly WorkflowSnippet[]>(this.load());
+    this.snippets$ = this.snippetsSubject.asObservable();
+  }
+
+  public getSnippets(): readonly WorkflowSnippet[] {
+    return this.snippetsSubject.value;
+  }
+
+  public createFromSectionBox(sectionBoxID: string, description: string): WorkflowSnippet {
+    const graph = this.fragmentService.captureSectionBox(sectionBoxID);
+    const normalizedName = graph.sectionBox!.name.trim();
+    const timestamp = new Date().toISOString();
+    const snippet: WorkflowSnippet = {
+      id: uuid(),
+      schemaVersion: WORKFLOW_SNIPPET_SCHEMA_VERSION,
+      name: normalizedName,
+      description: description.trim(),
+      createdAt: timestamp,
+      updatedAt: timestamp,
+      fragment: graph,
+    };
+    this.replaceSnippets([...this.snippetsSubject.value, snippet]);
+    return snippet;
+  }
+
+  public insert(id: string, anchor: Point): InsertedWorkflowFragment {
+    const snippet = this.snippetsSubject.value.find(candidate => candidate.id === id);
+    if (!snippet) {
+      throw new Error("The selected reusable section no longer exists.");
+    }
+    return this.fragmentService.insert(snippet.fragment, anchor);
+  }
+
+  public delete(id: string): void {
+    this.replaceSnippets(this.snippetsSubject.value.filter(snippet => snippet.id !== id));
+  }
+
+  private replaceSnippets(snippets: readonly WorkflowSnippet[]): void {
+    localStorage.setItem(WorkflowSnippetService.STORAGE_KEY, JSON.stringify(snippets));
+    this.snippetsSubject.next(snippets);
+  }
+
+  private load(): readonly WorkflowSnippet[] {
+    const stored = localStorage.getItem(WorkflowSnippetService.STORAGE_KEY);
+    if (!stored) {
+      return [];
+    }
+    try {
+      const snippets = JSON.parse(stored) as unknown;
+      if (!Array.isArray(snippets)) {
+        return [];
+      }
+      return snippets.filter(this.isSupportedSnippet);
+    } catch {
+      return [];
+    }
+  }
+
+  private isSupportedSnippet(value: unknown): value is WorkflowSnippet {
+    if (!value || typeof value !== "object") {
+      return false;
+    }
+    const snippet = value as Partial<WorkflowSnippet>;
+    const fragment = snippet.fragment;
+    const sectionBox = fragment?.sectionBox;
+    return (
+      snippet.schemaVersion === WORKFLOW_SNIPPET_SCHEMA_VERSION &&
+      typeof snippet.id === "string" &&
+      typeof snippet.name === "string" &&
+      snippet.name.trim().length > 0 &&
+      typeof snippet.description === "string" &&
+      !!fragment &&
+      !!sectionBox &&
+      sectionBox.name === snippet.name &&
+      typeof sectionBox.color === "string" &&
+      /^#[0-9a-f]{6}$/i.test(sectionBox.color) &&
+      Number.isFinite(sectionBox.width) &&
+      sectionBox.width > 0 &&
+      Number.isFinite(sectionBox.height) &&
+      sectionBox.height > 0 &&
+      !!fragment.operatorPositions &&
+      Array.isArray(fragment.operators) &&
+      fragment.operators.length > 0 &&
+      fragment.operators.every(
+        operator =>
+          typeof operator.operatorID === "string" &&
+          typeof operator.operatorType === "string" &&
+          Number.isFinite(fragment.operatorPositions[operator.operatorID]?.x) &&
+          Number.isFinite(fragment.operatorPositions[operator.operatorID]?.y)
+      ) &&
+      Array.isArray(fragment.links)
+    );
+  }
+}

--- a/frontend/src/app/workspace/types/workflow-common.interface.ts
+++ b/frontend/src/app/workspace/types/workflow-common.interface.ts
@@ -90,6 +90,13 @@ export interface CommentBox {
   commentBoxID: string;
   comments: Comment[];
   commentBoxPosition: Point;
+  /** Optional visual section frame; regular comments remain unchanged. */
+  overbox?: {
+    name: string;
+    color: string;
+    width: number;
+    height: number;
+  };
 }
 
 export interface OperatorLink

--- a/frontend/src/app/workspace/types/workflow-fragment.interface.ts
+++ b/frontend/src/app/workspace/types/workflow-fragment.interface.ts
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { CommentBox, OperatorLink, OperatorPredicate, Point } from "./workflow-common.interface";
+
+export type WorkflowFragmentSectionBox = NonNullable<CommentBox["overbox"]>;
+
+/** A detached, serializable portion of a workflow graph. */
+export interface WorkflowFragment {
+  operators: OperatorPredicate[];
+  operatorPositions: Record<string, Point>;
+  links: OperatorLink[];
+  sectionBox?: WorkflowFragmentSectionBox;
+}
+
+export interface InsertedWorkflowFragment {
+  operatorIDs: string[];
+  linkIDs: string[];
+  sectionBoxID?: string;
+}

--- a/frontend/src/app/workspace/types/workflow-snippet.interface.ts
+++ b/frontend/src/app/workspace/types/workflow-snippet.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { WorkflowFragment } from "./workflow-fragment.interface";
+
+export const WORKFLOW_SNIPPET_SCHEMA_VERSION = 2;
+
+/** A documented section-box snapshot saved in the user's browser for independent reuse. */
+export interface WorkflowSnippet {
+  id: string;
+  schemaVersion: typeof WORKFLOW_SNIPPET_SCHEMA_VERSION;
+  name: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+  fragment: WorkflowFragment;
+}


### PR DESCRIPTION
### What changes were proposed in this PR?

Add rectangle selection, explanatory section boxes, and a library of reusable workflow sections.

- Secondary-button drag or Alt + primary-button drag selects operators, internal links, and annotations. Selected elements can be moved together, copied, or deleted.
- Named, colored section boxes annotate workflow regions using the existing annotation model, persistence, undo, and collaboration.
- Saving a reusable section captures geometrically contained operators, their configuration (including UDF code), internal links, and the section box. Library entries provide a description and graph preview.
- Insertion creates independent copies with remapped IDs and selects the inserted elements for immediate placement.

The reusable library is stored in the current browser's localStorage; it is not a shared server-side library. This change is frontend-only and adds no dependencies.

### Any related issues, documentation, discussions?

Closes #8526.
Maintainer agreement has not yet been established.
Contribution workflow: https://github.com/apache/texera/blob/main/CONTRIBUTING.md

### How was this PR tested?

Focused unit/integration suites, from `frontend/`:

```bash
npm test -- --include=src/app/workspace/component/canvas-selection/canvas-selection.component.spec.ts --include=src/app/workspace/component/canvas-selection/selection-geometry.spec.ts --include=src/app/workspace/component/left-panel/left-panel.component.spec.ts --include=src/app/workspace/component/left-panel/my-snippets/my-snippets.component.spec.ts --include=src/app/workspace/component/left-panel/my-snippets/reusable-section-detail.component.spec.ts --include=src/app/workspace/component/overbox/overbox-dialog.component.spec.ts --include=src/app/workspace/component/overbox/overbox-interaction.component.spec.ts --include=src/app/workspace/component/workflow-editor/create-snippet-modal/create-snippet-modal.component.spec.ts --include=src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts --include=src/app/workspace/service/overbox/overbox-colors.spec.ts --include=src/app/workspace/service/overbox/overbox.service.spec.ts --include=src/app/workspace/service/workflow-fragment/workflow-fragment.service.spec.ts --include=src/app/workspace/service/workflow-snippet/workflow-snippet.service.spec.ts
```

179 tests passed across 13 suites against upstream main at 0b103f813.
Prettier and ESLint checked on the contributed files.
Browser-mode validation and before/after visual evidence remain pending; publish as a draft until these are complete.

Manual review steps:
1. Drag a selection rectangle around multiple operators and move the selection.
2. Create a section box, edit its name/color, and resize it.
3. Save it as a reusable section with a description.
4. Open the library preview, then insert into another workflow.
5. Verify that the section and its operators are selected and can move together.
6. Edit the inserted operators and confirm the saved library entry is unchanged.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: OpenAI Codex (GPT-6; earlier implementation also used GPT-5-based Codex).
