### PR TITLE
fix(ci): pull MinIO images from quay.io now that Docker Hub dropped minio/minio

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -519,7 +519,7 @@ jobs:
             docker run -d --name minio --network host \
               -e MINIO_ROOT_USER=texera_minio \
               -e MINIO_ROOT_PASSWORD=password \
-              minio/minio:RELEASE.2025-02-28T09-55-16Z server /data
+              quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z server /data
           else
             brew install minio/stable/minio
             mkdir -p /tmp/minio-data
@@ -609,10 +609,10 @@ jobs:
           LAKEKEEPER_BASE=${LAKEKEEPER_BASE%/}
 
           # bucket creation runs through `mc`; on Linux we keep the
-          # minio/mc image, on macOS we use the brew-installed native CLI
+          # quay.io/minio/mc image, on macOS we use the brew-installed native CLI
           # since docker is unavailable.
           if [ "$RUNNER_OS" = "Linux" ]; then
-            docker run --rm --network host --entrypoint sh minio/mc -c \
+            docker run --rm --network host --entrypoint sh quay.io/minio/mc:RELEASE.2025-05-21T01-59-54Z -c \
               "mc alias set minio $S3_ENDPOINT $S3_USERNAME $S3_PASSWORD && \
                mc mb --ignore-existing minio/$S3_BUCKET"
           else
@@ -1012,7 +1012,7 @@ jobs:
           docker run -d --name minio --network host \
             -e MINIO_ROOT_USER=texera_minio \
             -e MINIO_ROOT_PASSWORD=password \
-            minio/minio:RELEASE.2025-02-28T09-55-16Z server /data
+            quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z server /data
           for i in $(seq 1 15); do
             curl -sf http://localhost:9000/minio/health/live && break
             echo "Waiting for MinIO... (attempt $i)"; sleep 1

--- a/bin/single-node/docker-compose.yml
+++ b/bin/single-node/docker-compose.yml
@@ -20,7 +20,7 @@ services:
   # Part1: Specification of the storage services used by Texera
   # MinIO is an S3-compatible object storage used to store datasets and files.
   minio:
-    image: minio/minio:RELEASE.2025-02-28T09-55-16Z
+    image: quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z
     container_name: texera-minio
     ports:
       - "${MINIO_PORT:-9000}:9000"
@@ -41,7 +41,7 @@ services:
   # This job creates the S3 bucket used by the Iceberg warehouse that the
   # Lakekeeper service manages.
   minio-init:
-    image: minio/mc:RELEASE.2025-05-21T01-59-54Z
+    image: quay.io/minio/mc:RELEASE.2025-05-21T01-59-54Z
     container_name: texera-minio-init
     depends_on:
       minio:

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/util/LakeFSStorageClientMtimeSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/storage/util/LakeFSStorageClientMtimeSpec.scala
@@ -88,7 +88,9 @@ class LakeFSStorageClientMtimeSpec
       s"@${postgres.container.getNetworkAliases.get(0)}:5432/${postgres.databaseName}?sslmode=disable"
 
   private val minio: MinIOContainer = MinIOContainer(
-    dockerImageName = DockerImageName.parse("minio/minio:RELEASE.2025-02-28T09-55-16Z"),
+    dockerImageName = DockerImageName
+      .parse("quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z")
+      .asCompatibleSubstituteFor("minio/minio"),
     userName = minioUser,
     password = minioPassword
   )

--- a/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageTestBase.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/service/util/S3StorageTestBase.scala
@@ -42,7 +42,9 @@ trait S3StorageTestBase extends BeforeAndAfterAll { this: Suite =>
 object S3StorageTestBase {
   private lazy val container: MinIOContainer = {
     val c = MinIOContainer(
-      dockerImageName = DockerImageName.parse("minio/minio:RELEASE.2025-02-28T09-55-16Z"),
+      dockerImageName = DockerImageName
+        .parse("quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z")
+        .asCompatibleSubstituteFor("minio/minio"),
       userName = "texera_minio",
       password = "password"
     )

--- a/file-service/src/main/resources/docker-compose.yml
+++ b/file-service/src/main/resources/docker-compose.yml
@@ -18,7 +18,7 @@
 name: texera-lakefs
 services:
   minio:
-    image: minio/minio:RELEASE.2025-02-28T09-55-16Z
+    image: quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z
     container_name: texera-lakefs-minio
     restart: unless-stopped
     ports:

--- a/file-service/src/main/resources/minio-config.yml
+++ b/file-service/src/main/resources/minio-config.yml
@@ -19,7 +19,7 @@ version: '3.8'
 
 services:
   minio:
-    image: minio/minio:latest
+    image: quay.io/minio/minio:latest
     container_name: minio
     ports:
       - "9500:9000"   # MinIO API

--- a/file-service/src/test/scala/org/apache/texera/service/MockLakeFS.scala
+++ b/file-service/src/test/scala/org/apache/texera/service/MockLakeFS.scala
@@ -64,7 +64,9 @@ trait MockLakeFS extends ForAllTestContainer with BeforeAndAfterAll { self: Suit
 
   // MinIO for object storage
   val minio = MinIOContainer(
-    dockerImageName = DockerImageName.parse("minio/minio:RELEASE.2025-02-28T09-55-16Z"),
+    dockerImageName = DockerImageName
+      .parse("quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z")
+      .asCompatibleSubstituteFor("minio/minio"),
     userName = "texera_minio",
     password = "password"
   )


### PR DESCRIPTION
### What changes were proposed in this PR?

Docker Hub no longer serves `minio/minio` or `minio/mc`. As a result, every job that starts MinIO is currently red on `main` and on open PRs (e.g. #6896): `amber`, `amber-integration`, `platform (file-service)` and `platform-integration (file-service)`. They fail with:

```
pull access denied for minio/minio, repository does not exist or may require 'docker login'
```

This PR switches every MinIO image reference to MinIO's official mirror on `quay.io`, keeping the **same pinned tags**. The images there are byte-identical to the ones CI used before:

| image | old Docker Hub image ID | quay.io image ID |
|---|---|---|
| `minio:RELEASE.2025-02-28T09-55-16Z` | `sha256:a929054a…` | `sha256:a929054a…` |
| `mc:RELEASE.2025-05-21T01-59-54Z` | `sha256:09f93f53…` | `sha256:09f93f53…` |

Only the registry changes; MinIO behavior doesn't.

Non-obvious bits:
- Testcontainers' `MinIOContainer` calls `assertCompatibleWith("minio/minio")` and rejects any other image name. The Scala test fixtures therefore mark the quay.io image with `.asCompatibleSubstituteFor("minio/minio")`.
- The untagged `minio/mc` in the platform-integration bucket step is now pinned to the same `mc` release that `bin/single-node` uses.
- The macOS path (`brew install minio/stable/minio`) is unaffected. The tap still exists; that job only showed as failed because fail-fast cancelled it.
- `bin/k8s` uses `bitnamilegacy/minio`, which isn't affected, so it's left alone.

### Any related issues, documentation, discussions?

The breakage is visible on #6896 and every other PR that runs the MinIO-backed jobs.

### How was this PR tested?

- **Testcontainers specs, run locally with this branch:**
  - `WorkflowCore/testOnly S3StorageClientSpec LakeFSStorageClientMtimeSpec LargeBinaryManagerSpec`: 73 passed.
  - `FileService/testOnly DatasetResourceSpec` (via `MockLakeFS`): 152 passed.
  - The logs show containers created from `quay.io/minio/minio:RELEASE.2025-02-28T09-55-16Z`.
  - `WorkflowCore/Test/scalafmtCheck` and `FileService/Test/scalafmtCheck` pass.
- **Full `bin/single-node` stack with the updated compose file:**
  - All services came up healthy, including `minio`, `minio-init` (bucket created by quay.io `mc`), `lakefs`, `lakekeeper` and `file-service`.
  - End to end, I logged in, created a dataset, uploaded a file (200), and committed a version. The LakeFS objects for it appeared in the `texera-dataset` bucket in MinIO.
- This PR's own CI run covers the workflow changes.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127YDvJ55zTd2x2RpRjK5GF
